### PR TITLE
Add `international` steps

### DIFF
--- a/app/controllers/steps/international/jurisdiction_controller.rb
+++ b/app/controllers/steps/international/jurisdiction_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module International
+    class JurisdictionController < Steps::InternationalStepController
+      def edit
+        @form_object = JurisdictionForm.build(current_c100_application)
+      end
+
+      def update
+        update_and_advance(JurisdictionForm, as: :jurisdiction)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/international/request_controller.rb
+++ b/app/controllers/steps/international/request_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module International
+    class RequestController < Steps::InternationalStepController
+      def edit
+        @form_object = RequestForm.build(current_c100_application)
+      end
+
+      def update
+        update_and_advance(RequestForm, as: :request)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/international/resident_controller.rb
+++ b/app/controllers/steps/international/resident_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module International
+    class ResidentController < Steps::InternationalStepController
+      def edit
+        @form_object = ResidentForm.build(current_c100_application)
+      end
+
+      def update
+        update_and_advance(ResidentForm, as: :resident)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/international_step_controller.rb
+++ b/app/controllers/steps/international_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class InternationalStepController < StepController
+    private
+
+    def decision_tree_class
+      C100App::InternationalDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/international/jurisdiction_form.rb
+++ b/app/forms/steps/international/jurisdiction_form.rb
@@ -1,0 +1,14 @@
+module Steps
+  module International
+    class JurisdictionForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :international_jurisdiction,
+                       reset_when_no: [:international_jurisdiction_details]
+
+      attribute :international_jurisdiction_details, String
+
+      validates_presence_of :international_jurisdiction_details, if: -> { international_jurisdiction&.yes? }
+    end
+  end
+end

--- a/app/forms/steps/international/request_form.rb
+++ b/app/forms/steps/international/request_form.rb
@@ -1,0 +1,14 @@
+module Steps
+  module International
+    class RequestForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :international_request,
+                       reset_when_no: [:international_request_details]
+
+      attribute :international_request_details, String
+
+      validates_presence_of :international_request_details, if: -> { international_request&.yes? }
+    end
+  end
+end

--- a/app/forms/steps/international/resident_form.rb
+++ b/app/forms/steps/international/resident_form.rb
@@ -1,0 +1,14 @@
+module Steps
+  module International
+    class ResidentForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :international_resident,
+                       reset_when_no: [:international_resident_details]
+
+      attribute :international_resident_details, String
+
+      validates_presence_of :international_resident_details, if: -> { international_resident&.yes? }
+    end
+  end
+end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -7,7 +7,7 @@ module C100App
       when :without_notice
         after_without_notice
       when :without_notice_details
-        edit(:without_notice) # TODO: change when we have international steps
+        start_international_journey
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
@@ -19,8 +19,12 @@ module C100App
       if question(:without_notice).yes?
         edit(:without_notice_details)
       else
-        edit(:without_notice)
+        start_international_journey
       end
+    end
+
+    def start_international_journey
+      edit('/steps/international/resident')
     end
   end
 end

--- a/app/services/c100_app/international_decision_tree.rb
+++ b/app/services/c100_app/international_decision_tree.rb
@@ -4,9 +4,12 @@ module C100App
       return next_step if next_step
 
       case step_name
-      # TODO: Put decision logic here
-      when :name
-        root_path
+      when :resident
+        edit(:jurisdiction)
+      when :jurisdiction
+        edit(:request)
+      when :request
+        edit(:resident) # TODO: update when we have the next block of steps
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/services/c100_app/international_decision_tree.rb
+++ b/app/services/c100_app/international_decision_tree.rb
@@ -1,0 +1,15 @@
+module C100App
+  class InternationalDecisionTree < BaseDecisionTree
+    def destination
+      return next_step if next_step
+
+      case step_name
+      # TODO: Put decision logic here
+      when :name
+        root_path
+      else
+        raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+  end
+end

