### PR TITLE
Add initial MIAM exemption steps

### DIFF
--- a/app/controllers/steps/miam_exemptions/safety_controller.rb
+++ b/app/controllers/steps/miam_exemptions/safety_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module MiamExemptions
+    class SafetyController < Steps::MiamExemptionsStepController
+      def edit
+        @form_object = SafetyForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(SafetyForm, as: :safety)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/miam_exemptions/urgency_controller.rb
+++ b/app/controllers/steps/miam_exemptions/urgency_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module MiamExemptions
+    class UrgencyController < Steps::MiamExemptionsStepController
+      def edit
+        @form_object = UrgencyForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(UrgencyForm, as: :urgency)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/miam_exemptions_step_controller.rb
+++ b/app/controllers/steps/miam_exemptions_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class MiamExemptionsStepController < StepController
+    private
+
+    def decision_tree_class
+      C100App::MiamExemptionsDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/miam_exemptions/safety_form.rb
+++ b/app/forms/steps/miam_exemptions/safety_form.rb
@@ -1,0 +1,26 @@
+module Steps
+  module MiamExemptions
+    class SafetyForm < BaseForm
+      include HasOneAssociationForm
+
+      has_one_association :exemption
+
+      attribute :group_police, Boolean
+      attribute :police_arrested, Boolean
+      attribute :police_caution, Boolean
+      attribute :police_ongoing_proceedings, Boolean
+      attribute :police_conviction, Boolean
+      attribute :police_dvpn, Boolean
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record_to_persist.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/miam_exemptions/urgency_form.rb
+++ b/app/forms/steps/miam_exemptions/urgency_form.rb
@@ -1,0 +1,25 @@
+module Steps
+  module MiamExemptions
+    class UrgencyForm < BaseForm
+      include HasOneAssociationForm
+
+      has_one_association :exemption
+
+      attribute :group_risk, Boolean
+      attribute :risk_applicant, Boolean
+      attribute :risk_unreasonable_hardship, Boolean
+      attribute :risk_children, Boolean
+      attribute :risk_unlawful_removal_retention, Boolean
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record_to_persist.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -4,6 +4,7 @@ class C100Application < ApplicationRecord
   has_one  :abduction_detail, dependent: :destroy
   has_one  :asking_order,     dependent: :destroy
   has_one  :court_order,      dependent: :destroy
+  has_one  :exemption,        dependent: :destroy
 
   has_many :abuse_concerns,   dependent: :destroy
   has_many :relationships,    dependent: :destroy

--- a/app/models/exemption.rb
+++ b/app/models/exemption.rb
@@ -1,0 +1,3 @@
+class Exemption < ApplicationRecord
+  belongs_to :c100_application
+end

--- a/app/services/c100_app/abuse_concerns_decision_tree.rb
+++ b/app/services/c100_app/abuse_concerns_decision_tree.rb
@@ -7,7 +7,7 @@ module C100App
       when :details
         after_details_step
       when :contact
-        edit('/steps/petition/orders')
+        edit('/steps/miam_exemptions/safety')
       when :previous_proceedings
         after_previous_proceedings
       when :emergency_proceedings

--- a/app/services/c100_app/miam_exemptions_decision_tree.rb
+++ b/app/services/c100_app/miam_exemptions_decision_tree.rb
@@ -4,9 +4,10 @@ module C100App
       return next_step if next_step
 
       case step_name
-      # TODO: Put decision logic here
-      when :name
-        root_path
+      when :safety
+        edit(:urgency)
+      when :urgency
+        edit('/steps/petition/orders')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/services/c100_app/miam_exemptions_decision_tree.rb
+++ b/app/services/c100_app/miam_exemptions_decision_tree.rb
@@ -1,0 +1,15 @@
+module C100App
+  class MiamExemptionsDecisionTree < BaseDecisionTree
+    def destination
+      return next_step if next_step
+
+      case step_name
+      # TODO: Put decision logic here
+      when :name
+        root_path
+      else
+        raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+  end
+end

