### PR TITLE
DRY HasOrders form using `SingleQuestionForm`

### DIFF
--- a/app/forms/steps/court_orders/has_orders_form.rb
+++ b/app/forms/steps/court_orders/has_orders_form.rb
@@ -1,19 +1,9 @@
 module Steps
   module CourtOrders
     class HasOrdersForm < BaseForm
-      attribute :has_court_orders, YesNo
+      include SingleQuestionForm
 
-      validates_inclusion_of :has_court_orders, in: GenericYesNo.values
-
-      private
-
-      def persist!
-        raise C100ApplicationNotFound unless c100_application
-
-        c100_application.update(
-          has_court_orders: has_court_orders
-        )
-      end
+      yes_no_attribute :has_court_orders
     end
   end
 end

--- a/spec/forms/steps/court_orders/has_orders_form_spec.rb
+++ b/spec/forms/steps/court_orders/has_orders_form_spec.rb
@@ -1,29 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe Steps::CourtOrders::HasOrdersForm do
-  let(:arguments) { {
-    c100_application: c100_application,
-    has_court_orders: has_court_orders
-  } }
-  let(:c100_application) { instance_double(C100Application, has_court_orders: nil) }
-  let(:has_court_orders) { 'no' }
-
-  subject { described_class.new(arguments) }
-
-  describe '#save' do
-    it_behaves_like 'a value object form', attribute_name: :has_court_orders, example_value: 'no'
-
-    context 'validations on field presence' do
-      it { should validate_presence_of(:has_court_orders, :inclusion) }
-    end
-
-    context 'when has_court_orders is valid' do
-      it 'saves the record' do
-        expect(c100_application).to receive(:update).with(
-          has_court_orders: GenericYesNo::NO
-        ).and_return(true)
-        expect(subject.save).to be(true)
-      end
-    end
-  end
+  it_behaves_like 'a yes-no question form', attribute_name: :has_court_orders
 end


### PR DESCRIPTION
Ok, it turned out this is the other form we can DRY making use of the
concern, but eventually we will have MANY more forms with just one
Yes/No question, and then this will be seen more useful.