### PR TITLE
Chg style of what-is-needed page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -149,5 +149,12 @@ background-image:url(https://assets.publishing.service.gov.uk/static/icon-steps/
     background-color: #fff;
     color: #0053a5;
   }
+  & .panel-border-wide {
+    border-color: #fff;
+  }
+  & .panel-border-wide p {
+    font-size: 1.6rem;
+    font-weight: 700;
+  }
 }
 /* */


### PR DESCRIPTION
Added style properties to the following stylesheet so that the rails application page https://c100-demo.herokuapp.com/entrypoint/what_is_needed matches the styling of the prototype.

app/assets/stylesheets/application.scss

fixes #112