### PR TITLE
Add `other children` journey

### DIFF
--- a/app/controllers/steps/other_children/names_controller.rb
+++ b/app/controllers/steps/other_children/names_controller.rb
@@ -1,0 +1,35 @@
+module Steps
+  module OtherChildren
+    class NamesController < Steps::OtherChildrenStepController
+      include CrudStep
+
+      def edit
+        @form_object = NamesForm.new(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          NamesForm,
+          as: params.fetch(:button, :names_finished)
+        )
+      end
+
+      def destroy
+        current_record.destroy
+        redirect_to action: :edit, id: nil
+      end
+
+      private
+
+      def additional_permitted_params
+        [names_attributes: [:id, :full_name]]
+      end
+
+      def record_collection
+        @_record_collection ||= current_c100_application.children.secondary
+      end
+    end
+  end
+end

--- a/app/controllers/steps/other_children/personal_details_controller.rb
+++ b/app/controllers/steps/other_children/personal_details_controller.rb
@@ -1,0 +1,27 @@
+module Steps
+  module OtherChildren
+    class PersonalDetailsController < Steps::OtherChildrenStepController
+      include CrudStep
+
+      def edit
+        @form_object = PersonalDetailsForm.build(
+          current_record, c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          PersonalDetailsForm,
+          record: current_record,
+          as: :personal_details
+        )
+      end
+
+      private
+
+      def record_collection
+        @_record_collection ||= current_c100_application.children.secondary
+      end
+    end
+  end
+end

--- a/app/controllers/steps/other_children_step_controller.rb
+++ b/app/controllers/steps/other_children_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class OtherChildrenStepController < StepController
+    private
+
+    def decision_tree_class
+      C100App::OtherChildrenDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/other_children/names_form.rb
+++ b/app/forms/steps/other_children/names_form.rb
@@ -1,0 +1,46 @@
+module Steps
+  module OtherChildren
+    class NamesForm < BaseForm
+      attribute :names_attributes, Hash
+      attribute :new_name, StrippedString
+
+      validates_presence_of :new_name, if: :first_name?
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        create_new_child_with_name
+        update_existing_children_names
+
+        true
+      end
+
+      def create_new_child_with_name
+        return if new_name.blank?
+
+        record_collection.create(
+          full_name: new_name,
+          kind: ChildrenType::SECONDARY
+        )
+      end
+
+      def update_existing_children_names
+        names_attributes.each_value do |attrs|
+          next if attrs.fetch('full_name').blank?
+          record_collection.update(attrs.fetch('id'), attrs)
+        end
+      end
+
+      def first_name?
+        return if c100_application.nil?
+        record_collection.empty?
+      end
+
+      def record_collection
+        @_record_collection ||= c100_application.children.secondary
+      end
+    end
+  end
+end