--- a/app/views/steps/miam_exemptions/safety/edit.html.erb
+++ b/app/views/steps/miam_exemptions/safety/edit.html.erb
@@ -1,0 +1,33 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <div class=" govuk-govspeak gv-s-prose">
+      <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
+        <p><%= t '.lead_text' %></p>
+      </div>
+    </div>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.check_box_fieldset :exemptions_group_police, [:group_police] do |fieldset|
+          fieldset.check_box_input(:group_police) {
+            f.check_box_fieldset :exemptions_group_police, [
+              :police_arrested,
+              :police_caution,
+              :police_ongoing_proceedings,
+              :police_conviction,
+              :police_dvpn
+            ]
+          }
+        end
+      %>
+
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/miam_exemptions/urgency/edit.html.erb
+++ b/app/views/steps/miam_exemptions/urgency/edit.html.erb
@@ -14,14 +14,13 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.check_box_fieldset :exemptions_group, [:group_police] do |fieldset|
-          fieldset.check_box_input(:group_police) {
+        f.check_box_fieldset :exemptions_group, [:group_risk] do |fieldset|
+          fieldset.check_box_input(:group_risk) {
             f.check_box_fieldset :exemptions_group, [
-              :police_arrested,
-              :police_caution,
-              :police_ongoing_proceedings,
-              :police_conviction,
-              :police_dvpn
+              :risk_applicant,
+              :risk_unreasonable_hardship,
+              :risk_children,
+              :risk_unlawful_removal_retention
             ]
           }
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -608,6 +608,11 @@ en:
           page_title: Evidence of safety concerns
           heading: Can you provide evidence of any safety concerns?
           lead_text: You will need to provide evidence to support your claim
+      urgency:
+        edit:
+          page_title: Evidence that your application is urgent
+          heading: Can you provide evidence that your application is urgent?
+          lead_text: You will need to provide evidence to support your claim
 
   home:
     index:
@@ -715,7 +720,9 @@ en:
       steps_miam_certification_form:
         miam_certification_html: ""
       steps_miam_exemptions_safety_form:
-        exemptions_group_police_html: ""
+        exemptions_group_html: ""
+      steps_miam_exemptions_urgency_form:
+        exemptions_group_html: ""
       steps_petition_orders_form:
         orders_html: ""
       steps_help_with_fees_help_paying_form:
@@ -865,6 +872,14 @@ en:
         police_ongoing_proceedings: Evidence of relevant criminal proceedings for a domestic violence offence which have not concluded
         police_conviction: Evidence of a relevant conviction for a domestic violence offence
         police_dvpn: A domestic violence protection notice issued under section 24 of the Crime and Security Act 2010 against a prospective party
+      steps_miam_exemptions_urgency_form:
+        group_risk_html: |
+          <span class="heading-small gv-u-heading-small">There’s an immediate risk of harm</span><br/>
+          <span class="form-hint">This includes if you, your children or home are at immediate risk of harm</span>
+        risk_applicant: There is risk to the life, liberty or physical safety of the prospective applicant or his or her family or his or her home
+        risk_unreasonable_hardship: Any delay caused by attending a MIAM would cause unreasonable hardship to the prospective applicant
+        risk_children: Any delay caused by attending a MIAM would cause a risk of harm to a child
+        risk_unlawful_removal_retention: Any delay caused by attending a MIAM would cause a risk of unlawful removal of a child from the United Kingdom, or a risk of unlawful retention of a child who is currently outside England and Wales
       steps_help_with_fees_help_paying_form:
         help_paying:
           yes_with_ref_number: Yes, I have a Help with Fees reference number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -602,6 +602,12 @@ en:
         edit:
           page_title: International request
           heading: Has a court case about your children already started in another country?
+    miam_exemptions:
+      safety:
+        edit:
+          page_title: Evidence of safety concerns
+          heading: Can you provide evidence of any safety concerns?
+          lead_text: You will need to provide evidence to support your claim
 
   home:
     index:
@@ -708,6 +714,8 @@ en:
         miam_attended_html: ""
       steps_miam_certification_form:
         miam_certification_html: ""
+      steps_miam_exemptions_safety_form:
+        exemptions_group_police_html: ""
       steps_petition_orders_form:
         orders_html: ""
       steps_help_with_fees_help_paying_form:
@@ -848,6 +856,15 @@ en:
         miam_acknowledgement: I understand that I have to attend a MIAM or provide a valid reason for not attending.
       steps_miam_certification_number_form:
         miam_certification_number: FMC registration number
+      steps_miam_exemptions_safety_form:
+        group_police_html: |
+          <span class="heading-small gv-u-heading-small">The police have been involved</span><br/>
+          <span class="form-hint">For example, you or the other person (the respondent) has been arrested or cautioned for domestic or child abuse offences.</span>
+        police_arrested: Evidence that a prospective party has been arrested for a relevant domestic violence offence
+        police_caution: Evidence of a relevant police caution for a domestic violence offence
+        police_ongoing_proceedings: Evidence of relevant criminal proceedings for a domestic violence offence which have not concluded
+        police_conviction: Evidence of a relevant conviction for a domestic violence offence
+        police_dvpn: A domestic violence protection notice issued under section 24 of the Crime and Security Act 2010 against a prospective party
       steps_help_with_fees_help_paying_form:
         help_paying:
           yes_with_ref_number: Yes, I have a Help with Fees reference number

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
     end
     namespace :miam_exemptions do
       edit_step :safety
+      edit_step :urgency
     end
     namespace :abduction do
       edit_step :international

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
       show_step :certification_confirmation
     end
     namespace :miam_exemptions do
+      edit_step :safety
     end
     namespace :abduction do
       edit_step :international

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,8 @@ Rails.application.routes.draw do
       edit_step :certification_number
       show_step :certification_confirmation
     end
+    namespace :miam_exemptions do
+    end
     namespace :abduction do
       edit_step :international
       edit_step :children_have_passport

--- a/db/migrate/20180119102958_create_exemptions_table.rb
+++ b/db/migrate/20180119102958_create_exemptions_table.rb
@@ -1,0 +1,53 @@
+class CreateExemptionsTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :exemptions, id: :uuid do |t|
+      t.boolean :group_police, default: false
+      t.boolean :police_arrested, default: false
+      t.boolean :police_caution, default: false
+      t.boolean :police_ongoing_proceedings, default: false
+      t.boolean :police_conviction, default: false
+      t.boolean :police_dvpn, default: false
+
+      t.boolean :group_court, default: false
+      t.boolean :court_bound_over, default: false
+      t.boolean :court_protective_injunction, default: false
+      t.boolean :court_undertaking, default: false
+      t.boolean :court_finding_of_fact, default: false
+      t.boolean :court_expert_report, default: false
+
+      t.boolean :group_specialist, default: false
+      t.boolean :specialist_examination, default: false
+      t.boolean :specialist_referral, default: false
+
+      t.boolean :group_local_authority, default: false
+      t.boolean :local_authority_marac, default: false
+      t.boolean :local_authority_la_ha, default: false
+      t.boolean :local_authority_public_authority, default: false
+
+      t.boolean :group_da_service, default: false
+      t.boolean :da_service_idva, default: false
+      t.boolean :da_service_isva, default: false
+      t.boolean :da_service_organisation, default: false
+      t.boolean :da_service_refuge_refusal, default: false
+
+      t.boolean :right_to_remain, default: false
+      t.boolean :financial_abuse, default: false
+
+      t.boolean :safety_none, default: false
+
+      t.boolean :group_risk, default: false
+      t.boolean :risk_applicant, default: false
+      t.boolean :risk_unreasonable_hardship, default: false
+      t.boolean :risk_children, default: false
+      t.boolean :risk_unlawful_removal_retention, default: false
+
+      t.boolean :group_miscarriage, default: false
+      t.boolean :miscarriage_justice, default: false
+      t.boolean :miscarriage_irretrievable_problems, default: false
+
+      t.boolean :urgency_none, default: false
+    end
+
+    add_reference :exemptions, :c100_application, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180118131931) do
+ActiveRecord::Schema.define(version: 20180119102958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,47 @@ ActiveRecord::Schema.define(version: 20180118131931) do
     t.index ["c100_application_id"], name: "index_court_orders_on_c100_application_id"
   end
 
+  create_table "exemptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "group_police", default: false
+    t.boolean "police_arrested", default: false
+    t.boolean "police_caution", default: false
+    t.boolean "police_ongoing_proceedings", default: false
+    t.boolean "police_conviction", default: false
+    t.boolean "police_dvpn", default: false
+    t.boolean "group_court", default: false
+    t.boolean "court_bound_over", default: false
+    t.boolean "court_protective_injunction", default: false
+    t.boolean "court_undertaking", default: false
+    t.boolean "court_finding_of_fact", default: false
+    t.boolean "court_expert_report", default: false
+    t.boolean "group_specialist", default: false
+    t.boolean "specialist_examination", default: false
+    t.boolean "specialist_referral", default: false
+    t.boolean "group_local_authority", default: false
+    t.boolean "local_authority_marac", default: false
+    t.boolean "local_authority_la_ha", default: false
+    t.boolean "local_authority_public_authority", default: false
+    t.boolean "group_da_service", default: false
+    t.boolean "da_service_idva", default: false
+    t.boolean "da_service_isva", default: false
+    t.boolean "da_service_organisation", default: false
+    t.boolean "da_service_refuge_refusal", default: false
+    t.boolean "right_to_remain", default: false
+    t.boolean "financial_abuse", default: false
+    t.boolean "safety_none", default: false
+    t.boolean "group_risk", default: false
+    t.boolean "risk_applicant", default: false
+    t.boolean "risk_unreasonable_hardship", default: false
+    t.boolean "risk_children", default: false
+    t.boolean "risk_unlawful_removal_retention", default: false
+    t.boolean "group_miscarriage", default: false
+    t.boolean "miscarriage_justice", default: false
+    t.boolean "miscarriage_irretrievable_problems", default: false
+    t.boolean "urgency_none", default: false
+    t.uuid "c100_application_id"
+    t.index ["c100_application_id"], name: "index_exemptions_on_c100_application_id"
+  end
+
   create_table "people", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -243,6 +284,7 @@ ActiveRecord::Schema.define(version: 20180118131931) do
   add_foreign_key "child_orders", "people", column: "child_id"
   add_foreign_key "child_residences", "people", column: "child_id"
   add_foreign_key "court_orders", "c100_applications"
+  add_foreign_key "exemptions", "c100_applications"
   add_foreign_key "people", "c100_applications"
   add_foreign_key "relationships", "c100_applications"
   add_foreign_key "relationships", "people"

--- a/spec/controllers/steps/miam_exemptions/safety_controller_spec.rb
+++ b/spec/controllers/steps/miam_exemptions/safety_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::MiamExemptions::SafetyController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::MiamExemptions::SafetyForm, C100App::MiamExemptionsDecisionTree
+end

--- a/spec/controllers/steps/miam_exemptions/urgency_controller_spec.rb
+++ b/spec/controllers/steps/miam_exemptions/urgency_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::MiamExemptions::UrgencyController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::MiamExemptions::UrgencyForm, C100App::MiamExemptionsDecisionTree
+end

--- a/spec/forms/steps/miam_exemptions/safety_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/safety_form_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe Steps::MiamExemptions::SafetyForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    group_police: true,
+    police_arrested: false,
+    police_caution: true,
+    police_ongoing_proceedings: false,
+    police_conviction: true,
+    police_dvpn: false
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    it_behaves_like 'a has-one-association form',
+                    association_name: :exemption,
+                    expected_attributes: {
+                      group_police: true,
+                      police_arrested: false,
+                      police_caution: true,
+                      police_ongoing_proceedings: false,
+                      police_conviction: true,
+                      police_dvpn: false
+                    }
+  end
+end

--- a/spec/forms/steps/miam_exemptions/urgency_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/urgency_form_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe Steps::MiamExemptions::UrgencyForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    group_risk: true,
+    risk_applicant: false,
+    risk_unreasonable_hardship: true,
+    risk_children: false,
+    risk_unlawful_removal_retention: true
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    it_behaves_like 'a has-one-association form',
+                    association_name: :exemption,
+                    expected_attributes: {
+                      group_risk: true,
+                      risk_applicant: false,
+                      risk_unreasonable_hardship: true,
+                      risk_children: false,
+                      risk_unlawful_removal_retention: true
+                    }
+  end
+end

--- a/spec/services/c100_app/abuse_concerns_decision_tree_spec.rb
+++ b/spec/services/c100_app/abuse_concerns_decision_tree_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe C100App::AbuseConcernsDecisionTree do
 
   describe 'when the step is `contact`' do
     let(:as) { 'contact' }
-    it { is_expected.to have_destination('/steps/petition/orders', :edit) }
+    it { is_expected.to have_destination('/steps/miam_exemptions/safety', :edit) }
   end
 
   describe 'when the step is `previous_proceedings`' do

--- a/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
+++ b/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
@@ -10,21 +10,13 @@ RSpec.describe C100App::MiamExemptionsDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-  pending 'Write specs for MiamExemptionsDecisionTree!'
+  context 'when the step is `safety`' do
+    let(:step_params) { { safety: 'anything' } }
+    it { is_expected.to have_destination(:urgency, :edit) }
+  end
 
-  # TODO: The below can be uncommented and serves as a starting point
-
-  # context 'when the step is `user_type`' do
-  #   let(:step_params) { { user_type: 'anything' } }
-  #
-  #   context 'and the answer is `themself`' do
-  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::THEMSELF) }
-  #     it { is_expected.to have_destination(:user_type, :edit) }
-  #   end
-  #
-  #   context 'and the answer is `representative`' do
-  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::REPRESENTATIVE) }
-  #     it { is_expected.to have_destination(:user_type, :edit) }
-  #   end
-  # end
+  context 'when the step is `urgency`' do
+    let(:step_params) { { urgency: 'anything' } }
+    it { is_expected.to have_destination('/steps/petition/orders', :edit) }
+  end
 end

