### PR TITLE
Add `other parties` steps

### DIFF
--- a/app/controllers/steps/other_parties/contact_details_controller.rb
+++ b/app/controllers/steps/other_parties/contact_details_controller.rb
@@ -1,0 +1,19 @@
+module Steps
+  module OtherParties
+    class ContactDetailsController < Steps::OtherPartiesStepController
+      def edit
+        @form_object = ContactDetailsForm.build(
+          current_record, c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          ContactDetailsForm,
+          record: current_record,
+          as: :contact_details
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/steps/other_parties/names_controller.rb
+++ b/app/controllers/steps/other_parties/names_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module OtherParties
+    class NamesController < Steps::OtherPartiesStepController
+      include NamesCrudStep
+    end
+  end
+end

--- a/app/controllers/steps/other_parties/personal_details_controller.rb
+++ b/app/controllers/steps/other_parties/personal_details_controller.rb
@@ -1,0 +1,19 @@
+module Steps
+  module OtherParties
+    class PersonalDetailsController < Steps::OtherPartiesStepController
+      def edit
+        @form_object = PersonalDetailsForm.build(
+          current_record, c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          PersonalDetailsForm,
+          record: current_record,
+          as: :personal_details
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/steps/other_parties_step_controller.rb
+++ b/app/controllers/steps/other_parties_step_controller.rb
@@ -1,9 +1,17 @@
 module Steps
-  class OtherPartiesStepController < StepController
+  class OtherPartiesStepController < CrudStepController
     private
 
     def decision_tree_class
       C100App::OtherPartiesDecisionTree
+    end
+
+    def names_form_class
+      OtherParties::NamesForm
+    end
+
+    def record_collection
+      @_record_collection ||= current_c100_application.other_parties
     end
   end
 end

--- a/app/controllers/steps/other_parties_step_controller.rb
+++ b/app/controllers/steps/other_parties_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class OtherPartiesStepController < StepController
+    private
+
+    def decision_tree_class
+      C100App::OtherPartiesDecisionTree
+    end
+  end
+end

--- a/app/controllers/steps/respondent/has_other_parties_controller.rb
+++ b/app/controllers/steps/respondent/has_other_parties_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Respondent
+    class HasOtherPartiesController < Steps::RespondentStepController
+      def edit
+        @form_object = HasOtherPartiesForm.new(
+          c100_application: current_c100_application,
+          has_other_parties: current_c100_application.has_other_parties
+        )
+      end
+
+      def update
+        update_and_advance(HasOtherPartiesForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/other_parties/contact_details_form.rb
+++ b/app/forms/steps/other_parties/contact_details_form.rb
@@ -1,0 +1,22 @@
+module Steps
+  module OtherParties
+    class ContactDetailsForm < BaseForm
+      attribute :address, StrippedString
+      attribute :postcode, StrippedString
+      attribute :postcode_unknown, Boolean
+
+      validates_presence_of :postcode, unless: :postcode_unknown?
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        party = c100_application.other_parties.find_or_initialize_by(id: record_id)
+        party.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/other_parties/names_form.rb
+++ b/app/forms/steps/other_parties/names_form.rb
@@ -1,0 +1,11 @@
+module Steps
+  module OtherParties
+    class NamesForm < NamesBaseForm
+      private
+
+      def record_collection
+        @_record_collection ||= c100_application.other_parties
+      end
+    end
+  end
+end

--- a/app/forms/steps/other_parties/personal_details_form.rb
+++ b/app/forms/steps/other_parties/personal_details_form.rb
@@ -1,0 +1,43 @@
+module Steps
+  module OtherParties
+    class PersonalDetailsForm < BaseForm
+      include GovUkDateFields::ActsAsGovUkDate
+
+      attribute :has_previous_name, YesNoUnknown
+      attribute :previous_name, StrippedString
+      attribute :gender, String
+      attribute :dob, Date
+      attribute :dob_unknown, Boolean
+
+      acts_as_gov_uk_date :dob
+
+      def self.gender_choices
+        Gender.string_values
+      end
+      validates_inclusion_of :gender, in: gender_choices
+
+      validates_inclusion_of :has_previous_name, in: GenericYesNoUnknown.values
+      validates_presence_of  :previous_name, if: -> { has_previous_name&.yes? }
+      validates_presence_of  :dob, unless: :dob_unknown?
+
+      private
+
+      def gender_value
+        Gender.new(gender)
+      end
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        party = c100_application.other_parties.find_or_initialize_by(id: record_id)
+        party.update(
+          # Some attributes are value objects and thus we need to provide their values,
+          # but eventually we may end up with the same solution as for `YesNo` attributes.
+          attributes_map.merge(
+            gender: gender_value
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/respondent/has_other_parties_form.rb
+++ b/app/forms/steps/respondent/has_other_parties_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Respondent
+    class HasOtherPartiesForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :has_other_parties
+    end
+  end
+end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -8,10 +8,12 @@ class C100Application < ApplicationRecord
   has_many :abuse_concerns,   dependent: :destroy
 
   # Remember, we are using UUIDs as the record IDs, we can't rely on ID sequential ordering
-  has_many :children, -> { order(created_at: :asc) }, dependent: :destroy
-  has_many :other_children, -> { order(created_at: :asc) }, dependent: :destroy
+  has_many :children,    -> { order(created_at: :asc) }, dependent: :destroy
   has_many :applicants,  -> { order(created_at: :asc) }, dependent: :destroy
   has_many :respondents, -> { order(created_at: :asc) }, dependent: :destroy
+
+  has_many :other_children, -> { order(created_at: :asc) }, dependent: :destroy
+  has_many :other_parties,  -> { order(created_at: :asc) }, dependent: :destroy
 
   has_value_object :user_type
   has_value_object :help_paying

--- a/app/models/other_party.rb
+++ b/app/models/other_party.rb
@@ -1,0 +1,2 @@
+class OtherParty < Person
+end

--- a/app/services/c100_app/other_parties_decision_tree.rb
+++ b/app/services/c100_app/other_parties_decision_tree.rb
@@ -4,12 +4,31 @@ module C100App
       return next_step if next_step
 
       case step_name
-      # TODO: Put decision logic here
-      when :name
-        root_path
+      when :add_another_name
+        edit(:names)
+      when :names_finished
+        edit(:personal_details, id: next_record_id)
+      when :personal_details
+        edit(:contact_details, id: record)
+      when :contact_details
+        after_contact_details
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
+    end
+
+    private
+
+    def after_contact_details
+      if next_record_id
+        edit(:personal_details, id: next_record_id)
+      else
+        edit('/steps/abuse_concerns/previous_proceedings') # TODO: change when we have children residence step
+      end
+    end
+
+    def next_record_id
+      super(c100_application.other_party_ids)
     end
   end
 end

--- a/app/services/c100_app/other_parties_decision_tree.rb
+++ b/app/services/c100_app/other_parties_decision_tree.rb
@@ -1,0 +1,15 @@
+module C100App
+  class OtherPartiesDecisionTree < BaseDecisionTree
+    def destination
+      return next_step if next_step
+
+      case step_name
+      # TODO: Put decision logic here
+      when :name
+        root_path
+      else
+        raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+  end
+end

--- a/app/services/c100_app/respondent_decision_tree.rb
+++ b/app/services/c100_app/respondent_decision_tree.rb
@@ -12,6 +12,8 @@ module C100App
         edit(:contact_details, id: record)
       when :contact_details
         after_contact_details
+      when :has_other_parties
+        after_has_other_parties
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
@@ -23,7 +25,15 @@ module C100App
       if next_record_id
         edit(:personal_details, id: next_record_id)
       else
-        edit('/steps/respondent/names') # TODO: change when we have `other parties` journey
+        edit(:has_other_parties)
+      end
+    end
+
+    def after_has_other_parties
+      if question(:has_other_parties).yes?
+        edit('/steps/other_parties/names')
+      else
+        edit('/steps/abuse_concerns/previous_proceedings') # TODO: change when we have children residence step
       end
     end
 

--- a/app/views/steps/other_parties/contact_details/edit.html.erb
+++ b/app/views/steps/other_parties/contact_details/edit.html.erb
@@ -1,0 +1,18 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
+
+      <%= f.text_field :postcode %>
+      <%= f.check_box_fieldset :postcode_unknown, [:postcode_unknown] %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/other_parties/names/edit.html.erb
+++ b/app/views/steps/other_parties/names/edit.html.erb
@@ -1,0 +1,31 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <% @existing_records.each.with_index do |party, index| %>
+        <%= f.fields_for :names_attributes, party, index: index do |c| %>
+          <span><%= t('.record_index', index: index + 1) %></span>
+          <%= c.hidden_field :id %>
+          <%= c.text_field :full_name %>
+        <% end %>
+      <% end %>
+
+      <%= f.text_field :new_name %>
+
+      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: 'link-button' %>
+
+      <% if @existing_records.any? %>
+        <%= link_to t('.btn_remove'), steps_other_parties_names_path(@existing_records.last), method: :delete, class: 'link-button' %>
+      <% end %>
+
+      <div class="xform-group form-submit">
+        <%= f.submit class: 'button' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/other_parties/personal_details/edit.html.erb
+++ b/app/views/steps/other_parties/personal_details/edit.html.erb
@@ -1,0 +1,36 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.radio_button_fieldset :has_previous_name, inline: true do |fieldset|
+          fieldset.radio_input GenericYesNoUnknown::YES, panel_id: :previous_name_panel
+          fieldset.radio_input GenericYesNoUnknown::NO
+          fieldset.radio_input GenericYesNoUnknown::UNKNOWN
+          fieldset.revealing_panel(:previous_name_panel) { |panel| panel.text_field :previous_name }
+        end
+      %>
+
+      <%= f.radio_button_fieldset :gender, inline: true,
+        choices: Steps::Respondent::PersonalDetailsForm.gender_choices %>
+
+      <div class="form-group">
+        <%= f.gov_uk_date_field :dob,
+          placeholders: true,
+          legend_text: t('shared.form_elements.dob'),
+          legend_class: 'form-label-bold',
+          form_hint_text: '' %>
+      </div>
+      <%= f.check_box_fieldset :dob_unknown, [:dob_unknown] %>
+
+      <div class="xform-group form-submit">
+        <%= f.submit class: 'button' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/respondent/has_other_parties/edit.html.erb
+++ b/app/views/steps/respondent/has_other_parties/edit.html.erb
@@ -1,0 +1,15 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :has_other_parties, inline: true, choices: GenericYesNo.values %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,10 @@ en:
         edit:
           page_title: Respondent contact details
           heading: "Contact details of %{name}"
+      has_other_parties:
+        edit:
+          page_title: Other parties required
+          heading: Are there any other people who should be given notice of the hearing?
     children:
       names:
         edit:
@@ -572,6 +576,8 @@ en:
         postcode_unknown_html: ""
         mobile_phone_unknown_html: ""
         email_unknown_html: ""
+      steps_respondent_has_other_parties_form:
+        has_other_parties_html: ""
       steps_children_personal_details_form:
         dob_unknown_html: ""
         gender: Sex

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,7 @@ en:
       full_name: Full name
       has_previous_name:
         <<: *YESNO
-      previous_name: Please enter previous name
+      previous_name: What was their previous name?
       gender:
         female: Female
         male: Male
@@ -178,6 +178,22 @@ en:
         edit:
           page_title: Child personal details
           heading: "Provide details for %{name}"
+    other_parties:
+      names:
+        edit:
+          page_title: Other parties
+          heading: Enter the other party’s name
+          record_index: "Party %{index}"
+          btn_add_another: Add another party
+          btn_remove: Remove last party
+      personal_details:
+        edit:
+          page_title: Other party personal details
+          heading: "Provide details for %{name}"
+      contact_details:
+        edit:
+          page_title: Other party contact details
+          heading: "Contact details of %{name}"
     abuse_concerns:
       question:
         edit:
@@ -485,6 +501,12 @@ en:
         steps/other_children/personal_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
+        steps/other_parties/personal_details_form:
+          attributes:
+            <<: *PERSONAL_DETAILS_ERRORS
+        steps/other_parties/contact_details_form:
+          attributes:
+            <<: *PERSONAL_DETAILS_ERRORS
 
   helpers:
     fieldset:
@@ -591,6 +613,12 @@ en:
       steps_other_children_personal_details_form:
         dob_unknown_html: ""
         gender: Sex
+      steps_other_parties_personal_details_form:
+        has_previous_name: Have they changed their name?
+        gender: Sex
+        dob_unknown_html: ""
+      steps_other_parties_contact_details_form:
+        postcode_unknown_html: ""
     label:
       steps_applicant_user_type_form:
         user_type:
@@ -645,11 +673,15 @@ en:
         new_name: Full name of child
       steps_other_children_names_form[names_attributes]:
         name: Full name
+      steps_other_parties_names_form:
+        new_name: Full name of other party
+      steps_other_parties_names_form[names_attributes]:
+        name: Full name
       steps_applicant_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
+        previous_name: Please enter previous name
       steps_respondent_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
-        previous_name: What was their previous name?
       steps_applicant_contact_details_form:
         <<: *PERSONAL_CONTACT_FIELDS
         residence_history: Provide details and dates of all previous addresses for the last 5 years
@@ -658,6 +690,10 @@ en:
         residence_history: Please provide details of all previous addresses for the last 5 years below (if known, including the dates and starting with the most recent)
       steps_other_children_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
+      steps_other_parties_personal_details_form:
+        <<: *PERSONAL_DETAILS_FIELDS
+      steps_other_parties_contact_details_form:
+        <<: *PERSONAL_CONTACT_FIELDS
       steps_children_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
       steps_children_additional_details_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,9 @@ Rails.application.routes.draw do
       crud_step :names
       crud_step :personal_details, only: [:edit, :update]
       crud_step :contact_details,  only: [:edit, :update]
+      edit_step :has_other_parties
+    end
+    namespace :other_parties do
     end
     namespace :help_with_fees do
       edit_step :help_paying

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,9 @@ Rails.application.routes.draw do
       edit_step :has_other_parties
     end
     namespace :other_parties do
+      crud_step :names
+      crud_step :personal_details, only: [:edit, :update]
+      crud_step :contact_details,  only: [:edit, :update]
     end
     namespace :help_with_fees do
       edit_step :help_paying

--- a/db/migrate/20171211090718_add_has_other_parties_field.rb
+++ b/db/migrate/20171211090718_add_has_other_parties_field.rb
@@ -1,0 +1,5 @@
+class AddHasOtherPartiesField < ActiveRecord::Migration[5.0]
+  def change
+    add_column :c100_applications, :has_other_parties, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171208150846) do
+ActiveRecord::Schema.define(version: 20171211090718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,6 +114,7 @@ ActiveRecord::Schema.define(version: 20171208150846) do
     t.date     "miam_certification_date"
     t.string   "miam_certification_number"
     t.string   "has_other_children"
+    t.string   "has_other_parties"
     t.index ["user_id"], name: "index_c100_applications_on_user_id", using: :btree
   end
 

--- a/spec/controllers/steps/other_parties/contact_details_controller_spec.rb
+++ b/spec/controllers/steps/other_parties/contact_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::OtherParties::ContactDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::OtherParties::ContactDetailsForm, C100App::OtherPartiesDecisionTree
+end

--- a/spec/controllers/steps/other_parties/names_controller_spec.rb
+++ b/spec/controllers/steps/other_parties/names_controller_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Steps::OtherParties::NamesController, type: :controller do
+  it_behaves_like 'an names CRUD step controller',
+                  Steps::OtherParties::NamesForm,
+                  C100App::OtherPartiesDecisionTree,
+                  OtherParty
+end

--- a/spec/controllers/steps/other_parties/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/other_parties/personal_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::OtherParties::PersonalDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::OtherParties::PersonalDetailsForm, C100App::OtherPartiesDecisionTree
+end

--- a/spec/controllers/steps/respondent/has_other_parties_controller_spec.rb
+++ b/spec/controllers/steps/respondent/has_other_parties_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Respondent::HasOtherPartiesController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Respondent::HasOtherPartiesForm, C100App::RespondentDecisionTree
+end

--- a/spec/forms/steps/other_parties/contact_details_form_spec.rb
+++ b/spec/forms/steps/other_parties/contact_details_form_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+RSpec.describe Steps::OtherParties::ContactDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    record: record,
+    address: address,
+    postcode: postcode,
+    postcode_unknown: postcode_unknown
+  } }
+
+  let(:c100_application) { instance_double(C100Application, other_parties: other_parties_collection) }
+  let(:other_parties_collection) { double('other_parties_collection') }
+  let(:party) { double('Party', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
+
+  let(:record) { nil }
+  let(:address) { 'address' }
+  let(:postcode) { 'postcode' }
+  let(:postcode_unknown) { false }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'validations on field presence unless `unknown`' do
+      it { should validate_presence_unless_unknown_of(:postcode) }
+    end
+
+    context 'for valid details' do
+      let(:expected_attributes) {
+        {
+          address: 'address',
+          postcode: 'postcode',
+          postcode_unknown: false
+        }
+      }
+
+      context 'when record does not exist' do
+        let(:record) { nil }
+
+        it 'creates the record if it does not exist' do
+          expect(other_parties_collection).to receive(:find_or_initialize_by).with(
+            id: nil
+          ).and_return(party)
+
+          expect(party).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when record already exists' do
+        let(:record) { party }
+
+        it 'updates the record if it already exists' do
+          expect(other_parties_collection).to receive(:find_or_initialize_by).with(
+            id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6'
+          ).and_return(party)
+
+          expect(party).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/other_parties/names_form_spec.rb
+++ b/spec/forms/steps/other_parties/names_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::OtherParties::NamesForm do
+  it_behaves_like 'a names CRUD form', OtherParty
+end

--- a/spec/forms/steps/other_parties/personal_details_form_spec.rb
+++ b/spec/forms/steps/other_parties/personal_details_form_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+RSpec.describe Steps::OtherParties::PersonalDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    record: record,
+    has_previous_name: has_previous_name,
+    previous_name: previous_name,
+    gender: gender,
+    dob: dob,
+    dob_unknown: dob_unknown
+  } }
+
+  let(:c100_application) { instance_double(C100Application, other_parties: other_parties_collection) }
+  let(:other_parties_collection) { double('other_parties_collection') }
+  let(:other_party) { double('OtherParty', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
+
+  let(:record) { nil }
+  let(:has_previous_name) { 'no' }
+  let(:previous_name) { nil }
+  let(:gender) { 'male' }
+  let(:dob) { Date.today }
+  let(:dob_unknown) { false }
+
+  subject { described_class.new(arguments) }
+
+  describe '.gender_choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.gender_choices).to eq(%w(female male))
+    end
+  end
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'has previous name' do
+      context 'when attribute is not given' do
+        let(:has_previous_name) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:has_previous_name]).to_not be_empty
+        end
+      end
+
+      context 'when attribute is given and requires previous name' do
+        let(:has_previous_name) { 'yes' }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the `previous_name` field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:previous_name]).to_not be_empty
+        end
+      end
+
+      context 'when attribute value is not valid' do
+        let(:has_previous_name) {'INVALID VALUE'}
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:has_previous_name]).to_not be_empty
+        end
+      end
+    end
+
+    context 'validations on field presence unless `unknown`' do
+      it { should validate_presence_unless_unknown_of(:dob) }
+    end
+
+    context 'for valid details' do
+      let(:expected_attributes) {
+        {
+          has_previous_name: GenericYesNoUnknown::NO,
+          previous_name: '',
+          gender: Gender::MALE,
+          dob: Date.today,
+          dob_unknown: false
+        }
+      }
+
+      context 'when record does not exist' do
+        let(:record) { nil }
+
+        it 'creates the record if it does not exist' do
+          expect(other_parties_collection).to receive(:find_or_initialize_by).with(
+            id: nil
+          ).and_return(other_party)
+
+          expect(other_party).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when record already exists' do
+        let(:record) { other_party }
+
+        it 'updates the record if it already exists' do
+          expect(other_parties_collection).to receive(:find_or_initialize_by).with(
+            id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6'
+          ).and_return(other_party)
+
+          expect(other_party).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/respondent/has_other_parties_form_spec.rb
+++ b/spec/forms/steps/respondent/has_other_parties_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Respondent::HasOtherPartiesForm do
+  it_behaves_like 'a yes-no question form', attribute_name: :has_other_parties
+end

