### PR TITLE
Add `emergency proceedings` step and refactor

### DIFF
--- a/app/controllers/steps/abuse_concerns/emergency_proceedings_controller.rb
+++ b/app/controllers/steps/abuse_concerns/emergency_proceedings_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module AbuseConcerns
+    class EmergencyProceedingsController < Steps::AbuseConcernsStepController
+      def edit
+        @form_object = EmergencyProceedingsForm.new(
+          c100_application: current_c100_application,
+          emergency_proceedings: current_c100_application.emergency_proceedings
+        )
+      end
+
+      def update
+        update_and_advance(EmergencyProceedingsForm, as: :emergency_proceedings)
+      end
+    end
+  end
+end

--- a/app/forms/concerns/single_question_form.rb
+++ b/app/forms/concerns/single_question_form.rb
@@ -1,0 +1,37 @@
+module SingleQuestionForm
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    attr_accessor :reset_attributes
+
+    private
+
+    def yes_no_attribute(name, reset_when_yes: [], reset_when_no: [])
+      attribute name, YesNo
+      validates_inclusion_of name, in: GenericYesNo.values
+
+      self.reset_attributes = {
+        GenericYesNo::YES => reset_when_yes,
+        GenericYesNo::NO  => reset_when_no
+      }
+    end
+  end
+
+  private
+
+  def answer
+    attributes_map.values.first
+  end
+
+  def attributes_to_reset
+    Hash[self.class.reset_attributes[answer].collect { |att| [att, nil] }]
+  end
+
+  def persist!
+    raise BaseForm::C100ApplicationNotFound unless c100_application
+
+    c100_application.update(
+      attributes_map.merge(attributes_to_reset)
+    )
+  end
+end

--- a/app/forms/steps/abuse_concerns/emergency_proceedings_form.rb
+++ b/app/forms/steps/abuse_concerns/emergency_proceedings_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module AbuseConcerns
+    class EmergencyProceedingsForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :emergency_proceedings
+    end
+  end
+end

--- a/app/forms/steps/abuse_concerns/previous_proceedings_form.rb
+++ b/app/forms/steps/abuse_concerns/previous_proceedings_form.rb
@@ -1,19 +1,9 @@
 module Steps
   module AbuseConcerns
     class PreviousProceedingsForm < BaseForm
-      attribute :children_previous_proceedings, YesNo
+      include SingleQuestionForm
 
-      validates_inclusion_of :children_previous_proceedings, in: GenericYesNo.values
-
-      private
-
-      def persist!
-        raise C100ApplicationNotFound unless c100_application
-
-        c100_application.update(
-          children_previous_proceedings: children_previous_proceedings
-        )
-      end
+      yes_no_attribute :children_previous_proceedings, reset_when_no: [:emergency_proceedings]
     end
   end
 end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -13,6 +13,7 @@ class C100Application < ApplicationRecord
   has_value_object :concerns_contact_type
   has_value_object :concerns_contact_other,        class_name: 'GenericYesNo'
   has_value_object :children_previous_proceedings, class_name: 'GenericYesNo'
+  has_value_object :emergency_proceedings,         class_name: 'GenericYesNo'
 
   # Children additional details
   has_value_object :children_residence

--- a/app/services/c100_app/abuse_concerns_decision_tree.rb
+++ b/app/services/c100_app/abuse_concerns_decision_tree.rb
@@ -9,6 +9,8 @@ module C100App
       when :contact
         edit(:previous_proceedings)
       when :previous_proceedings
+        after_previous_proceedings
+      when :emergency_proceedings
         show('/steps/children/instructions') # TODO: change when we have next step
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
@@ -25,8 +27,17 @@ module C100App
       AbuseType.new(step_params[:kind])
     end
 
-    def answer
+    def abuse_answer
       GenericYesNo.new(step_params[:answer])
+    end
+
+    def after_previous_proceedings
+      case step_params.fetch(:children_previous_proceedings)
+      when GenericYesNo::YES.to_s
+        edit(:emergency_proceedings)
+      else
+        show('/steps/children/instructions') # TODO: change when we have next step
+      end
     end
 
     def after_question_step