--- a/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
+++ b/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe C100App::MiamExemptionsDecisionTree do
+  let(:c100_application) { double('Object') }
+  let(:step_params)      { double('Step') }
+  let(:next_step)        { nil }
+  let(:as)               { nil }
+
+  subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
+
+  it_behaves_like 'a decision tree'
+
+  pending 'Write specs for MiamExemptionsDecisionTree!'
+
+  # TODO: The below can be uncommented and serves as a starting point
+
+  # context 'when the step is `user_type`' do
+  #   let(:step_params) { { user_type: 'anything' } }
+  #
+  #   context 'and the answer is `themself`' do
+  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::THEMSELF) }
+  #     it { is_expected.to have_destination(:user_type, :edit) }
+  #   end
+  #
+  #   context 'and the answer is `representative`' do
+  #     let(:c100_application) { instance_double(C100Application, user_type: UserType::REPRESENTATIVE) }
+  #     it { is_expected.to have_destination(:user_type, :edit) }
+  #   end
+  # end
+end


### PR DESCRIPTION
This will set the foundations of the MIAM exemptions (so still lots of things to do).

Initially this PR introduces the **Safety** exemptions and the **Urgency** exemptions, but only with a limited group of exemptions as an initial version.

As this PR otherwise would grow too much, better to get something functional out. Next to do would be introduce the rest of exemptions groups (for which we have the DB table fields) and refactor them in a sensible way to be able to handle validations, resets, etc. into a ValueObject.