### PR TITLE
Implement the `under age` validation/step

### DIFF
--- a/app/controllers/steps/applicant/under_age_controller.rb
+++ b/app/controllers/steps/applicant/under_age_controller.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Applicant
+    class UnderAgeController < Steps::ApplicantStepController
+      def edit
+        @form_object = Steps::Shared::UnderAgeForm.build(
+          current_record, c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          Steps::Shared::UnderAgeForm,
+          record: current_record,
+          as: :under_age
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/steps/respondent/under_age_controller.rb
+++ b/app/controllers/steps/respondent/under_age_controller.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Respondent
+    class UnderAgeController < Steps::RespondentStepController
+      def edit
+        @form_object = Steps::Shared::UnderAgeForm.build(
+          current_record, c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          Steps::Shared::UnderAgeForm,
+          record: current_record,
+          as: :under_age
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/shared/under_age_form.rb
+++ b/app/forms/steps/shared/under_age_form.rb
@@ -1,0 +1,14 @@
+module Steps
+  module Shared
+    class UnderAgeForm < BaseForm
+      # This form does nothing really, but we use it for the interstitials 'under 18 years'
+      # warning pages, which are complex in the sense we need to keep track of the current
+      # applicant and, for the following page, the child to ask for their relationship.
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+        true
+      end
+    end
+  end
+end

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -11,7 +11,9 @@ module C100App
       when :names_finished
         edit(:personal_details, id: next_applicant_id)
       when :personal_details
-        edit(:relationship, id: record, child_id: first_child_id)
+        after_personal_details
+      when :under_age
+        edit_first_child_relationships
       when :relationship
         children_relationships
       when :contact_details
@@ -22,6 +24,14 @@ module C100App
     end
 
     private
+
+    def after_personal_details
+      if dob_under_age?
+        edit(:under_age, id: record)
+      else
+        edit_first_child_relationships
+      end
+    end
 
     def after_contact_details
       if next_applicant_id
@@ -37,6 +47,14 @@ module C100App
       else
         edit(:contact_details, id: record.applicant)
       end
+    end
+
+    def dob_under_age?
+      record.reload.dob > 18.years.ago
+    end
+
+    def edit_first_child_relationships
+      edit(:relationship, id: record, child_id: first_child_id)
     end
 
     def next_applicant_id

--- a/app/services/c100_app/respondent_decision_tree.rb
+++ b/app/services/c100_app/respondent_decision_tree.rb
@@ -9,7 +9,9 @@ module C100App
       when :names_finished
         edit(:personal_details, id: next_respondent_id)
       when :personal_details
-        edit(:relationship, id: record, child_id: first_child_id)
+        after_personal_details
+      when :under_age
+        edit_first_child_relationships
       when :relationship
         children_relationships
       when :contact_details
@@ -22,6 +24,14 @@ module C100App
     end
 
     private
+
+    def after_personal_details
+      if dob_under_age?
+        edit(:under_age, id: record)
+      else
+        edit_first_child_relationships
+      end
+    end
 
     def after_contact_details
       if next_respondent_id
@@ -45,6 +55,18 @@ module C100App
       else
         edit(:contact_details, id: record.respondent)
       end
+    end
+
+    def dob_under_age?
+      # Respondents, unlike Applicants, can have an 'unknown' DoB and they can fill
+      # an 'approximate age or year born' free input text. The prototype does some fancy
+      # stuff to try to come up with a valid date/age from the text field, but for now,
+      # I will leave out that functionality as there are more important things to do!
+      record.reload.dob.present? && (record.dob > 18.years.ago)
+    end
+
+    def edit_first_child_relationships
+      edit(:relationship, id: record, child_id: first_child_id)
     end
 
     def next_respondent_id

--- a/app/views/steps/applicant/under_age/edit.html.erb
+++ b/app/views/steps/applicant/under_age/edit.html.erb
@@ -1,0 +1,17 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <!-- TODO: prototype still needs to finish this view -->
+
+    <%= step_form @form_object do |f| %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/respondent/under_age/edit.html.erb
+++ b/app/views/steps/respondent/under_age/edit.html.erb
@@ -1,0 +1,17 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <!-- TODO: prototype still needs to finish this view -->
+
+    <%= step_form @form_object do |f| %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,12 @@ en:
       relationship:
         edit:
           page_title: Respondent relationship
+      under_age:
+        edit:
+          page_title: Respondent under age
+          heading: The respondent is (or may be) less than 18 years old
+          lead_text: CB1 text to go here
+          continue: Continue
     children:
       names:
         edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,12 @@ en:
       relationship:
         edit:
           page_title: Applicant relationship
+      under_age:
+        edit:
+          page_title: Applicant under age
+          heading: The applicant is (or may be) less than 18 years old
+          lead_text: CB1 text to go here
+          continue: Continue
     help_with_fees:
       help_paying:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,7 @@ Rails.application.routes.draw do
       edit_step :user_type
       crud_step :names
       crud_step :personal_details, only: [:edit, :update]
+      crud_step :under_age,        only: [:edit, :update]
       crud_step :contact_details,  only: [:edit, :update]
       edit_step :relationship, only: [] do
         edit_routes ':id/child/:child_id'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
     namespace :respondent do
       crud_step :names
       crud_step :personal_details, only: [:edit, :update]
+      crud_step :under_age,        only: [:edit, :update]
       crud_step :contact_details,  only: [:edit, :update]
       edit_step :has_other_parties
       edit_step :relationship, only: [] do

--- a/spec/controllers/steps/applicant/under_age_controller_spec.rb
+++ b/spec/controllers/steps/applicant/under_age_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Applicant::UnderAgeController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Shared::UnderAgeForm, C100App::ApplicantDecisionTree
+end

--- a/spec/controllers/steps/respondent/under_age_controller_spec.rb
+++ b/spec/controllers/steps/respondent/under_age_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Respondent::UnderAgeController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Shared::UnderAgeForm, C100App::RespondentDecisionTree
+end

--- a/spec/forms/steps/shared/under_age_form_spec.rb
+++ b/spec/forms/steps/shared/under_age_form_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Shared::UnderAgeForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    record: record
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:record) { double('Applicant') }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    it 'does nothing on the record and return true' do
+      expect(record).not_to receive(:update)
+      expect(subject.save).to be(true)
+    end
+  end
+end

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -50,6 +50,32 @@ RSpec.describe C100App::ApplicantDecisionTree do
 
   context 'when the step is `personal_details`' do
     let(:step_params) {{'personal_details' => 'anything'}}
+    let(:record) { double('Applicant', id: 1, dob: dob) }
+
+    before do
+      expect(record).to receive(:reload).and_return(record)
+      travel_to Date.new(2018, 1, 5) # Stub current date to 5 Jan 2018
+    end
+
+    context 'and the DoB is under age' do
+      let(:dob) { Date.new(2000, 1, 6) }
+
+      it 'goes to the warning under age page' do
+        expect(subject.destination).to eq(controller: :under_age, action: :edit, id: record)
+      end
+    end
+
+    context 'and the DoB is not under age' do
+      let(:dob) { Date.new(2000, 1, 5) }
+
+      it 'goes to edit the first child relationship for the current record' do
+        expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
+      end
+    end
+  end
+
+  context 'when the step is `under_age`' do
+    let(:step_params) {{'under_age' => 'anything'}}
     let(:record) {double('Applicant', id: 1)}
 
     it 'goes to edit the first child relationship for the current record' do

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -36,6 +36,48 @@ RSpec.describe C100App::RespondentDecisionTree do
 
   context 'when the step is `personal_details`' do
     let(:step_params) {{'personal_details' => 'anything'}}
+    let(:record) { double('Respondent', id: 1, dob: dob) }
+
+    before do
+      expect(record).to receive(:reload).and_return(record)
+      travel_to Date.new(2018, 1, 5) # Stub current date to 5 Jan 2018
+    end
+
+    context 'and the DoB is under age' do
+      let(:dob) { Date.new(2000, 1, 6) }
+
+      it 'goes to the warning under age page' do
+        expect(subject.destination).to eq(controller: :under_age, action: :edit, id: record)
+      end
+    end
+
+    context 'and the DoB is not under age' do
+      let(:dob) { Date.new(2000, 1, 5) }
+
+      it 'goes to edit the first child relationship for the current record' do
+        expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
+      end
+    end
+
+    context 'and the DoB is nil' do
+      let(:dob) { nil }
+
+      it 'goes to edit the first child relationship for the current record' do
+        expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
+      end
+    end
+
+    context 'and the DoB is an empty string (mutant kill)' do
+      let(:dob) { '' }
+
+      it 'goes to edit the first child relationship for the current record' do
+        expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
+      end
+    end
+  end
+
+  context 'when the step is `under_age`' do
+    let(:step_params) {{'under_age' => 'anything'}}
     let(:record) {double('Respondent', id: 1)}
 
     it 'goes to edit the first child relationship for the current record' do


### PR DESCRIPTION
This applies to applicants and respondents.

For respondents, for now only validating the DoB, not the free text 'approximate' age/year field. This can be a refinement when we have more time and are sure of the rules.

A bit of duplication which I considered refactor but then I thought only for 2 instances it doesn't make too much sense and this way makes the code more explicit and easy to read. If we end up having this age validation in more parties, then it might make more sense.