### PR TITLE
Add new children additional details step

### DIFF
--- a/app/controllers/steps/children/additional_details_controller.rb
+++ b/app/controllers/steps/children/additional_details_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Children
+    class AdditionalDetailsController < Steps::ChildrenStepController
+      def edit
+        @form_object = AdditionalDetailsForm.build(current_c100_application)
+      end
+
+      def update
+        update_and_advance(AdditionalDetailsForm, as: :additional_details)
+      end
+    end
+  end
+end

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -17,11 +17,11 @@ class BaseForm
   end
 
   # Initialize a new form object given an AR model, setting its attributes
-  def self.build(record, c100_application:)
+  def self.build(record, c100_application: nil)
     attributes = attributes_map(record)
 
     attributes.merge!(
-      c100_application: c100_application,
+      c100_application: c100_application || record,
       record_id: record.id
     )
 

--- a/app/forms/steps/children/additional_details_form.rb
+++ b/app/forms/steps/children/additional_details_form.rb
@@ -1,0 +1,92 @@
+module Steps
+  module Children
+    class AdditionalDetailsForm < BaseForm
+      attribute :children_known_to_authorities, String
+      attribute :children_known_to_authorities_details, String
+      attribute :children_protection_plan, String
+      attribute :children_protection_plan_details, String
+      attribute :children_same_parents, String
+      attribute :children_same_parents_yes_details, String
+      attribute :children_same_parents_no_details, String
+      attribute :children_parental_responsibility_details, String
+      attribute :children_residence, String
+      attribute :children_residence_details, String
+
+      def self.children_known_to_authorities_choices
+        GenericYesNoUnknown.values.map(&:to_s)
+      end
+      validates_inclusion_of :children_known_to_authorities, in: children_known_to_authorities_choices
+
+      def self.children_protection_plan_choices
+        GenericYesNoUnknown.values.map(&:to_s)
+      end
+      validates_inclusion_of :children_protection_plan, in: children_protection_plan_choices
+
+      def self.children_same_parents_choices
+        GenericYesNo.values.map(&:to_s)
+      end
+      validates_inclusion_of :children_same_parents, in: children_same_parents_choices
+
+      def self.children_residence_choices
+        ChildrenResidence.values.map(&:to_s)
+      end
+      validates_inclusion_of :children_residence, in: children_residence_choices
+
+      validates_presence_of :children_parental_responsibility_details
+      validates_presence_of :children_same_parents_yes_details, if: :same_parents_yes_details_needed?
+      validates_presence_of :children_same_parents_no_details,  if: :same_parents_no_details_needed?
+      validates_presence_of :children_residence_details,        if: :children_residence_details_needed?
+
+      private
+
+      def children_known_to_authorities_value
+        GenericYesNoUnknown.new(children_known_to_authorities)
+      end
+
+      def children_protection_plan_value
+        GenericYesNoUnknown.new(children_protection_plan)
+      end
+
+      def children_same_parents_value
+        GenericYesNo.new(children_same_parents)
+      end
+
+      def children_residence_value
+        ChildrenResidence.new(children_residence)
+      end
+
+      def same_parents_yes_details_needed?
+        children_same_parents.eql?(GenericYesNo::YES.to_s)
+      end
+
+      def same_parents_no_details_needed?
+        children_same_parents.eql?(GenericYesNo::NO.to_s)
+      end
+
+      def children_residence_details_needed?
+        children_residence.eql?(ChildrenResidence::OTHER.to_s)
+      end
+
+      # TODO: we don't know if any of these attributes might affect future steps, and if so, what
+      # linked attributed should we reset when the form answers are changed, so not implementing this yet.
+      def changed?
+        true
+      end
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+        return true unless changed?
+
+        c100_application.update(
+          # Some attributes are value objects and thus we need to provide their values
+          attributes_map.merge(
+            children_known_to_authorities: children_known_to_authorities_value,
+            children_protection_plan: children_protection_plan_value,
+            children_same_parents: children_same_parents_value,
+            children_residence: children_residence_value
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/respondent/personal_details_form.rb
+++ b/app/forms/steps/respondent/personal_details_form.rb
@@ -22,7 +22,7 @@ module Steps
       acts_as_gov_uk_date :dob
 
       def self.has_previous_name_choices
-        HasPreviousName.values.map(&:to_s)
+        GenericYesNoUnknown.values.map(&:to_s)
       end
       validates_inclusion_of :has_previous_name, in: has_previous_name_choices
 
@@ -42,11 +42,11 @@ module Steps
       private
 
       def has_previous_name?
-        has_previous_name.eql?(GenericYesNo::YES.to_s)
+        has_previous_name.eql?(GenericYesNoUnknown::YES.to_s)
       end
 
       def has_previous_name_value
-        GenericYesNo.new(has_previous_name)
+        GenericYesNoUnknown.new(has_previous_name)
       end
 
       def gender_value

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -7,4 +7,10 @@ class C100Application < ApplicationRecord
 
   has_value_object :user_type
   has_value_object :help_paying
+
+  # Children additional details
+  has_value_object :children_residence
+  has_value_object :children_same_parents,         class_name: 'GenericYesNo'
+  has_value_object :children_known_to_authorities, class_name: 'GenericYesNoUnknown'
+  has_value_object :children_protection_plan,      class_name: 'GenericYesNoUnknown'
 end

--- a/app/models/respondent.rb
+++ b/app/models/respondent.rb
@@ -1,6 +1,6 @@
 class Respondent < ApplicationRecord
   belongs_to :c100_application
 
-  has_value_object :has_previous_name
+  has_value_object :has_previous_name, class_name: 'GenericYesNoUnknown'
   has_value_object :gender
 end

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -7,6 +7,8 @@ module C100App
       when :number_of_children, :add_another_child
         edit(:personal_details)
       when :children_finished
+        edit(:additional_details)
+      when :additional_details
         root_path # TODO: update when we have next step
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"

--- a/app/value_objects/children_residence.rb
+++ b/app/value_objects/children_residence.rb
@@ -1,0 +1,11 @@
+class ChildrenResidence < ValueObject
+  VALUES = [
+    APPLICANT  = new(:applicant),
+    RESPONDENT = new(:respondent),
+    OTHER      = new(:other)
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/value_objects/generic_yes_no_unknown.rb
+++ b/app/value_objects/generic_yes_no_unknown.rb
@@ -1,4 +1,4 @@
-class HasPreviousName < ValueObject
+class GenericYesNoUnknown < ValueObject
   VALUES = [
     YES = new(:yes),
     NO  = new(:no),

--- a/app/views/steps/children/additional_details/edit.html.erb
+++ b/app/views/steps/children/additional_details/edit.html.erb
@@ -1,0 +1,45 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :children_known_to_authorities,
+        choices: Steps::Children::AdditionalDetailsForm.children_known_to_authorities_choices %>
+
+      <!-- TODO: make this show/hide based on previous radio options -->
+      <div class="panel toggleable" id="children_known_to_authorities_details">
+        <%= f.text_area :children_known_to_authorities_details, size: '40x4', class: 'form-control-3-4' %>
+      </div>
+
+      <%= f.radio_button_fieldset :children_protection_plan,
+        choices: Steps::Children::AdditionalDetailsForm.children_protection_plan_choices %>
+
+      <%= f.radio_button_fieldset :children_same_parents,
+        choices: Steps::Children::AdditionalDetailsForm.children_same_parents_choices %>
+
+      <!-- TODO: make these show/hide based on previous radio options -->
+      <div class="panel toggleable" id="children_same_parents_yes_details">
+        <%= f.text_area :children_same_parents_yes_details, size: '40x4', class: 'form-control-3-4' %>
+      </div>
+      <div class="panel toggleable" id="children_same_parents_no_details">
+        <%= f.text_area :children_same_parents_no_details, size: '40x4', class: 'form-control-3-4' %>
+      </div>
+
+      <%= f.text_area :children_parental_responsibility_details, size: '40x4', class: 'form-control-3-4' %>
+
+      <%= f.radio_button_fieldset :children_residence,
+        choices: Steps::Children::AdditionalDetailsForm.children_residence_choices %>
+
+      <!-- TODO: make this show/hide based on previous radio options -->
+      <div class="panel toggleable" id="children_residence_details">
+        <%= f.text_area :children_residence_details, size: '40x4', class: 'form-control-3-4' %>
+      </div>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,10 @@ en:
           page_title: Child personal details
           heading: Child details
           btn_add_another: Add another child
+      additional_details:
+        edit:
+          page_title: Further information about the child(ren)
+          heading: Further information about the child(ren)
 
   home:
     index:
@@ -161,6 +165,8 @@ en:
         steps/children/personal_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
+        steps/children/additional_details_form:
+          attributes:
 
   helpers:
     fieldset:
@@ -174,6 +180,11 @@ en:
         email_unknown_html: ""
       steps_children_personal_details_form:
         dob_unknown_html: ""
+      steps_children_additional_details_form:
+        children_known_to_authorities: Are any of the children known to the local authority children’s services?
+        children_protection_plan: Are any of the children the subject of a child protection plan?
+        children_same_parents: Do all the children have the same parents?
+        children_residence: Who do the children currently live with?
     label:
       steps_applicant_user_type_form:
         user_type:
@@ -196,6 +207,22 @@ en:
         orders_applied_for: Order(s) applied for
         applicants_relationship: Relationship to applicant(s)
         respondents_relationship: Relationship to respondent(s)
+      steps_children_additional_details_form:
+        children_known_to_authorities:
+          <<: *YESNO
+        children_protection_plan:
+          <<: *YESNO
+        children_same_parents:
+          <<: *YESNO
+        children_residence:
+          applicant: Applicant(s)
+          respondent: Respondent(s)
+          other: Other
+        children_known_to_authorities_details: Please state which child and the name of the Local Authority and Social worker (if known)
+        children_same_parents_yes_details: What are the names of the parents?
+        children_same_parents_no_details: Please give details of each parent and their children involved in this application
+        children_parental_responsibility_details: Please state everyone who has parental responsibility for each child and how they have parental responsibility
+        children_residence_details: Please give the full address of the child, the names of any adults living with the children and their relationship to or involvement with the child
       user:
         email: Your email address
         password: Choose password
@@ -215,6 +242,14 @@ en:
         birthplace: *birthplace_hint
       steps_respondent_personal_details_form:
         birthplace: *birthplace_hint
+      steps_children_additional_details_form:
+        children_parental_responsibility_details_html: |
+          e.g. ‘child’s mother’, ‘child’s father and was married to the mother when the child was born’ etc.
+          (See Section E of <a href="http://formfinder.hmctsformfinder.justice.gov.uk/cb1-eng.pdf">leaflet CB1</a>
+          for more information)
+        children_residence_details_html: |
+          If you do not wish this information to be made known to the Respondent, leave the details blank and complete
+          Confidential contact details <a href="https://formfinder.hmctsformfinder.justice.gov.uk/c8-eng.pdf">Form C8</a>.
     submit:
       create: Continue
       update: Continue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     namespace :children do
       show_step :instructions
       edit_step :personal_details, enable_crud: true
+      edit_step :additional_details
     end
     namespace :applicant do
       edit_step :user_type

--- a/db/migrate/20171108113601_add_children_additional_details_fields.rb
+++ b/db/migrate/20171108113601_add_children_additional_details_fields.rb
@@ -1,0 +1,18 @@
+class AddChildrenAdditionalDetailsFields < ActiveRecord::Migration[5.0]
+  def change
+    add_column :c100_applications, :children_known_to_authorities, :string
+    add_column :c100_applications, :children_known_to_authorities_details, :text
+
+    add_column :c100_applications, :children_protection_plan, :string
+    add_column :c100_applications, :children_protection_plan_details, :text
+
+    add_column :c100_applications, :children_same_parents, :string
+    add_column :c100_applications, :children_same_parents_yes_details, :text
+    add_column :c100_applications, :children_same_parents_no_details, :text
+
+    add_column :c100_applications, :children_parental_responsibility_details, :text
+
+    add_column :c100_applications, :children_residence, :string
+    add_column :c100_applications, :children_residence_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107123012) do
+ActiveRecord::Schema.define(version: 20171108113601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,14 +35,24 @@ ActiveRecord::Schema.define(version: 20171107123012) do
   end
 
   create_table "c100_applications", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.string   "navigation_stack",     default: [],              array: true
+    t.datetime "created_at",                                            null: false
+    t.datetime "updated_at",                                            null: false
+    t.string   "navigation_stack",                         default: [],              array: true
     t.uuid     "user_id"
     t.string   "user_type"
     t.integer  "number_of_children"
     t.string   "help_paying"
     t.string   "hwf_reference_number"
+    t.string   "children_known_to_authorities"
+    t.text     "children_known_to_authorities_details"
+    t.string   "children_protection_plan"
+    t.text     "children_protection_plan_details"
+    t.string   "children_same_parents"
+    t.text     "children_same_parents_yes_details"
+    t.text     "children_same_parents_no_details"
+    t.text     "children_parental_responsibility_details"
+    t.string   "children_residence"
+    t.text     "children_residence_details"
     t.index ["user_id"], name: "index_c100_applications_on_user_id", using: :btree
   end
 

--- a/spec/controllers/steps/children/additional_details_controller_spec.rb
+++ b/spec/controllers/steps/children/additional_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Children::AdditionalDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Children::AdditionalDetailsForm, C100App::ChildrenDecisionTree
+end

--- a/spec/forms/steps/children/additional_details_form_spec.rb
+++ b/spec/forms/steps/children/additional_details_form_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Children::AdditionalDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    children_known_to_authorities: children_known_to_authorities,
+    children_known_to_authorities_details: children_known_to_authorities_details,
+    children_protection_plan: children_protection_plan,
+    children_protection_plan_details: children_protection_plan_details,
+    children_same_parents: children_same_parents,
+    children_same_parents_yes_details: children_same_parents_yes_details,
+    children_same_parents_no_details: children_same_parents_no_details,
+    children_parental_responsibility_details: children_parental_responsibility_details,
+    children_residence: children_residence,
+    children_residence_details: children_residence_details
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:children_known_to_authorities) { 'unknown' }
+  let(:children_known_to_authorities_details) { nil }
+  let(:children_protection_plan) { 'yes' }
+  let(:children_protection_plan_details) { nil }
+  let(:children_same_parents) { 'yes' }
+  let(:children_same_parents_yes_details) { 'details' }
+  let(:children_same_parents_no_details) { nil }
+  let(:children_parental_responsibility_details) { 'details' }
+  let(:children_residence) { 'applicant' }
+  let(:children_residence_details) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '.children_known_to_authorities_choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.children_known_to_authorities_choices).to eq(%w(yes no unknown))
+    end
+  end
+
+  describe '.children_protection_plan_choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.children_protection_plan_choices).to eq(%w(yes no unknown))
+    end
+  end
+
+  describe '.children_same_parents_choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.children_same_parents_choices).to eq(%w(yes no))
+    end
+  end
+
+  describe '.children_residence_choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.children_residence_choices).to eq(%w(applicant respondent other))
+    end
+  end
+
+  describe '#save' do
+    it_behaves_like 'a value object form', attribute_name: :children_protection_plan, example_value: 'yes'
+
+    let(:expected_attributes) {
+      {
+        children_known_to_authorities: GenericYesNoUnknown::UNKNOWN,
+        children_known_to_authorities_details: nil,
+        children_protection_plan: GenericYesNoUnknown::YES,
+        children_protection_plan_details: nil,
+        children_same_parents: GenericYesNo::YES,
+        children_same_parents_yes_details: 'details',
+        children_same_parents_no_details: nil,
+        children_parental_responsibility_details: 'details',
+        children_residence: ChildrenResidence::APPLICANT,
+        children_residence_details: nil
+      }
+    }
+
+    context 'validations on field presence' do
+      it {should validate_presence_of(:children_parental_responsibility_details)}
+      it {should validate_presence_of(:children_known_to_authorities, :inclusion)}
+      it {should validate_presence_of(:children_protection_plan, :inclusion)}
+      it {should validate_presence_of(:children_same_parents, :inclusion)}
+      it {should validate_presence_of(:children_residence, :inclusion)}
+    end
+
+    context 'validation for `children_same_parents` option' do
+      context 'when answer is `yes`' do
+        let(:children_same_parents) {'yes'}
+        it {should validate_presence_of(:children_same_parents_yes_details)}
+        it {should_not validate_presence_of(:children_same_parents_no_details)}
+      end
+
+      context 'when answer is `no`' do
+        let(:children_same_parents) {'no'}
+        it {should validate_presence_of(:children_same_parents_no_details)}
+        it {should_not validate_presence_of(:children_same_parents_yes_details)}
+      end
+    end
+
+    context 'validation for `children_residence` option' do
+      context 'when answer is `applicant`' do
+        let(:children_residence) {'applicant'}
+        it {should_not validate_presence_of(:children_residence_details)}
+      end
+
+      context 'when answer is `respondent`' do
+        let(:children_residence) {'applicant'}
+        it {should_not validate_presence_of(:children_residence_details)}
+      end
+
+      context 'when answer is `other`' do
+        let(:children_residence) {'other'}
+        it {should validate_presence_of(:children_residence_details)}
+      end
+    end
+
+    context 'when form object is valid' do
+      it 'saves the record' do
+        expect(c100_application).to receive(:update).with(
+          expected_attributes
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when the form has not changed values' do
+      before do
+        allow(subject).to receive(:changed?).and_return(false)
+      end
+
+      it 'does not save the record but returns true' do
+        expect(c100_application).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/forms/steps/respondent/personal_details_form_spec.rb
+++ b/spec/forms/steps/respondent/personal_details_form_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Steps::Respondent::PersonalDetailsForm do
       let(:expected_attributes) {
         {
           full_name: 'Full Name',
-          has_previous_name: GenericYesNo::NO,
+          has_previous_name: GenericYesNoUnknown::NO,
           previous_full_name: '',
           gender: Gender::MALE,
           dob: Date.today,

--- a/spec/services/c100_app/children_decision_tree_spec.rb
+++ b/spec/services/c100_app/children_decision_tree_spec.rb
@@ -24,9 +24,16 @@ RSpec.describe C100App::ChildrenDecisionTree do
     it {is_expected.to have_destination(:personal_details, :edit)}
   end
 
-  # TODO: this is a placeholder, to be updated when we actually have the next (real) step
   context 'when the step is `children_finished`' do
     let(:step_params) {{'children_finished' => 'anything'}}
+    let(:c100_application) {instance_double(C100Application)}
+
+    it {is_expected.to have_destination(:additional_details, :edit)}
+  end
+
+  # TODO: this is a placeholder, to be updated when we actually have the next (real) step
+  context 'when the step is `additional_details`' do
+    let(:step_params) {{'additional_details' => 'anything'}}
     let(:c100_application) {instance_double(C100Application)}
 
     it {is_expected.to have_destination('/entrypoint', :v1)}

--- a/spec/support/form_validation_shared_examples.rb
+++ b/spec/support/form_validation_shared_examples.rb
@@ -9,6 +9,8 @@ RSpec.shared_examples 'a value object form' do |options|
   end
 
   context 'when attribute is not given' do
+    let(options[:attribute_name]) { nil }
+
     it 'returns false' do
       expect(subject.save).to be(false)
     end

--- a/spec/support/matchers/validation_helpers.rb
+++ b/spec/support/matchers/validation_helpers.rb
@@ -3,7 +3,7 @@ module ValidationHelpers
 
   def check_errors(object, attribute, error)
     !object.valid?
-    object.errors.details[attribute].include?({error: error})
+    object.errors.added?(attribute, error)
   end
 
   def errors_for(attribute, object)


### PR DESCRIPTION
This form view has quite a lot of show/hide elements controlled by radio options. As we don't have a functional show/hide mechanism at the moment, all fields will be visible at once in the view, but the validations behind are implemented based on the prototype rules.

Talking about validations, for these kind of form objects are quite verbose and repetitive. Might be a potential area to try to refactor or come with a more cleaner way of doing it in the future.