### PR TITLE
Expose a helper method for a common task

### DIFF
--- a/app/forms/steps/abuse_concerns/base_abuse_form.rb
+++ b/app/forms/steps/abuse_concerns/base_abuse_form.rb
@@ -5,8 +5,8 @@ module Steps
       attribute :kind, String
 
       # This ensures no tampering with the values
-      validates_inclusion_of :subject, in: AbuseSubject.values.map(&:to_s)
-      validates_inclusion_of :kind,    in: AbuseType.values.map(&:to_s)
+      validates_inclusion_of :subject, in: AbuseSubject.string_values
+      validates_inclusion_of :kind,    in: AbuseType.string_values
 
       # As this form object is reused permuting `subject` and `kind`, sharing the
       # same view, this key will allow us to render the appropriate translations.

--- a/app/forms/steps/abuse_concerns/details_form.rb
+++ b/app/forms/steps/abuse_concerns/details_form.rb
@@ -10,9 +10,9 @@ module Steps
       # attribute :help_provided, String
       # attribute :help_description, String
 
-      validates_inclusion_of :behaviour_ongoing, in: GenericYesNo.values.map(&:to_s)
-      validates_inclusion_of :asked_for_help,    in: GenericYesNo.values.map(&:to_s)
-      # validates_inclusion_of :help_provided,    in: GenericYesNo.values.map(&:to_s), if: :asked_for_help?
+      validates_inclusion_of :behaviour_ongoing, in: GenericYesNo.string_values
+      validates_inclusion_of :asked_for_help,    in: GenericYesNo.string_values
+      # validates_inclusion_of :help_provided,    in: GenericYesNo.string_values, if: :asked_for_help?
 
       validates_presence_of :behaviour_description
       validates_presence_of :behaviour_start

--- a/app/forms/steps/abuse_concerns/question_form.rb
+++ b/app/forms/steps/abuse_concerns/question_form.rb
@@ -4,7 +4,7 @@ module Steps
       attribute :answer, String
 
       def self.choices
-        GenericYesNo.values.map(&:to_s)
+        GenericYesNo.string_values
       end
       validates_inclusion_of :answer, in: choices
 

--- a/app/forms/steps/applicant/personal_details_form.rb
+++ b/app/forms/steps/applicant/personal_details_form.rb
@@ -18,12 +18,12 @@ module Steps
       acts_as_gov_uk_date :dob
 
       def self.has_previous_name_choices
-        GenericYesNo.values.map(&:to_s)
+        GenericYesNo.string_values
       end
       validates_inclusion_of :has_previous_name, in: has_previous_name_choices
 
       def self.gender_choices
-        Gender.values.map(&:to_s)
+        Gender.string_values
       end
       validates_inclusion_of :gender, in: gender_choices
 

--- a/app/forms/steps/applicant/user_type_form.rb
+++ b/app/forms/steps/applicant/user_type_form.rb
@@ -4,7 +4,7 @@ module Steps
       attribute :user_type, String
 
       def self.choices
-        UserType.values.map(&:to_s)
+        UserType.string_values
       end
       validates_inclusion_of :user_type, in: choices
 

--- a/app/forms/steps/children/additional_details_form.rb
+++ b/app/forms/steps/children/additional_details_form.rb
@@ -13,22 +13,22 @@ module Steps
       attribute :children_residence_details, String
 
       def self.children_known_to_authorities_choices
-        GenericYesNoUnknown.values.map(&:to_s)
+        GenericYesNoUnknown.string_values
       end
       validates_inclusion_of :children_known_to_authorities, in: children_known_to_authorities_choices
 
       def self.children_protection_plan_choices
-        GenericYesNoUnknown.values.map(&:to_s)
+        GenericYesNoUnknown.string_values
       end
       validates_inclusion_of :children_protection_plan, in: children_protection_plan_choices
 
       def self.children_same_parents_choices
-        GenericYesNo.values.map(&:to_s)
+        GenericYesNo.string_values
       end
       validates_inclusion_of :children_same_parents, in: children_same_parents_choices
 
       def self.children_residence_choices
-        ChildrenResidence.values.map(&:to_s)
+        ChildrenResidence.string_values
       end
       validates_inclusion_of :children_residence, in: children_residence_choices
 

--- a/app/forms/steps/children/personal_details_form.rb
+++ b/app/forms/steps/children/personal_details_form.rb
@@ -14,7 +14,7 @@ module Steps
       acts_as_gov_uk_date :dob
 
       def self.gender_choices
-        Gender.values.map(&:to_s)
+        Gender.string_values
       end
       validates_inclusion_of :gender, in: gender_choices
 

--- a/app/forms/steps/help_with_fees/help_paying_form.rb
+++ b/app/forms/steps/help_with_fees/help_paying_form.rb
@@ -5,7 +5,7 @@ module Steps
       attribute :hwf_reference_number, String
 
       def self.choices
-        HelpPaying.values.map(&:to_s)
+        HelpPaying.string_values
       end
 
       validates_inclusion_of :help_paying, in: choices

--- a/app/forms/steps/respondent/personal_details_form.rb
+++ b/app/forms/steps/respondent/personal_details_form.rb
@@ -22,12 +22,12 @@ module Steps
       acts_as_gov_uk_date :dob
 
       def self.has_previous_name_choices
-        GenericYesNoUnknown.values.map(&:to_s)
+        GenericYesNoUnknown.string_values
       end
       validates_inclusion_of :has_previous_name, in: has_previous_name_choices
 
       def self.gender_choices
-        Gender.values.map(&:to_s)
+        Gender.string_values
       end
       validates_inclusion_of :gender, in: gender_choices
 

--- a/app/value_objects/value_object.rb
+++ b/app/value_objects/value_object.rb
@@ -13,6 +13,10 @@ class ValueObject
   alias === ==
   alias eql? ==
 
+  def self.string_values
+    values.map(&:to_s)
+  end
+
   def hash
     [ValueObject, self.class, value].hash
   end

--- a/lib/generators/step/templates/edit/form.rb
+++ b/lib/generators/step/templates/edit/form.rb
@@ -6,7 +6,7 @@ module Steps
 
       # TODO: Delete this method and add different validation if you don't have a value object
       def self.choices
-        <%= step_name.camelize %>.values.map(&:to_s)
+        <%= step_name.camelize %>.string_values
       end
       validates_inclusion_of :<%= step_name.underscore %>, in: choices
 


### PR DESCRIPTION
We are using a lot, in different places `.values.map(&:to_s)` so this
exposes a helper method in the ValueObject superclass to encapsulate it.