### PR TITLE
Add `Concerns about risk` section to PDF

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -29,6 +29,12 @@
     width: 100%;
   }
 
+  table.no-borders {
+    td {
+      border: none;
+    }
+  }
+
   td {
     vertical-align: top;
     font-size: 70%;
@@ -41,6 +47,19 @@
     font-weight: 700;
     width: 50%;
     padding-right: 10px;
+  }
+
+  table.subtable {
+    td {
+      padding: 0 0 5px;
+    }
+    td.question {
+      font-weight: 500;
+      width: 100%;
+    }
+    td.answer {
+      text-align: right;
+    }
   }
 
   .user-text {
@@ -61,5 +80,12 @@
 
   div.newpage {
     page-break-before: always;
+  }
+
+  #risk-concerns-section {
+    td.description {
+      width: 50%;
+      padding-right: 10px;
+    }
   }
 }

--- a/app/presenters/summary/base_answer.rb
+++ b/app/presenters/summary/base_answer.rb
@@ -2,9 +2,9 @@ module Summary
   class BaseAnswer
     attr_reader :question, :value, :show, :change_path
 
-    def initialize(question, value, show: nil, change_path: nil)
+    def initialize(question, value, default: nil, show: nil, change_path: nil)
       @question = question
-      @value = value
+      @value = value || default
       @show = show
       @change_path = change_path
     end

--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -12,6 +12,7 @@ module Summary
         Sections::HelpWithFees.new(c100_application),
         Sections::ApplicantRespondent.new(c100_application),
         Sections::NatureOfApplication.new(c100_application),
+        Sections::RiskConcerns.new(c100_application),
       ].select(&:show?)
     end
 

--- a/app/presenters/summary/sections/risk_concerns.rb
+++ b/app/presenters/summary/sections/risk_concerns.rb
@@ -1,0 +1,39 @@
+module Summary
+  module Sections
+    class RiskConcerns < BaseSectionPresenter
+      def name
+        :risk_concerns
+      end
+
+      def to_partial_path
+        'shared/risk_concerns'
+      end
+
+      def answers
+        [
+          Answer.new(:domestic_abuse,     c100.domestic_abuse,    default: default_value),
+          Answer.new(:children_abduction, c100.risk_of_abduction, default: default_value),
+          Answer.new(:children_abuse,     c100.children_abuse,    default: default_value),
+          Answer.new(:substance_abuse,    c100.substance_abuse,   default: default_value),
+          Answer.new(:other_concerns,     c100.other_abuse,       default: default_value),
+        ]
+      end
+
+      def any?
+        [
+          c100.domestic_abuse,
+          c100.risk_of_abduction,
+          c100.children_abuse,
+          c100.substance_abuse,
+          c100.other_abuse
+        ].any? { |abuse| abuse.eql?(GenericYesNo::YES.to_s) }
+      end
+
+      private
+
+      def default_value
+        GenericYesNo::NO
+      end
+    end
+  end
+end

--- a/app/views/steps/completion/shared/_risk_concerns.html.erb
+++ b/app/views/steps/completion/shared/_risk_concerns.html.erb
@@ -1,0 +1,2 @@
+<!-- HTML version to be implemented when needed for check your answers -->
+<p>Not implemented: <%= __FILE__ %></p>

--- a/app/views/steps/completion/shared/_risk_concerns.pdf.erb
+++ b/app/views/steps/completion/shared/_risk_concerns.pdf.erb
@@ -1,0 +1,23 @@
+<h2 class="section-header"><%= t "check_answers.sections.#{risk_concerns.name}" %></h2>
+
+<table id="risk-concerns-section">
+  <tr>
+    <td class="description">
+      <%= t "check_answers.descriptions.#{risk_concerns.name}" %>
+    </td>
+
+    <td>
+      <table class="no-borders subtable">
+        <%= render risk_concerns.answers %>
+
+        <% if risk_concerns.any? %>
+          <tr>
+            <td class="question">
+              <%=t "check_answers.descriptions.c1a_attached_html" %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -1,4 +1,10 @@
 en:
+  dictionary:
+    YESNO: &YESNO
+      'yes': 'Yes'
+      'no': 'No'
+      unknown: "Don't know"
+
   check_answers:
     headers:
       c100_form:
@@ -8,6 +14,10 @@ en:
       help_with_fees: Help with fees
       applicant_respondent: Applicant and respondent
       nature_of_application: Nature of application