--- a/app/views/steps/international/jurisdiction/edit.html.erb
+++ b/app/views/steps/international/jurisdiction/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.radio_button_fieldset :international_jurisdiction, inline: true do |fieldset|
+          fieldset.radio_input(GenericYesNo::YES, panel_id: :international_jurisdiction_panel)
+          fieldset.radio_input(GenericYesNo::NO)
+          fieldset.revealing_panel(:international_jurisdiction_panel) do |panel|
+            panel.text_area :international_jurisdiction_details, size: '40x4', class: 'form-control-3-4'
+          end
+        end
+      %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/international/request/edit.html.erb
+++ b/app/views/steps/international/request/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.radio_button_fieldset :international_request, inline: true do |fieldset|
+          fieldset.radio_input(GenericYesNo::YES, panel_id: :international_request_panel)
+          fieldset.radio_input(GenericYesNo::NO)
+          fieldset.revealing_panel(:international_request_panel) do |panel|
+            panel.text_area :international_request_details, size: '40x4', class: 'form-control-3-4'
+          end
+        end
+      %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/international/resident/edit.html.erb
+++ b/app/views/steps/international/resident/edit.html.erb
@@ -1,0 +1,25 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.radio_button_fieldset :international_resident, inline: true do |fieldset|
+          fieldset.radio_input(GenericYesNo::YES, panel_id: :international_resident_panel)
+          fieldset.radio_input(GenericYesNo::NO)
+          fieldset.revealing_panel(:international_resident_panel) do |panel|
+            panel.text_area :international_resident_details, size: '40x4', class: 'form-control-3-4'
+          end
+        end
+      %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -534,6 +534,10 @@ en:
         edit:
           page_title: International jurisdiction
           heading: Do you think the other person may have grounds to apply for a similar order in another country?
+      request:
+        edit:
+          page_title: International request
+          heading: Has a court case about your children already started in another country?
 
   home:
     index:
@@ -739,6 +743,8 @@ en:
         international_resident_html: ""
       steps_international_jurisdiction_form:
         international_jurisdiction_html: ""
+      steps_international_request_form:
+        international_request_html: ""
     label:
       steps_shared_relationship_form:
         relation_other_value: *provide_details
@@ -867,6 +873,8 @@ en:
         international_resident_details: *provide_details
       steps_international_jurisdiction_form:
         international_jurisdiction_details: *provide_details
+      steps_international_request_form:
+        international_request_details: *provide_details
       user:
         email: Your email address
         password: Choose password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
     order_current_error: &order_current_error "Please answer if the order is current"
     order_length: &order_length "How long is the order for?"
     order_court_name: &order_court_name "Which court issued the order?"
+    provide_details: &provide_details "Provide details"
 
     YESNO: &YESNO
       'yes': 'Yes'
@@ -529,6 +530,10 @@ en:
           page_title: International resident
           heading: Does anyone significant to your children live in another country?
           lead_text: For example, a grandparent or other close relatives
+      jurisdiction:
+        edit:
+          page_title: International jurisdiction
+          heading: Do you think the other person may have grounds to apply for a similar order in another country?
 
   home:
     index:
@@ -732,15 +737,17 @@ en:
         postcode_unknown_html: ""
       steps_international_resident_form:
         international_resident_html: ""
+      steps_international_jurisdiction_form:
+        international_jurisdiction_html: ""
     label:
       steps_shared_relationship_form:
-        relation_other_value: Provide details
+        relation_other_value: *provide_details
         relation:
           <<: *RELATIONS
       steps_application_without_notice_details_form:
         without_notice_details: Give as much information as you can
-        without_notice_frustrate_details: Provide details
-        without_notice_impossible_details: Provide details
+        without_notice_frustrate_details: *provide_details
+        without_notice_impossible_details: *provide_details
       steps_applicant_user_type_form:
         user_type:
           themself: Yes, I am the person making the application
@@ -857,7 +864,9 @@ en:
         undertaking_length: *order_length
         undertaking_court_name: *order_court_name
       steps_international_resident_form:
