### PR TITLE
Add a `start` page to Alternatives journey

### DIFF
--- a/app/controllers/steps/alternatives/start_controller.rb
+++ b/app/controllers/steps/alternatives/start_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Alternatives
+    class StartController < Steps::AlternativesStepController
+      def show; end
+    end
+  end
+end

--- a/app/services/c100_app/alternatives_decision_tree.rb
+++ b/app/services/c100_app/alternatives_decision_tree.rb
@@ -11,8 +11,6 @@ module C100App
       when :lawyer_negotiation
         edit(:collaborative_law)
       when :collaborative_law
-        edit(:court)
-      when :court
         edit('/steps/petition/orders')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"

--- a/app/services/c100_app/safety_questions_decision_tree.rb
+++ b/app/services/c100_app/safety_questions_decision_tree.rb
@@ -59,7 +59,7 @@ module C100App
       if question(:other_abuse).yes?
         start_abuse_concerns_journey
       else
-        edit('/steps/alternatives/negotiation_tools')
+        show('/steps/alternatives/start')
       end
     end
 

--- a/app/views/steps/alternatives/start/show.en.html.erb
+++ b/app/views/steps/alternatives/start/show.en.html.erb
@@ -1,0 +1,22 @@
+<% title 'Alternative ways to reach an agreement' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <div class="grid_content_header">
+      <h1 class="heading-xlarge gv-u-heading-xxlarge">Alternative ways to reach an agreement</h1>
+    </div>
+
+    <div class= govuk-govspeak gv-s-prose">
+      <p>As you have no safety concerns you should see if there’s a more suitable way to agree child arrangements than going to court.</p>
+      <p>Outcomes for children are usually better if you can reach an agreement another way. For example, mediation can be quicker than court and cheaper than using a lawyer.</p>
+      <div role="note" aria-label="Information" class=" panel panel-border-wide info-notice TODO"><p>If you can make your arrangements out of court you’ll help families in urgent situations that involve domestic abuse get to court quicker.</p>
+      </div>
+    </div>
+
+    <div class="xform-group form-submit">
+      <%= link_to 'Continue', edit_steps_alternatives_negotiation_tools_path, class: 'button', role: 'button' %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
       edit_step :details
     end
     namespace :alternatives do
+      show_step :start
       edit_step :negotiation_tools
       edit_step :mediation
       edit_step :lawyer_negotiation

--- a/spec/controllers/steps/alternatives/start_controller_spec.rb
+++ b/spec/controllers/steps/alternatives/start_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Alternatives::StartController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/services/c100_app/alternatives_decision_tree_spec.rb
+++ b/spec/services/c100_app/alternatives_decision_tree_spec.rb
@@ -27,11 +27,6 @@ RSpec.describe C100App::AlternativesDecisionTree do
 
   context 'when the step is `collaborative_law`' do
     let(:step_params) { { collaborative_law: 'anything' } }
-    it { is_expected.to have_destination(:court, :edit) }
-  end
-
-  context 'when the step is `court`' do
-    let(:step_params) { { court: 'anything' } }
     it { is_expected.to have_destination('/steps/petition/orders', :edit) }
   end
 end

--- a/spec/services/c100_app/safety_questions_decision_tree_spec.rb
+++ b/spec/services/c100_app/safety_questions_decision_tree_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe C100App::SafetyQuestionsDecisionTree do
 
     context 'and the answer is `no`' do
       let(:value) { 'no' }
-      it { is_expected.to have_destination('/steps/alternatives/negotiation_tools', :edit) }
+      it { is_expected.to have_destination('/steps/alternatives/start', :show) }
     end
   end
 end


### PR DESCRIPTION
Also, disabling for now the `court` step until prototype decides
what to do with it.