### PR TITLE
Unify in one table the common details of people

### DIFF
--- a/app/controllers/steps/children/names_controller.rb
+++ b/app/controllers/steps/children/names_controller.rb
@@ -28,7 +28,7 @@ module Steps
       end
 
       def record_collection
-        @_record_collection ||= current_c100_application.children.primary
+        @_record_collection ||= current_c100_application.children
       end
     end
   end

--- a/app/controllers/steps/children/personal_details_controller.rb
+++ b/app/controllers/steps/children/personal_details_controller.rb
@@ -20,7 +20,7 @@ module Steps
       private
 
       def record_collection
-        @_record_collection ||= current_c100_application.children.primary
+        @_record_collection ||= current_c100_application.children
       end
     end
   end

--- a/app/controllers/steps/other_children/names_controller.rb
+++ b/app/controllers/steps/other_children/names_controller.rb
@@ -28,7 +28,7 @@ module Steps
       end
 
       def record_collection
-        @_record_collection ||= current_c100_application.children.secondary
+        @_record_collection ||= current_c100_application.other_children
       end
     end
   end

--- a/app/controllers/steps/other_children/personal_details_controller.rb
+++ b/app/controllers/steps/other_children/personal_details_controller.rb
@@ -20,7 +20,7 @@ module Steps
       private
 
       def record_collection
-        @_record_collection ||= current_c100_application.children.secondary
+        @_record_collection ||= current_c100_application.other_children
       end
     end
   end

--- a/app/forms/steps/children/names_form.rb
+++ b/app/forms/steps/children/names_form.rb
@@ -18,12 +18,7 @@ module Steps
       end
 
       def create_new_child_with_name
-        return if new_name.blank?
-
-        record_collection.create(
-          name: new_name,
-          kind: ChildrenType::PRIMARY
-        )
+        record_collection.create(name: new_name) unless new_name.blank?
       end
 
       def update_existing_children_names
@@ -39,7 +34,7 @@ module Steps
       end
 
       def record_collection
-        @_record_collection ||= c100_application.children.primary
+        @_record_collection ||= c100_application.children
       end
     end
   end

--- a/app/forms/steps/other_children/names_form.rb
+++ b/app/forms/steps/other_children/names_form.rb
@@ -18,12 +18,7 @@ module Steps
       end
 
       def create_new_child_with_name
-        return if new_name.blank?
-
-        record_collection.create(
-          full_name: new_name,
-          kind: ChildrenType::SECONDARY
-        )
+        record_collection.create(full_name: new_name) unless new_name.blank?
       end
 
       def update_existing_children_names
@@ -39,7 +34,7 @@ module Steps
       end
 
       def record_collection
-        @_record_collection ||= c100_application.children.secondary
+        @_record_collection ||= c100_application.other_children
       end
     end
   end

--- a/app/forms/steps/other_children/personal_details_form.rb
+++ b/app/forms/steps/other_children/personal_details_form.rb
@@ -25,11 +25,7 @@ module Steps
       def persist!
         raise C100ApplicationNotFound unless c100_application
 