-        international_resident_details: Provide details
+        international_resident_details: *provide_details
+      steps_international_jurisdiction_form:
+        international_jurisdiction_details: *provide_details
       user:
         email: Your email address
         password: Choose password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,6 +523,12 @@ en:
         edit:
           page_title: Details of without notice hearing
           heading: Details of without notice hearing
+    international:
+      resident:
+        edit:
+          page_title: International resident
+          heading: Does anyone significant to your children live in another country?
+          lead_text: For example, a grandparent or other close relatives
 
   home:
     index:
@@ -724,6 +730,8 @@ en:
         dob_unknown_html: ""
       steps_other_parties_contact_details_form:
         postcode_unknown_html: ""
+      steps_international_resident_form:
+        international_resident_html: ""
     label:
       steps_shared_relationship_form:
         relation_other_value: Provide details
@@ -848,6 +856,8 @@ en:
         injunctive_court_name: *order_court_name
         undertaking_length: *order_length
         undertaking_court_name: *order_court_name
+      steps_international_resident_form:
+        international_resident_details: Provide details
       user:
         email: Your email address
         password: Choose password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,8 @@ Rails.application.routes.draw do
         edit_routes ':id/child/:child_id'
       end
     end
+    namespace :international do
+    end
     namespace :help_with_fees do
       edit_step :help_paying
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
     namespace :international do
       edit_step :resident
       edit_step :jurisdiction
+      edit_step :request
     end
     namespace :help_with_fees do
       edit_step :help_paying

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,7 @@ Rails.application.routes.draw do
     end
     namespace :international do
       edit_step :resident
+      edit_step :jurisdiction
     end
     namespace :help_with_fees do
       edit_step :help_paying

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,7 @@ Rails.application.routes.draw do
       end
     end
     namespace :international do
+      edit_step :resident
     end
     namespace :help_with_fees do
       edit_step :help_paying