@@ -48,7 +59,7 @@ module C100App
     end
 
     def applicant_questions_destination
-      case answer
+      case abuse_answer
       when GenericYesNo::YES
         edit(:details, subject: abuse_subject, kind: abuse_kind)
       else
@@ -66,7 +77,7 @@ module C100App
     end
 
     def children_questions_destination
-      case answer
+      case abuse_answer
       when GenericYesNo::YES
         edit(:details, subject: abuse_subject, kind: abuse_kind)
       else

--- a/app/views/steps/abuse_concerns/emergency_proceedings/edit.html.erb
+++ b/app/views/steps/abuse_concerns/emergency_proceedings/edit.html.erb
@@ -1,0 +1,14 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :emergency_proceedings, inline: true, choices: GenericYesNo.values %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,6 +209,10 @@ en:
           page_title: Previous proceedings
           heading: Have any of the children in this application been involved in another family court case?
           lead_text: For example an emergency protection order or supervision order. Include any ongoing cases.
+      emergency_proceedings:
+        edit:
+          page_title: Emergency proceedings
+          heading: Were any of the cases about an emergency protection order, care or supervision order?
     court_orders:
       has_orders:
         edit:
@@ -307,6 +311,8 @@ en:
         concerns_contact_other_html: "Do you agree to your children having other forms of contact with the other person?"
       steps_abuse_concerns_previous_proceedings_form:
         children_previous_proceedings_html: ""
+      steps_abuse_concerns_emergency_proceedings_form:
+        emergency_proceedings_html: ""
       steps_court_orders_has_orders_form:
         has_court_orders_html: ""
       steps_court_orders_details_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
       end
       edit_step :contact
       edit_step :previous_proceedings
+      edit_step :emergency_proceedings
     end
     namespace :court_orders do
       edit_step :has_orders

--- a/db/migrate/20171120112650_add_emergency_proceedings_field.rb
+++ b/db/migrate/20171120112650_add_emergency_proceedings_field.rb
@@ -1,0 +1,5 @@
+class AddEmergencyProceedingsField < ActiveRecord::Migration[5.0]
+  def change
+    add_column :c100_applications, :emergency_proceedings, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171120101456) do
+ActiveRecord::Schema.define(version: 20171120112650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20171120101456) do
     t.string   "concerns_contact_type"
     t.string   "concerns_contact_other"
     t.string   "children_previous_proceedings"
+    t.string   "emergency_proceedings"
     t.index ["user_id"], name: "index_c100_applications_on_user_id", using: :btree
   end
 

--- a/spec/controllers/steps/abuse_concerns/emergency_proceedings_controller_spec.rb
+++ b/spec/controllers/steps/abuse_concerns/emergency_proceedings_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::AbuseConcerns::EmergencyProceedingsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::AbuseConcerns::EmergencyProceedingsForm, C100App::AbuseConcernsDecisionTree
+end

--- a/spec/forms/steps/abuse_concerns/emergency_proceedings_form_spec.rb
+++ b/spec/forms/steps/abuse_concerns/emergency_proceedings_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::AbuseConcerns::EmergencyProceedingsForm do
+  it_behaves_like 'a yes-no question form', attribute_name: :emergency_proceedings
+end

--- a/spec/forms/steps/abuse_concerns/previous_proceedings_form_spec.rb
+++ b/spec/forms/steps/abuse_concerns/previous_proceedings_form_spec.rb
@@ -1,31 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Steps::AbuseConcerns::PreviousProceedingsForm do
-  let(:arguments) { {
-    c100_application: c100_application,
-    children_previous_proceedings: children_previous_proceedings
-  } }
-  let(:c100_application) { instance_double(C100Application) }
-  let(:children_previous_proceedings) { 'yes' }
-
-  subject { described_class.new(arguments) }
-
-  describe '#save' do
-    it_behaves_like 'a value object form', attribute_name: :children_previous_proceedings, example_value: 'yes'
-
-    context 'validations on field presence' do
-      it { should validate_presence_of(:children_previous_proceedings, :inclusion) }
-    end
-
-    context 'when previous_proceedings is valid' do
-      let(:children_previous_proceedings) { 'yes' }
-
-      it 'saves the record' do
-        expect(c100_application).to receive(:update).with(
-          children_previous_proceedings: GenericYesNo::YES
-        ).and_return(true)
-        expect(subject.save).to be(true)
-      end
-    end
-  end
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :children_previous_proceedings,
+                  reset_when_no: [:emergency_proceedings]
 end

