### PR TITLE
Add a page title in generated step template

### DIFF
--- a/lib/generators/step/templates/edit.html.erb
+++ b/lib/generators/step/templates/edit.html.erb
@@ -1,3 +1,5 @@
+<% title t('.page_title') %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%%= step_header %>


### PR DESCRIPTION
Without this, every generated page raises a missing page title
exception when it is rendered.