### PR TITLE
Add `relationship` step to OtherParty

### DIFF
--- a/app/controllers/steps/other_parties/relationship_controller.rb
+++ b/app/controllers/steps/other_parties/relationship_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module OtherParties
+    class RelationshipController < Steps::OtherPartiesStepController
+      include RelationshipStep
+    end
+  end
+end

--- a/app/services/c100_app/other_parties_decision_tree.rb
+++ b/app/services/c100_app/other_parties_decision_tree.rb
@@ -7,9 +7,11 @@ module C100App
       when :add_another_name
         edit(:names)
       when :names_finished
-        edit(:personal_details, id: next_record_id)
+        edit(:personal_details, id: next_party_id)
       when :personal_details
-        edit(:contact_details, id: record)
+        edit(:relationship, id: record, child_id: first_child_id)
+      when :relationship
+        children_relationships
       when :contact_details
         after_contact_details
       else
@@ -20,15 +22,31 @@ module C100App
     private
 
     def after_contact_details
-      if next_record_id
-        edit(:personal_details, id: next_record_id)
+      if next_party_id
+        edit(:personal_details, id: next_party_id)
       else
         edit('/steps/abuse_concerns/previous_proceedings') # TODO: change when we have children residence step
       end
     end
 
-    def next_record_id
-      super(c100_application.other_party_ids)
+    def children_relationships
+      if next_child_id
+        edit(:relationship, id: record.other_party, child_id: next_child_id)
+      else
+        edit(:contact_details, id: record.other_party)
+      end
+    end
+
+    def next_party_id
+      next_record_id(c100_application.other_party_ids)
+    end
+
+    def next_child_id
+      next_record_id(c100_application.child_ids, current: record.child)
+    end
+
+    def first_child_id
+      c100_application.child_ids.first
     end
   end
 end

--- a/app/views/steps/other_parties/relationship/edit.html.erb
+++ b/app/views/steps/other_parties/relationship/edit.html.erb
@@ -1,0 +1,9 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <%= render partial: 'steps/shared/relationship_step', locals: { form_object: @form_object } %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,6 +230,9 @@ en:
         edit:
           page_title: Other party contact details
           heading: "Contact details of %{name}"
+      relationship:
+        edit:
+          page_title: Other party relationship
     abuse_concerns:
       question:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,9 @@ Rails.application.routes.draw do
       crud_step :names
       crud_step :personal_details, only: [:edit, :update]
       crud_step :contact_details,  only: [:edit, :update]
+      edit_step :relationship, only: [] do
+        edit_routes ':id/child/:child_id'
+      end
     end
     namespace :help_with_fees do
       edit_step :help_paying

--- a/spec/controllers/steps/other_parties/relationship_controller_spec.rb
+++ b/spec/controllers/steps/other_parties/relationship_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::OtherParties::RelationshipController, type: :controller do
+  it_behaves_like 'a relationship step controller', Steps::Shared::RelationshipForm, C100App::OtherPartiesDecisionTree
+end

--- a/spec/services/c100_app/other_parties_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_parties_decision_tree_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
   let(:as)               { nil }
   let(:record)           { nil }
 
-  let(:c100_application) { instance_double(C100Application, other_party_ids: [1, 2, 3]) }
+  let(:c100_application) { instance_double(C100Application, other_party_ids: [1, 2, 3], child_ids: [1, 2, 3]) }
 
   subject {
     described_class.new(
@@ -38,8 +38,31 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
     let(:step_params) {{'personal_details' => 'anything'}}
     let(:record) {double('OtherParty', id: 1)}
 
-    it 'goes to edit the contact details of the current record' do
-      expect(subject.destination).to eq(controller: :contact_details, action: :edit, id: record)
+    it 'goes to edit the first child relationship for the current record' do
+      expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
+    end
+  end
+
+  context 'when the step is `relationship`' do
+    let(:step_params) {{'relationship' => 'anything'}}
+    let(:record) { double('Relationship', other_party: other_party, child: child) }
+
+    let(:other_party) { double('OtherParty', id: 1) }
+
+    context 'when there are remaining children' do
+      let(:child) { double('Child', id: 1) }
+
+      it 'goes to edit the relationship of the next child' do
+        expect(subject.destination).to eq(controller: :relationship, action: :edit, id: other_party, child_id: 2)
+      end
+    end
+
+    context 'when all child relationships have been edited' do
+      let(:child) { double('Child', id: 3) }
+
+      it 'goes to edit the contact details of the current party' do
+        expect(subject.destination).to eq(controller: :contact_details, action: :edit, id: other_party)
+      end
     end
   end
 


### PR DESCRIPTION
Just using the previously created code.

Again, some repetition in the decision tree, which probably will be
extracted sooner rather than later as all these decision trees
(applicants, respondents, other parties) share almost identical steps
(names, personal details, relationships and contact details).