### PR TITLE
Add Respondent task and steps with CRUD

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -495,14 +495,15 @@ SpaceInsideHashLiteralBraces:
 PredicateName:
   Enabled: false
 
+# We have several big form objects with lots of attributes and this cop keeps complaining.
+# Disabling for now until we have a more stable code base.
+AbcSize:
+  Enabled: false
+
 AccessModifierIndentation:
   Enabled: true
   EnforcedStyle: indent
 
 MethodLength:
-  Enabled: true
-  Max: 20
-
-AbcSize:
   Enabled: true
   Max: 20

--- a/app/controllers/steps/applicant/personal_details_controller.rb
+++ b/app/controllers/steps/applicant/personal_details_controller.rb
@@ -3,7 +3,6 @@ module Steps
     class PersonalDetailsController < Steps::ApplicantStepController
       before_action :set_existing_applicants
 
-      # rubocop:disable Metrics/AbcSize
       def edit
         @form_object = PersonalDetailsForm.new(
           c100_application: current_c100_application,
@@ -21,7 +20,6 @@ module Steps
           email: current_applicant.email
         )
       end
-      # rubocop:enable Metrics/AbcSize
 
       def update
         update_and_advance(

--- a/app/controllers/steps/respondent/personal_details_controller.rb
+++ b/app/controllers/steps/respondent/personal_details_controller.rb
@@ -1,0 +1,52 @@
+module Steps
+  module Respondent
+    class PersonalDetailsController < Steps::RespondentStepController
+      before_action :set_existing_respondents
+
+      def edit
+        @form_object = PersonalDetailsForm.new(
+          c100_application: current_c100_application,
+          record_id: current_respondent.id,
+          full_name: current_respondent.full_name,
+          has_previous_name: current_respondent.has_previous_name,
+          previous_full_name: current_respondent.previous_full_name,
+          gender: current_respondent.gender,
+          dob: current_respondent.dob,
+          dob_unknown: current_respondent.dob_unknown,
+          birthplace: current_respondent.birthplace,
+          address: current_respondent.address,
+          postcode: current_respondent.postcode,
+          postcode_unknown: current_respondent.postcode_unknown,
+          home_phone: current_respondent.home_phone,
+          mobile_phone: current_respondent.mobile_phone,
+          mobile_phone_unknown: current_respondent.mobile_phone_unknown,
+          email: current_respondent.email,
+          email_unknown: current_respondent.email_unknown
+        )
+      end
+
+      def update
+        update_and_advance(
+          PersonalDetailsForm,
+          record_id: current_respondent.id,
+          as: params.fetch(:button, :respondents_finished)
+        )
+      end
+
+      def destroy
+        current_respondent.destroy
+        redirect_to action: :edit, id: current_c100_application.saved_respondents.first
+      end
+
+      private
+
+      def current_respondent
+        @_current_respondent ||= current_c100_application.respondents.find_or_initialize_by(id: params[:id])
+      end
+
+      def set_existing_respondents
+        @existing_respondents = current_c100_application.saved_respondents
+      end
+    end
+  end
+end

--- a/app/controllers/steps/respondent_step_controller.rb
+++ b/app/controllers/steps/respondent_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class RespondentStepController < StepController
+    private
+
+    def decision_tree_class
+      C100App::RespondentDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/respondent/personal_details_form.rb
+++ b/app/forms/steps/respondent/personal_details_form.rb
@@ -1,0 +1,80 @@
+module Steps
+  module Respondent
+    class PersonalDetailsForm < BaseForm
+      include GovUkDateFields::ActsAsGovUkDate
+
+      attribute :full_name, StrippedString
+      attribute :has_previous_name, String
+      attribute :previous_full_name, StrippedString
+      attribute :gender, String
+      attribute :dob, Date
+      attribute :dob_unknown, Boolean
+      attribute :birthplace, StrippedString
+      attribute :address, StrippedString
+      attribute :postcode, StrippedString
+      attribute :postcode_unknown, Boolean
+      attribute :home_phone, StrippedString
+      attribute :mobile_phone, StrippedString
+      attribute :mobile_phone_unknown, Boolean
+      attribute :email, NormalisedEmail
+      attribute :email_unknown, Boolean
+
+      acts_as_gov_uk_date :dob
+
+      def self.has_previous_name_choices
+        HasPreviousName.values.map(&:to_s)
+      end
+      validates_inclusion_of :has_previous_name, in: has_previous_name_choices
+
+      def self.gender_choices
+        Gender.values.map(&:to_s)
+      end
+      validates_inclusion_of :gender, in: gender_choices
+
+      validates_presence_of :full_name, :address, :home_phone
+      validates_presence_of :previous_full_name, if: :has_previous_name?
+
+      # Validations -unless- 'I don't know checkbox' is selected
+      validates_presence_of :dob,      unless: :dob_unknown?
+      validates_presence_of :postcode, unless: :postcode_unknown?
+      validates :email, email: true,   unless: :email_unknown?
+
+      private
+
+      def has_previous_name?
+        has_previous_name.eql?(GenericYesNo::YES.to_s)
+      end
+
+      def has_previous_name_value
+        GenericYesNo.new(has_previous_name)
+      end
+
+      def gender_value
+        Gender.new(gender)
+      end
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        respondent = c100_application.respondents.find_or_initialize_by(id: record_id)
+        respondent.update(
+          full_name: full_name,
+          has_previous_name: has_previous_name_value,
+          previous_full_name: previous_full_name,
+          gender: gender_value,
+          dob: dob,
+          dob_unknown: dob_unknown,
+          birthplace: birthplace,
+          address: address,
+          postcode: postcode,
+          postcode_unknown: postcode_unknown,
+          home_phone: home_phone,
+          mobile_phone: mobile_phone,
+          mobile_phone_unknown: mobile_phone_unknown,
+          email: email,
+          email_unknown: email_unknown
+        )
+      end
+    end
+  end
+end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -4,6 +4,9 @@ class C100Application < ApplicationRecord
   has_many :applicants, dependent: :destroy
   has_many :saved_applicants, -> { where.not(id: nil).order(created_at: :asc) }, class_name: Applicant
 
+  has_many :respondents, dependent: :destroy
+  has_many :saved_respondents, -> { where.not(id: nil).order(created_at: :asc) }, class_name: Respondent
+
   has_value_object :user_type
   has_value_object :help_paying
 end

--- a/app/models/respondent.rb
+++ b/app/models/respondent.rb
@@ -1,0 +1,6 @@
+class Respondent < ApplicationRecord
+  belongs_to :c100_application
+
+  has_value_object :has_previous_name
+  has_value_object :gender
+end

--- a/app/services/c100_app/respondent_decision_tree.rb
+++ b/app/services/c100_app/respondent_decision_tree.rb
@@ -1,0 +1,16 @@
+module C100App
+  class RespondentDecisionTree < BaseDecisionTree
+    def destination
+      return next_step if next_step
+
+      case step_name
+      when :number_of_children, :add_another_respondent
+        edit(:personal_details)
+      when :respondents_finished
+        root_path # TODO: update when we have next step
+      else
+        raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+  end
+end

--- a/app/value_objects/has_previous_name.rb
+++ b/app/value_objects/has_previous_name.rb
@@ -1,0 +1,11 @@
+class HasPreviousName < ValueObject
+  VALUES = [
+    YES = new(:yes),
+    NO  = new(:no),
+    UNKNOWN = new(:unknown)
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/views/steps/respondent/personal_details/_respondent_row.html.erb
+++ b/app/views/steps/respondent/personal_details/_respondent_row.html.erb
@@ -1,0 +1,7 @@
+<li>
+  <%= respondent.full_name %> (<%= respondent.id %>)
+  <span class="right actions actions-tight">
+    <%= link_to 'edit', edit_steps_respondent_personal_details_path(respondent), class: 'button' %>
+    <%= button_to 'delete', steps_respondent_personal_details_path(respondent), method: :delete, data: {confirm: 'Are you sure?'}, class: 'button button-secondary' %>
+  </span>
+</li>

--- a/app/views/steps/respondent/personal_details/edit.html.erb
+++ b/app/views/steps/respondent/personal_details/edit.html.erb
@@ -1,0 +1,57 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <!-- This is just for the sake of having a functional CRUD. Pending UI/UX. -->
+    <% if @existing_respondents.any? %>
+      <p>Saved respondents:</p>
+      <ul class="list list-bullet">
+        <% @existing_respondents.each do |respondent| %>
+          <%= render partial: 'respondent_row', locals: {respondent: respondent} %>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_field :full_name, class: 'form-control' %>
+
+      <%= f.radio_button_fieldset :has_previous_name,
+        choices: Steps::Respondent::PersonalDetailsForm.has_previous_name_choices %>
+
+      <div class="panel toggleable" id="previous_full_name" aria-hidden="true" data-show-elements="form input:radio:first" data-hide-elements="form input:radio:not(:first)">
+        <%= f.text_field :previous_full_name %>
+      </div>
+
+      <%= f.radio_button_fieldset :gender, inline: true,
+        choices: Steps::Respondent::PersonalDetailsForm.gender_choices %>
+
+      <div class="form-group">
+        <%= f.gov_uk_date_field :dob,
+          placeholders: true,
+          legend_text: t('shared.form_elements.dob'),
+          legend_class: 'form-label-bold',
+          form_hint_text: t('shared.form_elements.dob_hint_html') %>
+      </div>
+      <%= f.check_box_fieldset :dob_unknown, [:dob_unknown] %>
+
+      <%= f.text_field :birthplace %>
+      <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.text_field :postcode %>
+      <%= f.check_box_fieldset :postcode_unknown, [:postcode_unknown] %>
+      <%= f.text_field :home_phone %>
+      <%= f.text_field :mobile_phone %>
+      <%= f.check_box_fieldset :mobile_phone_unknown, [:mobile_phone_unknown] %>
+      <%= f.text_field :email %>
+      <%= f.check_box_fieldset :email_unknown, [:email_unknown] %>
+
+      <div class="xform-group form-submit">
+        <%= f.submit class: 'button' %>
+        <%= f.button t('.btn_add_another'), class: 'button', type: :submit, value: :add_another_respondent %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,9 +131,9 @@ en:
   helpers:
     fieldset:
       steps_applicant_personal_details_form:
-        has_previous_name: Do you have a previous name?
+        has_previous_name: Previous name?
       steps_respondent_personal_details_form:
-        has_previous_name: Do you have a previous name?
+        has_previous_name: Previous name?
         dob_unknown_html: ""
         postcode_unknown_html: ""
         mobile_phone_unknown_html: ""

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,13 @@
 en:
   dictionary:
     default_service_title: &default_service_title "C100 Children and the Family Courts - GOV.UK"
+    dont_know: &dont_know "Don't know"
+    birthplace_hint: &birthplace_hint "Town/County/Country"
 
     YESNO: &YESNO
       'yes': 'Yes'
       'no': 'No'
+      unknown: *dont_know
 
     START_FINISH: &START_FINISH
       start_again: Start again
@@ -34,6 +37,12 @@ en:
           page_title: Help paying
           heading: Do you need help paying the court fee?
           lead_text: You may be able to get help paying the £215 fee if you’re on a low income, receive certain benefits or have little or no savings.
+    respondent:
+      personal_details:
+        edit:
+          page_title: Respondent personal details
+          heading: The respondent(s)
+          btn_add_another: Add another respondent
 
   home:
     index:
@@ -103,10 +112,32 @@ en:
               blank: Please enter your place of birth
             email:
               invalid: Please enter a valid email
+        steps/respondent/personal_details_form:
+          attributes:
+            full_name:
+              blank: Please enter the full name
+            previous_full_name:
+              blank: Please enter the previous name
+            dob:
+              blank: Please enter the date of birth
+            birthplace:
+              blank: Please enter the place of birth
+            address:
+              blank: Please enter the address
+            home_phone:
+              blank: Please enter the home phone
+            email:
+              invalid: Please enter a valid email
   helpers:
     fieldset:
       steps_applicant_personal_details_form:
         has_previous_name: Do you have a previous name?
+      steps_respondent_personal_details_form:
+        has_previous_name: Do you have a previous name?
+        dob_unknown_html: ""
+        postcode_unknown_html: ""
+        mobile_phone_unknown_html: ""
+        email_unknown_html: ""
     label:
       steps_applicant_user_type_form:
         user_type:
@@ -134,6 +165,25 @@ en:
         home_phone: Home phone
         mobile_phone: Mobile phone
         email: Email address
+      # TODO: share as much keys as possible between Applicant and Respondent
+      steps_respondent_personal_details_form:
+        full_name: Full name
+        has_previous_name:
+          <<: *YESNO
+        previous_full_name: Please enter previous name
+        gender:
+          female: Female
+          male: Male
+        birthplace: Place of birth
+        address: Address (to which documents relating to this application should be sent)
+        postcode: Postcode
+        home_phone: Home phone
+        mobile_phone: Mobile phone
+        email: Email address
+        dob_unknown: *dont_know
+        postcode_unknown: *dont_know
+        mobile_phone_unknown: *dont_know
+        email_unknown: *dont_know
       user:
         email: Your email address
         password: Choose password
@@ -150,7 +200,9 @@ en:
         password: Must be at least 8 characters
         current_password: We need your current password to confirm your changes
       steps_applicant_personal_details_form:
-        birthplace: Town/County/Country
+        birthplace: *birthplace_hint
+      steps_respondent_personal_details_form:
+        birthplace: *birthplace_hint
     submit:
       create: Continue
       update: Continue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,9 @@ Rails.application.routes.draw do
       edit_step :number_of_children
       edit_step :personal_details, enable_crud: true
     end
+    namespace :respondent do
+      edit_step :personal_details, enable_crud: true
+    end
     namespace :help_with_fees do
       edit_step :help_paying
     end

--- a/db/migrate/20171106112653_create_respondents_table.rb
+++ b/db/migrate/20171106112653_create_respondents_table.rb
@@ -1,0 +1,25 @@
+class CreateRespondentsTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :respondents, id: :uuid do |t|
+      t.timestamps null: false
+
+      t.string  :full_name
+      t.string  :has_previous_name
+      t.string  :previous_full_name
+      t.string  :gender
+      t.date    :dob
+      t.boolean :dob_unknown
+      t.string  :birthplace
+      t.string  :address
+      t.string  :postcode
+      t.boolean :postcode_unknown
+      t.string  :home_phone
+      t.string  :mobile_phone
+      t.boolean :mobile_phone_unknown
+      t.string  :email
+      t.boolean :email_unknown
+    end
+
+    add_reference :respondents, :c100_application, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171103090618) do
+ActiveRecord::Schema.define(version: 20171106112653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,28 @@ ActiveRecord::Schema.define(version: 20171103090618) do
     t.index ["user_id"], name: "index_c100_applications_on_user_id", using: :btree
   end
 
+  create_table "respondents", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.string   "full_name"
+    t.string   "has_previous_name"
+    t.string   "previous_full_name"
+    t.string   "gender"
+    t.date     "dob"
+    t.boolean  "dob_unknown"
+    t.string   "birthplace"
+    t.string   "address"
+    t.string   "postcode"
+    t.boolean  "postcode_unknown"
+    t.string   "home_phone"
+    t.string   "mobile_phone"
+    t.boolean  "mobile_phone_unknown"
+    t.string   "email"
+    t.boolean  "email_unknown"
+    t.uuid     "c100_application_id"
+    t.index ["c100_application_id"], name: "index_respondents_on_c100_application_id", using: :btree
+  end
+
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
@@ -62,4 +84,5 @@ ActiveRecord::Schema.define(version: 20171103090618) do
 
   add_foreign_key "applicants", "c100_applications"
   add_foreign_key "c100_applications", "users"
+  add_foreign_key "respondents", "c100_applications"
 end

--- a/spec/controllers/steps/respondent/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/respondent/personal_details_controller_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Respondent::PersonalDetailsController, type: :controller do
+  it_behaves_like 'an intermediate CRUD step controller',
+                  Steps::Respondent::PersonalDetailsForm,
+                  C100App::RespondentDecisionTree,
+                  Respondent
+end

--- a/spec/forms/steps/respondent/personal_details_form_spec.rb
+++ b/spec/forms/steps/respondent/personal_details_form_spec.rb
@@ -1,0 +1,201 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Respondent::PersonalDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    record_id: record_id,
+    full_name: full_name,
+    has_previous_name: has_previous_name,
+    previous_full_name: previous_full_name,
+    gender: gender,
+    dob: dob,
+    dob_unknown: dob_unknown,
+    birthplace: birthplace,
+    address: address,
+    postcode: postcode,
+    postcode_unknown: postcode_unknown,
+    home_phone: home_phone,
+    mobile_phone: mobile_phone,
+    mobile_phone_unknown: mobile_phone_unknown,
+    email: email,
+    email_unknown: email_unknown
+  } }
+
+  let(:c100_application) { instance_double(C100Application, respondents: respondents_collection) }
+  let(:respondents_collection) { double('respondents_collection') }
+  let(:respondent) { double('Respondent') }
+
+  let(:record_id) { nil }
+  let(:full_name) { 'Full Name' }
+  let(:has_previous_name) { 'no' }
+  let(:previous_full_name) { nil }
+  let(:gender) { 'male' }
+  let(:dob) { Date.today }
+  let(:dob_unknown) { false }
+  let(:birthplace) { 'London' }
+  let(:address) { 'Address' }
+  let(:postcode) { nil }
+  let(:postcode_unknown) { true }
+  let(:home_phone) { '123456789' }
+  let(:mobile_phone) { nil }
+  let(:mobile_phone_unknown) { false }
+  let(:email) { 'email@example.com' }
+  let(:email_unknown) { false }
+
+  subject { described_class.new(arguments) }
+
+  describe '.gender_choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.gender_choices).to eq(%w(female male))
+    end
+  end
+
+  describe '.has_previous_name_choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.has_previous_name_choices).to eq(%w(yes no unknown))
+    end
+  end
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'has previous name' do
+      context 'when attribute is not given' do
+        let(:has_previous_name) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:has_previous_name]).to_not be_empty
+        end
+      end
+
+      context 'when attribute is given and requires previous name' do
+        let(:has_previous_name) { 'yes' }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the `previous_full_name` field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:previous_full_name]).to_not be_empty
+        end
+      end
+
+      context 'when attribute value is not valid' do
+        let(:has_previous_name) {'INVALID VALUE'}
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:has_previous_name]).to_not be_empty
+        end
+      end
+    end
+
+    context 'gender' do
+      context 'when attribute is not given' do
+        let(:gender) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:gender]).to_not be_empty
+        end
+      end
+
+      context 'when attribute value is not valid' do
+        let(:gender) {'INVALID VALUE'}
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:gender]).to_not be_empty
+        end
+      end
+    end
+
+    context 'validations on field presence' do
+      it { should validate_presence_of(:full_name) }
+      it { should validate_presence_of(:address) }
+      it { should validate_presence_of(:home_phone) }
+    end
+
+    context 'validations on field presence unless `unknown`' do
+      it {should validate_presence_unless_unknown_of(:dob)}
+      it {should validate_presence_unless_unknown_of(:postcode)}
+      it {should validate_presence_unless_unknown_of(:email)}
+    end
+
+    context 'for valid details' do
+      let(:expected_attributes) {
+        {
+          full_name: 'Full Name',
+          has_previous_name: GenericYesNo::NO,
+          previous_full_name: '',
+          gender: Gender::MALE,
+          dob: Date.today,
+          dob_unknown: false,
+          birthplace: 'London',
+          address: 'Address',
+          postcode: '',
+          postcode_unknown: true,
+          home_phone: '123456789',
+          mobile_phone: '',
+          mobile_phone_unknown: false,
+          email: 'email@example.com',
+          email_unknown: false
+        }
+      }
+
+      context 'when record does not exist' do
+        it 'creates the record if it does not exist' do
+          expect(respondents_collection).to receive(:find_or_initialize_by).with(
+            id: nil
+          ).and_return(respondent)
+
+          expect(respondent).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when record already exists' do
+        let(:record_id) { 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6' }
+
+        it 'updates the record if it already exists' do
+          expect(respondents_collection).to receive(:find_or_initialize_by).with(
+            id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6'
+          ).and_return(respondent)
+
+          expect(respondent).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe C100App::RespondentDecisionTree do
+  let(:c100_application) { double('Object') }
+  let(:step_params)      { double('Step') }
+  let(:next_step)        { nil }
+  let(:as)               { nil }
+
+  subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
+
+  it_behaves_like 'a decision tree'
+
+  context 'when the step is `number_of_children`' do
+    let(:step_params) {{'number_of_children' => 'anything'}}
+    let(:c100_application) {instance_double(C100Application, number_of_children: 1)}
+
+    it {is_expected.to have_destination(:personal_details, :edit)}
+  end
+
+  context 'when the step is `add_another_respondent`' do
+    let(:step_params) {{'add_another_respondent' => 'anything'}}
+    let(:c100_application) {instance_double(C100Application)}
+
+    it {is_expected.to have_destination(:personal_details, :edit)}
+  end
+
+  # TODO: this is a placeholder, to be updated when we actually have the next (real) step
+  context 'when the step is `respondents_finished`' do
+    let(:step_params) {{'respondents_finished' => 'anything'}}
+    let(:c100_application) {instance_double(C100Application)}
+
+    it {is_expected.to have_destination('/entrypoint', :v1)}
+  end
+end

--- a/spec/support/matchers/validation_matchers.rb
+++ b/spec/support/matchers/validation_matchers.rb
@@ -19,6 +19,25 @@ RSpec::Matchers.define :validate_presence_of do |attribute, error = :blank|
   end
 end
 
+RSpec::Matchers.define :validate_presence_unless_unknown_of do |attribute, error = :blank|
+  include ValidationHelpers
+
+  match do |object|
+    object.send("#{attribute}=", nil)
+    check_errors(object, attribute, error)
+    object.send("#{attribute}_unknown=", true)
+    object.valid?
+  end
+
+  description do
+    "validate_presence_unless_unknown_of #{attribute}"
+  end
+
+  failure_message do |object|
+    "expected `#{attribute}` not to have error `#{error}` but got `#{errors_for(attribute, object)}`"
+  end
+end
+
 RSpec::Matchers.define :validate_email do |attribute, error = :invalid|
   include ValidationHelpers
 


### PR DESCRIPTION
This mimics the Applicant CRUD and allows to add 1 or more Respondant.
Right now there is no limitation on how many you can add but apparently
there will be a limit of 2 (to be clarified).

Also, there is (on purpose) duplication as we have now 2 very similar
form objects and views, so next step will be to DRY all this, including
i18n and specs (potential to extract shared examples).