-        child = c100_application.children.find_or_initialize_by(
-          id: record_id,
-          kind: ChildrenType::SECONDARY.to_s
-        )
-
+        child = c100_application.other_children.find_or_initialize_by(id: record_id)
         child.update(
           # Some attributes are value objects and thus we need to provide their values
           attributes_map.merge(

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -8,7 +8,8 @@ class C100Application < ApplicationRecord
   has_many :abuse_concerns,   dependent: :destroy
 
   # Remember, we are using UUIDs as the record IDs, we can't rely on ID sequential ordering
-  has_many :children,    -> { order(created_at: :asc) }, dependent: :destroy
+  has_many :children, -> { order(created_at: :asc) }, dependent: :destroy
+  has_many :other_children, -> { order(created_at: :asc) }, dependent: :destroy
   has_many :applicants,  -> { order(created_at: :asc) }, dependent: :destroy
   has_many :respondents, -> { order(created_at: :asc) }, dependent: :destroy
 

--- a/app/models/other_child.rb
+++ b/app/models/other_child.rb
@@ -1,3 +1,3 @@
-class Child < Person
+class OtherChild < Person
   belongs_to :c100_application
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,3 +1,3 @@
-class Child < Person
+class Person < ApplicationRecord
   belongs_to :c100_application
 end

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -43,7 +43,7 @@ module C100App
 
     def next_child
       @_next_child ||= begin
-        ids = c100_application.children.primary.pluck(:id)
+        ids = c100_application.child_ids
 
         return ids.first if record.nil?
 

--- a/app/services/c100_app/other_children_decision_tree.rb
+++ b/app/services/c100_app/other_children_decision_tree.rb
@@ -31,7 +31,7 @@ module C100App
 
     def next_child
       @_next_child ||= begin
-        ids = c100_application.children.secondary.pluck(:id)
+        ids = c100_application.other_child_ids
 
         return ids.first if record.nil?
 

--- a/app/value_objects/person_type.rb
+++ b/app/value_objects/person_type.rb
@@ -1,0 +1,9 @@
+class PersonType < ValueObject
+  VALUES = [
+    APPLICANT   = new(:applicant),
+    RESPONDENT  = new(:respondent),
+    CHILD       = new(:child),
+    OTHER_CHILD = new(:other_child),
+    OTHER_PARTY = new(:other_party)
+  ].freeze
+end

--- a/db/migrate/20171206093223_create_people_table.rb
+++ b/db/migrate/20171206093223_create_people_table.rb
@@ -1,0 +1,31 @@
+class CreatePeopleTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :people, id: :uuid do |t|
+      t.timestamps null: false
+
+      t.string  :type, null: false
+      t.string  :name
+      t.string  :full_name
+      t.string  :has_previous_name
+      t.string  :previous_name
+      t.string  :gender
+      t.date    :dob
+      t.boolean :dob_unknown, default: false
+      t.string  :age_estimate
+      t.string  :birthplace
+      t.text    :address
+      t.string  :postcode
+      t.boolean :postcode_unknown, default: false
+      t.string  :home_phone
+      t.boolean :home_phone_unknown, default: false
+      t.string  :mobile_phone
+      t.boolean :mobile_phone_unknown, default: false
+      t.string  :email
+      t.boolean :email_unknown, default: false
+      t.string  :residence_requirement_met
+      t.text    :residence_history
+    end
+
+    add_reference :people, :c100_application, type: :uuid, foreign_key: true
+  end
+end

--- a/db/migrate/20171207092509_drop_children_table.rb
+++ b/db/migrate/20171207092509_drop_children_table.rb
@@ -1,0 +1,5 @@
+class DropChildrenTable < ActiveRecord::Migration[5.0]
+  def up
+    drop_table :children
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171204134208) do
+ActiveRecord::Schema.define(version: 20171207092509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,20 +135,6 @@ ActiveRecord::Schema.define(version: 20171204134208) do
     t.index ["user_id"], name: "index_c100_applications_on_user_id", using: :btree
   end
 
-  create_table "children", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
-    t.string   "full_name"
-    t.date     "dob"
-    t.boolean  "dob_unknown"
-    t.string   "gender"
-    t.uuid     "c100_application_id"
-    t.string   "name"
-    t.string   "age_estimate"
-    t.string   "kind"
-    t.index ["c100_application_id"], name: "index_children_on_c100_application_id", using: :btree
-  end
-
   create_table "court_orders", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "non_molestation"
     t.date   "non_molestation_issue_date"
@@ -182,6 +168,34 @@ ActiveRecord::Schema.define(version: 20171204134208) do
     t.string "undertaking_court_name"
     t.uuid   "c100_application_id"
     t.index ["c100_application_id"], name: "index_court_orders_on_c100_application_id", using: :btree
+  end
+
+  create_table "people", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
+    t.string   "type",                                      null: false
+    t.string   "name"
+    t.string   "full_name"
+    t.string   "has_previous_name"
+    t.string   "previous_name"
+    t.string   "gender"
+    t.date     "dob"
+    t.boolean  "dob_unknown",               default: false
+    t.string   "age_estimate"
+    t.string   "birthplace"
+    t.text     "address"
+    t.string   "postcode"
+    t.boolean  "postcode_unknown",          default: false
+    t.string   "home_phone"
+    t.boolean  "home_phone_unknown",        default: false
+    t.string   "mobile_phone"
+    t.boolean  "mobile_phone_unknown",      default: false
+    t.string   "email"
+    t.boolean  "email_unknown",             default: false
+    t.string   "residence_requirement_met"
+    t.text     "residence_history"
+    t.uuid     "c100_application_id"
+    t.index ["c100_application_id"], name: "index_people_on_c100_application_id", using: :btree
   end
 
   create_table "respondents", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -225,7 +239,7 @@ ActiveRecord::Schema.define(version: 20171204134208) do
   add_foreign_key "applicants", "c100_applications"
   add_foreign_key "asking_orders", "c100_applications"
   add_foreign_key "c100_applications", "users"
-  add_foreign_key "children", "c100_applications"
   add_foreign_key "court_orders", "c100_applications"
+  add_foreign_key "people", "c100_applications"
   add_foreign_key "respondents", "c100_applications"
 end

--- a/spec/forms/steps/children/names_form_spec.rb
+++ b/spec/forms/steps/children/names_form_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe Steps::Children::NamesForm do
   subject { described_class.new(arguments) }
 
   describe '#save' do
-    before do
-      allow(children_collection).to receive(:primary).and_return(children_collection)
-    end
-
     context 'when no c100_application is associated with the form' do
       let(:c100_application) { nil }
 
@@ -46,17 +42,12 @@ RSpec.describe Steps::Children::NamesForm do
     end
 
     context 'when form is valid' do
-      before do
-        expect(children_collection).to receive(:primary).and_return(children_collection)
-      end
-
       context 'adding new children names' do
         let(:new_name) { 'Gareth' }
 
         it 'it creates a new child with the provided name' do
           expect(children_collection).to receive(:create).with(
-            name: 'Gareth',
-            kind: ChildrenType::PRIMARY
+            name: 'Gareth'
           ).and_return(true)
 
           expect(subject.save).to be(true)

--- a/spec/forms/steps/other_children/names_form_spec.rb
+++ b/spec/forms/steps/other_children/names_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Steps::OtherChildren::NamesForm do
     new_name: new_name
   } }
 
