### PR TITLE
Remove postcodes from all parties

### DIFF
--- a/app/forms/steps/applicant/contact_details_form.rb
+++ b/app/forms/steps/applicant/contact_details_form.rb
@@ -2,14 +2,13 @@ module Steps
   module Applicant
     class ContactDetailsForm < BaseForm
       attribute :address, StrippedString
-      attribute :postcode, StrippedString
       attribute :home_phone, StrippedString
       attribute :mobile_phone, StrippedString
       attribute :email, NormalisedEmail
       attribute :residence_requirement_met, YesNo
       attribute :residence_history, String
 
-      validates_presence_of :address, :postcode
+      validates_presence_of :address
 
       validates_inclusion_of :residence_requirement_met, in: GenericYesNo.values
       validates_presence_of  :residence_history, if: -> { residence_requirement_met&.no? }

--- a/app/forms/steps/other_parties/contact_details_form.rb
+++ b/app/forms/steps/other_parties/contact_details_form.rb
@@ -2,10 +2,9 @@ module Steps
   module OtherParties
     class ContactDetailsForm < BaseForm
       attribute :address, StrippedString
-      attribute :postcode, StrippedString
-      attribute :postcode_unknown, Boolean
+      attribute :address_unknown, Boolean
 
-      validates_presence_of :postcode, unless: :postcode_unknown?
+      validates_presence_of :address, unless: :address_unknown?
 
       private
 

--- a/app/forms/steps/respondent/contact_details_form.rb
+++ b/app/forms/steps/respondent/contact_details_form.rb
@@ -2,8 +2,7 @@ module Steps
   module Respondent
     class ContactDetailsForm < BaseForm
       attribute :address, StrippedString
-      attribute :postcode, StrippedString
-      attribute :postcode_unknown, Boolean
+      attribute :address_unknown, Boolean
       attribute :home_phone, StrippedString
       attribute :mobile_phone, StrippedString
       attribute :mobile_phone_unknown, Boolean
@@ -12,7 +11,7 @@ module Steps
       attribute :residence_requirement_met, YesNoUnknown
       attribute :residence_history, String
 
-      validates_presence_of :postcode,     unless: :postcode_unknown?
+      validates_presence_of :address,      unless: :address_unknown?
       validates_presence_of :mobile_phone, unless: :mobile_phone_unknown?
       validates_presence_of :email,        unless: :email_unknown?
 

--- a/app/views/steps/applicant/contact_details/edit.html.erb
+++ b/app/views/steps/applicant/contact_details/edit.html.erb
@@ -8,10 +8,6 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
-      <%= f.text_field :postcode %>
-      <%= f.text_field :home_phone %>
-      <%= f.text_field :mobile_phone %>
-      <%= f.text_field :email %>
 
       <%=
         f.radio_button_fieldset :residence_requirement_met, inline: true do |fieldset|
@@ -19,6 +15,10 @@
           fieldset.radio_input(GenericYesNo::NO) { f.text_area :residence_history, size: '40x4', class: 'form-control-3-4' }
         end
       %>
+
+      <%= f.text_field :home_phone %>
+      <%= f.text_field :mobile_phone %>
+      <%= f.text_field :email %>
 
       <%= f.submit class: 'button' %>
     <% end %>

--- a/app/views/steps/other_parties/contact_details/edit.html.erb
+++ b/app/views/steps/other_parties/contact_details/edit.html.erb
@@ -8,9 +8,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
-
-      <%= f.text_field :postcode %>
-      <%= f.check_box_fieldset :postcode_unknown, [:postcode_unknown] %>
+      <%= f.check_box_fieldset :address_unknown, [:address_unknown] %>
 
       <%= f.submit class: 'button' %>
     <% end %>

--- a/app/views/steps/respondent/contact_details/edit.html.erb
+++ b/app/views/steps/respondent/contact_details/edit.html.erb
@@ -8,17 +8,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
-
-      <%= f.text_field :postcode %>
-      <%= f.check_box_fieldset :postcode_unknown, [:postcode_unknown] %>
-
-      <%= f.text_field :home_phone %>
-
-      <%= f.text_field :mobile_phone %>
-      <%= f.check_box_fieldset :mobile_phone_unknown, [:mobile_phone_unknown] %>
-
-      <%= f.text_field :email %>
-      <%= f.check_box_fieldset :email_unknown, [:email_unknown] %>
+      <%= f.check_box_fieldset :address_unknown, [:address_unknown] %>
 
       <%=
         f.radio_button_fieldset :residence_requirement_met, inline: true do |fieldset|