--- a/spec/services/c100_app/other_parties_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_parties_decision_tree_spec.rb
@@ -5,26 +5,58 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
   let(:step_params)      { double('Step') }
   let(:next_step)        { nil }
   let(:as)               { nil }
+  let(:record)           { nil }
 
-  subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
+  let(:c100_application) { instance_double(C100Application, other_party_ids: [1, 2, 3]) }
+
+  subject {
+    described_class.new(
+      c100_application: c100_application,
+      record: record,
+      step_params: step_params,
+      as: as,
+      next_step: next_step
+    )
+  }
 
   it_behaves_like 'a decision tree'
 
-  pending 'Write specs for OtherPartiesDecisionTree!'
+  context 'when the step is `add_another_name`' do
+    let(:step_params) {{'add_another_name' => 'anything'}}
+    it {is_expected.to have_destination(:names, :edit)}
+  end
 
-  # TODO: The below can be uncommented and serves as a starting point
+  context 'when the step is `names_finished`' do
+    let(:step_params) {{'names_finished' => 'anything'}}
 
-  # context 'when the step is `user_type`' do
-  #   let(:step_params) { { user_type: 'anything' } }
-  #
-  #   context 'and the answer is `themself`' do
-  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::THEMSELF) }
-  #     it { is_expected.to have_destination(:user_type, :edit) }
-  #   end
-  #
-  #   context 'and the answer is `representative`' do
-  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::REPRESENTATIVE) }
-  #     it { is_expected.to have_destination(:user_type, :edit) }
-  #   end
-  # end
+    it 'goes to edit the details of the first party' do
+      expect(subject.destination).to eq(controller: :personal_details, action: :edit, id: 1)
+    end
+  end
+
+  context 'when the step is `personal_details`' do
+    let(:step_params) {{'personal_details' => 'anything'}}
+    let(:record) {double('OtherParty', id: 1)}
+
+    it 'goes to edit the contact details of the current record' do
+      expect(subject.destination).to eq(controller: :contact_details, action: :edit, id: record)
+    end
+  end
+
+  context 'when the step is `contact_details`' do
+    let(:step_params) {{'contact_details' => 'anything'}}
+
+    context 'when there are remaining parties' do
+      let(:record) { double('OtherParty', id: 1) }
+
+      it 'goes to edit the personal details of the next party' do
+        expect(subject.destination).to eq(controller: :personal_details, action: :edit, id: 2)
+      end
+    end
+
+    context 'when all parties have been edited' do
+      let(:record) { double('OtherParty', id: 3) }
+      it {is_expected.to have_destination('/steps/abuse_concerns/previous_proceedings', :edit)}
+    end
+  end
 end

