### PR TITLE
DRY crud controllers

### DIFF
--- a/app/controllers/concerns/crud_step.rb
+++ b/app/controllers/concerns/crud_step.rb
@@ -1,0 +1,28 @@
+module CrudStep
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_existing_records
+  end
+
+  def destroy
+    current_record.destroy
+    redirect_to action: :edit, id: @existing_records.first
+  end
+
+  private
+
+  # :nocov:
+  def record_collection
+    raise 'implement in the class including this module'
+  end
+  # :nocov:
+
+  def current_record
+    @_current_record ||= record_collection.find_or_initialize_by(id: params[:id])
+  end
+
+  def set_existing_records
+    @existing_records = record_collection.persisted
+  end
+end

--- a/app/controllers/steps/applicant/personal_details_controller.rb
+++ b/app/controllers/steps/applicant/personal_details_controller.rb
@@ -1,47 +1,38 @@
 module Steps
   module Applicant
     class PersonalDetailsController < Steps::ApplicantStepController
-      before_action :set_existing_applicants
+      include CrudStep
 
       def edit
         @form_object = PersonalDetailsForm.new(
           c100_application: current_c100_application,
-          record_id: current_applicant.id,
-          full_name: current_applicant.full_name,
-          has_previous_name: current_applicant.has_previous_name,
-          previous_full_name: current_applicant.previous_full_name,
-          gender: current_applicant.gender,
-          dob: current_applicant.dob,
-          birthplace: current_applicant.birthplace,
-          address: current_applicant.address,
-          postcode: current_applicant.postcode,
-          home_phone: current_applicant.home_phone,
-          mobile_phone: current_applicant.mobile_phone,
-          email: current_applicant.email
+          record_id: current_record.id,
+          full_name: current_record.full_name,
+          has_previous_name: current_record.has_previous_name,
+          previous_full_name: current_record.previous_full_name,
+          gender: current_record.gender,
+          dob: current_record.dob,
+          birthplace: current_record.birthplace,
+          address: current_record.address,
+          postcode: current_record.postcode,
+          home_phone: current_record.home_phone,
+          mobile_phone: current_record.mobile_phone,
+          email: current_record.email
         )
       end
 
       def update
         update_and_advance(
           PersonalDetailsForm,
-          record_id: current_applicant.id,
+          record_id: current_record.id,
           as: params.fetch(:button, :applicants_finished)
         )
       end
 
-      def destroy
-        current_applicant.destroy
-        redirect_to action: :edit, id: current_c100_application.saved_applicants.first
-      end
-
       private
 
-      def current_applicant
-        @_current_applicant ||= current_c100_application.applicants.find_or_initialize_by(id: params[:id])
-      end
-
-      def set_existing_applicants
-        @existing_applicants = current_c100_application.saved_applicants
+      def record_collection
+        @_record_collection ||= current_c100_application.applicants
       end
     end
   end

--- a/app/controllers/steps/respondent/personal_details_controller.rb
+++ b/app/controllers/steps/respondent/personal_details_controller.rb
@@ -1,51 +1,42 @@
 module Steps
   module Respondent
     class PersonalDetailsController < Steps::RespondentStepController