@@ -28,6 +18,14 @@
           fieldset.revealing_panel(:residence_history_panel) { |panel| panel.text_area :residence_history, size: '40x4', class: 'form-control-3-4' }
         end
       %>
+
+      <%= f.text_field :home_phone %>
+
+      <%= f.text_field :mobile_phone %>
+      <%= f.check_box_fieldset :mobile_phone_unknown, [:mobile_phone_unknown] %>
+
+      <%= f.text_field :email %>
+      <%= f.check_box_fieldset :email_unknown, [:email_unknown] %>
 
       <%= f.submit class: 'button' %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,6 @@ en:
     # This is a compilation of all possible fields shared between Applicants and Respondents (maybe others later)
     PERSONAL_CONTACT_FIELDS: &PERSONAL_CONTACT_FIELDS
       address: Address
-      postcode: Postcode
       address_unknown: *dont_know
       home_phone: Home phone
       mobile_phone: Mobile phone
@@ -82,8 +81,6 @@ en:
         blank: Please enter the place of birth
       address:
         blank: Please enter the address
-      postcode:
-        blank: Please enter the postcode
       mobile_phone:
         blank: Please enter the mobile phone
       email:
@@ -962,6 +959,8 @@ en:
         birthplace: *birthplace_hint
       steps_respondent_contact_details_form:
         address: Documents for this application will be sent here. Include the postcode
+      steps_other_parties_contact_details_form:
+        address: Enter the full address including postcode
       steps_children_additional_details_form:
         children_protection_plan_html: |
           A child protection plan sets out how a child can be kept safe and is usually drawn up by a local authority

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -955,6 +955,9 @@ en:
         previous_attempt_agency_involved: Including in the UK or abroad
       steps_applicant_personal_details_form:
         birthplace: *birthplace_hint
+      steps_applicant_contact_details_form:
+        address: Enter your full address including postcode
+        residence_history: Start with the most recent
       steps_respondent_personal_details_form:
         birthplace: *birthplace_hint
       steps_respondent_contact_details_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,7 +61,7 @@ en:
     PERSONAL_CONTACT_FIELDS: &PERSONAL_CONTACT_FIELDS
       address: Address
       postcode: Postcode
-      postcode_unknown: *dont_know
+      address_unknown: *dont_know
       home_phone: Home phone
       mobile_phone: Mobile phone
       mobile_phone_unknown: *dont_know
@@ -765,7 +765,7 @@ en:
         dob_unknown_html: ""
       steps_respondent_contact_details_form:
         residence_requirement_met: Have they lived at this address for more than 5 years?
-        postcode_unknown_html: ""
+        address_unknown_html: ""
         mobile_phone_unknown_html: ""
         email_unknown_html: ""
       steps_respondent_has_other_parties_form:
@@ -790,7 +790,7 @@ en:
         gender: Sex
         dob_unknown_html: ""
       steps_other_parties_contact_details_form:
-        postcode_unknown_html: ""
+        address_unknown_html: ""
       steps_international_resident_form:
         international_resident_html: ""
       steps_international_jurisdiction_form:
@@ -961,7 +961,7 @@ en:
       steps_respondent_personal_details_form:
         birthplace: *birthplace_hint
       steps_respondent_contact_details_form:
-        address: Documents for this application will be sent here
+        address: Documents for this application will be sent here. Include the postcode
       steps_children_additional_details_form:
         children_protection_plan_html: |
           A child protection plan sets out how a child can be kept safe and is usually drawn up by a local authority

--- a/db/migrate/20180117154337_rename_postcode_unknown_field.rb
+++ b/db/migrate/20180117154337_rename_postcode_unknown_field.rb
@@ -1,0 +1,5 @@
+class RenamePostcodeUnknownField < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :people, :postcode_unknown, :address_unknown
+  end
+end

--- a/db/migrate/20180117160059_remove_postcode_field.rb
+++ b/db/migrate/20180117160059_remove_postcode_field.rb
@@ -1,0 +1,5 @@
+class RemovePostcodeField < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :people, :postcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180116125030) do
+ActiveRecord::Schema.define(version: 20180117154337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,7 +198,7 @@ ActiveRecord::Schema.define(version: 20180116125030) do
     t.string "birthplace"
     t.text "address"
     t.string "postcode"
-    t.boolean "postcode_unknown", default: false
+    t.boolean "address_unknown", default: false
     t.string "home_phone"
     t.boolean "home_phone_unknown", default: false
     t.string "mobile_phone"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180117154337) do