--- a/spec/services/c100_app/other_parties_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_parties_decision_tree_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe C100App::OtherPartiesDecisionTree do
+  let(:c100_application) { double('Object') }
+  let(:step_params)      { double('Step') }
+  let(:next_step)        { nil }
+  let(:as)               { nil }
+
+  subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
+
+  it_behaves_like 'a decision tree'
+
+  pending 'Write specs for OtherPartiesDecisionTree!'
+
+  # TODO: The below can be uncommented and serves as a starting point
+
+  # context 'when the step is `user_type`' do
+  #   let(:step_params) { { user_type: 'anything' } }
+  #
+  #   context 'and the answer is `themself`' do
+  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::THEMSELF) }
+  #     it { is_expected.to have_destination(:user_type, :edit) }
+  #   end
+  #
+  #   context 'and the answer is `representative`' do
+  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::REPRESENTATIVE) }
+  #     it { is_expected.to have_destination(:user_type, :edit) }
+  #   end
+  # end
+end

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -56,7 +56,22 @@ RSpec.describe C100App::RespondentDecisionTree do
 
     context 'when all respondents have been edited' do
       let(:record) { double('Respondent', id: 3) }
-      it {is_expected.to have_destination('/steps/respondent/names', :edit)}
+      it {is_expected.to have_destination(:has_other_parties, :edit)}
+    end
+  end
+
+  context 'when the step is `has_other_parties`' do
+    let(:c100_application) { instance_double(C100Application, has_other_parties: value) }
+    let(:step_params) { { has_other_parties: 'anything' } }
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+      it { is_expected.to have_destination('/steps/other_parties/names', :edit) }
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+      it { is_expected.to have_destination('/steps/abuse_concerns/previous_proceedings', :edit) }
     end
   end
 end


### PR DESCRIPTION
This includes the usual, as we did for applicants, respondents, etc.

- names step
- personal and contact details steps
- update decision trees