### PR TITLE
Disabling `Danger` checks temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
 
 script:
   - bundle exec rake
-  - bundle exec danger
+  #- bundle exec danger


### PR DESCRIPTION
Danger is slowing down Steph PR's and my time is limited to help
resolve these conflicts, so Danger has to go temporarily.