### PR TITLE
Reset abuse details when answering `no`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -498,6 +498,9 @@ PredicateName:
 RedundantMerge:
   Enabled: false
 
+MultilineIfModifier:
+  Enabled: false
+
 AccessModifierIndentation:
   Enabled: true
   EnforcedStyle: indent

--- a/app/forms/steps/abuse_concerns/question_form.rb
+++ b/app/forms/steps/abuse_concerns/question_form.rb
@@ -10,10 +10,26 @@ module Steps
 
       private
 
+      def answer_value
+        GenericYesNo.new(answer)
+      end
+
       def persist!
-        super(
-          answer: GenericYesNo.new(answer)
-        )
+        abuse_attributes = { answer: answer_value }
+
+        # The following are dependent attributes that need to be reset
+        abuse_attributes.merge!(
+          behaviour_description: nil,
+          behaviour_start: nil,
+          behaviour_ongoing: nil,
+          behaviour_stop: nil,
+          asked_for_help: nil,
+          help_party: nil,
+          help_provided: nil,
+          help_description: nil
+        ) if answer_value.eql?(GenericYesNo::NO)
+
+        super(abuse_attributes)
       end
     end
   end

--- a/spec/forms/steps/abuse_concerns/question_form_spec.rb
+++ b/spec/forms/steps/abuse_concerns/question_form_spec.rb
@@ -80,17 +80,43 @@ RSpec.describe Steps::AbuseConcerns::QuestionForm do
     end
 
     context 'for valid details' do
-      it 'creates the record if it does not exist' do
-        expect(concerns_collection).to receive(:find_or_initialize_by).with(
+      before do
+        allow(concerns_collection).to receive(:find_or_initialize_by).with(
           subject: AbuseSubject::APPLICANT,
           kind: AbuseType::EMOTIONAL
         ).and_return(abuse_concern)
+      end
 
-        expect(abuse_concern).to receive(:update).with(
-          answer: GenericYesNo::NO
-        ).and_return(true)
+      context 'for a `yes` answer' do
+        let(:abuse_answer) { 'yes' }
 
-        expect(subject.save).to be(true)
+        it 'saves the answer' do
+          expect(abuse_concern).to receive(:update).with(
+            answer: GenericYesNo::YES
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'for a `no` answer' do
+        let(:abuse_answer) { 'no' }
+
+        it 'saves the answer and also reset the details attributes' do
+          expect(abuse_concern).to receive(:update).with(
+            answer: GenericYesNo::NO,
+            behaviour_description: nil,
+            behaviour_start: nil,
+            behaviour_ongoing: nil,
+            behaviour_stop: nil,
+            asked_for_help: nil,
+            help_party: nil,
+            help_provided: nil,
+            help_description: nil
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
       end
     end
   end


### PR DESCRIPTION
Although technically this doesn't affect following questions, we can
safely reset the abuse detail fields when the answer is `no` in order
to not leave leftovers or if the user go back and changes the answer
multiple times.

If the details are still not filled this has no negative impact as they
are already nil.