### PR TITLE
Add `abduction` task and first steps

### DIFF
--- a/app/controllers/steps/abduction/children_have_passport_controller.rb
+++ b/app/controllers/steps/abduction/children_have_passport_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Abduction
+    class ChildrenHavePassportController < Steps::AbductionStepController
+      def edit
+        @form_object = ChildrenHavePassportForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(ChildrenHavePassportForm)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/abduction_step_controller.rb
+++ b/app/controllers/steps/abduction_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class AbductionStepController < StepController
+    private
+
+    def decision_tree_class
+      C100App::AbductionDecisionTree
+    end
+  end
+end

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -72,6 +72,12 @@ class BaseForm
 
   private
 
+  # This can be overridden by more specific implementations, for example as we do
+  # within the `HasOneAssociationForm` concern. The default is always the 'main' model.
+  def record
+    c100_application
+  end
+
   # :nocov:
   def persist!
     raise 'Subclasses of BaseForm need to implement #persist!'

--- a/app/forms/concerns/has_one_association_form.rb
+++ b/app/forms/concerns/has_one_association_form.rb
@@ -1,0 +1,27 @@
+module HasOneAssociationForm
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    attr_accessor :association_name
+
+    def build(c100_application:)
+      super(record(c100_application), c100_application: c100_application)
+    end
+
+    def record(parent)
+      parent.public_send(association_name) || parent.public_send("build_#{association_name}")
+    end
+
+    private
+
+    def has_one_association(name)
+      self.association_name = name
+    end
+  end
+
+  private
+
+  def record
+    @_record ||= self.class.record(c100_application)
+  end
+end

--- a/app/forms/concerns/single_question_form.rb
+++ b/app/forms/concerns/single_question_form.rb
@@ -30,7 +30,7 @@ module SingleQuestionForm
   def persist!
     raise BaseForm::C100ApplicationNotFound unless c100_application
 
