### PR TITLE
Speed up mutant, reducing scope by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ password should be available from the MoJ Rattic server, in the Family Justice g
 * `RAILS_ENV=test bundle exec rails db:migrate`
 * `RAILS_ENV=test bundle exec rake`
 
+## Mutation testing
+
+This project uses extensive mutation coverage, which makes the (mutation) tests take a long time to run, and can end up with the CI killing the build due to excessive job work time.
+
+In order to make this a bit faster, by default in CI (and in local when run without any flags), the scope of mutant testing will be reduced to the models, and a randomized small sample of classes in each of these groups: Form objects and Decision trees.
+
+However it is still possible to have full flexibility of what mutant runs in your local environment:
+
+##### Run mutation on a specific file:
+`bundle exec rake mutant C100App::OtherPartiesDecisionTree`
+
+##### Run mutation on the whole project (no random samples):
+`bundle exec rake mutant all`
+
+##### Run mutation on a small sample of classes (default):
+`bundle exec rake mutant`
 
 [taxtribs]: https://github.com/ministryofjustice/tax-tribunals-datacapture
 [heroku-demo]: https://c100-demo.herokuapp.com

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -20,8 +20,22 @@ private
 
 def classes_to_mutate
   Rails.application.eager_load!
-  Array(ARGV[1]).presence ||
-    ApplicationRecord.descendants.map(&:name) +
-    BaseForm.descendants.map(&:name).grep(/^Steps::/) +
-    ['C100App*']
+
+  case ARGV[1]
+    when nil
+      # Quicker run, reduced testing scope (random sample), default option
+      puts '> running quick sample mutant testing'
+      ApplicationRecord.descendants.map(&:name) +
+        BaseForm.descendants.map(&:name).grep(/^Steps::/).sample(10) +
+        BaseDecisionTree.descendants.map(&:name).sample(5)
+    when 'all'
+      # Complete coverage, very long run time
+      puts '> running complete mutant testing'
+      ApplicationRecord.descendants.map(&:name) +
+        BaseForm.descendants.map(&:name).grep(/^Steps::/) +
+        ['C100App*']
+    else
+      # Individual class testing, very quick
+      Array(ARGV[1])
+  end
 end


### PR DESCRIPTION
As the project grows, mutant is taking a huge amount of time to finish,
and lately Travis can't handle it, killing the build after 45 mins or so.

With these changes, by default mutant will run in a smaller sample of
classes but still can be run on the whole project manually.

Updated README to explain the options.