### PR TITLE
Update international abduction markup with panel

### DIFF
--- a/app/forms/steps/abduction/international_form.rb
+++ b/app/forms/steps/abduction/international_form.rb
@@ -19,7 +19,6 @@ module Steps
       validates_inclusion_of :passport_office_notified, in: GenericYesNo.values, if: -> { international_risk&.yes? }
 
       validates_presence_of :passport_possession_other_details, if: :passport_possession_other?
-      validates_absence_of  :passport_possession_other_details, unless: :passport_possession_other?
 
       private
 
@@ -27,7 +26,9 @@ module Steps
         raise C100ApplicationNotFound unless c100_application
 
         record_to_persist.update(
-          attributes_map
+          attributes_map.merge(
+            passport_possession_other_details: (passport_possession_other_details if passport_possession_other)
+          )
         )
       end
     end

--- a/app/views/steps/abduction/international/edit.html.erb
+++ b/app/views/steps/abduction/international/edit.html.erb
@@ -20,15 +20,17 @@
 
       <%= f.radio_button_fieldset :children_multiple_passports, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.check_box_fieldset :passport_possesion, [
-        :passport_possession_mother,
-        :passport_possession_father,
-        :passport_possession_other
-      ] %>
-
-      <!-- TODO: the following text area should be in a revealing panel triggered by -->
-      <!-- above `other` checkbox. Gem needs to support checkbox revealing panels for this. -->
-      <%= f.text_area :passport_possession_other_details, size: '40x4', class: 'form-control-3-4' %>
+      <%=
+        f.check_box_fieldset :passport_possesion, [
+          :passport_possession_mother, :passport_possession_father, :passport_possession_other
+        ] do |fieldset|
+          fieldset.check_box_input(:passport_possession_mother)
+          fieldset.check_box_input(:passport_possession_father)
+          fieldset.check_box_input(:passport_possession_other) {
+            f.text_area :passport_possession_other_details, size: '40x4', class: 'form-control-3-4'
+          }
+        end
+      %>
 
       <%= f.submit class: 'button' %>
     <% end %>

--- a/app/views/steps/help_with_fees/help_paying/edit.html.erb
+++ b/app/views/steps/help_with_fees/help_paying/edit.html.erb
@@ -8,10 +8,6 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <!--TODO: We need to come back to this to implement the show/hide properly as it is not-->
-    <!--working at the moment due to a combination of different markup and custom JS code-->
-    <!--inherited from the taxtribs project-->
-
     <%= step_form @form_object do |f| %>
       <%=
         f.radio_button_fieldset :help_paying do |fieldset|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -762,7 +762,7 @@ en:
         passport_possession_mother: Mother
         passport_possession_father: Father
         passport_possession_other: Other
-        passport_possession_other_details: Provide more details (If 'other' is selected)
+        passport_possession_other_details: Provide more details
       steps_abduction_previous_attempt_details_form:
         previous_attempt_details: Give a short description
         previous_attempt_agency_details: Provide more details

--- a/spec/forms/steps/abduction/international_form_spec.rb
+++ b/spec/forms/steps/abduction/international_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Steps::Abduction::InternationalForm do
     passport_possession_mother: true,
     passport_possession_father: false,
     passport_possession_other: passport_possession_other,
-    passport_possession_other_details: nil
+    passport_possession_other_details: passport_possession_other_details
   } }
 
   let(:c100_application) { instance_double(C100Application) }
@@ -17,6 +17,7 @@ RSpec.describe Steps::Abduction::InternationalForm do
   let(:international_risk) { 'yes' }
   let(:passport_office_notified) { 'no' }
   let(:passport_possession_other) { false }
+  let(:passport_possession_other_details) { nil }
 
   subject { described_class.new(arguments) }
 
@@ -42,20 +43,43 @@ RSpec.describe Steps::Abduction::InternationalForm do
 
       context 'when `passport_possession_other_details` is not checked' do
         let(:passport_possession_other) { false }
-        it { should validate_absence_of(:passport_possession_other_details) }
+        it { should_not validate_presence_of(:passport_possession_other_details) }
       end
     end
 
-    it_behaves_like 'a has-one-association form',
-                    association_name: :abduction_detail,
-                    expected_attributes: {
-                      international_risk: GenericYesNo::YES,
-                      passport_office_notified: GenericYesNo::NO,
-                      children_multiple_passports: GenericYesNo::NO,
-                      passport_possession_mother: true,
-                      passport_possession_father: false,
-                      passport_possession_other: false,
-                      passport_possession_other_details: nil
-                    }
+    context 'when `passport_possession_other` is true and `passport_possession_other_details` is filled' do
+      let(:passport_possession_other) { true }
+      let(:passport_possession_other_details) { 'blah blah' }
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :abduction_detail,
+                      expected_attributes: {
+                        international_risk: GenericYesNo::YES,
+                        passport_office_notified: GenericYesNo::NO,
+                        children_multiple_passports: GenericYesNo::NO,
+                        passport_possession_mother: true,
+                        passport_possession_father: false,
+                        passport_possession_other: true,
+                        passport_possession_other_details: 'blah blah'
+                      }
     end
+
+    # Mutant killer
+    context 'when `passport_possession_other` is false and `passport_possession_other_details` is filled' do
+      let(:passport_possession_other) { false }
+      let(:passport_possession_other_details) { 'blah blah' }
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :abduction_detail,
+                      expected_attributes: {
+                        international_risk: GenericYesNo::YES,
+                        passport_office_notified: GenericYesNo::NO,
+                        children_multiple_passports: GenericYesNo::NO,
+                        passport_possession_mother: true,
+                        passport_possession_father: false,
+                        passport_possession_other: false,
+                        passport_possession_other_details: nil
+                      }
+    end
+  end
 end


### PR DESCRIPTION
As we can now use revealing panels triggered by checkboxes, this is
one of the views where we can start using it.

Also updated form object to reset the free text input when the `other`
checkbox is unselected, to not leave leftovers in DB.