### PR TITLE
DRY yes/no/unknown attributes and value-objects

### DIFF
--- a/app/attributes/yes_no.rb
+++ b/app/attributes/yes_no.rb
@@ -1,5 +1,10 @@
 class YesNo < Virtus::Attribute
   def coerce(value)
-    value ? GenericYesNo.new(value) : nil
+    case value
+    when String, Symbol
+      GenericYesNo.new(value)
+    when GenericYesNo
+      value
+    end
   end
 end

--- a/app/attributes/yes_no_unknown.rb
+++ b/app/attributes/yes_no_unknown.rb
@@ -1,0 +1,10 @@
+class YesNoUnknown < Virtus::Attribute
+  def coerce(value)
+    case value
+    when String, Symbol
+      GenericYesNoUnknown.new(value)
+    when GenericYesNoUnknown
+      value
+    end
+  end
+end

--- a/app/forms/steps/abuse_concerns/base_abuse_form.rb
+++ b/app/forms/steps/abuse_concerns/base_abuse_form.rb
@@ -22,7 +22,9 @@ module Steps
         c100_application.abuse_concerns.find_or_initialize_by(
           subject: AbuseSubject.new(subject),
           kind: AbuseType.new(kind),
-        ).update(attributes)
+        ).update(
+          attributes.except(:subject, :kind)
+        )
       end
     end
   end

--- a/app/forms/steps/abuse_concerns/details_form.rb
+++ b/app/forms/steps/abuse_concerns/details_form.rb
@@ -3,45 +3,28 @@ module Steps
     class DetailsForm < BaseAbuseForm
       attribute :behaviour_description, String
       attribute :behaviour_start, String
-      attribute :behaviour_ongoing, String
+      attribute :behaviour_ongoing, YesNo
       attribute :behaviour_stop, String
-      attribute :asked_for_help, String
+      attribute :asked_for_help, YesNo
       attribute :help_party, String
-      attribute :help_provided, String
+      attribute :help_provided, YesNo
       attribute :help_description, String
 
-      validates_inclusion_of :behaviour_ongoing, in: GenericYesNo.string_values
-      validates_inclusion_of :asked_for_help,    in: GenericYesNo.string_values
-      validates_inclusion_of :help_provided,     in: GenericYesNo.string_values, if: :asked_for_help?
+      validates_inclusion_of :behaviour_ongoing, in: GenericYesNo.values
+      validates_inclusion_of :asked_for_help,    in: GenericYesNo.values
+      validates_inclusion_of :help_provided,     in: GenericYesNo.values, if: -> { asked_for_help&.yes? }
 
       validates_presence_of :behaviour_description
       validates_presence_of :behaviour_start
-      validates_presence_of :behaviour_stop, unless: :behaviour_ongoing?
+      validates_presence_of :behaviour_stop, if: -> { behaviour_ongoing&.no? }
 
       validates_presence_of :help_party,
-                            :help_description, if: :asked_for_help?
+                            :help_description, if: -> { asked_for_help&.yes? }
 
       private
 
-      def behaviour_ongoing?
-        behaviour_ongoing.eql?(GenericYesNo::YES.to_s)
-      end
-
-      def asked_for_help?
-        asked_for_help.eql?(GenericYesNo::YES.to_s)
-      end
-
       def persist!
-        super(
-          behaviour_description: behaviour_description,
-          behaviour_start: behaviour_start,
-          behaviour_ongoing: GenericYesNo.new(behaviour_ongoing),
-          behaviour_stop: behaviour_stop,
-          asked_for_help: GenericYesNo.new(asked_for_help),
-          help_party: help_party,
-          help_provided: (GenericYesNo.new(help_provided) if help_provided),
-          help_description: help_description
-        )
+        super(attributes_map)
       end
     end
   end

--- a/app/forms/steps/abuse_concerns/question_form.rb
+++ b/app/forms/steps/abuse_concerns/question_form.rb
@@ -1,21 +1,14 @@
 module Steps
   module AbuseConcerns
     class QuestionForm < BaseAbuseForm
