### PR TITLE
Add children residence step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
-services: postgresql
+
+addons:
+  postgresql: "9.5"
+
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
 

--- a/app/controllers/steps/children/residence_controller.rb
+++ b/app/controllers/steps/children/residence_controller.rb
@@ -1,0 +1,25 @@
+module Steps
+  module Children
+    class ResidenceController < Steps::ChildrenStepController
+      def edit
+        @form_object = ResidenceForm.build(
+          residence_record, c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          ResidenceForm,
+          record: residence_record,
+          as: :residence
+        )
+      end
+
+      private
+
+      def residence_record
+        current_record.child_residence || current_record.build_child_residence
+      end
+    end
+  end
+end

--- a/app/controllers/steps/children/residence_controller.rb
+++ b/app/controllers/steps/children/residence_controller.rb
@@ -20,6 +20,10 @@ module Steps
       def residence_record
         current_record.child_residence || current_record.build_child_residence
       end
+
+      def additional_permitted_params
+        [person_ids: []]
+      end
     end
   end
 end

--- a/app/forms/steps/children/residence_form.rb
+++ b/app/forms/steps/children/residence_form.rb
@@ -1,10 +1,20 @@
 module Steps
   module Children
     class ResidenceForm < BaseForm
+      attribute :person_ids, Array[String]
       attribute :other, Boolean
       attribute :other_full_name, StrippedString
 
       validates_presence_of :other_full_name, if: :other?
+
+      # These are all the parties available to choose from
+      def people
+        [
+          c100_application.applicants,
+          c100_application.respondents,
+          c100_application.other_parties
+        ].flatten
+      end
 
       private
 
@@ -12,6 +22,7 @@ module Steps
         raise C100ApplicationNotFound unless c100_application
 
         record.update(
+          person_ids: person_ids,
           other: other,
           other_full_name: (other_full_name if other)
         )

--- a/app/forms/steps/children/residence_form.rb
+++ b/app/forms/steps/children/residence_form.rb
@@ -1,0 +1,21 @@
+module Steps
+  module Children
+    class ResidenceForm < BaseForm
+      attribute :other, Boolean
+      attribute :other_full_name, StrippedString
+
+      validates_presence_of :other_full_name, if: :other?
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record.update(
+          other: other,
+          other_full_name: (other_full_name if other)
+        )
+      end
+    end
+  end
+end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,4 +1,6 @@
 class Child < Person
   has_one :child_order, dependent: :destroy
+  has_one :child_residence, dependent: :destroy
+
   has_many :relationships, source: :child, dependent: :destroy
 end

--- a/app/models/child_residence.rb
+++ b/app/models/child_residence.rb
@@ -1,0 +1,3 @@
+class ChildResidence < ApplicationRecord
+  belongs_to :child
+end

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -7,7 +7,7 @@ module C100App
       when :add_another_name
         edit(:names)
       when :names_finished
-        edit(:personal_details, id: next_record_id)
+        edit(:personal_details, id: next_child_id)
       when :personal_details
         edit(:orders, id: record) # TODO: refinement to bypass `orders` when children < 2
       when :orders
@@ -16,20 +16,14 @@ module C100App
         edit(:has_other_children)
       when :has_other_children
         after_has_other_children
+      when :residence
+        after_child_residence
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
     end
 
     private
-
-    def after_orders
-      if next_record_id
-        edit(:personal_details, id: next_record_id)
-      else
-        edit(:additional_details)
-      end
-    end
 
     def after_has_other_children
       if question(:has_other_children).yes?
@@ -39,8 +33,28 @@ module C100App
       end
     end
 
-    def next_record_id
-      super(c100_application.child_ids)
+    def after_orders
+      if next_child_id
+        edit(:personal_details, id: next_child_id)
+      else
+        edit(:additional_details)
+      end
+    end
+
+    def after_child_residence
+      # Here `record` is not a Child but instead a ChildResidence instance, so we
+      # need to pass an explicit `current` argument with the associated Child record.
+      child_id = next_child_id(current: record.child)
+
+      if child_id
+        edit(:residence, id: child_id)
+      else
+        edit('/steps/abuse_concerns/previous_proceedings')
+      end
+    end
+
+    def next_child_id(current: record)
+      next_record_id(c100_application.child_ids, current: current)
     end
   end
 end

