### PR TITLE
Add `international` abduction step

### DIFF
--- a/app/controllers/steps/abduction/international_controller.rb
+++ b/app/controllers/steps/abduction/international_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Abduction
+    class InternationalController < Steps::AbductionStepController
+      def edit
+        @form_object = InternationalForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(InternationalForm, as: :international)
+      end
+    end
+  end
+end

--- a/app/forms/steps/abduction/international_form.rb
+++ b/app/forms/steps/abduction/international_form.rb
@@ -1,0 +1,35 @@
+module Steps
+  module Abduction
+    class InternationalForm < BaseForm
+      include HasOneAssociationForm
+
+      has_one_association :abduction_detail
+
+      attribute :international_risk, YesNo
+      attribute :passport_office_notified, YesNo
+      attribute :children_multiple_passports, YesNo
+      attribute :passport_possession_mother, Boolean
+      attribute :passport_possession_father, Boolean
+      attribute :passport_possession_other, Boolean
+      attribute :passport_possession_other_details, String
+
+      validates_inclusion_of :international_risk,
+                             :children_multiple_passports, in: GenericYesNo.values
+
+      validates_inclusion_of :passport_office_notified, in: GenericYesNo.values, if: -> { international_risk&.yes? }
+
+      validates_presence_of :passport_possession_other_details, if: :passport_possession_other?
+      validates_absence_of  :passport_possession_other_details, unless: :passport_possession_other?
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -26,6 +26,10 @@ class BaseDecisionTree
     step_params.fetch(attribute_name, '0').true?
   end
 
+  def selected?(attribute_name, value: 'yes')
+    step_params.fetch(attribute_name).eql?(value)
+  end
+
   # Enable again when needed. Coverage complains otherwise.
   # def root_path
   #   { controller: '/entrypoint', action: :v1 }

--- a/app/services/c100_app/abduction_decision_tree.rb
+++ b/app/services/c100_app/abduction_decision_tree.rb
@@ -5,9 +5,21 @@ module C100App
 
       case step_name
       when :children_have_passport
+        after_children_have_passport
+      when :international
         edit('/steps/safety_questions/substance_abuse') # TODO: change when we have next step
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+
+    private
+
+    def after_children_have_passport
+      if selected?(:children_have_passport)
+        edit(:international)
+      else
+        edit('/steps/safety_questions/substance_abuse') # TODO: change when we have next step
       end
     end
   end

--- a/app/views/steps/abduction/international/edit.html.erb
+++ b/app/views/steps/abduction/international/edit.html.erb
@@ -1,0 +1,36 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.radio_button_fieldset :international_risk, inline: true do |fieldset|
+          fieldset.radio_input(GenericYesNo::YES, panel_id: :international_risk_panel)
+          fieldset.radio_input(GenericYesNo::NO)
+          fieldset.revealing_panel(:international_risk_panel) do |panel|
+            panel.radio_button_fieldset(:passport_office_notified, inline: true, choices: GenericYesNo.values)
+            panel.content_tag(:p, t('.contact_info_html'))
+          end
+        end
+      %>
+
+      <%= f.radio_button_fieldset :children_multiple_passports, inline: true, choices: GenericYesNo.values %>
+
+      <%= f.check_box_fieldset :passport_possesion, [
+        :passport_possession_mother,
+        :passport_possession_father,
+        :passport_possession_other
+      ] %>
+
+      <!-- TODO: the following text area should be in a revealing panel triggered by -->
+      <!-- above `other` checkbox. Gem needs to support checkbox revealing panels for this. -->
+      <%= f.text_area :passport_possession_other_details, size: '40x4', class: 'form-control-3-4' %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,6 +271,14 @@ en:
         edit:
           page_title: Children have passport
           heading: Do any of your children have a passport?
+      international:
+        edit:
+          page_title: International abduction risk
+          heading: Are you worried your children will be taken out of the country?
+          contact_info_html: |
+            If you think your children are at risk of being abducted abroad you must
+            <a href="https://www.gov.uk/government/organisations/hm-passport-office" target="external_link">contact
+            the passport office</a> immediately.
 
   home:
     index:
@@ -294,6 +302,7 @@ en:
     format: "%{message}"
     messages:
       blank: Please enter an answer
+      present: Please leave empty
       inclusion: Please select an option
     error_summary:
       heading: There was a problem on the page
@@ -376,6 +385,11 @@ en:
         other_abuse_html: ""
       steps_abduction_children_have_passport_form:
         children_have_passport_html: ""
