### PR TITLE
Add step `children names`

### DIFF
--- a/app/assets/stylesheets/local/buttons.scss
+++ b/app/assets/stylesheets/local/buttons.scss
@@ -1,3 +1,15 @@
 .button-secondary {
   @include button($grey-3);
 }
+
+.link-button {
+  background: none;
+  color: $link-colour;
+  border: none;
+  box-shadow: none;
+  text-decoration: underline;
+  padding-right: 50px;
+  margin: 0;
+  font-size: 19px;
+  cursor: pointer;
+}

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -37,7 +37,13 @@ class StepController < ApplicationController
   def permitted_params(form_class)
     params
       .fetch(form_class.model_name.singular, {})
-      .permit(form_attribute_names(form_class))
+      .permit(form_attribute_names(form_class) + additional_permitted_params)
+  end
+
+  # Some form objects might contain complex attribute structures or nested params.
+  # Override in subclasses to declare any additional parameters that should be permitted.
+  def additional_permitted_params
+    []
   end
 
   def form_attribute_names(form_class)

--- a/app/controllers/steps/children/names_controller.rb
+++ b/app/controllers/steps/children/names_controller.rb
@@ -1,0 +1,35 @@
+module Steps
+  module Children
+    class NamesController < Steps::ChildrenStepController
+      include CrudStep
+
+      def edit
+        @form_object = NamesForm.new(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          NamesForm,
+          as: params.fetch(:button, :names_finished)
+        )
+      end
+
+      def destroy
+        current_record.destroy
+        redirect_to action: :edit, id: nil
+      end
+
+      private
+
+      def additional_permitted_params
+        [names_attributes: [:id, :name]]
+      end
+
+      def record_collection
+        @_record_collection ||= current_c100_application.children
+      end
+    end
+  end
+end

--- a/app/forms/steps/children/names_form.rb
+++ b/app/forms/steps/children/names_form.rb
@@ -1,0 +1,40 @@
+module Steps
+  module Children
+    class NamesForm < BaseForm
+      attribute :names_attributes, Hash
+      attribute :new_name, StrippedString
+
+      validates_presence_of :new_name, if: :first_name?
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        create_new_child_with_name
+        update_existing_children_names
+
+        true
+      end
+
+      def create_new_child_with_name
+        record_collection.create(name: new_name) unless new_name.blank?
+      end
+
+      def update_existing_children_names
+        names_attributes.each_value do |attrs|
+          record_collection.update(attrs.fetch('id'), attrs) unless attrs.fetch('name').blank?
+        end
+      end
+
+      def first_name?
+        return if c100_application.nil?
+        record_collection.empty?
+      end
+
+      def record_collection
+        @_record_collection ||= c100_application.children
+      end
+    end
+  end
+end

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -4,7 +4,9 @@ module C100App
       return next_step if next_step
 
       case step_name
-      when :personal_details, :add_another_child
+      when :add_another_name, :remove_name
+        edit(:names)
+      when :names_finished, :personal_details, :add_another_child
         edit(:personal_details)
       when :children_finished
         edit(:additional_details)

--- a/app/views/steps/children/names/edit.html.erb
+++ b/app/views/steps/children/names/edit.html.erb
@@ -1,0 +1,33 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <% @existing_records.each.with_index do |child, index| %>
+        <%= f.fields_for :names_attributes, child, index: index do |c| %>
+          <span><%= t('.child_index', index: index + 1) %></span>
+          <%= c.hidden_field :id %>
+          <%= c.text_field :name %>
+        <% end %>
+      <% end %>
+
+      <%= f.text_field :new_name %>
+
+      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: 'link-button' %>
+
+      <% if @existing_records.any? %>
+        <%= link_to t('.btn_remove'), steps_children_names_path(@existing_records.last), method: :delete, class: 'link-button' %>
+      <% end %>
+
+      <div class="xform-group form-submit">
+        <%= f.submit class: 'button' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,14 @@ en:
           heading: The respondent(s)
           btn_add_another: Add another respondent
     children:
+      names:
+        edit:
+          page_title: Enter the names of your children
+          heading: Enter the names of your children
+          lead_text: Only include the children you’re making this application for
+          child_index: "Child %{index}"
+          btn_add_another: Add another child
+          btn_remove: Remove last child
       personal_details:
         edit:
           page_title: Child personal details
@@ -567,6 +575,10 @@ en:
         previous_attempt_agency_details: Provide more details
       steps_abduction_risk_details_form:
         risk_details: Give a short description
+      steps_children_names_form[names_attributes]:
+        name: Name
+      steps_children_names_form:
+        new_name: Name you normally use for your child
       steps_applicant_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
       steps_respondent_personal_details_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
     end
     namespace :children do
       show_step :instructions
+      edit_step :names, enable_crud: true
       edit_step :personal_details, enable_crud: true
       edit_step :additional_details
     end