--- a/app/services/c100_app/other_parties_decision_tree.rb
+++ b/app/services/c100_app/other_parties_decision_tree.rb
@@ -25,7 +25,7 @@ module C100App
       if next_party_id
         edit(:personal_details, id: next_party_id)
       else
-        edit('/steps/abuse_concerns/previous_proceedings') # TODO: change when we have children residence step
+        edit('/steps/children/residence', id: first_child_id)
       end
     end
 

--- a/app/services/c100_app/respondent_decision_tree.rb
+++ b/app/services/c100_app/respondent_decision_tree.rb
@@ -35,7 +35,7 @@ module C100App
       if question(:has_other_parties).yes?
         edit('/steps/other_parties/names')
       else
-        edit('/steps/abuse_concerns/previous_proceedings') # TODO: change when we have children residence step
+        edit('/steps/children/residence', id: first_child_id)
       end
     end
 

--- a/app/views/steps/children/residence/edit.html.erb
+++ b/app/views/steps/children/residence/edit.html.erb
@@ -1,0 +1,24 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">
+      <%=t '.heading', name: @form_object.record.child.full_name %>
+    </h1>
+
+    <%= step_form @form_object do |f| %>
+      <!-- TODO: Add checkboxes for all existing parties -->
+
+      <!--
+        TODO: The following checkbox should reveal the `other_full_name` input
+        but for now we don't have a solution for this until the gem is updated.
+       -->
+      <%= f.check_box_fieldset :other, [:other] %>
+      <%= f.text_field :other_full_name %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/children/residence/edit.html.erb
+++ b/app/views/steps/children/residence/edit.html.erb
@@ -9,14 +9,33 @@
     </h1>
 
     <%= step_form @form_object do |f| %>
-      <!-- TODO: Add checkboxes for all existing parties -->
+      <div class="form-group" id="child-residence" data-block-name="child-residence">
+        <fieldset class="fieldset-block">
+          <legend>
+            <span class="form-label-bold visuallyhidden">
+              <%=t '.heading', name: @form_object.record.child.full_name %>
+            </span>
+            <span class="form-hint">
+              <%=t '.form_hint' %>
+            </span>
+          </legend>
 
-      <!--
-        TODO: The following checkbox should reveal the `other_full_name` input
-        but for now we don't have a solution for this until the gem is updated.
-       -->
-      <%= f.check_box_fieldset :other, [:other] %>
-      <%= f.text_field :other_full_name %>
+          <%= f.collection_check_boxes :person_ids, @form_object.people, :id, :full_name do |cb| %>
+            <div class="multiple-choice">
+              <%= cb.check_box %>
+              <%= cb.label class: 'block-label selection-button-checkbox' %>
+            </div>
+          <% end %>
+
+          <div class="multiple-choice" data-target="children_residence_other_panel">
+            <%= f.check_box :other, {'aria-controls': 'children_residence_other_panel'} %>
+            <%= f.label(:other, class: 'block-label selection-button-checkbox') %>
+          </div>
+          <div class="panel panel-border-narrow js-hidden" id="children_residence_other_panel">
+            <%= f.text_field :other_full_name %>
+          </div>
+        </fieldset>
+      </div>
 
       <%= f.submit class: 'button' %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,7 @@ en:
         edit:
           page_title: Child residence
           heading: "Who does %{name} live with?"
+          form_hint: Select all that apply
     other_children:
       names:
         edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,10 @@ en:
         edit:
           page_title: Which orders apply to the child
           heading: "Which of the requested orders relate to %{name}?"
+      residence:
+        edit:
+          page_title: Child residence
+          heading: "Who does %{name} live with?"
     other_children:
       names:
         edit:
@@ -690,6 +694,8 @@ en:
         gender: Sex
       steps_children_orders_form:
         orders_html: ""
+      steps_children_residence_form:
+        other_html: ""
       steps_children_additional_details_form:
         children_known_to_authorities: Are any of the children known to social services?
         children_protection_plan: Are any of the children the subject of a child protection plan?
