### PR TITLE
Add a `question step` generator

### DIFF
--- a/lib/generators/step/templates/question/controller.rb
+++ b/lib/generators/step/templates/question/controller.rb
@@ -1,0 +1,1 @@
+../edit/controller.rb

--- a/lib/generators/step/templates/question/controller_spec.rb
+++ b/lib/generators/step/templates/question/controller_spec.rb
@@ -1,0 +1,1 @@
+../edit/controller_spec.rb

--- a/lib/generators/step/templates/question/edit.html.erb
+++ b/lib/generators/step/templates/question/edit.html.erb
@@ -1,0 +1,17 @@
+<%% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%%=t '.heading' %></h1>
+
+    <p class="lede gv-u-text-lede"><%%=t '.lead_text' %></p>
+
+    <%%= step_form @form_object do |f| %>
+      <%%= f.radio_button_fieldset :<%= step_name.underscore %>, inline: true, choices: GenericYesNo.values %>
+
+      <%%= f.submit class: 'button' %>
+    <%% end %>
+  </div>
+</div>

--- a/lib/generators/step/templates/question/form.rb
+++ b/lib/generators/step/templates/question/form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module <%= task_name.camelize %>
+    class <%= step_name.camelize %>Form < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :<%= step_name.underscore %>
+    end
+  end
+end

--- a/lib/generators/step/templates/question/form_spec.rb
+++ b/lib/generators/step/templates/question/form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Form do
+  it_behaves_like 'a yes-no question form', attribute_name: :<%= step_name.underscore %>
+end


### PR DESCRIPTION
This is similar to the `edit` one but the form object uses the
`SingleQuestionForm` and the test, and view are also adapted to this.

As the controller and its spec are identical, using symlinks to those
files in the `edit` directory.