### PR TITLE
Add `relationship` step to Applicants

### DIFF
--- a/app/controllers/steps/applicant/relationship_controller.rb
+++ b/app/controllers/steps/applicant/relationship_controller.rb
@@ -1,0 +1,31 @@
+module Steps
+  module Applicant
+    class RelationshipController < Steps::ApplicantStepController
+      def edit
+        @form_object = RelationshipForm.build(
+          relationship_record, c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          RelationshipForm,
+          record: relationship_record,
+          as: :relationship
+        )
+      end
+
+      private
+
+      def child_record
+        current_c100_application.children.find(params[:child_id])
+      end
+
+      def relationship_record
+        current_c100_application.relationships.find_or_initialize_by(
+          applicant: current_record, child: child_record
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/applicant/relationship_form.rb
+++ b/app/forms/steps/applicant/relationship_form.rb
@@ -1,0 +1,38 @@
+module Steps
+  module Applicant
+    class RelationshipForm < BaseForm
+      attribute :relation, String
+      attribute :relation_other_value, String
+
+      def self.choices
+        Relation.string_values
+      end
+      validates_inclusion_of :relation, in: choices
+
+      validates_presence_of :relation_other_value, if: :other_value_needed?
+
+      private
+
+      def relation_value
+        Relation.new(relation)
+      end
+
+      def other_value
+        relation_other_value if other_value_needed?
+      end
+
+      def other_value_needed?
+        relation_value.eql?(Relation::OTHER)
+      end
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record.update(
+          relation: relation_value,
+          relation_other_value: other_value
+        )
+      end
+    end
+  end
+end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -6,6 +6,7 @@ class C100Application < ApplicationRecord
   has_one  :court_order,      dependent: :destroy
 
   has_many :abuse_concerns,   dependent: :destroy
+  has_many :relationships,    dependent: :destroy
 
   # Remember, we are using UUIDs as the record IDs, we can't rely on ID sequential ordering
   has_many :children,    -> { order(created_at: :asc) }, dependent: :destroy

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,3 +1,4 @@
 class Child < Person
   has_one :child_order, dependent: :destroy
+  has_many :relationships, source: :child, dependent: :destroy
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,3 +1,4 @@
 class Person < ApplicationRecord
   belongs_to :c100_application
+  has_many :relationships, dependent: :destroy
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,8 @@
+class Relationship < ApplicationRecord
+  belongs_to :c100_application
+
+  belongs_to :child,       foreign_key: :child_id
+  belongs_to :applicant,   foreign_key: :person_id
+  belongs_to :respondent,  foreign_key: :person_id
+  belongs_to :other_party, foreign_key: :person_id
+end

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -45,11 +45,11 @@ class BaseDecisionTree
     {controller: step_controller, action: :edit}.merge(params)
   end
 
-  def next_record_id(collection_ids)
+  def next_record_id(collection_ids, current: record)
     @_next_record_id ||= begin
-      return collection_ids.first if record.nil?
+      return collection_ids.first if current.nil?
 
-      pos = collection_ids.index(record.id)
+      pos = collection_ids.index(current.id)
       collection_ids.at(pos + 1)
     end
   end

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -11,9 +11,11 @@ module C100App
       when :add_another_name
         edit(:names)
       when :names_finished
-        edit(:personal_details, id: next_record_id)
+        edit(:personal_details, id: next_applicant_id)
       when :personal_details
-        edit(:contact_details, id: record)
+        edit(:relationship, id: record, child_id: first_child_id)
+      when :relationship
+        children_relationships
       when :contact_details
         after_contact_details
       else
@@ -24,15 +26,31 @@ module C100App
     private
 
     def after_contact_details
-      if next_record_id
-        edit(:personal_details, id: next_record_id)
+      if next_applicant_id
+        edit(:personal_details, id: next_applicant_id)
       else
         edit('/steps/respondent/names')
       end
     end
 
-    def next_record_id
-      super(c100_application.applicant_ids)
+    def children_relationships
+      if next_child_id
+        edit(:relationship, id: record.applicant, child_id: next_child_id)
+      else
+        edit(:contact_details, id: record.applicant)
+      end
+    end
+
+    def next_applicant_id
+      next_record_id(c100_application.applicant_ids)
+    end
+
+    def next_child_id
+      next_record_id(c100_application.child_ids, current: record.child)
+    end
+
+    def first_child_id
+      c100_application.child_ids.first
     end
   end
 end

--- a/app/value_objects/relation.rb
+++ b/app/value_objects/relation.rb
@@ -1,0 +1,16 @@
+class Relation < ValueObject
+  VALUES = [
+    MOTHER         = new(:mother),
+    FATHER         = new(:father),
+    LEGAL_GUARDIAN = new(:legal_guardian),
+    GRANDPARENT    = new(:grandparent),
+    RELATIVE       = new(:relative),
+    FAMILY_FRIEND  = new(:family_friend),
+    SOCIAL_WORKER  = new(:social_worker),
+    OTHER          = new(:other)
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/views/steps/applicant/relationship/edit.html.erb
+++ b/app/views/steps/applicant/relationship/edit.html.erb
@@ -1,0 +1,30 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">
+      <%= t('.heading',
+        applicant_name: @form_object.record.applicant.full_name,
+        child_name: @form_object.record.child.full_name) %>
+    </h1>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.radio_button_fieldset :relation do |fieldset|
+          fieldset.radio_input Relation::MOTHER
+          fieldset.radio_input Relation::FATHER
+          fieldset.radio_input Relation::LEGAL_GUARDIAN
+          fieldset.radio_input Relation::GRANDPARENT
+          fieldset.radio_input Relation::RELATIVE
+          fieldset.radio_input Relation::FAMILY_FRIEND
+          fieldset.radio_input Relation::SOCIAL_WORKER
+          fieldset.radio_input(Relation::OTHER) { f.text_field :relation_other_value }
+        end
+      %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,16 @@ en:
       start_again: Start again
       finish: Finish
 
+    RELATIONS: &RELATIONS
+      mother: Mother
+      father: Father
+      legal_guardian: Legal guardian
+      grandparent: Grandparent
+      relative: Relative
+      family_friend: Family friend
+      social_worker: Social worker
+      other: Other
+
     PETITION_ORDERS: &PETITION_ORDERS
       child_home: Arrange where they live
       child_times: Arrange how much time they spend with each parent
@@ -131,6 +141,10 @@ en:
         edit:
           page_title: Applicant contact details
           heading: "Contact details of %{name}"
+      relationship:
+        edit:
+          page_title: Applicant relationship
+          heading: "How is %{applicant_name} related to %{child_name}"
     help_with_fees:
       help_paying:
         edit:
@@ -633,6 +647,8 @@ en:
       steps_applicant_personal_details_form:
         has_previous_name: Previous name?
         gender: Sex
+      steps_applicant_relationship_form:
+        relation_html: ""
       steps_applicant_contact_details_form:
         residence_requirement_met: Have you lived at your current address for more than 5 years?
       steps_respondent_personal_details_form:
@@ -723,6 +739,10 @@ en:
       steps_applicant_contact_details_form:
         <<: *PERSONAL_CONTACT_FIELDS
         residence_history: Provide details and dates of all previous addresses for the last 5 years
+      steps_applicant_relationship_form:
+        relation_other_value: Provide details
+        relation:
+          <<: *RELATIONS
       steps_respondent_contact_details_form:
         <<: *PERSONAL_CONTACT_FIELDS
         residence_history: Please provide details of all previous addresses for the last 5 years below (if known, including the dates and starting with the most recent)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,12 @@ Rails.application.routes.draw do
       crud_step :names
       crud_step :personal_details, only: [:edit, :update]
       crud_step :contact_details,  only: [:edit, :update]
+
+      namespace :relationship do
+        get   ':id/child/:child_id', action: :edit
+        put   ':id/child/:child_id', action: :update
+        patch ':id/child/:child_id', action: :update
+      end
     end
     namespace :respondent do
       crud_step :names

--- a/db/migrate/20171218141037_create_relationships_table.rb
+++ b/db/migrate/20171218141037_create_relationships_table.rb
@@ -1,0 +1,17 @@
+class CreateRelationshipsTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :relationships, id: :uuid do |t|
+      t.string :relation
+      t.string :relation_other_value
+      t.uuid   :child_id,  null: false
+      t.uuid   :person_id, null: false
+    end
+
+    add_index :relationships, [:child_id, :person_id], unique: true
+
+    add_reference :relationships, :c100_application, type: :uuid, foreign_key: true
+
+    add_foreign_key :relationships, :people, column: :child_id
+    add_foreign_key :relationships, :people, column: :person_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171215143416) do
+ActiveRecord::Schema.define(version: 20171218141037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,6 +181,16 @@ ActiveRecord::Schema.define(version: 20171215143416) do
     t.index ["c100_application_id"], name: "index_people_on_c100_application_id", using: :btree
   end
 
+  create_table "relationships", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.string "relation"
+    t.string "relation_other_value"
+    t.uuid   "child_id",             null: false
+    t.uuid   "person_id",            null: false
+    t.uuid   "c100_application_id"
+    t.index ["c100_application_id"], name: "index_relationships_on_c100_application_id", using: :btree
+    t.index ["child_id", "person_id"], name: "index_relationships_on_child_id_and_person_id", unique: true, using: :btree
+  end
+
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
@@ -202,4 +212,7 @@ ActiveRecord::Schema.define(version: 20171215143416) do
   add_foreign_key "child_orders", "people", column: "child_id"
   add_foreign_key "court_orders", "c100_applications"
   add_foreign_key "people", "c100_applications"
+  add_foreign_key "relationships", "c100_applications"
+  add_foreign_key "relationships", "people"
+  add_foreign_key "relationships", "people", column: "child_id"
 end

--- a/spec/controllers/steps/applicant/relationship_controller_spec.rb
+++ b/spec/controllers/steps/applicant/relationship_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Applicant::RelationshipController, type: :controller do
+  it_behaves_like 'a relationship step controller', Steps::Applicant::RelationshipForm, C100App::ApplicantDecisionTree
+end

--- a/spec/forms/steps/applicant/relationship_form_spec.rb
+++ b/spec/forms/steps/applicant/relationship_form_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Applicant::RelationshipForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    record: record,
+    relation: relation,
+    relation_other_value: relation_other_value
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:record) { double('Relationship') }
+  let(:relation) { 'mother' }
+  let(:relation_other_value) { nil }
+
+  subject { described_class.new(arguments) }
+
+
+  describe '.choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.choices).to eq(%w(
+        mother
+        father
+        legal_guardian
+        grandparent
+        relative
+        family_friend
+        social_worker
+        other
+      ))
+    end
+  end
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'validations on field presence' do
+      it { should validate_presence_of(:relation, :inclusion) }
+    end
+
+    context 'validations on `relation_other_value`' do
+      context 'when relation is `other` and `relation_other_value` is not provided' do
+        let(:relation) { 'other' }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the `relation_other_value` field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:relation_other_value]).to_not be_empty
+        end
+      end
+
+      context 'when relation is `other` and `relation_other_value` is provided' do
+        let(:relation) { 'other' }
+        let(:relation_other_value) { 'anything' }
+
+        it 'has no validation errors' do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    context 'for valid details' do
+      let(:relation_other_value) { 'anything' }
+
+      it 'updates the record' do
+        expect(record).to receive(:update).with(
+          relation: Relation::MOTHER,
+          relation_other_value: nil
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+
+      context 'for `other` relation' do
+        let(:relation) { 'other' }
+
+        it 'updates the record' do
+          expect(record).to receive(:update).with(
+            relation: Relation::OTHER,
+            relation_other_value: 'anything'
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe C100App::ApplicantDecisionTree do
   let(:as)               { nil }
   let(:record)           { nil }
 
-  let(:c100_application) { instance_double(C100Application, applicant_ids: [1, 2, 3]) }
+  let(:c100_application) { instance_double(C100Application, applicant_ids: [1, 2, 3], child_ids: [1, 2, 3]) }
 
   subject {
     described_class.new(
@@ -59,8 +59,31 @@ RSpec.describe C100App::ApplicantDecisionTree do
     let(:step_params) {{'personal_details' => 'anything'}}
     let(:record) {double('Applicant', id: 1)}
 
-    it 'goes to edit the contact details of the current record' do
-      expect(subject.destination).to eq(controller: :contact_details, action: :edit, id: record)
+    it 'goes to edit the first child relationship for the current record' do
+      expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
+    end
+  end
+
+  context 'when the step is `relationship`' do
+    let(:step_params) {{'relationship' => 'anything'}}
+    let(:record) { double('Relationship', applicant: applicant, child: child) }
+
+    let(:applicant) { double('Applicant', id: 1) }
+
+    context 'when there are remaining children' do
+      let(:child) { double('Child', id: 1) }
+
+      it 'goes to edit the relationship of the next child' do
+        expect(subject.destination).to eq(controller: :relationship, action: :edit, id: applicant, child_id: 2)
+      end
+    end
+
+    context 'when all child relationships have been edited' do
+      let(:child) { double('Child', id: 3) }
+
+      it 'goes to edit the contact details of the current applicant' do
+        expect(subject.destination).to eq(controller: :contact_details, action: :edit, id: applicant)
+      end
     end
   end
 

--- a/spec/support/relationship_step_controller_shared_examples.rb
+++ b/spec/support/relationship_step_controller_shared_examples.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+# TODO: at the moment this `shared examples` are not really generic enough to cope with
+# models other than `Applicant`, but once we start implementing the relationships for another
+# model, for example `Respondent`, it will be more clear what changes we need to make.
+#
+RSpec.shared_examples 'a relationship step controller' do |form_class, decision_tree_class|
+  let(:relationships) { double('relationships').as_null_object }
+  let(:children)      { double('children').as_null_object }
+  let(:applicant)     { double('Applicant') }
+  let(:child)         { double('Child') }
+
+  let(:existing_case) { instance_double(C100Application, relationships: relationships, children: children) }
+
+  # This is a side effect of everything being a double, we have to do a lot of 'setup', but all this
+  # is not part of these tests and we don't need to test the functionality, just trust it.
+  before do
+    allow(controller).to receive(:current_c100_application).and_return(existing_case)
+    allow(controller).to receive(:update_navigation_stack)
+    allow(controller).to receive(:set_existing_records)
+  end
+
+  describe '#update' do
+    let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+    let(:form_class_params_name) { form_class.name.underscore }
+    let(:expected_params) { { form_class_params_name => { foo: 'bar' }, id: '123', child_id: '123' } }
+
+    context 'when there is no case in the session' do
+      before do
+        # Needed because some specs that include these examples stub current_c100_application,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_c100_application).and_return(nil)
+      end
+
+      it 'redirects to the invalid session error page' do
+        put :update, params: expected_params
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when a case in progress is in the session' do
+      before do
+        allow(form_class).to receive(:new).and_return(form_object)
+        allow(controller).to receive(:current_record).and_return(applicant)
+        allow(children).to receive(:find).with('123').and_return(child)
+
+        expect(relationships).to receive(:find_or_initialize_by).with(applicant: applicant, child: child)
+      end
+
+      context 'when the form saves successfully' do
+        before do
+          allow(form_object).to receive(:save).and_return(true)
+        end
+
+        let(:decision_tree) { instance_double(decision_tree_class, destination: '/expected_destination') }
+
+        it 'asks the decision tree for the next destination and redirects there' do
+          expect(decision_tree_class).to receive(:new).and_return(decision_tree)
+          put :update, params: expected_params
+          expect(subject).to redirect_to('/expected_destination')
+        end
+      end
+
+      context 'when the form fails to save' do
+        before do
+          allow(form_object).to receive(:save).and_return(false)
+        end
+
+        it 'renders the question page again' do
+          put :update, params: expected_params
+          expect(subject).to render_template(:edit)
+        end
+      end
+    end
+  end
+
+  describe '#edit' do
+    context 'when no case exists in the session yet' do
+      before do
+        # Needed because some specs that include these examples stub current_c100_application,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_c100_application).and_return(nil)
+      end
+
+      it 'redirects to the invalid session error page' do
+        get :edit, params: { id: '123', child_id: '123' }
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when a case exists in the session' do
+      before do
+        allow(controller).to receive(:current_record).and_return(applicant)
+        allow(children).to receive(:find).with('123').and_return(child)
+        expect(relationships).to receive(:find_or_initialize_by).with(applicant: applicant, child: child)
+      end
+
+      it 'responds with HTTP success' do
+        get :edit, params: { id: '123', child_id: '123' }
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/value_objects/relation_spec.rb
+++ b/spec/value_objects/relation_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Relation do
+  let(:value) { :foo }
+  subject     { described_class.new(value) }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(
+        mother
+        father
+        legal_guardian
+        grandparent
+        relative
+        family_friend
+        social_worker
+        other
+      ))
+    end
+  end
+end


### PR DESCRIPTION
This step will create the relationship between each applicant and
each child. The same will apply to respondents and other parties, and
we should be able to extract most of the code to a module/superclass.