### PR TITLE
Add approximate age revealing panels

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
-  revision: a1849b05d6d4bfe8e6107191ec3a6b9da245f118
+  revision: d8304e7daa0122dba26da8ce6ccba240ce8f8680
   branch: show-hide-radios
   specs:
     govuk_elements_form_builder (1.0.0)

--- a/app/forms/steps/children/personal_details_form.rb
+++ b/app/forms/steps/children/personal_details_form.rb
@@ -6,6 +6,7 @@ module Steps
       attribute :gender, String
       attribute :dob, Date
       attribute :dob_unknown, Boolean
+      attribute :age_estimate, StrippedString
 
       acts_as_gov_uk_date :dob
 

--- a/app/forms/steps/other_children/personal_details_form.rb
+++ b/app/forms/steps/other_children/personal_details_form.rb
@@ -6,6 +6,7 @@ module Steps
       attribute :gender, String
       attribute :dob, Date
       attribute :dob_unknown, Boolean
+      attribute :age_estimate, StrippedString
 
       acts_as_gov_uk_date :dob
 

--- a/app/forms/steps/other_parties/personal_details_form.rb
+++ b/app/forms/steps/other_parties/personal_details_form.rb
@@ -8,6 +8,7 @@ module Steps
       attribute :gender, String
       attribute :dob, Date
       attribute :dob_unknown, Boolean
+      attribute :age_estimate, StrippedString
 
       acts_as_gov_uk_date :dob
 

--- a/app/forms/steps/respondent/personal_details_form.rb
+++ b/app/forms/steps/respondent/personal_details_form.rb
@@ -8,6 +8,7 @@ module Steps
       attribute :gender, String
       attribute :dob, Date
       attribute :dob_unknown, Boolean
+      attribute :age_estimate, StrippedString
       attribute :birthplace, StrippedString
 
       acts_as_gov_uk_date :dob

--- a/app/views/steps/children/personal_details/edit.html.erb
+++ b/app/views/steps/children/personal_details/edit.html.erb
@@ -14,7 +14,12 @@
           legend_class: 'form-label-bold',
           form_hint_text: '' %>
       </div>
-      <%= f.check_box_fieldset :dob_unknown, [:dob_unknown] %>
+
+      <%=
+        f.check_box_fieldset :dob_unknown, [:dob_unknown] do |fieldset|
+          fieldset.check_box_input(:dob_unknown) { f.text_field :age_estimate }
+        end
+      %>
 
       <%= f.radio_button_fieldset :gender, inline: true,
         choices: Steps::Children::PersonalDetailsForm.gender_choices %>

--- a/app/views/steps/other_children/personal_details/edit.html.erb
+++ b/app/views/steps/other_children/personal_details/edit.html.erb
@@ -16,7 +16,12 @@
           legend_class: 'form-label-bold',
           form_hint_text: '' %>
       </div>
-      <%= f.check_box_fieldset :dob_unknown, [:dob_unknown] %>
+
+      <%=
+        f.check_box_fieldset :dob_unknown, [:dob_unknown] do |fieldset|
+          fieldset.check_box_input(:dob_unknown) { f.text_field :age_estimate }
+        end
+      %>
 
       <%= f.radio_button_fieldset :gender, inline: true,
         choices: Steps::Children::PersonalDetailsForm.gender_choices %>

--- a/app/views/steps/other_parties/personal_details/edit.html.erb
+++ b/app/views/steps/other_parties/personal_details/edit.html.erb
@@ -26,7 +26,12 @@
           legend_class: 'form-label-bold',
           form_hint_text: '' %>
       </div>
-      <%= f.check_box_fieldset :dob_unknown, [:dob_unknown] %>
+
+      <%=
+        f.check_box_fieldset :dob_unknown, [:dob_unknown] do |fieldset|
+          fieldset.check_box_input(:dob_unknown) { f.text_field :age_estimate }
+        end
+      %>
 
       <div class="xform-group form-submit">
         <%= f.submit class: 'button' %>

--- a/app/views/steps/respondent/personal_details/edit.html.erb
+++ b/app/views/steps/respondent/personal_details/edit.html.erb
@@ -26,7 +26,12 @@
           legend_class: 'form-label-bold',
           form_hint_text: t('shared.form_elements.dob_hint_html') %>
       </div>
-      <%= f.check_box_fieldset :dob_unknown, [:dob_unknown] %>
+
+      <%=
+        f.check_box_fieldset :dob_unknown, [:dob_unknown] do |fieldset|
+          fieldset.check_box_input(:dob_unknown) { f.text_field :age_estimate }
+        end
+      %>
 
       <%= f.text_field :birthplace %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
         female: Female
         male: Male
       dob_unknown: *dont_know
+      age_estimate: Approximate age or year born
       birthplace: Place of birth
 
     # This is a compilation of all possible fields shared between Applicants and Respondents (maybe others later)
