### PR TITLE
Enable a basic CRUD for Applicants

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -505,4 +505,4 @@ MethodLength:
 
 AbcSize:
   Enabled: true
-  Max: 18
+  Max: 20

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -15,7 +15,7 @@ class StepController < ApplicationController
 
     @next_step   = params[:next_step].presence
     @form_object = form_class.new(
-      hash.merge(c100_application: current_c100_application)
+      hash.merge(c100_application: current_c100_application, record_id: opts[:record_id])
     )
 
     if @form_object.save

--- a/app/controllers/steps/applicant/personal_details_controller.rb
+++ b/app/controllers/steps/applicant/personal_details_controller.rb
@@ -1,11 +1,13 @@
 module Steps
   module Applicant
     class PersonalDetailsController < Steps::ApplicantStepController
+      before_action :set_existing_applicants
+
       # rubocop:disable Metrics/AbcSize
       def edit
         @form_object = PersonalDetailsForm.new(
           c100_application: current_c100_application,
-          applicant_id: current_applicant.id,
+          record_id: current_applicant.id,
           full_name: current_applicant.full_name,
           has_previous_name: current_applicant.has_previous_name,
           previous_full_name: current_applicant.previous_full_name,
@@ -21,14 +23,26 @@ module Steps
       # rubocop:enable Metrics/AbcSize
 
       def update
-        update_and_advance(PersonalDetailsForm, as: :personal_details)
+        update_and_advance(
+          PersonalDetailsForm,
+          record_id: current_applicant.id,
+          as: params.fetch(:button, :applicants_finished)
+        )
+      end
+
+      def destroy
+        current_applicant.destroy
+        redirect_to action: :edit, id: current_c100_application.saved_applicants.first
       end
 
       private
 
-      # TODO: for now, hardcoded to get the first one if exists.
       def current_applicant
-        @_current_applicant ||= current_c100_application.applicants.first_or_initialize
+        @_current_applicant ||= current_c100_application.applicants.find_or_initialize_by(id: params[:id])
+      end
+
+      def set_existing_applicants
+        @existing_applicants = current_c100_application.saved_applicants
       end
     end
   end

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -5,6 +5,7 @@ class BaseForm
   include ActiveModel::Validations
 
   attr_accessor :c100_application
+  attr_accessor :record_id
 
   def save
     if valid?

--- a/app/forms/steps/applicant/personal_details_form.rb
+++ b/app/forms/steps/applicant/personal_details_form.rb
@@ -1,7 +1,6 @@
 module Steps
   module Applicant
     class PersonalDetailsForm < BaseForm
-      attribute :applicant_id, String
       attribute :full_name, StrippedString
       attribute :has_previous_name, String
       attribute :previous_full_name, StrippedString
@@ -44,7 +43,7 @@ module Steps
       def persist!
         raise C100ApplicationNotFound unless c100_application
 
-        applicant = c100_application.applicants.find_or_initialize_by(id: applicant_id)
+        applicant = c100_application.applicants.find_or_initialize_by(id: record_id)
         applicant.update(
           full_name: full_name,
           has_previous_name: has_previous_name_value,

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -2,6 +2,7 @@ class C100Application < ApplicationRecord
   belongs_to :user, optional: true, dependent: :destroy
 
   has_many :applicants, dependent: :destroy
+  has_many :saved_applicants, -> { where.not(id: nil).order(created_at: :asc) }, class_name: Applicant
 
   has_value_object :user_type
   has_value_object :help_paying

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -28,6 +28,6 @@ class BaseDecisionTree
   # end
 
   def edit(step_controller)
-    {controller: step_controller, action: :edit}
+    {controller: step_controller, action: :edit, id: nil}
   end
 end

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -6,10 +6,10 @@ module C100App
       case step_name
       when :user_type
         edit(:number_of_children)
-      when :number_of_children
+      when :number_of_children, :add_another_applicant
         edit(:personal_details)
-      when :personal_details
-        edit(:number_of_children) # TODO: update when able to add more applicants
+      when :applicants_finished
+        edit(:number_of_children) # TODO: update when we have next step
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/views/steps/applicant/personal_details/_applicant_row.html.erb
+++ b/app/views/steps/applicant/personal_details/_applicant_row.html.erb
@@ -1,0 +1,7 @@
+<li>
+  <%= applicant.full_name %> (<%= applicant.id %>)
+  <span class="right actions actions-tight">
+    <%= link_to 'edit', edit_steps_applicant_personal_details_path(applicant), class: 'button' %>
+    <%= button_to 'delete', steps_applicant_personal_details_path(applicant), method: :delete, data: {confirm: 'Are you sure?'}, class: 'button button-secondary' %>
+  </span>
+</li>

--- a/app/views/steps/applicant/personal_details/edit.html.erb
+++ b/app/views/steps/applicant/personal_details/edit.html.erb
@@ -4,6 +4,16 @@
   <div class="column-two-thirds">
     <%= step_header %>
 
+    <!-- This is just for the sake of having a functional CRUD. Pending UI/UX. -->
+    <% if @existing_applicants.any? %>
+      <p>Saved applicants:</p>
+      <ul class="list list-bullet">
+        <% @existing_applicants.each do |applicant| %>
+          <%= render partial: 'applicant_row', locals: {applicant: applicant} %>
+        <% end %>
+      </ul>
+    <% end %>
+
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
@@ -33,7 +43,10 @@
       <%= f.text_field :mobile_phone %>
       <%= f.text_field :email %>
 
-      <%= f.submit class: 'button' %>
+      <div class="xform-group form-submit">
+        <%= f.submit class: 'button' %>
+        <%= f.button t('.btn_add_another'), class: 'button', type: :submit, value: :add_another_applicant %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,8 +25,9 @@ en:
       personal_details:
         edit:
           page_title: Applicant personal details
-          heading: About you (the applicant(s)) - Applicant {n}
+          heading: About you (the applicant(s))
           privacy_warning_html: '<p><strong>If you do not wish your address to be made known to the respondent</strong>, leave the details below blank and complete <a href="https://formfinder.hmctsformfinder.justice.gov.uk/c8-eng.pdf">Confidential contact details Form C8</a>. Please ensure that any documents submitted with this form or at a later date, <strong>do not</strong> disclose the confidential contact details you wish to withhold.</p>'
+          btn_add_another: Add another applicant
     help_with_fees:
       help_paying:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,15 @@
 # :nocov:
 class ActionDispatch::Routing::Mapper
-  def edit_step(name)
+  def edit_step(name, opts = {})
     resource name,
              only:       [:edit, :update],
              controller: name,
-             path_names: { edit: '' }
+             path_names: { edit: '' } do
+
+      resources only:       [:edit, :update, :destroy],
+                controller: name,
+                path_names: { edit: '' } if opts.fetch(:enable_crud, false)
+    end
   end
 
   def show_step(name)
@@ -31,7 +36,7 @@ Rails.application.routes.draw do
     namespace :applicant do
       edit_step :user_type
       edit_step :number_of_children
-      edit_step :personal_details
+      edit_step :personal_details, enable_crud: true
     end
     namespace :help_with_fees do
       edit_step :help_paying

--- a/spec/controllers/steps/applicant/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/applicant/personal_details_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Applicant::PersonalDetailsController, type: :controller do
-  it_behaves_like 'an intermediate step controller', Steps::Applicant::PersonalDetailsForm, C100App::ApplicantDecisionTree
+  it_behaves_like 'an intermediate CRUD step controller', Steps::Applicant::PersonalDetailsForm, C100App::ApplicantDecisionTree
 end

--- a/spec/controllers/steps/applicant/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/applicant/personal_details_controller_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Applicant::PersonalDetailsController, type: :controller do
-  it_behaves_like 'an intermediate CRUD step controller', Steps::Applicant::PersonalDetailsForm, C100App::ApplicantDecisionTree
+  it_behaves_like 'an intermediate CRUD step controller',
+                  Steps::Applicant::PersonalDetailsForm,
+                  C100App::ApplicantDecisionTree,
+                  Applicant
 end

--- a/spec/forms/steps/applicant/personal_details_form_spec.rb
+++ b/spec/forms/steps/applicant/personal_details_form_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Steps::Applicant::PersonalDetailsForm do
   let(:arguments) { {
     c100_application: c100_application,
-    applicant_id: applicant_id,
+    record_id: record_id,
     full_name: full_name,
     has_previous_name: has_previous_name,
     previous_full_name: previous_full_name,
@@ -20,7 +20,7 @@ RSpec.describe Steps::Applicant::PersonalDetailsForm do
   let(:applicants_collection) { double('applicants_collection') }
   let(:applicant) { double('Applicant') }
 
-  let(:applicant_id) { nil }
+  let(:record_id) { nil }
   let(:full_name) { 'Full Name' }
   let(:has_previous_name) { 'no' }
   let(:previous_full_name) { nil }
@@ -150,7 +150,7 @@ RSpec.describe Steps::Applicant::PersonalDetailsForm do
     end
 
     context 'when all the details are valid and record already exists' do
-      let(:applicant_id) { 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6' }
+      let(:record_id) { 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6' }
 
       it 'updates the record if it already exists' do
         expect(applicants_collection).to receive(:find_or_initialize_by).with(

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -31,8 +31,16 @@ RSpec.describe C100App::ApplicantDecisionTree do
     it {is_expected.to have_destination(:personal_details, :edit)}
   end
 
-  context 'when the step is `personal_details`' do
-    let(:step_params) {{'personal_details' => 'anything'}}
+  context 'when the step is `add_another_applicant`' do
+    let(:step_params) {{'add_another_applicant' => 'anything'}}
+    let(:c100_application) {instance_double(C100Application)}
+
+    it {is_expected.to have_destination(:personal_details, :edit)}
+  end
+
+  # TODO: this is a placeholder, to be updated when we actually have the next (real) step
+  context 'when the step is `applicants_finished`' do
+    let(:step_params) {{'applicants_finished' => 'anything'}}
     let(:c100_application) {instance_double(C100Application)}
 
     it {is_expected.to have_destination(:number_of_children, :edit)}

--- a/spec/support/matchers/decision_tree_matcher.rb
+++ b/spec/support/matchers/decision_tree_matcher.rb
@@ -2,11 +2,12 @@ require 'rspec/expectations'
 
 RSpec::Matchers.define :have_destination do |controller, action|
   match do |decision_tree|
-    decision_tree.destination == { controller: controller, action: action }
+    decision_tree.destination == { controller: controller, action: action } ||
+      decision_tree.destination == { controller: controller, action: action, id: nil }
   end
 
   failure_message do |decision_tree|
-    if decision_tree.destination.is_a?(Hash) && decision_tree.destination.keys == [:controller, :action]
+    if decision_tree.destination.is_a?(Hash) && decision_tree.destination.keys.include?(:controller, :action)
 			"expected decision tree to have a destination of " +
       "'#{controller}##{action}', " +
       "got '#{decision_tree.destination[:controller]}##{decision_tree.destination[:action]}'"

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -211,3 +211,36 @@ RSpec.shared_examples 'an intermediate step controller without update' do
     end
   end
 end
+
+RSpec.shared_examples 'an intermediate CRUD step controller' do |form_class, decision_tree_class|
+  include_examples 'an intermediate step controller', form_class, decision_tree_class
+
+  describe '#destroy' do
+    context 'when no case exists in the session yet' do
+      before do
+        # Needed because some specs that include these examples stub current_c100_application,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_c100_application).and_return(nil)
+      end
+
+      it 'redirects to the invalid session error page' do
+        delete :destroy, params: {id: '123'}
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when a case exists in the session' do
+      let!(:existing_case) {C100Application.create}
+      let!(:existing_applicant) {existing_case.applicants.create}
+
+      before do
+        allow(controller).to receive(:current_c100_application).and_return(existing_case)
+      end
+
+      it 'responds with HTTP success' do
+        delete :destroy, params: {id: existing_applicant.id}
+        expect(response).to redirect_to(action: :edit, id: nil)
+      end
+    end
+  end
+end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -212,7 +212,7 @@ RSpec.shared_examples 'an intermediate step controller without update' do
   end
 end
 
-RSpec.shared_examples 'an intermediate CRUD step controller' do |form_class, decision_tree_class|
+RSpec.shared_examples 'an intermediate CRUD step controller' do |form_class, decision_tree_class, resource_class|
   include_examples 'an intermediate step controller', form_class, decision_tree_class
 
   describe '#destroy' do
@@ -231,14 +231,14 @@ RSpec.shared_examples 'an intermediate CRUD step controller' do |form_class, dec
 
     context 'when a case exists in the session' do
       let!(:existing_case) {C100Application.create}
-      let!(:existing_applicant) {existing_case.applicants.create}
+      let!(:existing_resource) { resource_class.create(c100_application: existing_case) }
 
       before do
         allow(controller).to receive(:current_c100_application).and_return(existing_case)
       end
 
-      it 'responds with HTTP success' do
-        delete :destroy, params: {id: existing_applicant.id}
+      it 'redirects to edit an empty resource' do
+        delete :destroy, params: {id: existing_resource.id}
         expect(response).to redirect_to(action: :edit, id: nil)
       end
     end


### PR DESCRIPTION
Following the previous PR, this will enable the ability to add multiple
Applicants, and also edit and delete existing ones.

Some of the code will be candidate to extract to superclasses or modules
once we are happy with the solution and also once we have another similar
step (like Respondents) where we will be able to reuse some stuff.

There are however some rough corners in this solution, which hopefully we
will be polishing as part of following PRs.

A very ugly little interface has been incorporated to the top of the step
view to be able to manipulate the Applicant entries visually. Of course this
will change in the future.

<img width="684" alt="screen shot 2017-11-02 at 15 16 18" src="https://user-images.githubusercontent.com/687910/32334141-a270b7f0-bfe1-11e7-8188-80a6e01a9eb5.png">