--- a/spec/services/c100_app/abuse_concerns_decision_tree_spec.rb
+++ b/spec/services/c100_app/abuse_concerns_decision_tree_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe C100App::AbuseConcernsDecisionTree do
   it 'retrieve the abuse kind from the `step_params`' do
     expect(subject.step_params).to receive(:[]).with(:kind).and_return(:other)
     allow(subject).to receive(:abuse_subject).and_return(AbuseSubject::APPLICANT)
-    allow(subject).to receive(:answer).and_return(GenericYesNo::NO)
+    allow(subject).to receive(:abuse_answer).and_return(GenericYesNo::NO)
     subject.destination
   end
 
@@ -322,6 +322,20 @@ RSpec.describe C100App::AbuseConcernsDecisionTree do
 
   describe 'when the step is `previous_proceedings`' do
     let(:as) { 'previous_proceedings' }
+
+    context 'when answer is `yes`' do
+      let(:step_params) { {children_previous_proceedings: 'yes'} }
+      it { is_expected.to have_destination(:emergency_proceedings, :edit) }
+    end
+
+    context 'when answer is `no`' do
+      let(:step_params) { {children_previous_proceedings: 'no'} }
+      it { is_expected.to have_destination('/steps/children/instructions', :show) }
+    end
+  end
+
+  describe 'when the step is `emergency_proceedings`' do
+    let(:as) { 'emergency_proceedings' }
     it { is_expected.to have_destination('/steps/children/instructions', :show) }
   end
 

--- a/spec/support/form_validation_shared_examples.rb
+++ b/spec/support/form_validation_shared_examples.rb
@@ -34,3 +34,60 @@ RSpec.shared_examples 'a value object form' do |options|
     end
   end
 end
+
+RSpec.shared_examples 'a yes-no question form' do |options|
+  let(:question_attribute) { options[:attribute_name] }
+  let(:answer_value) { 'yes' }
+
+  let(:reset_when_yes) { options.fetch(:reset_when_yes, []) }
+  let(:reset_when_no)  { options.fetch(:reset_when_no,  []) }
+
+  let(:arguments) { {
+    c100_application: c100_application,
+    question_attribute => answer_value
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  def attributes_to_reset(attrs)
+    Hash[attrs.collect {|att| [att, nil]}]
+  end
+
+  describe 'validations on field presence' do
+    it { should validate_presence_of(question_attribute, :inclusion) }
+  end
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { described_class.new(arguments).save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'when answer is `yes`' do
+      let(:answer_value) { 'yes' }
+      let(:additional_attributes) { attributes_to_reset(reset_when_yes) }
+
+      it 'saves the record' do
+        expect(c100_application).to receive(:update).with(
+          { options[:attribute_name] => GenericYesNo::YES }.merge(additional_attributes)
+        ).and_return(true)
+        expect(described_class.new(arguments).save).to be(true)
+      end
+    end
+
+    context 'when answer is `no`' do
+      let(:answer_value) { 'no' }
+      let(:additional_attributes) { attributes_to_reset(reset_when_no) }
+
+      it 'saves the record' do
+        expect(c100_application).to receive(:update).with(
+          { options[:attribute_name] => GenericYesNo::NO }.merge(additional_attributes)
+        ).and_return(true)
+        expect(described_class.new(arguments).save).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Other than adding another step, with a single question Yes/No, this
PR will extract duplicated and shared code to a concern module called
`SingleQuestionForm` to be used when we have form objects with only
one Yes/No question (as these are quite common) and also added shared
examples to simplify the testing of these form objects.

In a follow-up PR I will refactor the rest of form objects we have with
one question to use this concern, and their tests, as I didn't want to
grow too much this PR.