--- a/db/migrate/20180112105909_add_international_fields.rb
+++ b/db/migrate/20180112105909_add_international_fields.rb
@@ -1,0 +1,12 @@
+class AddInternationalFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :c100_applications, :international_resident, :string
+    add_column :c100_applications, :international_resident_details, :text
+
+    add_column :c100_applications, :international_jurisdiction, :string
+    add_column :c100_applications, :international_jurisdiction_details, :text
+
+    add_column :c100_applications, :international_request, :string
+    add_column :c100_applications, :international_request_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180108145551) do
+ActiveRecord::Schema.define(version: 20180112105909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,12 @@ ActiveRecord::Schema.define(version: 20180108145551) do
     t.text "without_notice_frustrate_details"
     t.string "without_notice_impossible"
     t.text "without_notice_impossible_details"
+    t.string "international_resident"
+    t.text "international_resident_details"
+    t.string "international_jurisdiction"
+    t.text "international_jurisdiction_details"
+    t.string "international_request"
+    t.text "international_request_details"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end
 

--- a/spec/controllers/steps/international/jurisdiction_controller_spec.rb
+++ b/spec/controllers/steps/international/jurisdiction_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::International::JurisdictionController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::International::JurisdictionForm, C100App::InternationalDecisionTree
+end

--- a/spec/controllers/steps/international/request_controller_spec.rb
+++ b/spec/controllers/steps/international/request_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::International::RequestController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::International::RequestForm, C100App::InternationalDecisionTree
+end

--- a/spec/controllers/steps/international/resident_controller_spec.rb
+++ b/spec/controllers/steps/international/resident_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::International::ResidentController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::International::ResidentForm, C100App::InternationalDecisionTree
+end

--- a/spec/forms/steps/international/jurisdiction_form_spec.rb
+++ b/spec/forms/steps/international/jurisdiction_form_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+RSpec.describe Steps::International::JurisdictionForm do
+  it_behaves_like 'a yes-no question form',
+                  attribute_name:   :international_jurisdiction,
+                  linked_attribute: :international_jurisdiction_details,
+                  reset_when_no:   [:international_jurisdiction_details]
+end

--- a/spec/forms/steps/international/request_form_spec.rb
+++ b/spec/forms/steps/international/request_form_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+RSpec.describe Steps::International::RequestForm do
+  it_behaves_like 'a yes-no question form',
+                  attribute_name:   :international_request,
+                  linked_attribute: :international_request_details,
+                  reset_when_no:   [:international_request_details]
+end

--- a/spec/forms/steps/international/resident_form_spec.rb
+++ b/spec/forms/steps/international/resident_form_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+RSpec.describe Steps::International::ResidentForm do
+  it_behaves_like 'a yes-no question form',
+                  attribute_name:   :international_resident,
+                  linked_attribute: :international_resident_details,
+                  reset_when_no:   [:international_resident_details]
+end

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
     context 'and the answer is `no`' do
       let(:answer) { 'no' }
-      it { is_expected.to have_destination(:without_notice, :edit) }
+      it { is_expected.to have_destination('/steps/international/resident', :edit) }
     end
   end
 
   context 'when the step is `without_notice_details`' do
     let(:step_params) { { without_notice_details: 'anything' } }
-    it { is_expected.to have_destination(:without_notice, :edit) }
+    it { is_expected.to have_destination('/steps/international/resident', :edit) }
   end
 end

--- a/spec/services/c100_app/international_decision_tree_spec.rb
+++ b/spec/services/c100_app/international_decision_tree_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe C100App::InternationalDecisionTree do
+  let(:c100_application) { double('Object') }
+  let(:step_params)      { double('Step') }
+  let(:next_step)        { nil }
+  let(:as)               { nil }
+
+  subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
+
+  it_behaves_like 'a decision tree'
+
+  pending 'Write specs for InternationalDecisionTree!'
+
+  # TODO: The below can be uncommented and serves as a starting point
+
+  # context 'when the step is `user_type`' do
+  #   let(:step_params) { { user_type: 'anything' } }
+  #
+  #   context 'and the answer is `themself`' do
+  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::THEMSELF) }
+  #     it { is_expected.to have_destination(:user_type, :edit) }
+  #   end
+  #
+  #   context 'and the answer is `representative`' do
+  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::REPRESENTATIVE) }
+  #     it { is_expected.to have_destination(:user_type, :edit) }
+  #   end
+  # end
+end

--- a/spec/services/c100_app/international_decision_tree_spec.rb
+++ b/spec/services/c100_app/international_decision_tree_spec.rb
@@ -10,21 +10,18 @@ RSpec.describe C100App::InternationalDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-  pending 'Write specs for InternationalDecisionTree!'
+  context 'when the step is `resident`' do
+    let(:step_params) { { resident: 'anything' } }
+    it { is_expected.to have_destination(:jurisdiction, :edit) }
+  end
 
-  # TODO: The below can be uncommented and serves as a starting point
+  context 'when the step is `jurisdiction`' do
+    let(:step_params) { { jurisdiction: 'anything' } }
+    it { is_expected.to have_destination(:request, :edit) }
+  end
 
-  # context 'when the step is `user_type`' do
-  #   let(:step_params) { { user_type: 'anything' } }
-  #
-  #   context 'and the answer is `themself`' do
-  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::THEMSELF) }
-  #     it { is_expected.to have_destination(:user_type, :edit) }
-  #   end
-  #
-  #   context 'and the answer is `representative`' do
-  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::REPRESENTATIVE) }
-  #     it { is_expected.to have_destination(:user_type, :edit) }
-  #   end
-  # end
+  context 'when the step is `request`' do
+    let(:step_params) { { request: 'anything' } }
+    it { is_expected.to have_destination(:resident, :edit) } # TODO: update when we have the next block of steps
+  end
 end


### PR DESCRIPTION
3 new yes-no steps, but with a linked, revealing panel for a text area.

As this is going to be common pattern for a few remaining steps, I've updated the shared spec examples to cope with this extra linked attribute.