### PR TITLE
Support for code blocks inside revealing panels

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
-  revision: d3b3b2e312459783fed823a13a9a0c8a43ed512b
+  revision: a1849b05d6d4bfe8e6107191ec3a6b9da245f118
   branch: show-hide-radios
   specs:
     govuk_elements_form_builder (1.0.0)

--- a/app/forms/steps/abuse_concerns/details_form.rb
+++ b/app/forms/steps/abuse_concerns/details_form.rb
@@ -7,19 +7,19 @@ module Steps
       attribute :behaviour_stop, String
       attribute :asked_for_help, String
       attribute :help_party, String
-      # attribute :help_provided, String
-      # attribute :help_description, String
+      attribute :help_provided, String
+      attribute :help_description, String
 
       validates_inclusion_of :behaviour_ongoing, in: GenericYesNo.string_values
       validates_inclusion_of :asked_for_help,    in: GenericYesNo.string_values
-      # validates_inclusion_of :help_provided,    in: GenericYesNo.string_values, if: :asked_for_help?
+      validates_inclusion_of :help_provided,     in: GenericYesNo.string_values, if: :asked_for_help?
 
       validates_presence_of :behaviour_description
       validates_presence_of :behaviour_start
       validates_presence_of :behaviour_stop, unless: :behaviour_ongoing?
 
-      validates_presence_of :help_party, if: :asked_for_help?
-      # validates_presence_of :help_description, if: :asked_for_help?
+      validates_presence_of :help_party,
+                            :help_description, if: :asked_for_help?
 
       private
 
@@ -31,11 +31,6 @@ module Steps
         asked_for_help.eql?(GenericYesNo::YES.to_s)
       end
 
-      # This is an optional reveal question so we can't assume we always get a value
-      # def help_provided_value
-      #   help_provided ? GenericYesNo.new(help_provided) : nil
-      # end
-
       def persist!
         super(
           behaviour_description: behaviour_description,
@@ -44,8 +39,8 @@ module Steps
           behaviour_stop: behaviour_stop,
           asked_for_help: GenericYesNo.new(asked_for_help),
           help_party: help_party,
-          # help_provided: help_provided_value,
-          # help_description: help_description
+          help_provided: (GenericYesNo.new(help_provided) if help_provided),
+          help_description: help_description
         )
       end
     end

--- a/app/views/steps/abuse_concerns/details/edit.html.erb
+++ b/app/views/steps/abuse_concerns/details/edit.html.erb
@@ -14,22 +14,21 @@
       <%= f.text_field :behaviour_start %>
 
       <%=
-        f.radio_button_fieldset :behaviour_ongoing do |fieldset|
+        f.radio_button_fieldset :behaviour_ongoing, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES)
           fieldset.radio_input(GenericYesNo::NO) { f.text_field :behaviour_stop }
         end
       %>
 
-      <!-- TODO: we have a problem with revealing fields showing more than one form element. -->
-      <!-- It will require some extra work on the gem. Leaving it for now. -->
       <%=
-        f.radio_button_fieldset :asked_for_help do |fieldset|
-          fieldset.radio_input(GenericYesNo::YES) do
-            f.text_field(:help_party)
-            #f.radio_button_fieldset(:help_provided, inline: true, choices: [GenericYesNo::YES, GenericYesNo::NO])
-            #f.text_area(:help_description, size: '40x4', class: 'form-control-3-4')
-          end
+        f.radio_button_fieldset :asked_for_help, inline: true do |fieldset|
+          fieldset.radio_input(GenericYesNo::YES, panel_id: :asked_for_help_panel)
           fieldset.radio_input(GenericYesNo::NO)
+          fieldset.revealing_panel(:asked_for_help_panel) do |panel|
+            panel.text_field(:help_party)
+            panel.radio_button_fieldset(:help_provided, inline: true, choices: GenericYesNo.values)
+            panel.text_area(:help_description, size: '40x4', class: 'form-control-3-4')
+          end
         end
       %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,6 +281,7 @@ en:
       steps_abuse_concerns_details_form:
         behaviour_ongoing_html: Are you concerned the issue is still affecting your children?
         asked_for_help_html: Have you ever asked for help?
+        help_provided_html: Did they help you?
       steps_applicant_personal_details_form:
         has_previous_name: Previous name?
       steps_respondent_personal_details_form:
@@ -339,6 +340,7 @@ en:
         behaviour_start: When did your concerns about your children start?
         behaviour_stop: When did you stop being concerned about the issue affecting your children?
         help_party: Who did you ask for help?
+        help_description: What did they do?
         behaviour_ongoing:
           <<: *YESNO
         asked_for_help:


### PR DESCRIPTION
Making use of latest changes pushed to the `govuk_elements_form_builder`
to enable code blocks inside the panel (so not limited to one single
element anymore) and also to allow to have the panel markup not
immediately follows the radio, but position it in another place with
easy, and reference it in the radio with the `panel_id` attribute.

<img width="652" alt="screen shot 2017-11-15 at 11 48 50" src="https://user-images.githubusercontent.com/687910/32834581-fc34487e-c9fa-11e7-822e-24caae5f1d0b.png">