-      attribute :answer, String
+      attribute :answer, YesNo
 
-      def self.choices
-        GenericYesNo.string_values
-      end
-      validates_inclusion_of :answer, in: choices
+      validates_inclusion_of :answer, in: GenericYesNo.values
 
       private
 
-      def answer_value
-        GenericYesNo.new(answer)
-      end
-
       def persist!
-        abuse_attributes = { answer: answer_value }
+        abuse_attributes = { answer: answer }
 
         # The following are dependent attributes that need to be reset
         abuse_attributes.merge!(
@@ -27,7 +20,7 @@ module Steps
           help_party: nil,
           help_provided: nil,
           help_description: nil
-        ) if answer_value.eql?(GenericYesNo::NO)
+        ) if answer.no?
 
         super(abuse_attributes)
       end

--- a/app/forms/steps/children/additional_details_form.rb
+++ b/app/forms/steps/children/additional_details_form.rb
@@ -1,66 +1,35 @@
 module Steps
   module Children
     class AdditionalDetailsForm < BaseForm
-      attribute :children_known_to_authorities, String
+      attribute :children_known_to_authorities, YesNoUnknown
       attribute :children_known_to_authorities_details, String
-      attribute :children_protection_plan, String
+      attribute :children_protection_plan, YesNoUnknown
       attribute :children_protection_plan_details, String
-      attribute :children_same_parents, String
+      attribute :children_same_parents, YesNo
       attribute :children_same_parents_yes_details, String
       attribute :children_same_parents_no_details, String
       attribute :children_parental_responsibility_details, String
       attribute :children_residence, String
       attribute :children_residence_details, String
 
-      def self.children_known_to_authorities_choices
-        GenericYesNoUnknown.string_values
-      end
-      validates_inclusion_of :children_known_to_authorities, in: children_known_to_authorities_choices
-
-      def self.children_protection_plan_choices
-        GenericYesNoUnknown.string_values
-      end
-      validates_inclusion_of :children_protection_plan, in: children_protection_plan_choices
-
-      def self.children_same_parents_choices
-        GenericYesNo.string_values
-      end
-      validates_inclusion_of :children_same_parents, in: children_same_parents_choices
-
       def self.children_residence_choices
         ChildrenResidence.string_values
       end
       validates_inclusion_of :children_residence, in: children_residence_choices
 
+      validates_inclusion_of :children_known_to_authorities, in: GenericYesNoUnknown.values
+      validates_inclusion_of :children_protection_plan,      in: GenericYesNoUnknown.values
+      validates_inclusion_of :children_same_parents,         in: GenericYesNo.values
+
       validates_presence_of :children_parental_responsibility_details
-      validates_presence_of :children_same_parents_yes_details, if: :same_parents_yes_details_needed?
-      validates_presence_of :children_same_parents_no_details,  if: :same_parents_no_details_needed?
+      validates_presence_of :children_same_parents_yes_details, if: -> { children_same_parents&.yes? }
+      validates_presence_of :children_same_parents_no_details,  if: -> { children_same_parents&.no? }
       validates_presence_of :children_residence_details,        if: :children_residence_details_needed?
 
       private
 
-      def children_known_to_authorities_value
-        GenericYesNoUnknown.new(children_known_to_authorities)
-      end
-
-      def children_protection_plan_value
-        GenericYesNoUnknown.new(children_protection_plan)
-      end
-
-      def children_same_parents_value
-        GenericYesNo.new(children_same_parents)
-      end
-
       def children_residence_value
         ChildrenResidence.new(children_residence)
-      end
-
-      def same_parents_yes_details_needed?
-        children_same_parents.eql?(GenericYesNo::YES.to_s)
-      end
-
-      def same_parents_no_details_needed?
-        children_same_parents.eql?(GenericYesNo::NO.to_s)
       end
 
       def children_residence_details_needed?