@@ -787,6 +793,9 @@ en:
         children_protection_plan:
           <<: *YESNO
         children_known_to_authorities_details: State which child and the name of the local authority and social worker (if known)
+      steps_children_residence_form:
+        other: Other
+        other_full_name: Enter full name
       steps_safety_questions_substance_abuse_details_form:
         substance_abuse_details: Details
       steps_abuse_concerns_details_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
       crud_step :orders, only: [:edit, :update]
       edit_step :additional_details
       edit_step :has_other_children
+      crud_step :residence, only: [:edit, :update]
     end
     namespace :other_children do
       crud_step :names

--- a/db/migrate/20180108145551_create_child_residences_table.rb
+++ b/db/migrate/20180108145551_create_child_residences_table.rb
@@ -1,0 +1,12 @@
+class CreateChildResidencesTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :child_residences, id: :uuid do |t|
+      t.uuid    :child_id, index: true
+      t.string  :person_ids, array: true, default: []
+      t.boolean :other
+      t.string  :other_full_name
+    end
+
+    add_foreign_key :child_residences, :people, column: :child_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180108123316) do
+ActiveRecord::Schema.define(version: 20180108145551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,14 @@ ActiveRecord::Schema.define(version: 20180108123316) do
     t.index ["child_id"], name: "index_child_orders_on_child_id"
   end
 
+  create_table "child_residences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "child_id"
+    t.string "person_ids", default: [], array: true
+    t.boolean "other"
+    t.string "other_full_name"
+    t.index ["child_id"], name: "index_child_residences_on_child_id"
+  end
+
   create_table "court_orders", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "non_molestation"
     t.date "non_molestation_issue_date"
@@ -216,6 +224,7 @@ ActiveRecord::Schema.define(version: 20180108123316) do
   add_foreign_key "asking_orders", "c100_applications"
   add_foreign_key "c100_applications", "users"
   add_foreign_key "child_orders", "people", column: "child_id"
+  add_foreign_key "child_residences", "people", column: "child_id"
   add_foreign_key "court_orders", "c100_applications"
   add_foreign_key "people", "c100_applications"
   add_foreign_key "relationships", "c100_applications"

--- a/spec/controllers/steps/children/residence_controller_spec.rb
+++ b/spec/controllers/steps/children/residence_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Children::ResidenceController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Children::ResidenceForm, C100App::ChildrenDecisionTree
+end

--- a/spec/forms/steps/children/residence_form_spec.rb
+++ b/spec/forms/steps/children/residence_form_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Steps::Children::ResidenceForm do
   let(:arguments) { {
     c100_application: c100_application,
     record: record,
+    person_ids: person_ids,
     other: other,
     other_full_name: other_full_name
   } }
@@ -11,10 +12,21 @@ RSpec.describe Steps::Children::ResidenceForm do
   let(:c100_application) { instance_double(C100Application) }
 
   let(:record) { double('Residence') }
+  let(:person_ids) { %w(1 2) }
   let(:other) { true }
   let(:other_full_name) { 'John Doe' }
 
   subject { described_class.new(arguments) }
+
+  describe '#people' do
+    it 'returns a flattened collection of all the people children can live with' do
+      expect(c100_application).to receive(:applicants).and_return(['a'])
+      expect(c100_application).to receive(:respondents).and_return(['b', 'c'])
+      expect(c100_application).to receive(:other_parties).and_return(['d'])
+
+      expect(subject.people).to eq(%w(a b c d))
+    end
+  end
 
   describe '#save' do
     context 'when no c100_application is associated with the form' do
@@ -53,6 +65,7 @@ RSpec.describe Steps::Children::ResidenceForm do
     context 'for valid details' do
       it 'updates the record' do
         expect(record).to receive(:update).with(
+          person_ids: %w(1 2),
           other: true,
           other_full_name: 'John Doe'
         ).and_return(true)
@@ -66,6 +79,7 @@ RSpec.describe Steps::Children::ResidenceForm do
 
         it 'reset `other_full_name` when no needed' do
           expect(record).to receive(:update).with(
+            person_ids: %w(1 2),
             other: false,
             other_full_name: nil
           ).and_return(true)

--- a/spec/forms/steps/children/residence_form_spec.rb
+++ b/spec/forms/steps/children/residence_form_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Children::ResidenceForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    record: record,
+    other: other,
+    other_full_name: other_full_name
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:record) { double('Residence') }
+  let(:other) { true }
+  let(:other_full_name) { 'John Doe' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'validations on `other_full_name`' do
+      context 'when residence is `other` and `other_full_name` is not provided' do
+        let(:other) { true }
+        let(:other_full_name) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the `other_full_name` field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:other_full_name]).to_not be_empty
+        end
+      end
+
+      context 'when residence is `other` and `other_full_name` is provided' do
+        let(:other) { true }
+        let(:other_full_name) { 'John Doe' }
+
+        it 'has no validation errors' do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    context 'for valid details' do
+      it 'updates the record' do
+        expect(record).to receive(:update).with(
+          other: true,
+          other_full_name: 'John Doe'
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+
+      context 'reset values' do
+        let(:other) { false }
+        let(:other_full_name) { 'John Doe' }
+
+        it 'reset `other_full_name` when no needed' do
+          expect(record).to receive(:update).with(
+            other: false,
+            other_full_name: nil
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/children_decision_tree_spec.rb
+++ b/spec/services/c100_app/children_decision_tree_spec.rb
@@ -79,4 +79,22 @@ RSpec.describe C100App::ChildrenDecisionTree do
       it { is_expected.to have_destination('/steps/applicant/names', :edit) }
     end
   end
+
+  context 'when the step is `residence`' do
+    let(:step_params) {{'residence' => 'anything'}}
+    let(:record) { double('ChildResidence', child: child) }
+
+    context 'when there are remaining children' do
+      let(:child) { double('Child', id: 1) }
+
+      it 'goes to edit the residence of the next child' do
+        expect(subject.destination).to eq(controller: :residence, action: :edit, id: 2)
+      end
+    end
+
+    context 'when all child residences have been edited' do
+      let(:child) { double('Child', id: 3) }
+      it { is_expected.to have_destination('/steps/abuse_concerns/previous_proceedings', :edit) }
+    end
+  end
 end

--- a/spec/services/c100_app/other_parties_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_parties_decision_tree_spec.rb
@@ -79,7 +79,10 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
 
     context 'when all parties have been edited' do
       let(:record) { double('OtherParty', id: 3) }
-      it {is_expected.to have_destination('/steps/abuse_concerns/previous_proceedings', :edit)}
+
+      it 'goes to edit the residence of the first child' do
+        expect(subject.destination).to eq(controller: '/steps/children/residence', action: :edit, id: 1)
+      end
     end
   end
 end

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -84,8 +84,11 @@ RSpec.describe C100App::RespondentDecisionTree do
   end
 
   context 'when the step is `has_other_parties`' do
-    let(:c100_application) { instance_double(C100Application, has_other_parties: value) }
     let(:step_params) { { has_other_parties: 'anything' } }
+
+    before do
+      allow(c100_application).to receive(:has_other_parties).and_return(value)
+    end
 
     context 'and the answer is `yes`' do
       let(:value) { 'yes' }
@@ -94,7 +97,10 @@ RSpec.describe C100App::RespondentDecisionTree do
 
     context 'and the answer is `no`' do
       let(:value) { 'no' }
-      it { is_expected.to have_destination('/steps/abuse_concerns/previous_proceedings', :edit) }
+
+      it 'goes to edit the residence of the first child' do
+        expect(subject.destination).to eq(controller: '/steps/children/residence', action: :edit, id: 1)
+      end
     end
   end
 end


### PR DESCRIPTION
This step will show a list of names (checkboxes) of all people previously created (applicants, respondents and "other parties" but not children and other children, obviously) and let the user choose who each of the children lives with.

There is also an `other` checkbox to reveal a hidden panel with a text field input.

<img width="659" alt="screen shot 2018-01-09 at 14 51 04" src="https://user-images.githubusercontent.com/687910/34726770-dd3a55d0-f54c-11e7-8310-f6d68e068173.png">

  