### PR TITLE
Cleanup humongous mass assignments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -495,9 +495,7 @@ SpaceInsideHashLiteralBraces:
 PredicateName:
   Enabled: false
 
-# We have several big form objects with lots of attributes and this cop keeps complaining.
-# Disabling for now until we have a more stable code base.
-AbcSize:
+RedundantMerge:
   Enabled: false
 
 AccessModifierIndentation:
@@ -505,5 +503,9 @@ AccessModifierIndentation:
   EnforcedStyle: indent
 
 MethodLength:
+  Enabled: true
+  Max: 20
+
+AbcSize:
   Enabled: true
   Max: 20

--- a/app/controllers/steps/applicant/personal_details_controller.rb
+++ b/app/controllers/steps/applicant/personal_details_controller.rb
@@ -4,20 +4,8 @@ module Steps
       include CrudStep
 
       def edit
-        @form_object = PersonalDetailsForm.new(
-          c100_application: current_c100_application,
-          record_id: current_record.id,
-          full_name: current_record.full_name,
-          has_previous_name: current_record.has_previous_name,
-          previous_full_name: current_record.previous_full_name,
-          gender: current_record.gender,
-          dob: current_record.dob,
-          birthplace: current_record.birthplace,
-          address: current_record.address,
-          postcode: current_record.postcode,
-          home_phone: current_record.home_phone,
-          mobile_phone: current_record.mobile_phone,
-          email: current_record.email
+        @form_object = PersonalDetailsForm.build(
+          current_record, c100_application: current_c100_application
         )
       end
 

--- a/app/controllers/steps/respondent/personal_details_controller.rb
+++ b/app/controllers/steps/respondent/personal_details_controller.rb
@@ -4,24 +4,8 @@ module Steps
       include CrudStep
 
       def edit
-        @form_object = PersonalDetailsForm.new(
-          c100_application: current_c100_application,
-          record_id: current_record.id,
-          full_name: current_record.full_name,
-          has_previous_name: current_record.has_previous_name,
-          previous_full_name: current_record.previous_full_name,
-          gender: current_record.gender,
-          dob: current_record.dob,
-          dob_unknown: current_record.dob_unknown,
-          birthplace: current_record.birthplace,
-          address: current_record.address,
-          postcode: current_record.postcode,
-          postcode_unknown: current_record.postcode_unknown,
-          home_phone: current_record.home_phone,
-          mobile_phone: current_record.mobile_phone,
-          mobile_phone_unknown: current_record.mobile_phone_unknown,
-          email: current_record.email,
-          email_unknown: current_record.email_unknown
+        @form_object = PersonalDetailsForm.build(
+          current_record, c100_application: current_c100_application
         )
       end
 

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -16,6 +16,18 @@ class BaseForm
     run_callbacks(:initialize) { super }
   end
 
+  # Initialize a new form object given an AR model, setting its attributes
+  def self.build(record, c100_application:)
+    attributes = attributes_map(record)
+
+    attributes.merge!(
+      c100_application: c100_application,
+      record_id: record.id
+    )
+
+    new(attributes)
+  end
+
   def save
     if valid?
       persist!
@@ -33,6 +45,15 @@ class BaseForm
 
   def []=(attr_name, value)
     instance_variable_set("@#{attr_name}".to_sym, value)
+  end
+
+  # Iterates through all declared attributes in the form object, mapping its values
+  def self.attributes_map(origin)
+    attribute_set.map { |attr| [attr.name, origin[attr.name]] }.to_h
+  end
+
+  def attributes_map
+    self.class.attributes_map(self)
   end
 
   def to_key

--- a/app/forms/steps/applicant/personal_details_form.rb
+++ b/app/forms/steps/applicant/personal_details_form.rb
@@ -50,17 +50,11 @@ module Steps
 
         applicant = c100_application.applicants.find_or_initialize_by(id: record_id)
         applicant.update(
-          full_name: full_name,
-          has_previous_name: has_previous_name_value,
-          previous_full_name: previous_full_name,
-          gender: gender_value,
-          dob: dob,
-          birthplace: birthplace,
-          address: address,
-          postcode: postcode,
-          home_phone: home_phone,
-          mobile_phone: mobile_phone,
-          email: email
+          # Some attributes are value objects and thus we need to provide their values
+          attributes_map.merge(
+            has_previous_name: has_previous_name_value,
+            gender: gender_value
+          )
         )
       end
     end

--- a/app/forms/steps/respondent/personal_details_form.rb
+++ b/app/forms/steps/respondent/personal_details_form.rb
@@ -58,21 +58,11 @@ module Steps
 
         respondent = c100_application.respondents.find_or_initialize_by(id: record_id)
         respondent.update(
-          full_name: full_name,
-          has_previous_name: has_previous_name_value,
-          previous_full_name: previous_full_name,
-          gender: gender_value,
-          dob: dob,
-          dob_unknown: dob_unknown,
-          birthplace: birthplace,
-          address: address,
-          postcode: postcode,
-          postcode_unknown: postcode_unknown,
-          home_phone: home_phone,
-          mobile_phone: mobile_phone,
-          mobile_phone_unknown: mobile_phone_unknown,
-          email: email,
-          email_unknown: email_unknown
+          # Some attributes are value objects and thus we need to provide their values
+          attributes_map.merge(
+            has_previous_name: has_previous_name_value,
+            gender: gender_value
+          )
         )
       end
     end


### PR DESCRIPTION
Simplified and removed duplication of attribute mass assignments in
personal details controllers and form objects.

This same approach can be extended to any other controller or form
object, but the ones we have at the moment are pretty simple with only
one or two attributes, so for now it is not worth changing those.