@@ -78,11 +47,9 @@ module Steps
         return true unless changed?
 
         c100_application.update(
-          # Some attributes are value objects and thus we need to provide their values
+          # Some attributes are value objects and thus we need to provide their values,
+          # but eventually we may end up with the same solution as for `YesNo` attributes.
           attributes_map.merge(
-            children_known_to_authorities: children_known_to_authorities_value,
-            children_protection_plan: children_protection_plan_value,
-            children_same_parents: children_same_parents_value,
             children_residence: children_residence_value
           )
         )

--- a/app/forms/steps/court_orders/has_orders_form.rb
+++ b/app/forms/steps/court_orders/has_orders_form.rb
@@ -1,12 +1,9 @@
 module Steps
   module CourtOrders
     class HasOrdersForm < BaseForm
-      attribute :has_court_orders, String
+      attribute :has_court_orders, YesNo
 
-      def self.choices
-        GenericYesNo.string_values
-      end
-      validates_inclusion_of :has_court_orders, in: choices
+      validates_inclusion_of :has_court_orders, in: GenericYesNo.values
 
       private
 
@@ -14,7 +11,7 @@ module Steps
         raise C100ApplicationNotFound unless c100_application
 
         c100_application.update(
-          has_court_orders: GenericYesNo.new(has_court_orders)
+          has_court_orders: has_court_orders
         )
       end
     end

--- a/app/forms/steps/respondent/personal_details_form.rb
+++ b/app/forms/steps/respondent/personal_details_form.rb
@@ -4,7 +4,7 @@ module Steps
       include GovUkDateFields::ActsAsGovUkDate
 
       attribute :full_name, StrippedString
-      attribute :has_previous_name, String
+      attribute :has_previous_name, YesNoUnknown
       attribute :previous_full_name, StrippedString
       attribute :gender, String
       attribute :dob, Date
@@ -21,18 +21,15 @@ module Steps
 
       acts_as_gov_uk_date :dob
 
-      def self.has_previous_name_choices
-        GenericYesNoUnknown.string_values
-      end
-      validates_inclusion_of :has_previous_name, in: has_previous_name_choices
-
       def self.gender_choices
         Gender.string_values
       end
       validates_inclusion_of :gender, in: gender_choices
 
+      validates_inclusion_of :has_previous_name, in: GenericYesNoUnknown.values
+
       validates_presence_of :full_name, :address, :home_phone
-      validates_presence_of :previous_full_name, if: :has_previous_name?
+      validates_presence_of :previous_full_name, if: -> { has_previous_name&.yes? }
 
       # Validations -unless- 'I don't know checkbox' is selected
       validates_presence_of :dob,      unless: :dob_unknown?
@@ -40,14 +37,6 @@ module Steps
       validates :email, email: true,   unless: :email_unknown?
 
       private
-
-      def has_previous_name?
-        has_previous_name.eql?(GenericYesNoUnknown::YES.to_s)
-      end
-
-      def has_previous_name_value
-        GenericYesNoUnknown.new(has_previous_name)
-      end
 
       def gender_value
         Gender.new(gender)
@@ -58,9 +47,9 @@ module Steps
 
         respondent = c100_application.respondents.find_or_initialize_by(id: record_id)
         respondent.update(
-          # Some attributes are value objects and thus we need to provide their values
+          # Some attributes are value objects and thus we need to provide their values,
+          # but eventually we may end up with the same solution as for `YesNo` attributes.
           attributes_map.merge(
-            has_previous_name: has_previous_name_value,
             gender: gender_value
           )
         )

--- a/app/value_objects/generic_yes_no_unknown.rb
+++ b/app/value_objects/generic_yes_no_unknown.rb
@@ -8,4 +8,16 @@ class GenericYesNoUnknown < ValueObject
   def self.values
     VALUES
   end
+
+  def yes?
+    value == :yes
+  end
+
+  def no?
+    value == :no
+  end
+
+  def unknown?
+    value == :unknown
+  end
 end

--- a/app/views/steps/abuse_concerns/question/edit.html.erb
+++ b/app/views/steps/abuse_concerns/question/edit.html.erb
@@ -14,8 +14,7 @@
       <%= f.hidden_field :subject %>
       <%= f.hidden_field :kind %>
 
