### PR TITLE
Redo children details

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -12,15 +12,17 @@ class StepController < ApplicationController
 
   def update_and_advance(form_class, opts = {})
     hash = permitted_params(form_class).to_h
+    record = opts[:record]
 
     @next_step   = params[:next_step].presence
     @form_object = form_class.new(
-      hash.merge(c100_application: current_c100_application, record_id: opts[:record_id])
+      hash.merge(c100_application: current_c100_application, record: record)
     )
 
     if @form_object.save
       destination = decision_tree_class.new(
         c100_application: current_c100_application,
+        record:        record,
         step_params:   hash,
         # Used when the step name in the decision tree is not the same as the first
         # (and usually only) attribute in the form.

--- a/app/controllers/steps/applicant/personal_details_controller.rb
+++ b/app/controllers/steps/applicant/personal_details_controller.rb
@@ -12,7 +12,7 @@ module Steps
       def update
         update_and_advance(
           PersonalDetailsForm,
-          record_id: current_record.id,
+          record: current_record,
           as: params.fetch(:button, :applicants_finished)
         )
       end

--- a/app/controllers/steps/children/personal_details_controller.rb
+++ b/app/controllers/steps/children/personal_details_controller.rb
@@ -12,8 +12,8 @@ module Steps
       def update
         update_and_advance(
           PersonalDetailsForm,
-          record_id: current_record.id,
-          as: params.fetch(:button, :children_finished)
+          record: current_record,
+          as: :personal_details
         )
       end
 

--- a/app/controllers/steps/respondent/personal_details_controller.rb
+++ b/app/controllers/steps/respondent/personal_details_controller.rb
@@ -12,7 +12,7 @@ module Steps
       def update
         update_and_advance(
           PersonalDetailsForm,
-          record_id: current_record.id,
+          record: current_record,
           as: params.fetch(:button, :respondents_finished)
         )
       end

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -6,7 +6,7 @@ class BaseForm
   extend ActiveModel::Callbacks
 
   attr_accessor :c100_application
-  attr_accessor :record_id
+  attr_accessor :record
 
   # This will allow subclasses to define after_initialize callbacks
   # and is needed for some functionality to work, i.e. acts_as_gov_uk_date
@@ -22,7 +22,7 @@ class BaseForm
 
     attributes.merge!(
       c100_application: c100_application || record,
-      record_id: record.id
+      record: record
     )
 
     new(attributes)
@@ -72,10 +72,8 @@ class BaseForm
 
   private
 
-  # This can be overridden by more specific implementations, for example as we do
-  # within the `HasOneAssociationForm` concern. The default is always the 'main' model.
-  def record
-    c100_application
+  def record_id
+    record&.id
   end
 
   # :nocov:

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -76,6 +76,13 @@ class BaseForm
     record&.id
   end
 
+  # When using concerns like `HasOneAssociationForm` or `SingleQuestionForm`, this ensures
+  # a common interface to always have the correct record being updated in the `persist!` method.
+  # The default is the main model, i.e. `c100_application` unless overridden by subclasses.
+  def record_to_persist
+    c100_application
+  end
+
   # :nocov:
   def persist!
     raise 'Subclasses of BaseForm need to implement #persist!'

--- a/app/forms/concerns/has_one_association_form.rb
+++ b/app/forms/concerns/has_one_association_form.rb
@@ -18,4 +18,10 @@ module HasOneAssociationForm
       self.association_name = name
     end
   end
+
+  private
+
+  def record_to_persist
+    @_record_to_persist ||= self.class.associated_record(c100_application)
+  end
 end

--- a/app/forms/concerns/has_one_association_form.rb
+++ b/app/forms/concerns/has_one_association_form.rb
@@ -5,10 +5,10 @@ module HasOneAssociationForm
     attr_accessor :association_name
 
     def build(c100_application:)
-      super(record(c100_application), c100_application: c100_application)
+      super(associated_record(c100_application), c100_application: c100_application)
     end
 
-    def record(parent)
+    def associated_record(parent)
       parent.public_send(association_name) || parent.public_send("build_#{association_name}")
     end
 
@@ -17,11 +17,5 @@ module HasOneAssociationForm
     def has_one_association(name)
       self.association_name = name
     end
-  end
-
-  private
-
-  def record
-    @_record ||= self.class.record(c100_application)
   end
 end

--- a/app/forms/concerns/single_question_form.rb
+++ b/app/forms/concerns/single_question_form.rb
@@ -30,7 +30,7 @@ module SingleQuestionForm
   def persist!
     raise BaseForm::C100ApplicationNotFound unless c100_application
 
-    record.update(
+    record_to_persist.update(
       attributes_map.merge(attributes_to_reset)
     )
   end

--- a/app/forms/steps/abduction/international_form.rb
+++ b/app/forms/steps/abduction/international_form.rb
@@ -26,7 +26,7 @@ module Steps
       def persist!
         raise C100ApplicationNotFound unless c100_application
 
-        record.update(
+        record_to_persist.update(
           attributes_map
         )
       end

--- a/app/forms/steps/abduction/previous_attempt_details_form.rb
+++ b/app/forms/steps/abduction/previous_attempt_details_form.rb
@@ -19,7 +19,7 @@ module Steps
       def persist!
         raise C100ApplicationNotFound unless c100_application
 
-        record.update(
+        record_to_persist.update(
           attributes_map
         )
       end

--- a/app/forms/steps/abduction/risk_details_form.rb
+++ b/app/forms/steps/abduction/risk_details_form.rb
@@ -14,7 +14,7 @@ module Steps
       def persist!
         raise C100ApplicationNotFound unless c100_application
 
-        record.update(
+        record_to_persist.update(
           attributes_map
         )
       end

--- a/app/forms/steps/children/personal_details_form.rb
+++ b/app/forms/steps/children/personal_details_form.rb
@@ -28,8 +28,8 @@ module Steps
       def persist!
         raise C100ApplicationNotFound unless c100_application
 
-        applicant = c100_application.children.find_or_initialize_by(id: record_id)
-        applicant.update(
+        child = c100_application.children.find_or_initialize_by(id: record_id)
+        child.update(
           # Some attributes are value objects and thus we need to provide their values
           attributes_map.merge(
             gender: gender_value

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  scope :persisted, -> { where.not(id: nil).order(created_at: :asc) }
+  scope :persisted, -> { where.not(id: nil) }
 
   def self.has_value_object(value_object, constructor: nil, class_name: nil)
     composed_of value_object,

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -5,10 +5,12 @@ class C100Application < ApplicationRecord
   has_one  :asking_order,     dependent: :destroy
   has_one  :court_order,      dependent: :destroy
 
-  has_many :abuse_concerns, dependent: :destroy
-  has_many :children,       dependent: :destroy
-  has_many :applicants,     dependent: :destroy
-  has_many :respondents,    dependent: :destroy
+  has_many :abuse_concerns,   dependent: :destroy
+
+  # Remember, we are using UUIDs as the record IDs, we can't rely on ID sequential ordering
+  has_many :children,    -> { order(created_at: :asc) }, dependent: :destroy
+  has_many :applicants,  -> { order(created_at: :asc) }, dependent: :destroy
+  has_many :respondents, -> { order(created_at: :asc) }, dependent: :destroy
 
   has_value_object :user_type
   has_value_object :help_paying

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -3,10 +3,11 @@ class BaseDecisionTree
 
   include ApplicationHelper
 
-  attr_reader :c100_application, :step_params, :as, :next_step
+  attr_reader :c100_application, :record, :step_params, :as, :next_step
 
-  def initialize(c100_application:, step_params: {}, as: nil, next_step: nil)
+  def initialize(c100_application:, record: nil, step_params: {}, as: nil, next_step: nil)
     @c100_application = c100_application
+    @record = record
     @step_params = step_params
     @as = as
     @next_step = next_step

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -6,14 +6,39 @@ module C100App
       case step_name
       when :add_another_name
         edit(:names)
-      when :names_finished, :personal_details, :add_another_child
-        edit(:personal_details)
-      when :children_finished
-        edit(:additional_details)
+      when :names_finished
+        after_names_finished
+      when :personal_details
+        after_personal_details
       when :additional_details
-        edit('/steps/applicant/personal_details')
+        edit('/steps/applicant/personal_details') # TODO: change once we have the `other children` journey
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+
+    private
+
+    def after_names_finished
+      edit(:personal_details, id: next_child)
+    end
+
+    def after_personal_details
+      if next_child
+        edit(:personal_details, id: next_child)
+      else
+        edit(:additional_details)
+      end
+    end
+
+    def next_child
+      @_next_child ||= begin
+        ids = c100_application.child_ids
+
+        return ids.first if record.nil?
+
+        pos = ids.index(record.id)
+        ids.at(pos + 1)
       end
     end
   end

--- a/app/views/steps/children/personal_details/_child_row.html.erb
+++ b/app/views/steps/children/personal_details/_child_row.html.erb
@@ -1,7 +1,0 @@
-<li>
-  <%= child.full_name %> (<%= child.id %>)
-  <span class="right actions actions-tight">
-    <%= link_to 'edit', edit_steps_children_personal_details_path(child), class: 'button' %>
-    <%= button_to 'delete', steps_children_personal_details_path(child), method: :delete, data: {confirm: 'Are you sure?'}, class: 'button button-secondary' %>
-  </span>
-</li>

--- a/app/views/steps/children/personal_details/edit.html.erb
+++ b/app/views/steps/children/personal_details/edit.html.erb
@@ -4,17 +4,7 @@
   <div class="column-two-thirds">
     <%= step_header %>
 
-    <!-- This is just for the sake of having a functional CRUD. Pending UI/UX. -->
-    <% if @existing_records.any? %>
-      <p>Saved children:</p>
-      <ul class="list list-bullet">
-        <% @existing_records.each do |child| %>
-          <%= render partial: 'child_row', locals: {child: child} %>
-        <% end %>
-      </ul>
-    <% end %>
-
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: 'ChangeMe' %></h1>
 
     <%= step_form @form_object do |f| %>
       <%= f.text_field :full_name, class: 'form-control' %>
@@ -31,10 +21,7 @@
       <%= f.radio_button_fieldset :gender, inline: true,
         choices: Steps::Children::PersonalDetailsForm.gender_choices %>
 
-      <div class="xform-group form-submit">
-        <%= f.submit class: 'button' %>
-        <%= f.button t('.btn_add_another'), class: 'button', type: :submit, value: :add_another_child %>
-      </div>
+      <%= f.submit class: 'button' %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/children/personal_details/edit.html.erb
+++ b/app/views/steps/children/personal_details/edit.html.erb
@@ -4,7 +4,7 @@
   <div class="column-two-thirds">
     <%= step_header %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: 'ChangeMe' %></h1>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.name %></h1>
 
     <%= step_form @form_object do |f| %>
       <%= f.text_field :full_name, class: 'form-control' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,8 +124,7 @@ en:
       personal_details:
         edit:
           page_title: Child personal details
-          heading: Child details
-          btn_add_another: Add another child
+          heading: "Provide details for %{name}"
       additional_details:
         edit:
           page_title: Further information about the child(ren)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,17 @@
 # :nocov:
 class ActionDispatch::Routing::Mapper
-  def edit_step(name, opts = {}, &block)
+  def edit_step(name, &block)
     resource name,
              only:       [:edit, :update],
              controller: name,
-             path_names: { edit: '' } do
+             path_names: { edit: '' } do; block.call if block_given?; end
+  end
 
-      resources only:       [:edit, :update, :destroy],
+  def crud_step(name, opts = {})
+    edit_step name do
+      resources only: opts.fetch(:only, [:edit, :update, :destroy]),
                 controller: name,
-                path_names: { edit: '' } if opts.fetch(:enable_crud, false)
-
-      block.call if block_given?
+                path_names: { edit: '' }
     end
   end
 
@@ -90,17 +91,17 @@ Rails.application.routes.draw do
       edit_step :court
     end
     namespace :children do
-      edit_step :names, enable_crud: true
-      edit_step :personal_details, enable_crud: true
+      crud_step :names
+      crud_step :personal_details, only: [:edit, :update]
       edit_step :additional_details
     end
     namespace :applicant do
       edit_step :user_type
       edit_step :number_of_children
-      edit_step :personal_details, enable_crud: true
+      crud_step :personal_details
     end
     namespace :respondent do
-      edit_step :personal_details, enable_crud: true
+      crud_step :personal_details
     end
     namespace :help_with_fees do
       edit_step :help_paying

--- a/spec/controllers/steps/children/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/children/personal_details_controller_spec.rb
@@ -1,8 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Children::PersonalDetailsController, type: :controller do
-  it_behaves_like 'an intermediate CRUD step controller',
-                  Steps::Children::PersonalDetailsForm,
-                  C100App::ChildrenDecisionTree,
-                  Child
+  it_behaves_like 'an intermediate step controller', Steps::Children::PersonalDetailsForm, C100App::ChildrenDecisionTree
 end

--- a/spec/forms/steps/applicant/personal_details_form_spec.rb
+++ b/spec/forms/steps/applicant/personal_details_form_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Steps::Applicant::PersonalDetailsForm do
   let(:arguments) { {
     c100_application: c100_application,
-    record_id: record_id,
+    record: record,
     full_name: full_name,
     has_previous_name: has_previous_name,
     previous_full_name: previous_full_name,
@@ -19,9 +19,9 @@ RSpec.describe Steps::Applicant::PersonalDetailsForm do
 
   let(:c100_application) { instance_double(C100Application, applicants: applicants_collection) }
   let(:applicants_collection) { double('applicants_collection') }
-  let(:applicant) { double('Applicant') }
+  let(:applicant) { double('Applicant', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
 
-  let(:record_id) { nil }
+  let(:record) { nil }
   let(:full_name) { 'Full Name' }
   let(:has_previous_name) { 'no' }
   let(:previous_full_name) { nil }
@@ -138,6 +138,8 @@ RSpec.describe Steps::Applicant::PersonalDetailsForm do
       }
 
       context 'when record does not exist' do
+        let(:record) { nil }
+
         it 'creates the record if it does not exist' do
           expect(applicants_collection).to receive(:find_or_initialize_by).with(
             id: nil
@@ -152,7 +154,7 @@ RSpec.describe Steps::Applicant::PersonalDetailsForm do
       end
 
       context 'when record already exists' do
-        let(:record_id) { 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6' }
+        let(:record) { applicant }
 
         it 'updates the record if it already exists' do
           expect(applicants_collection).to receive(:find_or_initialize_by).with(

--- a/spec/forms/steps/children/personal_details_form_spec.rb
+++ b/spec/forms/steps/children/personal_details_form_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Steps::Children::PersonalDetailsForm do
   let(:arguments) { {
     c100_application: c100_application,
-    record_id: record_id,
+    record: record,
     full_name: full_name,
     gender: gender,
     dob: dob,
@@ -12,9 +12,9 @@ RSpec.describe Steps::Children::PersonalDetailsForm do
 
   let(:c100_application) { instance_double(C100Application, children: children_collection) }
   let(:children_collection) { double('children_collection') }
-  let(:child) { double('Child') }
+  let(:child) { double('Child', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
 
-  let(:record_id) { nil }
+  let(:record) { nil }
   let(:full_name) { 'Full Name' }
   let(:gender) { 'male' }
   let(:dob) { Date.today }
@@ -84,6 +84,8 @@ RSpec.describe Steps::Children::PersonalDetailsForm do
       }
 
       context 'when record does not exist' do
+        let(:record) { nil }
+
         it 'creates the record if it does not exist' do
           expect(children_collection).to receive(:find_or_initialize_by).with(
             id: nil
@@ -98,7 +100,7 @@ RSpec.describe Steps::Children::PersonalDetailsForm do
       end
 
       context 'when record already exists' do
-        let(:record_id) { 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6' }
+        let(:record) { child }
 
         it 'updates the record if it already exists' do
           expect(children_collection).to receive(:find_or_initialize_by).with(

--- a/spec/forms/steps/respondent/personal_details_form_spec.rb
+++ b/spec/forms/steps/respondent/personal_details_form_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Steps::Respondent::PersonalDetailsForm do
   let(:arguments) { {
     c100_application: c100_application,
-    record_id: record_id,
+    record: record,
     full_name: full_name,
     has_previous_name: has_previous_name,
     previous_full_name: previous_full_name,
@@ -23,9 +23,9 @@ RSpec.describe Steps::Respondent::PersonalDetailsForm do
 
   let(:c100_application) { instance_double(C100Application, respondents: respondents_collection) }
   let(:respondents_collection) { double('respondents_collection') }
-  let(:respondent) { double('Respondent') }
+  let(:respondent) { double('Respondent', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
 
-  let(:record_id) { nil }
+  let(:record) { nil }
   let(:full_name) { 'Full Name' }
   let(:has_previous_name) { 'no' }
   let(:previous_full_name) { nil }
@@ -162,6 +162,8 @@ RSpec.describe Steps::Respondent::PersonalDetailsForm do
       }
 
       context 'when record does not exist' do
+        let(:record) { nil }
+
         it 'creates the record if it does not exist' do
           expect(respondents_collection).to receive(:find_or_initialize_by).with(
             id: nil
@@ -176,7 +178,7 @@ RSpec.describe Steps::Respondent::PersonalDetailsForm do
       end
 
       context 'when record already exists' do
-        let(:record_id) { 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6' }
+        let(:record) { respondent }
 
         it 'updates the record if it already exists' do
           expect(respondents_collection).to receive(:find_or_initialize_by).with(

--- a/spec/services/c100_app/children_decision_tree_spec.rb
+++ b/spec/services/c100_app/children_decision_tree_spec.rb
@@ -5,10 +5,19 @@ RSpec.describe C100App::ChildrenDecisionTree do
   let(:step_params)      { double('Step') }
   let(:next_step)        { nil }
   let(:as)               { nil }
+  let(:record)           { nil }
 
   let(:c100_application) {instance_double(C100Application)}
 
-  subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
+  subject {
+    described_class.new(
+      c100_application: c100_application,
+      record: record,
+      step_params: step_params,
+      as: as,
+      next_step: next_step
+    )
+  }
 
   it_behaves_like 'a decision tree'
 
@@ -19,22 +28,29 @@ RSpec.describe C100App::ChildrenDecisionTree do
 
   context 'when the step is `names_finished`' do
     let(:step_params) {{'names_finished' => 'anything'}}
-    it {is_expected.to have_destination(:personal_details, :edit)}
+    let(:c100_application) {instance_double(C100Application, child_ids: [1, 2, 3])}
+
+    it 'goes to edit the details of the first child' do
+      expect(subject.destination).to eq(controller: :personal_details, action: :edit, id: 1)
+    end
   end
 
   context 'when the step is `personal_details`' do
     let(:step_params) {{'personal_details' => 'anything'}}
-    it {is_expected.to have_destination(:personal_details, :edit)}
-  end
+    let(:c100_application) {instance_double(C100Application, child_ids: [1, 2, 3])}
 
-  context 'when the step is `add_another_child`' do
-    let(:step_params) {{'add_another_child' => 'anything'}}
-    it {is_expected.to have_destination(:personal_details, :edit)}
-  end
+    context 'when there are remaining children' do
+      let(:record) { double('Child', id: 1) }
 
-  context 'when the step is `children_finished`' do
-    let(:step_params) {{'children_finished' => 'anything'}}
-    it {is_expected.to have_destination(:additional_details, :edit)}
+      it 'goes to edit the details of the next child' do
+        expect(subject.destination).to eq(controller: :personal_details, action: :edit, id: 2)
+      end
+    end
+
+    context 'when all children have been edited' do
+      let(:record) { double('Child', id: 3) }
+      it {is_expected.to have_destination(:additional_details, :edit)}
+    end
   end
 
   context 'when the step is `additional_details`' do


### PR DESCRIPTION
For more complex views, like cycling through all the created children
and editing their details, also showing the child name being edited
in the view, we need a bit of refactor, to have always handy the current
record being edited.

We will need to apply the same changes to to applicants/respondents too.