+      steps_abduction_international_form:
+        international_risk_html: ""
+        passport_office_notified_html: "Has the passport office been notified?"
+        children_multiple_passports_html: "Do the children have more than one passport?"
+        passport_possesion_html: "Who is in possession of the children’s passports?"
       steps_abuse_concerns_question_form:
         answer_html: ""
       steps_abuse_concerns_contact_form:
@@ -453,6 +467,11 @@ en:
         child_arrangements_order: Child Arrangements Order
         prohibited_steps_order: Prohibited Steps Order
         specific_issue_order: Specific Issue Order
+      steps_abduction_international_form:
+        passport_possession_mother: Mother
+        passport_possession_father: Father
+        passport_possession_other: Other
+        passport_possession_other_details: Provide more details (If 'other' is selected)
       steps_applicant_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
       steps_respondent_personal_details_form:
@@ -533,6 +552,8 @@ en:
       steps_petition_other_issue_form:
         other_details: Give a short description
         other_issue: Select any that apply
+      steps_abduction_international_form:
+        passport_possesion: Select all that apply
       steps_applicant_personal_details_form:
         birthplace: *birthplace_hint
       steps_respondent_personal_details_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     end
     namespace :abduction do
       edit_step :children_have_passport
+      edit_step :international
     end
     namespace :safety_questions do
       show_step :start

--- a/spec/controllers/steps/abduction/international_controller_spec.rb
+++ b/spec/controllers/steps/abduction/international_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Abduction::InternationalController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Abduction::InternationalForm, C100App::AbductionDecisionTree
+end

--- a/spec/forms/steps/abduction/children_have_passport_form_spec.rb
+++ b/spec/forms/steps/abduction/children_have_passport_form_spec.rb
@@ -6,62 +6,19 @@ RSpec.describe Steps::Abduction::ChildrenHavePassportForm do
     children_have_passport: 'yes'
   } }
 
-  let(:c100_application) { instance_double(C100Application, abduction_detail: abduction_detail) }
-  let(:abduction_detail) { double('abduction_detail') }
+  let(:c100_application) { instance_double(C100Application) }
 
   subject { described_class.new(arguments) }
 
   describe '#save' do
-    context 'when no c100_application is associated with the form' do
-      let(:c100_application) { nil }
-
-      it 'raises an error' do
-        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
-      end
-    end
-
     context 'validations' do
       it { should validate_presence_of(:children_have_passport, :inclusion) }
     end
 
-    context 'for valid details' do
-      let(:expected_attributes) {
-        {
-          children_have_passport: GenericYesNo::YES
-        }
-      }
-
-      context 'when record does not exist' do
-        before do
-          allow(c100_application).to receive(:abduction_detail).and_return(nil)
-        end
-
-        it 'creates the record if it does not exist' do
-          expect(c100_application).to receive(:build_abduction_detail).and_return(abduction_detail)
-
-          expect(abduction_detail).to receive(:update).with(
-            expected_attributes
-          ).and_return(true)
-
-          expect(subject.save).to be(true)
-        end
-      end
-
-      context 'when record already exists' do
-        before do
-          allow(c100_application).to receive(:abduction_detail).and_return(abduction_detail)
-        end
-
-        it 'updates the record if it already exists' do
-          expect(c100_application).not_to receive(:build_abduction_detail)
-
-          expect(abduction_detail).to receive(:update).with(
-            expected_attributes
-          ).and_return(true)
-
-          expect(subject.save).to be(true)
-        end
-      end
-    end
+    it_behaves_like 'a has-one-association form',
+                    association_name: :abduction_detail,
+                    expected_attributes: {
+                      children_have_passport: GenericYesNo::YES,
+                    }
   end
 end