-      <%= f.radio_button_fieldset :answer, inline: true,
-        choices: Steps::AbuseConcerns::QuestionForm.choices %>
+      <%= f.radio_button_fieldset :answer, inline: true, choices: GenericYesNo.values %>
 
       <%= f.submit class: 'button' %>
     <% end %>

--- a/app/views/steps/children/additional_details/edit.html.erb
+++ b/app/views/steps/children/additional_details/edit.html.erb
@@ -17,8 +17,7 @@
         end
       %>
 
-      <%= f.radio_button_fieldset :children_protection_plan,
-        choices: Steps::Children::AdditionalDetailsForm.children_protection_plan_choices %>
+      <%= f.radio_button_fieldset :children_protection_plan, choices: GenericYesNoUnknown.values %>
 
       <%=
         f.radio_button_fieldset :children_same_parents do |fieldset|

--- a/app/views/steps/court_orders/has_orders/edit.html.erb
+++ b/app/views/steps/court_orders/has_orders/edit.html.erb
@@ -9,8 +9,7 @@
     <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object, inline: true do |f| %>
-      <%= f.radio_button_fieldset :has_court_orders, inline: true,
-        choices: Steps::CourtOrders::HasOrdersForm.choices %>
+      <%= f.radio_button_fieldset :has_court_orders, inline: true, choices: GenericYesNo.values %>
 
       <%= f.submit class: 'button' %>
     <% end %>

--- a/spec/attributes/yes_no_spec.rb
+++ b/spec/attributes/yes_no_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe YesNo do
+  subject { described_class.build(YesNo) }
+
+  let(:coerced_value) { subject.coerce(value) }
+
+  describe 'when value is `nil`' do
+    let(:value) { nil }
+    it { expect(coerced_value).to be_nil }
+  end
+
+  describe 'when value is a symbol' do
+    let(:value) { :yes }
+    it { expect(coerced_value).to eq(GenericYesNo::YES) }
+  end
+
+  describe 'when value is a string' do
+    let(:value) { 'yes' }
+    it { expect(coerced_value).to eq(GenericYesNo::YES) }
+  end
+
+  describe 'when value is already a value-object' do
+    let(:value) { GenericYesNo::YES }
+    it { expect(coerced_value).to eq(GenericYesNo::YES) }
+  end
+end

--- a/spec/attributes/yes_no_unknown_spec.rb
+++ b/spec/attributes/yes_no_unknown_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe YesNoUnknown do
+  subject { described_class.build(YesNoUnknown) }
+
+  let(:coerced_value) { subject.coerce(value) }
+
+  describe 'when value is `nil`' do
+    let(:value) { nil }
+    it { expect(coerced_value).to be_nil }
+  end
+
+  describe 'when value is a symbol' do
+    let(:value) { :yes }
+    it { expect(coerced_value).to eq(GenericYesNoUnknown::YES) }
+  end
+
+  describe 'when value is a string' do
+    let(:value) { 'yes' }
+    it { expect(coerced_value).to eq(GenericYesNoUnknown::YES) }
+  end
+
+  describe 'when value is already a value-object' do
+    let(:value) { GenericYesNoUnknown::YES }
+    it { expect(coerced_value).to eq(GenericYesNoUnknown::YES) }
+  end
+end

--- a/spec/forms/steps/abuse_concerns/question_form_spec.rb
+++ b/spec/forms/steps/abuse_concerns/question_form_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe Steps::AbuseConcerns::QuestionForm do
 
   subject { described_class.new(arguments) }
 
-  describe '.choices' do
-    it 'returns the relevant choices' do
-      expect(described_class.choices).to eq(%w(yes no))
-    end
-  end
-
   describe '.i18n_key' do
     context 'for an applicant subject' do
       let(:abuse_subject) { 'applicant' }

--- a/spec/forms/steps/applicant/personal_details_form_spec.rb
+++ b/spec/forms/steps/applicant/personal_details_form_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe Steps::Applicant::PersonalDetailsForm do
     end
   end
 
