### PR TITLE
Using latest version of `govuk_elements_form_builder`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,7 @@ ruby '2.4.2'
 
 gem 'devise'
 gem 'email_validator'
-# gem 'govuk_elements_form_builder', '~>1.0.0'
-# TODO: temporally using the branch until the PR is approved and merged and the gem version bumped
-gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git', branch: 'show-hide-radios'
+gem 'govuk_elements_form_builder', '~> 1.1.0'
 gem 'govuk_elements_rails', '~> 3.0'
 gem 'govuk_notify_rails', '~> 2.0.0'
 gem 'govuk_template'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
-  revision: d8304e7daa0122dba26da8ce6ccba240ce8f8680
-  branch: show-hide-radios
-  specs:
-    govuk_elements_form_builder (1.0.0)
-      govuk_elements_rails (>= 3.0.0)
-      govuk_frontend_toolkit (>= 6.0.0)
-      rails (>= 4.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -166,6 +156,10 @@ GEM
       activesupport (>= 4.2.0)
     gov_uk_date_fields (2.0.3)
       rails (>= 5.0)
+    govuk_elements_form_builder (1.1.0)
+      govuk_elements_rails (>= 3.0.0)
+      govuk_frontend_toolkit (>= 6.0.0)
+      rails (>= 4.2)
     govuk_elements_rails (3.1.2)
       govuk_frontend_toolkit (>= 6.0.2)
       rails (>= 4.1.0)
@@ -444,7 +438,7 @@ DEPENDENCIES
   email_validator
   faker
   gov_uk_date_fields (~> 2.0.0)
-  govuk_elements_form_builder!
+  govuk_elements_form_builder (~> 1.1.0)
   govuk_elements_rails (~> 3.0)
   govuk_notify_rails (~> 2.0.0)
   govuk_template


### PR DESCRIPTION
I can't believe the day has come where we can again use the latest
published version of this gem :-)

This version includes the PRs needed for radio/checkbox reveal panels,