### PR TITLE
Make mutant faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ password should be available from the MoJ Rattic server, in the Family Justice g
 
 This project uses extensive mutation coverage, which makes the (mutation) tests take a long time to run, and can end up with the CI killing the build due to excessive job work time.
 
-In order to make this a bit faster, by default in CI (and in local when run without any flags), the scope of mutant testing will be reduced to the models, and a randomized small sample of classes in each of these groups: Form objects and Decision trees.
+In order to make this a bit faster, by default in CI (and in local when run without any flags), the scope of mutant testing will be reduced to a few models, and a randomized small sample of classes in each of these groups: Form objects and Decision trees.
 
 However it is still possible to have full flexibility of what mutant runs in your local environment:
 

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -21,19 +21,23 @@ private
 def classes_to_mutate
   Rails.application.eager_load!
 
+  # As the current models are just empty shells for ActiveRecord relationships,
+  # and we don't even have corresponding spec tests for those, there is no point
+  # in including these in the mutation test, and thus we can save some time.
+  # Only include in this collection the models that matter and have specs.
+  model_classes = %w(C100Application User).freeze
+
   case ARGV[1]
     when nil
       # Quicker run, reduced testing scope (random sample), default option
       puts '> running quick sample mutant testing'
-      ApplicationRecord.descendants.map(&:name) +
-        BaseForm.descendants.map(&:name).grep(/^Steps::/).sample(10) +
-        BaseDecisionTree.descendants.map(&:name).sample(5)
+      BaseForm.descendants.map(&:name).grep(/^Steps::/).sample(10) +
+        BaseDecisionTree.descendants.map(&:name).sample(5) +
+        model_classes
     when 'all'
       # Complete coverage, very long run time
       puts '> running complete mutant testing'
-      ApplicationRecord.descendants.map(&:name) +
-        BaseForm.descendants.map(&:name).grep(/^Steps::/) +
-        ['C100App*']
+      BaseForm.descendants.map(&:name).grep(/^Steps::/) + ['C100App*'] + model_classes
     else
       # Individual class testing, very quick
       Array(ARGV[1])


### PR DESCRIPTION
I realised we don't need to run mutant on all models, as most of them
are 'empty shells' for ActiveRecord relationships, and we don't even
have corresponding spec tests for those, so there is no point including
these in the mutation test, and thus we can save some time.