+ActiveRecord::Schema.define(version: 20180117160059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -197,7 +197,6 @@ ActiveRecord::Schema.define(version: 20180117154337) do
     t.string "age_estimate"
     t.string "birthplace"
     t.text "address"
-    t.string "postcode"
     t.boolean "address_unknown", default: false
     t.string "home_phone"
     t.boolean "home_phone_unknown", default: false

--- a/spec/forms/steps/applicant/contact_details_form_spec.rb
+++ b/spec/forms/steps/applicant/contact_details_form_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
     c100_application: c100_application,
     record: record,
     address: address,
-    postcode: postcode,
     home_phone: home_phone,
     mobile_phone: mobile_phone,
     email: email,
@@ -19,7 +18,6 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
 
   let(:record) { nil }
   let(:address) { 'address' }
-  let(:postcode) { 'postcode' }
   let(:home_phone) { nil }
   let(:mobile_phone) { nil }
   let(:email) { nil }
@@ -75,7 +73,6 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
       let(:expected_attributes) {
         {
           address: 'address',
-          postcode: 'postcode',
           home_phone: '',
           mobile_phone: '',
           email: '',

--- a/spec/forms/steps/other_parties/contact_details_form_spec.rb
+++ b/spec/forms/steps/other_parties/contact_details_form_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Steps::OtherParties::ContactDetailsForm do
     c100_application: c100_application,
     record: record,
     address: address,
-    postcode: postcode,
-    postcode_unknown: postcode_unknown
+    address_unknown: address_unknown
   } }
 
   let(:c100_application) { instance_double(C100Application, other_parties: other_parties_collection) }
@@ -15,8 +14,7 @@ RSpec.describe Steps::OtherParties::ContactDetailsForm do
 
   let(:record) { nil }
   let(:address) { 'address' }
-  let(:postcode) { 'postcode' }
-  let(:postcode_unknown) { false }
+  let(:address_unknown) { false }
 
   subject { described_class.new(arguments) }
 
@@ -30,15 +28,14 @@ RSpec.describe Steps::OtherParties::ContactDetailsForm do
     end
 
     context 'validations on field presence unless `unknown`' do
-      it { should validate_presence_unless_unknown_of(:postcode) }
+      it { should validate_presence_unless_unknown_of(:address) }
     end
 
     context 'for valid details' do
       let(:expected_attributes) {
         {
           address: 'address',
-          postcode: 'postcode',
-          postcode_unknown: false
+          address_unknown: false
         }
       }
 

--- a/spec/forms/steps/respondent/contact_details_form_spec.rb
+++ b/spec/forms/steps/respondent/contact_details_form_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
     c100_application: c100_application,
     record: record,
     address: address,
-    postcode: postcode,
-    postcode_unknown: postcode_unknown,
+    address_unknown: address_unknown,
     home_phone: home_phone,
     mobile_phone: mobile_phone,
     mobile_phone_unknown: mobile_phone_unknown,
@@ -22,8 +21,7 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
 
   let(:record) { nil }
   let(:address) { 'address' }
-  let(:postcode) { 'postcode' }
-  let(:postcode_unknown) { false }
+  let(:address_unknown) { false }
   let(:home_phone) { nil }
   let(:mobile_phone) { nil }
   let(:mobile_phone_unknown) { true }
@@ -78,7 +76,7 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
     end
 
     context 'validations on field presence unless `unknown`' do
-      it { should validate_presence_unless_unknown_of(:postcode) }
+      it { should validate_presence_unless_unknown_of(:address) }
       it { should validate_presence_unless_unknown_of(:mobile_phone) }
       it { should validate_presence_unless_unknown_of(:email) }
     end
@@ -87,8 +85,7 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
       let(:expected_attributes) {
         {
           address: 'address',
-          postcode: 'postcode',
-          postcode_unknown: false,
+          address_unknown: false,
           home_phone: '',
           mobile_phone: '',
           mobile_phone_unknown: true,


### PR DESCRIPTION
The postcode is to be included in the `address` text area, and the previously named `postcode_unknown` is now `address_unknown`.

Removed `postcode` from everywhere.

A bit of fields reordering in the contact forms.