@@ -786,6 +787,7 @@ en:
         <<: *PERSONAL_CONTACT_FIELDS
       steps_children_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
+        age_estimate: Approximate age or year child was born
       steps_children_orders_form:
         <<: *PETITION_ORDERS
       steps_children_additional_details_form:

--- a/spec/forms/steps/children/personal_details_form_spec.rb
+++ b/spec/forms/steps/children/personal_details_form_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Steps::Children::PersonalDetailsForm do
     record: record,
     gender: gender,
     dob: dob,
-    dob_unknown: dob_unknown
+    dob_unknown: dob_unknown,
+    age_estimate: age_estimate
   } }
 
   let(:c100_application) { instance_double(C100Application, children: children_collection) }
@@ -17,6 +18,7 @@ RSpec.describe Steps::Children::PersonalDetailsForm do
   let(:gender) { 'male' }
   let(:dob) { Date.today }
   let(:dob_unknown) { false }
+  let(:age_estimate) { nil }
 
   subject { described_class.new(arguments) }
 
@@ -72,7 +74,8 @@ RSpec.describe Steps::Children::PersonalDetailsForm do
         {
           gender: Gender::MALE,
           dob: Date.today,
-          dob_unknown: false
+          dob_unknown: false,
+          age_estimate: ''
         }
       }
 

--- a/spec/forms/steps/other_children/personal_details_form_spec.rb
+++ b/spec/forms/steps/other_children/personal_details_form_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Steps::OtherChildren::PersonalDetailsForm do
     record: record,
     gender: gender,
     dob: dob,
-    dob_unknown: dob_unknown
+    dob_unknown: dob_unknown,
+    age_estimate: age_estimate
   } }
 
   let(:c100_application) { instance_double(C100Application, other_children: children_collection) }
@@ -17,6 +18,7 @@ RSpec.describe Steps::OtherChildren::PersonalDetailsForm do
   let(:gender) { 'male' }
   let(:dob) { Date.today }
   let(:dob_unknown) { false }
+  let(:age_estimate) { nil }
 
   subject { described_class.new(arguments) }
 
@@ -72,7 +74,8 @@ RSpec.describe Steps::OtherChildren::PersonalDetailsForm do
         {
           gender: Gender::MALE,
           dob: Date.today,
-          dob_unknown: false
+          dob_unknown: false,
+          age_estimate: ''
         }
       }
 

--- a/spec/forms/steps/other_parties/personal_details_form_spec.rb
+++ b/spec/forms/steps/other_parties/personal_details_form_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Steps::OtherParties::PersonalDetailsForm do
     previous_name: previous_name,
     gender: gender,
     dob: dob,
-    dob_unknown: dob_unknown
+    dob_unknown: dob_unknown,
+    age_estimate: age_estimate
   } }
 
   let(:c100_application) { instance_double(C100Application, other_parties: other_parties_collection) }
@@ -21,6 +22,7 @@ RSpec.describe Steps::OtherParties::PersonalDetailsForm do
   let(:gender) { 'male' }
   let(:dob) { Date.today }
   let(:dob_unknown) { false }
+  let(:age_estimate) { nil }
 
   subject { described_class.new(arguments) }
 
@@ -91,7 +93,8 @@ RSpec.describe Steps::OtherParties::PersonalDetailsForm do
           previous_name: '',
           gender: Gender::MALE,
           dob: Date.today,
-          dob_unknown: false
+          dob_unknown: false,
+          age_estimate: ''
         }
       }
 

--- a/spec/forms/steps/respondent/personal_details_form_spec.rb
+++ b/spec/forms/steps/respondent/personal_details_form_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Steps::Respondent::PersonalDetailsForm do
     gender: gender,
     dob: dob,
     dob_unknown: dob_unknown,
+    age_estimate: age_estimate,
     birthplace: birthplace
   } }
 
@@ -22,6 +23,7 @@ RSpec.describe Steps::Respondent::PersonalDetailsForm do
   let(:gender) { 'male' }
   let(:dob) { Date.today }
   let(:dob_unknown) { false }
+  let(:age_estimate) { nil }
   let(:birthplace) { 'London' }
 
   subject { described_class.new(arguments) }
@@ -94,6 +96,7 @@ RSpec.describe Steps::Respondent::PersonalDetailsForm do
           gender: Gender::MALE,
           dob: Date.today,
           dob_unknown: false,
+          age_estimate: '',
           birthplace: 'London'
         }
       }


### PR DESCRIPTION
The `govuk_elements_form_builder` gem has been updated to support
revealing panels triggered by checkboxes in a similar way to what we
already had for radio options.

Now we can implement this missing feature, mimicking the prototype.

Link to the PR (existing PR, new commit for check boxes):
https://github.com/ministryofjustice/govuk_elements_form_builder/pull/95