--- a/db/migrate/20171129153909_add_name_to_children_table.rb
+++ b/db/migrate/20171129153909_add_name_to_children_table.rb
@@ -1,0 +1,5 @@
+class AddNameToChildrenTable < ActiveRecord::Migration[5.0]
+  def change
+    add_column :children, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171129123803) do
+ActiveRecord::Schema.define(version: 20171129153909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -145,6 +145,7 @@ ActiveRecord::Schema.define(version: 20171129123803) do
     t.text     "applicants_relationship"
     t.text     "respondents_relationship"
     t.uuid     "c100_application_id"
+    t.string   "name"
     t.index ["c100_application_id"], name: "index_children_on_c100_application_id", using: :btree
   end
 

--- a/spec/controllers/steps/children/names_controller_spec.rb
+++ b/spec/controllers/steps/children/names_controller_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Children::NamesController, type: :controller do
+  it_behaves_like 'an intermediate CRUD step controller',
+                  Steps::Children::NamesForm,
+                  C100App::ChildrenDecisionTree,
+                  Child
+end

--- a/spec/forms/steps/children/names_form_spec.rb
+++ b/spec/forms/steps/children/names_form_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Children::NamesForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    names_attributes: names_attributes,
+    new_name: new_name
+  } }
+
+  let(:c100_application) { instance_double(C100Application, children: children_collection) }
+  let(:children_collection) { double('children_collection', empty?: false, create: true) }
+  let(:child) { double('Child') }
+
+  let(:names_attributes) { {} }
+  let(:new_name) { 'John' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'validations on `new_name`' do
+      context 'when there are no other children names' do
+        let(:children_collection) { [] }
+        it { should validate_presence_of(:new_name) }
+      end
+
+      context 'when there are existing children names' do
+        let(:children_collection) { ['whatever'] }
+        it { should_not validate_presence_of(:new_name) }
+      end
+    end
+
+    context 'when form is valid' do
+      context 'adding new children names' do
+        let(:new_name) { 'Gareth' }
+
+        it 'it creates a new child with the provided name' do
+          expect(children_collection).to receive(:create).with(
+            name: 'Gareth'
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'if the new name is blank, ignore it' do
+        let(:new_name) { '' }
+
+        it 'it creates a new child with the provided name' do
+          expect(children_collection).not_to receive(:create)
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'updating existing children names' do
+        let(:new_name) { nil }
+        let(:names_attributes) {
+          {
+            '0' => {'id' => 'uuid1', 'name' => 'Paul'},
+            '1' => {'id' => 'uuid2', 'name' => 'Alex'}
+          }
+        }
+
+        it 'it updates the names of the children' do
+          expect(children_collection).to receive(:update).with(
+            'uuid1', {'id' => 'uuid1', 'name' => 'Paul'}
+          ).and_return(true)
+
+          expect(children_collection).to receive(:update).with(
+            'uuid2', {'id' => 'uuid2', 'name' => 'Alex'}
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'ignore blank names when updating' do
+        let(:new_name) { nil }
+        let(:names_attributes) {
+          {
+            '0' => {'id' => 'uuid1', 'name' => ''},
+            '1' => {'id' => 'uuid2', 'name' => 'Alex'}
+          }
+        }
+
+        it 'it updates the names of the children' do
+          expect(children_collection).not_to receive(:update).with(
+            'uuid1', {'id' => 'uuid1', 'name' => ''}
+          )
+
+          expect(children_collection).to receive(:update).with(
+            'uuid2', {'id' => 'uuid2', 'name' => 'Alex'}
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/children_decision_tree_spec.rb
+++ b/spec/services/c100_app/children_decision_tree_spec.rb
@@ -6,35 +6,44 @@ RSpec.describe C100App::ChildrenDecisionTree do
   let(:next_step)        { nil }
   let(:as)               { nil }
 
+  let(:c100_application) {instance_double(C100Application)}
+
   subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
 
   it_behaves_like 'a decision tree'
 
+  context 'when the step is `add_another_name`' do
+    let(:step_params) {{'add_another_name' => 'anything'}}
+    it {is_expected.to have_destination(:names, :edit)}
+  end
+
+  context 'when the step is `remove_name`' do
+    let(:step_params) {{'remove_name' => 'anything'}}
+    it {is_expected.to have_destination(:names, :edit)}
+  end
+
+  context 'when the step is `names_finished`' do
+    let(:step_params) {{'names_finished' => 'anything'}}
+    it {is_expected.to have_destination(:personal_details, :edit)}
+  end
+
   context 'when the step is `personal_details`' do
     let(:step_params) {{'personal_details' => 'anything'}}
-    let(:c100_application) {instance_double(C100Application, number_of_children: 1)}
-
     it {is_expected.to have_destination(:personal_details, :edit)}
   end
 
   context 'when the step is `add_another_child`' do
     let(:step_params) {{'add_another_child' => 'anything'}}
-    let(:c100_application) {instance_double(C100Application)}
-
     it {is_expected.to have_destination(:personal_details, :edit)}
   end
 
   context 'when the step is `children_finished`' do
     let(:step_params) {{'children_finished' => 'anything'}}
-    let(:c100_application) {instance_double(C100Application)}
-
     it {is_expected.to have_destination(:additional_details, :edit)}
   end
 
   context 'when the step is `additional_details`' do
     let(:step_params) {{'additional_details' => 'anything'}}
-    let(:c100_application) {instance_double(C100Application)}
-
     it {is_expected.to have_destination('/steps/applicant/personal_details', :edit)}
   end
 end


### PR DESCRIPTION
This is a step using most of the code already created for the concern
`CrudStep` but with some modifications in the form object to be able to
create several children records at once, or update existing ones.

Next children steps now need to be adapted to use the children records
created by this step, to match the prototype, as these are now outdated.
This will be done in a follow-up PR.

<img width="661" alt="screen shot 2017-12-01 at 10 30 11" src="https://user-images.githubusercontent.com/687910/33478860-aa570106-d682-11e7-906e-8232fb096bac.png">