--- a/app/forms/steps/other_children/personal_details_form.rb
+++ b/app/forms/steps/other_children/personal_details_form.rb
@@ -1,0 +1,42 @@
+module Steps
+  module OtherChildren
+    class PersonalDetailsForm < BaseForm
+      include GovUkDateFields::ActsAsGovUkDate
+
+      attribute :gender, String
+      attribute :dob, Date
+      attribute :dob_unknown, Boolean
+
+      acts_as_gov_uk_date :dob
+
+      def self.gender_choices
+        Gender.string_values
+      end
+      validates_inclusion_of :gender, in: gender_choices
+
+      validates_presence_of :dob, unless: :dob_unknown?
+
+      private
+
+      def gender_value
+        Gender.new(gender)
+      end
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        child = c100_application.children.find_or_initialize_by(
+          id: record_id,
+          kind: ChildrenType::SECONDARY.to_s
+        )
+
+        child.update(
+          # Some attributes are value objects and thus we need to provide their values
+          attributes_map.merge(
+            gender: gender_value
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -2,4 +2,7 @@ class Child < ApplicationRecord
   belongs_to :c100_application
 
   has_value_object :gender
+
+  scope :principal, -> { where(kind: ChildrenType::PRINCIPAL.to_s) }
+  scope :secondary, -> { where(kind: ChildrenType::SECONDARY.to_s) }
 end

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -35,7 +35,7 @@ module C100App
 
     def after_other_children
       if question(:other_children).yes?
-        edit(:other_children) # TODO: change when we have `other children` journey
+        edit('/steps/other_children/names')
       else
         edit('/steps/applicant/personal_details')
       end

--- a/app/services/c100_app/other_children_decision_tree.rb
+++ b/app/services/c100_app/other_children_decision_tree.rb
@@ -7,9 +7,36 @@ module C100App
       when :add_another_name
         edit(:names)
       when :names_finished
-        edit('/steps/applicant/personal_details') # TODO: change when we have more steps
+        after_names_finished
+      when :personal_details
+        after_personal_details
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+
+    private
+
+    def after_names_finished
+      edit(:personal_details, id: next_child)
+    end
+
+    def after_personal_details
+      if next_child
+        edit(:personal_details, id: next_child)
+      else
+        edit('/steps/applicant/personal_details')
+      end
+    end
+
+    def next_child
+      @_next_child ||= begin
+        ids = c100_application.children.secondary.pluck(:id)
+
+        return ids.first if record.nil?
+
+        pos = ids.index(record.id)
+        ids.at(pos + 1)
       end
     end
   end

--- a/app/services/c100_app/other_children_decision_tree.rb
+++ b/app/services/c100_app/other_children_decision_tree.rb
@@ -1,0 +1,16 @@
+module C100App
+  class OtherChildrenDecisionTree < BaseDecisionTree
+    def destination
+      return next_step if next_step
+
+      case step_name
+      when :add_another_name
+        edit(:names)
+      when :names_finished
+        edit('/steps/applicant/personal_details') # TODO: change when we have more steps
+      else
+        raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+  end
+end

--- a/app/value_objects/children_type.rb
+++ b/app/value_objects/children_type.rb
@@ -1,0 +1,6 @@
+class ChildrenType < ValueObject
+  VALUES = [
+    PRINCIPAL = new(:principal),
+    SECONDARY = new(:secondary)
+  ].freeze
+end

--- a/app/views/steps/other_children/names/edit.html.erb
+++ b/app/views/steps/other_children/names/edit.html.erb
@@ -1,0 +1,31 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <% @existing_records.each.with_index do |child, index| %>
+        <%= f.fields_for :names_attributes, child, index: index do |c| %>
+          <span><%= t('.child_index', index: index + 1) %></span>
+          <%= c.hidden_field :id %>
+          <%= c.text_field :full_name %>
+        <% end %>
+      <% end %>
+
+      <%= f.text_field :new_name %>
+
+      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: 'link-button' %>
+
+      <% if @existing_records.any? %>
+        <%= link_to t('.btn_remove'), steps_other_children_names_path(@existing_records.last), method: :delete, class: 'link-button' %>
+      <% end %>
+
+      <div class="xform-group form-submit">
+        <%= f.submit class: 'button' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/other_children/personal_details/edit.html.erb
+++ b/app/views/steps/other_children/personal_details/edit.html.erb
@@ -1,0 +1,27 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">
+      <%=t '.heading', name: @form_object.record.full_name %>
+    </h1>
+
+    <%= step_form @form_object do |f| %>
+      <div class="form-group">
+        <%= f.gov_uk_date_field :dob,
+          placeholders: true,
+          legend_text: t('shared.form_elements.dob'),
+          legend_class: 'form-label-bold',
+          form_hint_text: '' %>
+      </div>
+      <%= f.check_box_fieldset :dob_unknown, [:dob_unknown] %>
+
+      <%= f.radio_button_fieldset :gender, inline: true,
+        choices: Steps::Children::PersonalDetailsForm.gender_choices %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,10 @@ en:
           child_index: "Child %{index}"
           btn_add_another: Add another child
           btn_remove: Remove last child
+      personal_details:
+        edit:
+          page_title: Child personal details
+          heading: "Provide details for %{name}"
     abuse_concerns:
       question:
         edit:
@@ -542,6 +546,8 @@ en:
         children_residence: Who do the children currently live with?
       steps_children_other_children_form:
         other_children_html: ""
+      steps_other_children_personal_details_form:
+        dob_unknown_html: ""
     label:
       steps_applicant_user_type_form:
         user_type:
@@ -599,6 +605,8 @@ en:
       steps_applicant_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
       steps_respondent_personal_details_form:
+        <<: *PERSONAL_DETAILS_FIELDS
+      steps_other_children_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
       steps_children_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,14 @@ en:
         edit:
           page_title: Other children required
           heading: Do you have other children that aren’t part of this application?
+    other_children:
+      names:
+        edit:
+          page_title: Other children
+          heading: Enter your other child’s name
+          child_index: "Child %{index}"
+          btn_add_another: Add another child
+          btn_remove: Remove last child
     abuse_concerns:
       question:
         edit:
@@ -584,6 +592,10 @@ en:
         name: Name
       steps_children_names_form:
         new_name: Name you normally use for your child
+      steps_other_children_names_form:
+        new_name: Full name of child
+      steps_other_children_names_form[names_attributes]:
+        name: Full name
       steps_applicant_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
       steps_respondent_personal_details_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,9 @@ Rails.application.routes.draw do
       edit_step :additional_details
       edit_step :other_children
     end
+    namespace :other_children do
+      crud_step :names
+    end
     namespace :applicant do
       edit_step :user_type
       edit_step :number_of_children

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
     end
     namespace :other_children do
       crud_step :names
+      crud_step :personal_details, only: [:edit, :update]
     end
     namespace :applicant do
       edit_step :user_type

--- a/spec/controllers/steps/other_children/names_controller_spec.rb
+++ b/spec/controllers/steps/other_children/names_controller_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Steps::OtherChildren::NamesController, type: :controller do
+  it_behaves_like 'an intermediate CRUD step controller',
+                  Steps::OtherChildren::NamesForm,
+                  C100App::OtherChildrenDecisionTree,
+                  Child
+end

--- a/spec/controllers/steps/other_children/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/other_children/personal_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::OtherChildren::PersonalDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::OtherChildren::PersonalDetailsForm, C100App::OtherChildrenDecisionTree
+end

--- a/spec/forms/steps/other_children/names_form_spec.rb
+++ b/spec/forms/steps/other_children/names_form_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Steps::OtherChildren::NamesForm do
     end
 
     context 'when form is valid' do
+      before do
+        expect(children_collection).to receive(:secondary).and_return(children_collection)
+      end
+
       context 'adding new children names' do
         let(:new_name) { 'Gareth XYZ' }
 

--- a/spec/forms/steps/other_children/names_form_spec.rb
+++ b/spec/forms/steps/other_children/names_form_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+RSpec.describe Steps::OtherChildren::NamesForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    names_attributes: names_attributes,
+    new_name: new_name
+  } }
+
+  let(:c100_application) { instance_double(C100Application, children: children_collection) }
+  let(:children_collection) { double('children_collection', empty?: false, create: true) }
+  let(:child) { double('Child') }
+
+  let(:names_attributes) { {} }
+  let(:new_name) { 'John Doe' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    before do
+      allow(children_collection).to receive(:secondary).and_return(children_collection)
+    end
+
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'validations on `new_name`' do
+      context 'when there are no other children names' do
+        it {
+          expect(children_collection).to receive(:empty?).and_return(true)
+          should validate_presence_of(:new_name)
+        }
+      end
+
+      context 'when there are existing children names' do
+        it {
+          expect(children_collection).to receive(:empty?).and_return(false)
+          should_not validate_presence_of(:new_name)
+        }
+      end
+    end
+
+    context 'when form is valid' do
+      context 'adding new children names' do
+        let(:new_name) { 'Gareth XYZ' }
+
+        it 'it creates a new child with the provided name' do
+          expect(children_collection).to receive(:create).with(
+            full_name: 'Gareth XYZ',
+            kind: ChildrenType::SECONDARY
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'if the new name is blank, ignore it' do
+        let(:new_name) { '' }
+
+        it 'it creates a new child with the provided name' do
+          expect(children_collection).not_to receive(:create)
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'updating existing children names' do
+        let(:new_name) { nil }
+        let(:names_attributes) {
+          {
+            '0' => {'id' => 'uuid1', 'full_name' => 'Paul A'},
+            '1' => {'id' => 'uuid2', 'full_name' => 'Alex B'}
+          }
+        }
+
+        it 'it updates the names of the children' do
+          expect(children_collection).to receive(:update).with(
+            'uuid1', {'id' => 'uuid1', 'full_name' => 'Paul A'}
+          ).and_return(true)
+
+          expect(children_collection).to receive(:update).with(
+              'uuid2', {'id' => 'uuid2', 'full_name' => 'Alex B'}
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'ignore blank names when updating' do
+        let(:new_name) { nil }
+        let(:names_attributes) {
+          {
+            '0' => {'id' => 'uuid1', 'full_name' => ''},
+            '1' => {'id' => 'uuid2', 'full_name' => 'Alex'}
+          }
+        }
+
+        it 'it updates the names of the children' do
+          expect(children_collection).not_to receive(:update).with(
+            'uuid1', {'id' => 'uuid1', 'full_name' => ''}
+          )
+
+          expect(children_collection).to receive(:update).with(
+            'uuid2', {'id' => 'uuid2', 'full_name' => 'Alex'}
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/other_children/personal_details_form_spec.rb
+++ b/spec/forms/steps/other_children/personal_details_form_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+RSpec.describe Steps::OtherChildren::PersonalDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    record: record,
+    gender: gender,
+    dob: dob,
+    dob_unknown: dob_unknown
+  } }
+
+  let(:c100_application) { instance_double(C100Application, children: children_collection) }
+  let(:children_collection) { double('children_collection') }
+  let(:child) { double('Child', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
+
+  let(:record) { nil }
+  let(:gender) { 'male' }
+  let(:dob) { Date.today }
+  let(:dob_unknown) { false }
+
+  subject { described_class.new(arguments) }
+
+  describe '.gender_choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.gender_choices).to eq(%w(female male))
+    end
+  end
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'gender' do
+      context 'when attribute is not given' do
+        let(:gender) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:gender]).to_not be_empty
+        end
+      end
+
+      context 'when attribute value is not valid' do
+        let(:gender) {'INVALID VALUE'}
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:gender]).to_not be_empty
+        end
+      end
+    end
+
+    context 'validations on field presence unless `unknown`' do
+      it {should validate_presence_unless_unknown_of(:dob)}
+    end
+
+    context 'for valid details' do
+      let(:expected_attributes) {
+        {
+          gender: Gender::MALE,
+          dob: Date.today,
+          dob_unknown: false
+        }
+      }
+
+      context 'when record does not exist' do
+        let(:record) { nil }
+
+        it 'creates the record if it does not exist' do
+          expect(children_collection).to receive(:find_or_initialize_by).with(
+            id: nil,
+            kind: 'secondary'
+          ).and_return(child)
+
+          expect(child).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when record already exists' do
+        let(:record) { child }
+
+        it 'updates the record if it already exists' do
+          expect(children_collection).to receive(:find_or_initialize_by).with(
+            id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6',
+            kind: 'secondary'
+          ).and_return(child)
+
+          expect(child).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/children_decision_tree_spec.rb
+++ b/spec/services/c100_app/children_decision_tree_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe C100App::ChildrenDecisionTree do
 
     context 'and the answer is `yes`' do
       let(:value) { 'yes' }