+      risk_concerns: Concerns about risk of harm
+    descriptions:
+      risk_concerns: Are you alleging that the child(ren) named in Section 1 of this form have experienced, or are at risk of experiencing, harm from any of the following by any person who has had contact with the child?
+      c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
     hwf_reference_number:
       question: Reference number
       absence_answer: Not applicable
@@ -37,3 +47,23 @@ en:
         child_flight: Stop the other parent taking them abroad or moving location without your permission
     other_details:
       question: 'Other:'
+    domestic_abuse:
+      question: Any form of domestic abuse?
+      answers:
+        <<: *YESNO
+    children_abduction:
+      question: Child abduction?
+      answers:
+        <<: *YESNO
+    children_abuse:
+      question: Child abuse?
+      answers:
+        <<: *YESNO
+    substance_abuse:
+      question: Drugs, alcohol or substance abuse?
+      answers:
+        <<: *YESNO
+    other_concerns:
+      question: Other safety or welfare concerns?
+      answers:
+        <<: *YESNO

--- a/spec/presenters/summary/base_answer_spec.rb
+++ b/spec/presenters/summary/base_answer_spec.rb
@@ -4,8 +4,9 @@ describe Summary::BaseAnswer do
   let(:question) {'Question?'}
   let(:value) {'Answer!'}
   let(:change_path) {nil}
+  let(:default) {nil}
 
-  subject { described_class.new(question, value, change_path: change_path) }
+  subject { described_class.new(question, value, default: default, change_path: change_path) }
 
   describe '#show?' do
     it 'returns true' do
@@ -39,6 +40,26 @@ describe Summary::BaseAnswer do
 
       it 'returns false' do
         expect(subject.value?).to eq(false)
+      end
+    end
+  end
+
+  describe 'can be given a default value' do
+    context 'when value is nil' do
+      let(:value) { nil }
+      let(:default) { 'no' }
+
+      it 'returns the default value' do
+        expect(subject.value).to eq('no')
+      end
+    end
+
+    context 'when value is not nil' do
+      let(:value) { 'yes' }
+      let(:default) { 'no' }
+
+      it 'returns the original value' do
+        expect(subject.value).to eq('yes')
       end
     end
   end

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -22,6 +22,7 @@ module Summary
           Sections::HelpWithFees,
           Sections::ApplicantRespondent,
           Sections::NatureOfApplication,
+          Sections::RiskConcerns,
         ])
       end
     end

--- a/spec/presenters/summary/sections/risk_concerns_spec.rb
+++ b/spec/presenters/summary/sections/risk_concerns_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::RiskConcerns do
+    let(:c100_application) { double(C100Application).as_null_object }
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:risk_concerns)
+      end
+    end
+
+    describe '#to_partial_path' do
+      it { expect(subject.to_partial_path).to eq('shared/risk_concerns') }
+    end
+
+    describe '#answers' do
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(5)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:domestic_abuse)
+        expect(c100_application).to have_received(:domestic_abuse)
+
+        expect(answers[1]).to be_an_instance_of(Answer)
+        expect(answers[1].question).to eq(:children_abduction)
+        expect(c100_application).to have_received(:risk_of_abduction)
+
+        expect(answers[2]).to be_an_instance_of(Answer)
+        expect(answers[2].question).to eq(:children_abuse)
+        expect(c100_application).to have_received(:children_abuse)
+
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:substance_abuse)
+        expect(c100_application).to have_received(:substance_abuse)
+
+        expect(answers[4]).to be_an_instance_of(Answer)
+        expect(answers[4].question).to eq(:other_concerns)
+        expect(c100_application).to have_received(:other_abuse)
+      end
+    end
+
+    describe '#any?' do
+      let(:c100_application) {
+        instance_double(C100Application,
+          domestic_abuse: domestic_abuse,
+          risk_of_abduction: 'no',
+          children_abuse: 'no',
+          substance_abuse: 'no',
+          other_abuse: 'no'
+        )
+      }
+
+      context 'at least one concern was answered as `YES`' do
+        let(:domestic_abuse) { 'yes' }
+
+        it 'returns true' do
+          expect(subject.any?).to eq(true)
+        end
+      end
+
+      context 'there are no concerns' do
+        let(:domestic_abuse) { 'no' }
+
+        it 'returns false' do
+          expect(subject.any?).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This involved a weirdly crafted table inside another table which is horrible but the PDF renders just well.

<img width="907" alt="screen shot 2018-01-25 at 12 53 36" src="https://user-images.githubusercontent.com/687910/35389218-c97905da-01ce-11e8-80ea-d86fdd5b9cc8.png">