-  let(:c100_application) { instance_double(C100Application, children: children_collection) }
+  let(:c100_application) { instance_double(C100Application, other_children: children_collection) }
   let(:children_collection) { double('children_collection', empty?: false, create: true) }
   let(:child) { double('Child') }
 
@@ -17,10 +17,6 @@ RSpec.describe Steps::OtherChildren::NamesForm do
   subject { described_class.new(arguments) }
 
   describe '#save' do
-    before do
-      allow(children_collection).to receive(:secondary).and_return(children_collection)
-    end
-
     context 'when no c100_application is associated with the form' do
       let(:c100_application) { nil }
 
@@ -46,17 +42,12 @@ RSpec.describe Steps::OtherChildren::NamesForm do
     end
 
     context 'when form is valid' do
-      before do
-        expect(children_collection).to receive(:secondary).and_return(children_collection)
-      end
-
       context 'adding new children names' do
         let(:new_name) { 'Gareth XYZ' }
 
         it 'it creates a new child with the provided name' do
           expect(children_collection).to receive(:create).with(
-            full_name: 'Gareth XYZ',
-            kind: ChildrenType::SECONDARY
+            full_name: 'Gareth XYZ'
           ).and_return(true)
 
           expect(subject.save).to be(true)

--- a/spec/forms/steps/other_children/personal_details_form_spec.rb
+++ b/spec/forms/steps/other_children/personal_details_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Steps::OtherChildren::PersonalDetailsForm do
     dob_unknown: dob_unknown
   } }
 