-      before_action :set_existing_respondents
+      include CrudStep
 
       def edit
         @form_object = PersonalDetailsForm.new(
           c100_application: current_c100_application,
-          record_id: current_respondent.id,
-          full_name: current_respondent.full_name,
-          has_previous_name: current_respondent.has_previous_name,
-          previous_full_name: current_respondent.previous_full_name,
-          gender: current_respondent.gender,
-          dob: current_respondent.dob,
-          dob_unknown: current_respondent.dob_unknown,
-          birthplace: current_respondent.birthplace,
-          address: current_respondent.address,
-          postcode: current_respondent.postcode,
-          postcode_unknown: current_respondent.postcode_unknown,
-          home_phone: current_respondent.home_phone,
-          mobile_phone: current_respondent.mobile_phone,
-          mobile_phone_unknown: current_respondent.mobile_phone_unknown,
-          email: current_respondent.email,
-          email_unknown: current_respondent.email_unknown
+          record_id: current_record.id,
+          full_name: current_record.full_name,
+          has_previous_name: current_record.has_previous_name,
+          previous_full_name: current_record.previous_full_name,
+          gender: current_record.gender,
+          dob: current_record.dob,
+          dob_unknown: current_record.dob_unknown,
+          birthplace: current_record.birthplace,
+          address: current_record.address,
+          postcode: current_record.postcode,
+          postcode_unknown: current_record.postcode_unknown,
+          home_phone: current_record.home_phone,
+          mobile_phone: current_record.mobile_phone,
+          mobile_phone_unknown: current_record.mobile_phone_unknown,
+          email: current_record.email,
+          email_unknown: current_record.email_unknown
         )
       end
 
       def update
         update_and_advance(
           PersonalDetailsForm,
-          record_id: current_respondent.id,
+          record_id: current_record.id,
           as: params.fetch(:button, :respondents_finished)
         )
       end
 
-      def destroy
-        current_respondent.destroy
-        redirect_to action: :edit, id: current_c100_application.saved_respondents.first
-      end
-
       private
 
-      def current_respondent
-        @_current_respondent ||= current_c100_application.respondents.find_or_initialize_by(id: params[:id])
-      end
-
-      def set_existing_respondents
-        @existing_respondents = current_c100_application.saved_respondents
+      def record_collection
+        @_record_collection ||= current_c100_application.respondents
       end
     end
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  scope :persisted, -> { where.not(id: nil).order(created_at: :asc) }
+
   def self.has_value_object(value_object, constructor: nil, class_name: nil)
     composed_of value_object,
                 allow_nil:   true,

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -1,11 +1,8 @@
 class C100Application < ApplicationRecord
   belongs_to :user, optional: true, dependent: :destroy
 
-  has_many :applicants, dependent: :destroy
-  has_many :saved_applicants, -> { where.not(id: nil).order(created_at: :asc) }, class_name: Applicant
-
+  has_many :applicants,  dependent: :destroy
   has_many :respondents, dependent: :destroy
-  has_many :saved_respondents, -> { where.not(id: nil).order(created_at: :asc) }, class_name: Respondent
 
   has_value_object :user_type
   has_value_object :help_paying

--- a/app/views/steps/applicant/personal_details/edit.html.erb
+++ b/app/views/steps/applicant/personal_details/edit.html.erb
@@ -5,10 +5,10 @@
     <%= step_header %>
 
     <!-- This is just for the sake of having a functional CRUD. Pending UI/UX. -->
-    <% if @existing_applicants.any? %>
+    <% if @existing_records.any? %>
       <p>Saved applicants:</p>
       <ul class="list list-bullet">
-        <% @existing_applicants.each do |applicant| %>
+        <% @existing_records.each do |applicant| %>
           <%= render partial: 'applicant_row', locals: {applicant: applicant} %>
         <% end %>
       </ul>

--- a/app/views/steps/respondent/personal_details/edit.html.erb
+++ b/app/views/steps/respondent/personal_details/edit.html.erb
@@ -5,10 +5,10 @@
     <%= step_header %>
 
     <!-- This is just for the sake of having a functional CRUD. Pending UI/UX. -->
-    <% if @existing_respondents.any? %>
+    <% if @existing_records.any? %>
       <p>Saved respondents:</p>
       <ul class="list list-bullet">
-        <% @existing_respondents.each do |respondent| %>
+        <% @existing_records.each do |respondent| %>
           <%= render partial: 'respondent_row', locals: {respondent: respondent} %>
         <% end %>
       </ul>


### PR DESCRIPTION
As we now have 2 entities (applicants and respondents) that requires CRUD
actions in the controller, we can create a concern to be included in these
and other future controllers to enforce the same interface.

For now, I'm leaving untouched the list of attributes although many are
common. Once we have more entities (children? etc.) we will have a more
clear opinion of how many of these attributes can be shared and extracted
to a superclass or a module.

As part of another PR we can also DRY the form objects unless it makes
them less readable/maintanable.