-      it { is_expected.to have_destination(:other_children, :edit) }
+      it { is_expected.to have_destination('/steps/other_children/names', :edit) }
     end
 
     context 'and the answer is `no`' do

--- a/spec/services/c100_app/other_children_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_children_decision_tree_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe C100App::OtherChildrenDecisionTree do
   let(:as)               { nil }
   let(:record)           { nil }
 
-  let(:c100_application) {instance_double(C100Application)}
+  let(:c100_application) { instance_double(C100Application, children: children_collection) }
+  let(:children_collection) { double('children_collection', secondary: filtered_collection) }
+  let(:filtered_collection) { double('filtered_collection') }
 
   subject {
     described_class.new(
@@ -28,6 +30,34 @@ RSpec.describe C100App::OtherChildrenDecisionTree do
 
   context 'when the step is `names_finished`' do
     let(:step_params) {{'names_finished' => 'anything'}}
-    it {is_expected.to have_destination('/steps/applicant/personal_details', :edit)}
+
+    before do
+      allow(filtered_collection).to receive(:pluck).with(:id).and_return([1, 2, 3])
+    end
+
+    it 'goes to edit the details of the first child' do
+      expect(subject.destination).to eq(controller: :personal_details, action: :edit, id: 1)
+    end
+  end
+
+  context 'when the step is `personal_details`' do
+    let(:step_params) {{'personal_details' => 'anything'}}
+
+    before do
+      allow(filtered_collection).to receive(:pluck).with(:id).and_return([1, 2, 3])
+    end
+
+    context 'when there are remaining children' do
+      let(:record) { double('Child', id: 1) }
+
+      it 'goes to edit the details of the next child' do
+        expect(subject.destination).to eq(controller: :personal_details, action: :edit, id: 2)
+      end
+    end
+
+    context 'when all children have been edited' do
+      let(:record) { double('Child', id: 3) }
+      it {is_expected.to have_destination('/steps/applicant/personal_details', :edit)}
+    end
   end
 end

--- a/spec/services/c100_app/other_children_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_children_decision_tree_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe C100App::OtherChildrenDecisionTree do
+  let(:c100_application) { double('Object') }
+  let(:step_params)      { double('Step') }
+  let(:next_step)        { nil }
+  let(:as)               { nil }
+  let(:record)           { nil }
+
+  let(:c100_application) {instance_double(C100Application)}
+
+  subject {
+    described_class.new(
+      c100_application: c100_application,
+      record: record,
+      step_params: step_params,
+      as: as,
+      next_step: next_step
+    )
+  }
+
+  it_behaves_like 'a decision tree'
+
+  context 'when the step is `add_another_name`' do
+    let(:step_params) {{'add_another_name' => 'anything'}}
+    it {is_expected.to have_destination(:names, :edit)}
+  end
+
+  context 'when the step is `names_finished`' do
+    let(:step_params) {{'names_finished' => 'anything'}}
+    it {is_expected.to have_destination('/steps/applicant/personal_details', :edit)}
+  end
+end


### PR DESCRIPTION
This is identical code to the `main children` names step and form object.

Will be refactored and extracted to a module/concern once we also create
some other, like the applicant names, to see how much code we can share
and how to parametrize the attributes/record set.

Still we need to update the `main children` journey to scope the DB
queries. Another PR coming soon for this.