-  let(:c100_application) { instance_double(C100Application, children: children_collection) }
+  let(:c100_application) { instance_double(C100Application, other_children: children_collection) }
   let(:children_collection) { double('children_collection') }
   let(:child) { double('Child', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
 
@@ -81,8 +81,7 @@ RSpec.describe Steps::OtherChildren::PersonalDetailsForm do
 
         it 'creates the record if it does not exist' do
           expect(children_collection).to receive(:find_or_initialize_by).with(
-            id: nil,
-            kind: 'secondary'
+            id: nil
           ).and_return(child)
 
           expect(child).to receive(:update).with(
@@ -98,8 +97,7 @@ RSpec.describe Steps::OtherChildren::PersonalDetailsForm do
 
         it 'updates the record if it already exists' do
           expect(children_collection).to receive(:find_or_initialize_by).with(
-            id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6',
-            kind: 'secondary'
+            id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6'
           ).and_return(child)
 
           expect(child).to receive(:update).with(

--- a/spec/services/c100_app/children_decision_tree_spec.rb
+++ b/spec/services/c100_app/children_decision_tree_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe C100App::ChildrenDecisionTree do
   let(:as)               { nil }
   let(:record)           { nil }
 
-  let(:c100_application) { instance_double(C100Application, children: children_collection) }
-  let(:children_collection) { double('children_collection', primary: filtered_collection) }
-  let(:filtered_collection) { double('filtered_collection') }
+  let(:c100_application) { instance_double(C100Application, child_ids: [1, 2, 3]) }
 
   subject {
     described_class.new(
@@ -31,10 +29,6 @@ RSpec.describe C100App::ChildrenDecisionTree do
   context 'when the step is `names_finished`' do
     let(:step_params) {{'names_finished' => 'anything'}}
 
-    before do
-      allow(filtered_collection).to receive(:pluck).with(:id).and_return([1, 2, 3])
-    end
-
     it 'goes to edit the details of the first child' do
       expect(subject.destination).to eq(controller: :personal_details, action: :edit, id: 1)
     end
@@ -42,10 +36,6 @@ RSpec.describe C100App::ChildrenDecisionTree do
 
   context 'when the step is `personal_details`' do
     let(:step_params) {{'personal_details' => 'anything'}}
-
-    before do
-      allow(filtered_collection).to receive(:pluck).with(:id).and_return([1, 2, 3])
-    end
 
     context 'when there are remaining children' do
       let(:record) { double('Child', id: 1) }

--- a/spec/services/c100_app/other_children_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_children_decision_tree_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe C100App::OtherChildrenDecisionTree do
   let(:as)               { nil }
   let(:record)           { nil }
 
-  let(:c100_application) { instance_double(C100Application, children: children_collection) }
-  let(:children_collection) { double('children_collection', secondary: filtered_collection) }
-  let(:filtered_collection) { double('filtered_collection') }
+  let(:c100_application) { instance_double(C100Application, other_child_ids: [1, 2, 3]) }
 
   subject {
     described_class.new(
@@ -31,10 +29,6 @@ RSpec.describe C100App::OtherChildrenDecisionTree do
   context 'when the step is `names_finished`' do
     let(:step_params) {{'names_finished' => 'anything'}}
 
-    before do
-      allow(filtered_collection).to receive(:pluck).with(:id).and_return([1, 2, 3])
-    end
-
     it 'goes to edit the details of the first child' do
       expect(subject.destination).to eq(controller: :personal_details, action: :edit, id: 1)
     end
@@ -42,10 +36,6 @@ RSpec.describe C100App::OtherChildrenDecisionTree do
 
   context 'when the step is `personal_details`' do
     let(:step_params) {{'personal_details' => 'anything'}}
-
-    before do
-      allow(filtered_collection).to receive(:pluck).with(:id).and_return([1, 2, 3])
-    end
 
     context 'when there are remaining children' do
       let(:record) { double('Child', id: 1) }


### PR DESCRIPTION
This creates a table with all the common details that we need to ask
about all the different parties (applicants, respondents, children...)

Dropped the children table in favour of this new table.

The next steps are to replace the `applicants` and `respondents` tables
with this one, and in the process, implement the `Names` step to ask for
the names of said people, the same we are doing with the children, and
hopefully extract all the shared and duplicated code to some superclass
or module to reuse.