--- a/spec/forms/steps/abduction/international_form_spec.rb
+++ b/spec/forms/steps/abduction/international_form_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Abduction::InternationalForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    international_risk: international_risk,
+    passport_office_notified: passport_office_notified,
+    children_multiple_passports: 'no',
+    passport_possession_mother: true,
+    passport_possession_father: false,
+    passport_possession_other: passport_possession_other,
+    passport_possession_other_details: nil
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:international_risk) { 'yes' }
+  let(:passport_office_notified) { 'no' }
+  let(:passport_possession_other) { false }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:international_risk, :inclusion) }
+      it { should validate_presence_of(:children_multiple_passports, :inclusion) }
+
+      context 'when `international_risk` is yes' do
+        let(:international_risk) { 'yes' }
+        it { should validate_presence_of(:passport_office_notified, :inclusion) }
+      end
+
+      context 'when `international_risk` is no' do
+        let(:international_risk) { 'no' }
+        it { should_not validate_presence_of(:passport_office_notified, :inclusion) }
+      end
+
+      context 'when `passport_possession_other_details` is checked' do
+        let(:passport_possession_other) { true }
+        it { should validate_presence_of(:passport_possession_other_details) }
+      end
+
+      context 'when `passport_possession_other_details` is not checked' do
+        let(:passport_possession_other) { false }
+        it { should validate_absence_of(:passport_possession_other_details) }
+      end
+    end
+
+    it_behaves_like 'a has-one-association form',
+                    association_name: :abduction_detail,
+                    expected_attributes: {
+                      international_risk: GenericYesNo::YES,
+                      passport_office_notified: GenericYesNo::NO,
+                      children_multiple_passports: GenericYesNo::NO,
+                      passport_possession_mother: true,
+                      passport_possession_father: false,
+                      passport_possession_other: false,
+                      passport_possession_other_details: nil
+                    }
+    end
+end

--- a/spec/services/c100_app/abduction_decision_tree_spec.rb
+++ b/spec/services/c100_app/abduction_decision_tree_spec.rb
@@ -5,13 +5,28 @@ RSpec.describe C100App::AbductionDecisionTree do
   let(:step_params)      { double('Step') }
   let(:next_step)        { nil }
   let(:as)               { nil }
+  let(:c100_application) { instance_double(C100Application) }
 
   subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
 
   it_behaves_like 'a decision tree'
 
   context 'when the step is `children_have_passport`' do
-    let(:step_params) { { children_have_passport: 'anything' } }
+    let(:step_params) { { children_have_passport: value } }
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+      it { is_expected.to have_destination(:international, :edit) }
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+      it { is_expected.to have_destination('/steps/safety_questions/substance_abuse', :edit) }
+    end
+  end
+
+  context 'when the step is `international`' do
+    let(:step_params) { { international: 'anything' } }
     it { is_expected.to have_destination('/steps/safety_questions/substance_abuse', :edit) }
   end
 end

--- a/spec/support/form_validation_shared_examples.rb
+++ b/spec/support/form_validation_shared_examples.rb
@@ -91,3 +91,53 @@ RSpec.shared_examples 'a yes-no question form' do |options|
     end
   end
 end
+
+RSpec.shared_examples 'a has-one-association form' do |options|
+  let(:association_name) { options[:association_name] }
+  let(:expected_attributes) { options[:expected_attributes] }
+  let(:build_method_name) { "build_#{association_name}".to_sym }
+
+  let(:association_double) { double(association_name) }
+
+  context 'when no c100_application is associated with the form' do
+    let(:c100_application) { nil }
+
+    it 'raises an error' do
+      expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+    end
+  end
+
+  context 'for valid details' do
+    context 'when record does not exist' do
+      before do
+        allow(c100_application).to receive(association_name).and_return(nil)
+      end
+
+      it 'creates the record if it does not exist' do
+        expect(c100_application).to receive(build_method_name).and_return(association_double)
+
+        expect(association_double).to receive(:update).with(
+          expected_attributes
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when record already exists' do
+      before do
+        allow(c100_application).to receive(association_name).and_return(association_double)
+      end
+
+      it 'updates the record if it already exists' do
+        expect(c100_application).not_to receive(build_method_name)
+
+        expect(association_double).to receive(:update).with(
+          expected_attributes
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/support/matchers/validation_matchers.rb
+++ b/spec/support/matchers/validation_matchers.rb
@@ -19,6 +19,27 @@ RSpec::Matchers.define :validate_presence_of do |attribute, error = :blank|
   end
 end
 
+RSpec::Matchers.define :validate_absence_of do |attribute, error = :present|
+  include ValidationHelpers
+
+  match do |object|
+    object.send("#{attribute}=", 'xxx')
+    check_errors(object, attribute, error)
+  end
+
+  description do
+    "validate_absence_of #{attribute}"
+  end
+
+  failure_message do |object|
+    "expected `#{attribute}` to have error `#{error}` but got `#{errors_for(attribute, object)}`"
+  end
+
+  failure_message_when_negated do |object|
+    "expected `#{attribute}` not to have error `#{error}` but got `#{errors_for(attribute, object)}`"
+  end
+end
+
 RSpec::Matchers.define :validate_presence_unless_unknown_of do |attribute, error = :blank|
   include ValidationHelpers
 


### PR DESCRIPTION
Also, beginning to extract some common code to shared examples. More
to come as we create more forms using `HasOneAssociationForm` concern.