-  describe '.has_previous_name_choices' do
-    it 'returns the relevant choices' do
-      expect(described_class.has_previous_name_choices).to eq(%w(yes no))
-    end
-  end
-
   describe '#save' do
     context 'when no c100_application is associated with the form' do
       let(:c100_application) { nil }

--- a/spec/forms/steps/children/additional_details_form_spec.rb
+++ b/spec/forms/steps/children/additional_details_form_spec.rb
@@ -30,24 +30,6 @@ RSpec.describe Steps::Children::AdditionalDetailsForm do
 
   subject { described_class.new(arguments) }
 
-  describe '.children_known_to_authorities_choices' do
-    it 'returns the relevant choices' do
-      expect(described_class.children_known_to_authorities_choices).to eq(%w(yes no unknown))
-    end
-  end
-
-  describe '.children_protection_plan_choices' do
-    it 'returns the relevant choices' do
-      expect(described_class.children_protection_plan_choices).to eq(%w(yes no unknown))
-    end
-  end
-
-  describe '.children_same_parents_choices' do
-    it 'returns the relevant choices' do
-      expect(described_class.children_same_parents_choices).to eq(%w(yes no))
-    end
-  end
-
   describe '.children_residence_choices' do
     it 'returns the relevant choices' do
       expect(described_class.children_residence_choices).to eq(%w(applicant respondent other))

--- a/spec/forms/steps/court_orders/has_orders_form_spec.rb
+++ b/spec/forms/steps/court_orders/has_orders_form_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe Steps::CourtOrders::HasOrdersForm do
 
   subject { described_class.new(arguments) }
 
-  describe '.choices' do
-    it 'returns the relevant choices' do
-      expect(described_class.choices).to eq(%w(yes no))
-    end
-  end
-
   describe '#save' do
     it_behaves_like 'a value object form', attribute_name: :has_court_orders, example_value: 'no'
 

--- a/spec/forms/steps/respondent/personal_details_form_spec.rb
+++ b/spec/forms/steps/respondent/personal_details_form_spec.rb
@@ -50,12 +50,6 @@ RSpec.describe Steps::Respondent::PersonalDetailsForm do
     end
   end
 
-  describe '.has_previous_name_choices' do
-    it 'returns the relevant choices' do
-      expect(described_class.has_previous_name_choices).to eq(%w(yes no unknown))
-    end
-  end
-
   describe '#save' do
     context 'when no c100_application is associated with the form' do
       let(:c100_application) { nil }

--- a/spec/value_objects/generic_yes_no_unknown_spec.rb
+++ b/spec/value_objects/generic_yes_no_unknown_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe GenericYesNoUnknown do
+  let(:value) { :foo }
+  subject     { described_class.new(value) }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(yes no unknown))
+    end
+  end
+
+  describe '#yes?' do
+    context 'when value is `yes`' do
+      let(:value) { :yes }
+      it { expect(subject.yes?).to eq(true) }
+    end
+
+    context 'when value is not `yes`' do
+      let(:value) { :no }
+      it { expect(subject.yes?).to eq(false) }
+    end
+  end
+
+  describe '#no?' do
+    context 'when value is `no`' do
+      let(:value) { :no }
+      it { expect(subject.no?).to eq(true) }
+    end
+
+    context 'when value is not `no`' do
+      let(:value) { :yes }
+      it { expect(subject.no?).to eq(false) }
+    end
+  end
+
+  describe '#unknown?' do
+    context 'when value is `unknown`' do
+      let(:value) { :unknown }
+      it { expect(subject.unknown?).to eq(true) }
+    end
+
+    context 'when value is not `unknown`' do
+      let(:value) { :yes }
+      it { expect(subject.unknown?).to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
Updating all the forms that currently use Yes/No/Unknown fields to make use of this better approach introduced in the PR #40 

Still we can go a bit further, and probably I will, as part of a future PR, to unify the 'Virtus' attributes and the ValueObject classes so we don't need 2 different classes.