### PR TITLE
Add concerns info pages

### DIFF
--- a/app/controllers/steps/abuse_concerns/applicant_info_controller.rb
+++ b/app/controllers/steps/abuse_concerns/applicant_info_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module AbuseConcerns
+    class ApplicantInfoController < Steps::AbuseConcernsStepController
+      def show; end
+    end
+  end
+end

--- a/app/controllers/steps/abuse_concerns/children_info_controller.rb
+++ b/app/controllers/steps/abuse_concerns/children_info_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module AbuseConcerns
+    class ChildrenInfoController < Steps::AbuseConcernsStepController
+      def show; end
+    end
+  end
+end

--- a/app/services/c100_app/abuse_concerns_decision_tree.rb
+++ b/app/services/c100_app/abuse_concerns_decision_tree.rb
@@ -88,7 +88,7 @@ module C100App
     def children_details_destination
       case abuse_kind
       when AbuseType::OTHER
-        edit(:question, subject: AbuseSubject::APPLICANT)
+        show(:applicant_info)
       else
         questions_destination(AbuseSubject::CHILDREN)
       end

--- a/app/views/steps/abuse_concerns/applicant_info/show.en.html.erb
+++ b/app/views/steps/abuse_concerns/applicant_info/show.en.html.erb
@@ -1,0 +1,23 @@
+<% title 'Your safety' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge">Your safety</h1>
+
+    <div class=" govuk-govspeak gv-s-prose">
+      <p>The court needs to know if the other person (the respondent) or anyone they’re in contact with poses a risk to
+        your safety.</p>
+      <p>The following questions will ask whether you have experienced, or are at risk of experiencing, any form of
+        harm.</p>
+      <p>Find out about the
+        <a href="http://www.refuge.org.uk/get-help-now/help-for-women/recognising-abuse/" target="external_link">signs
+          of domestic abuse</a>.</p>
+    </div>
+
+    <div class="xform-group form-submit">
+      <%= link_to 'Continue', edit_steps_abuse_concerns_question_path(subject: AbuseSubject::APPLICANT), class: 'button', role: 'button' %>
+    </div>
+  </div>
+</div>

--- a/app/views/steps/abuse_concerns/children_info/show.en.html.erb
+++ b/app/views/steps/abuse_concerns/children_info/show.en.html.erb
@@ -1,0 +1,23 @@
+<% title 'Your children’s safety' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge">Your children’s safety</h1>
+
+    <div class="govuk-govspeak gv-s-prose">
+      <p>The court needs to know if the other person (the respondent) or anyone they’re in contact with poses a risk to
+        the safety of your children.</p>
+      <p>The following questions will ask whether your children have experienced, or are at risk of experiencing, any
+        form of harm.</p>
+      <p>Find out about the
+        <a href="https://www.nspcc.org.uk/preventing-abuse/child-abuse-and-neglect/" target="external_link">signs
+          of child abuse</a>.</p>
+    </div>
+
+    <div class="xform-group form-submit">
+      <%= link_to 'Continue', edit_steps_abuse_concerns_question_path, class: 'button', role: 'button' %>
+    </div>
+  </div>
+</div>

--- a/app/views/steps/abuse_concerns/start/show.en.html.erb
+++ b/app/views/steps/abuse_concerns/start/show.en.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <div class="xform-group form-submit">
-      <%= link_to 'Continue', edit_steps_abuse_concerns_question_path, class: 'button', role: 'button' %>
+      <%= link_to 'Continue', steps_abuse_concerns_children_info_path, class: 'button', role: 'button' %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
     namespace :abuse_concerns do
       show_step :start
       show_step :children_info
+      show_step :applicant_info
       edit_step :question do
         get '/:subject/:kind', action: :edit
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
     end
     namespace :abuse_concerns do
       show_step :start
+      show_step :children_info
       edit_step :question do
         get '/:subject/:kind', action: :edit
       end

--- a/spec/controllers/steps/abuse_concerns/applicant_info_controller_spec.rb
+++ b/spec/controllers/steps/abuse_concerns/applicant_info_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::AbuseConcerns::ApplicantInfoController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/controllers/steps/abuse_concerns/children_info_controller_spec.rb
+++ b/spec/controllers/steps/abuse_concerns/children_info_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::AbuseConcerns::ChildrenInfoController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/services/c100_app/abuse_concerns_decision_tree_spec.rb
+++ b/spec/services/c100_app/abuse_concerns_decision_tree_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe C100App::AbuseConcernsDecisionTree do
 
         context 'abuse kind `other`' do
           let(:abuse_kind) { 'other' }
-          it {is_expected.to have_destination(:question, :edit, {subject: 'applicant'})}
+          it {is_expected.to have_destination(:applicant_info, :show)}
         end
       end
     end
@@ -295,7 +295,7 @@ RSpec.describe C100App::AbuseConcernsDecisionTree do
 
       context 'abuse kind `other`' do
         let(:abuse_kind) { 'other' }
-        it {is_expected.to have_destination(:question, :edit, {subject: 'applicant'})}
+        it {is_expected.to have_destination(:applicant_info, :show)}
       end
     end
   end


### PR DESCRIPTION
Add a couple of info pages, one before the start of children abuse concerns, and the other at the end of this journey and the beginning of applicant abuse concerns.

This matches the latest version of prototype.