### PR TITLE
Protect from a nil asking order

### DIFF
--- a/app/presenters/petition_presenter.rb
+++ b/app/presenters/petition_presenter.rb
@@ -15,6 +15,10 @@ class PetitionPresenter < SimpleDelegator
     selected_orders_from(PetitionOrder.values)
   end
 
+  def other_details
+    __getobj__&.other_details
+  end
+
   private
 
   def selected_orders_from(collection)

--- a/spec/presenters/petition_presenter_spec.rb
+++ b/spec/presenters/petition_presenter_spec.rb
@@ -66,4 +66,17 @@ RSpec.describe PetitionPresenter do
       )
     end
   end
+
+  describe '#other_details' do
+    context 'when there is an asking order' do
+      it { expect(subject.other_details).to eq('details') }
+    end
+
+    context 'when the asking order is nil' do
+      let(:asking_order) { nil }
+
+      it { expect { subject.other_details }.not_to raise_error(NoMethodError) }
+      it { expect(subject.other_details).to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
So we can render and iterate the PDF quickly, without having to go
through all of the questions. In this case, the render was blowing
up if we didn't answer the `Petition` orders step.