### PR TITLE
Add mediator details section to PDF

### DIFF
--- a/app/presenters/summary/date_answer.rb
+++ b/app/presenters/summary/date_answer.rb
@@ -1,0 +1,7 @@
+module Summary
+  class DateAnswer < BaseAnswer
+    def to_partial_path
+      'shared/date_row'
+    end
+  end
+end

--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -20,6 +20,8 @@ module Summary
         Sections::ChildrenRelationships.new(c100_application),
         Sections::SectionHeader.new(c100_application, name: :miam_requirement),
         Sections::MiamRequirement.new(c100_application),
+        Sections::SectionHeader.new(c100_application, name: :mediator_certification),
+        Sections::MediatorCertification.new(c100_application),
       ].select(&:show?)
     end
     # rubocop:enable Metrics/AbcSize

--- a/app/presenters/summary/sections/children_details.rb
+++ b/app/presenters/summary/sections/children_details.rb
@@ -21,7 +21,7 @@ module Summary
         c100.children.map do |child|
           [
             FreeTextAnswer.new(:child_full_name, child.full_name),
-            FreeTextAnswer.new(:child_dob, child.dob),
+            DateAnswer.new(:child_dob, child.dob),
             FreeTextAnswer.new(:child_age_estimate, child.age_estimate), # This shows only if a value is present
             Answer.new(:child_sex, child.gender),
             MultiAnswer.new(:child_applicants_relationship, relation_to_child(child, c100.applicants)),

--- a/app/presenters/summary/sections/mediator_certification.rb
+++ b/app/presenters/summary/sections/mediator_certification.rb
@@ -1,0 +1,22 @@
+module Summary
+  module Sections
+    class MediatorCertification < BaseSectionPresenter
+      def name
+        :mediator_certification
+      end
+
+      def show_header?
+        false
+      end
+
+      def answers
+        [
+          Answer.new(:miam_certification_details,        c100.miam_certification, default: GenericYesNo::NO),
+          FreeTextAnswer.new(:miam_certification_number, c100.miam_certification_number),
+          # TODO: we are missing some bits of information here (family mediation service name & sole trader name)
+          DateAnswer.new(:miam_certification_date,       c100.miam_certification_date),
+        ].select(&:show?)
+      end
+    end
+  end
+end

--- a/app/views/steps/completion/shared/_date_row.html.erb
+++ b/app/views/steps/completion/shared/_date_row.html.erb
@@ -1,0 +1,2 @@
+<!-- HTML version to be implemented when needed for check your answers -->
+<p>Not implemented: <%= __FILE__ %></p>

--- a/app/views/steps/completion/shared/_date_row.pdf.erb
+++ b/app/views/steps/completion/shared/_date_row.pdf.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td class="question">
+    <%=t "check_answers.#{date_row.question}.question" %>
+  </td>
+
+  <td class="answer answer-value">
+    <%= l(date_row.value) %>
+  </td>
+</tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1075,7 +1075,7 @@ en:
         precision: 0
   date:
     formats:
-      compact: '%d/%m/%Y'
+      default: '%d-%m-%Y'
       long: '%e %B %Y'
   time:
     case_expires_in:

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -44,6 +44,7 @@ en:
     section_headers:
       children: 1. The Child(ren)
       miam_requirement: 2. Requirement to attend a Mediation, Information and Assessment Meeting (MIAM)
+      mediator_certification: 4. Mediator certifies that the prospective applicant is exempt from attendance at Mediation Information and Assessment Meeting (MIAM) or confirms MIAM attendance
     sections:
       help_with_fees: Help with fees
       applicant_respondent: Applicant and respondent
@@ -179,3 +180,12 @@ en:
       question: Attended a MIAM
       answers:
         <<: *YESNO
+    miam_certification_details:
+      question: 'Mediator details:'
+      answers:
+        'yes': ''
+        'no': Not applicable
+    miam_certification_number:
+      question: FMC registration no
+    miam_certification_date:
+      question: Date

--- a/spec/presenters/summary/date_answer_spec.rb
+++ b/spec/presenters/summary/date_answer_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Summary::DateAnswer do
+  let(:question) {'Question?'}
+  let(:value) {'Answer!'}
+
+  subject { described_class.new(question, value) }
+
+  describe '#to_partial_path' do
+    it 'returns the correct partial path' do
+      expect(subject.to_partial_path).to eq('shared/date_row')
+    end
+  end
+end

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -29,6 +29,8 @@ module Summary
           Sections::ChildrenRelationships,
           Sections::SectionHeader,
           Sections::MiamRequirement,
+          Sections::SectionHeader,
+          Sections::MediatorCertification,
         ])
       end
     end

--- a/spec/presenters/summary/sections/children_details_spec.rb
+++ b/spec/presenters/summary/sections/children_details_spec.rb
@@ -53,7 +53,7 @@ module Summary
         expect(answers[0].question).to eq(:child_full_name)
         expect(answers[0].value).to eq('name')
 
-        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1]).to be_an_instance_of(DateAnswer)
         expect(answers[1].question).to eq(:child_dob)
         expect(answers[1].value).to eq(Date.new(2018, 1, 20))
 

--- a/spec/presenters/summary/sections/mediator_certification_spec.rb
+++ b/spec/presenters/summary/sections/mediator_certification_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::MediatorCertification do
+    let(:c100_application) {
+      instance_double(C100Application,
+        miam_certification: miam_certification,
+        miam_certification_number: miam_certification_number,
+        miam_certification_date: miam_certification_date,
+    ) }
+
+    let(:miam_certification) { 'yes' }
+    let(:miam_certification_number) { '12345-X' }
+    let(:miam_certification_date) { Date.new(2018, 1, 20) }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:mediator_certification) }
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(3)
+
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:miam_certification_details)
+        expect(c100_application).to have_received(:miam_certification)
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:miam_certification_number)
+        expect(c100_application).to have_received(:miam_certification_number)
+
+        expect(answers[2]).to be_an_instance_of(DateAnswer)
+        expect(answers[2].question).to eq(:miam_certification_date)
+        expect(c100_application).to have_received(:miam_certification_date)
+      end
+
+      context 'when no certification received' do
+        let(:miam_certification) { nil }
+        let(:miam_certification_number) { nil }
+        let(:miam_certification_date) { nil }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(1)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:miam_certification_details)
+          expect(answers[0].value).to eq(GenericYesNo::NO)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are 2 missing bits of information we need to ask in the MIAM steps but there is no design in the prototype yet, so holding on it for now.
The rest is pretty straight forward.

Added a new Date answer to handle the format locale properly.

<img width="909" alt="screen shot 2018-01-30 at 11 57 42" src="https://user-images.githubusercontent.com/687910/35565330-0fd83eb2-05b5-11e8-97d0-0e0ede825dd6.png">