### PR TITLE
Scope the children steps

### DIFF
--- a/app/controllers/steps/children/names_controller.rb
+++ b/app/controllers/steps/children/names_controller.rb
@@ -28,7 +28,7 @@ module Steps
       end
 
       def record_collection
-        @_record_collection ||= current_c100_application.children
+        @_record_collection ||= current_c100_application.children.primary
       end
     end
   end

--- a/app/controllers/steps/children/personal_details_controller.rb
+++ b/app/controllers/steps/children/personal_details_controller.rb
@@ -20,7 +20,7 @@ module Steps
       private
 
       def record_collection
-        @_record_collection ||= current_c100_application.children
+        @_record_collection ||= current_c100_application.children.primary
       end
     end
   end

--- a/app/forms/steps/children/names_form.rb
+++ b/app/forms/steps/children/names_form.rb
@@ -18,12 +18,18 @@ module Steps
       end
 
       def create_new_child_with_name
-        record_collection.create(name: new_name) unless new_name.blank?
+        return if new_name.blank?
+
+        record_collection.create(
+          name: new_name,
+          kind: ChildrenType::PRIMARY
+        )
       end
 
       def update_existing_children_names
         names_attributes.each_value do |attrs|
-          record_collection.update(attrs.fetch('id'), attrs) unless attrs.fetch('name').blank?
+          next if attrs.fetch('name').blank?
+          record_collection.update(attrs.fetch('id'), attrs)
         end
       end
 
@@ -33,7 +39,7 @@ module Steps
       end
 
       def record_collection
-        @_record_collection ||= c100_application.children
+        @_record_collection ||= c100_application.children.primary
       end
     end
   end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -3,6 +3,6 @@ class Child < ApplicationRecord
 
   has_value_object :gender
 
-  scope :principal, -> { where(kind: ChildrenType::PRINCIPAL.to_s) }
+  scope :primary,   -> { where(kind: ChildrenType::PRIMARY.to_s) }
   scope :secondary, -> { where(kind: ChildrenType::SECONDARY.to_s) }
 end

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -43,7 +43,7 @@ module C100App
 
     def next_child
       @_next_child ||= begin
-        ids = c100_application.child_ids
+        ids = c100_application.children.primary.pluck(:id)
 
         return ids.first if record.nil?
 

--- a/app/value_objects/children_type.rb
+++ b/app/value_objects/children_type.rb
@@ -1,6 +1,6 @@
 class ChildrenType < ValueObject
   VALUES = [
-    PRINCIPAL = new(:principal),
+    PRIMARY   = new(:primary),
     SECONDARY = new(:secondary)
   ].freeze
 end

--- a/spec/forms/steps/children/names_form_spec.rb
+++ b/spec/forms/steps/children/names_form_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Steps::Children::NamesForm do
   subject { described_class.new(arguments) }
 
   describe '#save' do
+    before do
+      allow(children_collection).to receive(:primary).and_return(children_collection)
+    end
+
     context 'when no c100_application is associated with the form' do
       let(:c100_application) { nil }
 
@@ -27,23 +31,32 @@ RSpec.describe Steps::Children::NamesForm do
 
     context 'validations on `new_name`' do
       context 'when there are no other children names' do
-        let(:children_collection) { [] }
-        it { should validate_presence_of(:new_name) }
+        it {
+          expect(children_collection).to receive(:empty?).and_return(true)
+          should validate_presence_of(:new_name)
+        }
       end
 
       context 'when there are existing children names' do
-        let(:children_collection) { ['whatever'] }
-        it { should_not validate_presence_of(:new_name) }
+        it {
+          expect(children_collection).to receive(:empty?).and_return(false)
+          should_not validate_presence_of(:new_name)
+        }
       end
     end
 
     context 'when form is valid' do
+      before do
+        expect(children_collection).to receive(:primary).and_return(children_collection)
+      end
+
       context 'adding new children names' do
         let(:new_name) { 'Gareth' }
 
         it 'it creates a new child with the provided name' do
           expect(children_collection).to receive(:create).with(
-            name: 'Gareth'
+            name: 'Gareth',
+            kind: ChildrenType::PRIMARY
           ).and_return(true)
 
           expect(subject.save).to be(true)

--- a/spec/services/c100_app/children_decision_tree_spec.rb
+++ b/spec/services/c100_app/children_decision_tree_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe C100App::ChildrenDecisionTree do
   let(:as)               { nil }
   let(:record)           { nil }
 
-  let(:c100_application) {instance_double(C100Application)}
+  let(:c100_application) { instance_double(C100Application, children: children_collection) }
+  let(:children_collection) { double('children_collection', primary: filtered_collection) }
+  let(:filtered_collection) { double('filtered_collection') }
 
   subject {
     described_class.new(
@@ -28,7 +30,10 @@ RSpec.describe C100App::ChildrenDecisionTree do
 
   context 'when the step is `names_finished`' do
     let(:step_params) {{'names_finished' => 'anything'}}
-    let(:c100_application) {instance_double(C100Application, child_ids: [1, 2, 3])}
+
+    before do
+      allow(filtered_collection).to receive(:pluck).with(:id).and_return([1, 2, 3])
+    end
 
     it 'goes to edit the details of the first child' do
       expect(subject.destination).to eq(controller: :personal_details, action: :edit, id: 1)
@@ -37,7 +42,10 @@ RSpec.describe C100App::ChildrenDecisionTree do
 
   context 'when the step is `personal_details`' do
     let(:step_params) {{'personal_details' => 'anything'}}
-    let(:c100_application) {instance_double(C100Application, child_ids: [1, 2, 3])}
+
+    before do
+      allow(filtered_collection).to receive(:pluck).with(:id).and_return([1, 2, 3])
+    end
 
     context 'when there are remaining children' do
       let(:record) { double('Child', id: 1) }


### PR DESCRIPTION
As we have now 2 kinds of children (primary and secondary) and we are
already scoping the secondary children, we need to also update the
`primary` children steps we had previously created.

Note: primary and secondary are just internal identifiers, not really
showing to the user at any time.