-    c100_application.update(
+    record.update(
       attributes_map.merge(attributes_to_reset)
     )
   end

--- a/app/forms/steps/abduction/children_have_passport_form.rb
+++ b/app/forms/steps/abduction/children_have_passport_form.rb
@@ -1,0 +1,12 @@
+module Steps
+  module Abduction
+    class ChildrenHavePassportForm < BaseForm
+      include SingleQuestionForm
+      include HasOneAssociationForm
+
+      has_one_association :abduction_detail
+
+      yes_no_attribute :children_have_passport
+    end
+  end
+end

--- a/app/models/abduction_detail.rb
+++ b/app/models/abduction_detail.rb
@@ -1,0 +1,3 @@
+class AbductionDetail < ApplicationRecord
+  belongs_to :c100_application
+end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -1,8 +1,9 @@
 class C100Application < ApplicationRecord
   belongs_to :user, optional: true, dependent: :destroy
 
-  has_one  :asking_order,   dependent: :destroy
-  has_one  :court_order,    dependent: :destroy
+  has_one  :abduction_detail, dependent: :destroy
+  has_one  :asking_order,     dependent: :destroy
+  has_one  :court_order,      dependent: :destroy
 
   has_many :abuse_concerns, dependent: :destroy
   has_many :children,       dependent: :destroy

--- a/app/services/c100_app/abduction_decision_tree.rb
+++ b/app/services/c100_app/abduction_decision_tree.rb
@@ -1,0 +1,14 @@
+module C100App
+  class AbductionDecisionTree < BaseDecisionTree
+    def destination
+      return next_step if next_step
+
+      case step_name
+      when :children_have_passport
+        edit('/steps/safety_questions/substance_abuse') # TODO: change when we have next step
+      else
+        raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+  end
+end

--- a/app/services/c100_app/safety_questions_decision_tree.rb
+++ b/app/services/c100_app/safety_questions_decision_tree.rb
@@ -5,7 +5,7 @@ module C100App
 
       case step_name
       when :risk_of_abduction
-        edit(:substance_abuse)
+        after_risk_of_abduction
       when :substance_abuse
         after_substance_abuse
       when :substance_abuse_details
@@ -22,6 +22,14 @@ module C100App
     end
 
     private
+
+    def after_risk_of_abduction
+      if question(:risk_of_abduction).yes?
+        edit('/steps/abduction/children_have_passport')
+      else
+        edit(:substance_abuse)
+      end
+    end
 
     def after_substance_abuse
       if question(:substance_abuse).yes?

--- a/app/views/steps/abduction/children_have_passport/edit.html.erb
+++ b/app/views/steps/abduction/children_have_passport/edit.html.erb
@@ -1,0 +1,15 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :children_have_passport, inline: true, choices: GenericYesNo.values %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -266,6 +266,11 @@ en:
         edit:
           page_title: Provide details of the issue
           heading: Provide details of the issue you’re asking the court to resolve
+    abduction:
+      children_have_passport:
+        edit:
+          page_title: Children have passport
+          heading: Do any of your children have a passport?
 
   home:
     index:
@@ -369,6 +374,8 @@ en:
         domestic_abuse_html: ""
       steps_safety_questions_other_abuse_form:
         other_abuse_html: ""
+      steps_abduction_children_have_passport_form:
+        children_have_passport_html: ""
       steps_abuse_concerns_question_form:
         answer_html: ""
       steps_abuse_concerns_contact_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,9 @@ Rails.application.routes.draw do
       edit_step :certification
       show_step :no_certification_kickout
     end
+    namespace :abduction do
+      edit_step :children_have_passport
+    end
     namespace :safety_questions do
       show_step :start
       edit_step :risk_of_abduction

--- a/db/migrate/20171124141636_create_abduction_details_table.rb
+++ b/db/migrate/20171124141636_create_abduction_details_table.rb
@@ -1,0 +1,24 @@
+class CreateAbductionDetailsTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :abduction_details, id: :uuid do |t|
+      t.string  :children_have_passport
+
+      t.string  :international_risk
+      t.string  :passport_office_notified
+      t.string  :children_multiple_passports
+      t.boolean :passport_possession_mother
+      t.boolean :passport_possession_father
+      t.boolean :passport_possession_other
+      t.text    :passport_possession_other_details
+
+      t.string  :previous_attempt
+      t.text    :previous_attempt_details
+      t.string  :previous_attempt_agency_involved
+      t.text    :previous_attempt_agency_details
+
+      t.text    :risk_details
+    end
+
+    add_reference :abduction_details, :c100_application, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171123125740) do
+ActiveRecord::Schema.define(version: 20171124141636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "abduction_details", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.string  "children_have_passport"
+    t.string  "international_risk"
+    t.string  "passport_office_notified"
+    t.string  "children_multiple_passports"
+    t.boolean "passport_possession_mother"
+    t.boolean "passport_possession_father"
+    t.boolean "passport_possession_other"
+    t.text    "passport_possession_other_details"
+    t.string  "previous_attempt"
+    t.text    "previous_attempt_details"
+    t.string  "previous_attempt_agency_involved"
+    t.text    "previous_attempt_agency_details"
+    t.text    "risk_details"
+    t.uuid    "c100_application_id"
+    t.index ["c100_application_id"], name: "index_abduction_details_on_c100_application_id", using: :btree
+  end
 
   create_table "abuse_concerns", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "subject"
@@ -194,6 +212,7 @@ ActiveRecord::Schema.define(version: 20171123125740) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "abduction_details", "c100_applications"
   add_foreign_key "abuse_concerns", "c100_applications"
   add_foreign_key "applicants", "c100_applications"
   add_foreign_key "asking_orders", "c100_applications"

--- a/spec/controllers/steps/abduction/children_have_passport_controller_spec.rb
+++ b/spec/controllers/steps/abduction/children_have_passport_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Abduction::ChildrenHavePassportController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Abduction::ChildrenHavePassportForm, C100App::AbductionDecisionTree
+end

--- a/spec/forms/steps/abduction/children_have_passport_form_spec.rb
+++ b/spec/forms/steps/abduction/children_have_passport_form_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Abduction::ChildrenHavePassportForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    children_have_passport: 'yes'
+  } }
+
+  let(:c100_application) { instance_double(C100Application, abduction_detail: abduction_detail) }
+  let(:abduction_detail) { double('abduction_detail') }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'validations' do
+      it { should validate_presence_of(:children_have_passport, :inclusion) }
+    end
+
+    context 'for valid details' do
+      let(:expected_attributes) {
+        {
+          children_have_passport: GenericYesNo::YES
+        }
+      }
+
+      context 'when record does not exist' do
+        before do
+          allow(c100_application).to receive(:abduction_detail).and_return(nil)
+        end
+
+        it 'creates the record if it does not exist' do
+          expect(c100_application).to receive(:build_abduction_detail).and_return(abduction_detail)
+
+          expect(abduction_detail).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when record already exists' do
+        before do
+          allow(c100_application).to receive(:abduction_detail).and_return(abduction_detail)
+        end
+
+        it 'updates the record if it already exists' do
+          expect(c100_application).not_to receive(:build_abduction_detail)
+
+          expect(abduction_detail).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/abduction_decision_tree_spec.rb
+++ b/spec/services/c100_app/abduction_decision_tree_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe C100App::AbductionDecisionTree do
+  let(:c100_application) { double('Object') }
+  let(:step_params)      { double('Step') }
+  let(:next_step)        { nil }
+  let(:as)               { nil }
+
+  subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
+
+  it_behaves_like 'a decision tree'
+
+  context 'when the step is `children_have_passport`' do
+    let(:step_params) { { children_have_passport: 'anything' } }
+    it { is_expected.to have_destination('/steps/safety_questions/substance_abuse', :edit) }
+  end
+end

--- a/spec/services/c100_app/safety_questions_decision_tree_spec.rb
+++ b/spec/services/c100_app/safety_questions_decision_tree_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe C100App::SafetyQuestionsDecisionTree do
 
     context 'and the answer is `yes`' do
       let(:value) { 'yes' }
-      it { is_expected.to have_destination(:substance_abuse, :edit) }
+      it { is_expected.to have_destination('/steps/abduction/children_have_passport', :edit) }
     end
 
     context 'and the answer is `no`' do


### PR DESCRIPTION
Also added as part of this, as we are going to need it for the whole
abduction journey (and others), a `HasOneAssociationForm` concern to
simplify and DRY the fact many forms read/update attributes from a
different model to the 'main' one.

For example in the Abduction journey, the details are stored in the
`abduction_details` table, which `belongs_to` a c100_application.

There are some old form objects that we can refactor to use this
concern, once we are sure it is fit for purpose.
Also when we do this, we will extract some of the common tests to
shared examples.