### PR TITLE
Add `applicants` section to PDF

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -47,12 +47,17 @@
   }
 
   td.question,
-  td.answer {
+  td.answer,
+  td.separator {
     width: 50%;
     padding-right: 10px;
     padding-bottom: 2px;
     padding-top: 2px;
     font-size: 60%;
+  }
+
+  td.separator {
+    font-weight: 700;
   }
 
   table.subtable {

--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -15,6 +15,7 @@ module Summary
         urgent_and_without_notice_sections,
         international_element_sections,
         litigation_capacity_sections,
+        applicants_section,
       ].flatten.select(&:show?)
     end
 
@@ -83,6 +84,13 @@ module Summary
       [
         Sections::SectionHeader.new(c100_application, name: :litigation_capacity),
         Sections::LitigationCapacity.new(c100_application),
+      ]
+    end
+
+    def applicants_section
+      [
+        Sections::SectionHeader.new(c100_application, name: :applicants_details),
+        Sections::ApplicantsDetails.new(c100_application),
       ]
     end
   end

--- a/app/presenters/summary/sections/applicants_details.rb
+++ b/app/presenters/summary/sections/applicants_details.rb
@@ -1,0 +1,33 @@
+module Summary
+  module Sections
+    class ApplicantsDetails < BaseSectionPresenter
+      def name
+        :applicants_details
+      end
+
+      def show_header?
+        false
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def answers
+        c100.applicants.map.with_index(1) do |applicant, index|
+          [
+            Separator.new(:applicant_index_title, index: index),
+            FreeTextAnswer.new(:person_full_name, applicant.full_name),
+            Answer.new(:person_has_previous_name, applicant.has_previous_name),
+            Answer.new(:person_sex, applicant.gender),
+            DateAnswer.new(:person_dob, applicant.dob),
+            FreeTextAnswer.new(:person_birthplace, applicant.birthplace),
+            FreeTextAnswer.new(:person_address, applicant.address),
+            Answer.new(:person_residence_requirement_met, applicant.residence_requirement_met),
+            FreeTextAnswer.new(:person_home_phone, applicant.home_phone),
+            FreeTextAnswer.new(:person_mobile_phone, applicant.mobile_phone),
+            FreeTextAnswer.new(:person_email, applicant.email),
+          ]
+        end.flatten.select(&:show?)
+      end
+      # rubocop:enable Metrics/AbcSize
+    end
+  end
+end

--- a/app/presenters/summary/sections/children_details.rb
+++ b/app/presenters/summary/sections/children_details.rb
@@ -18,8 +18,9 @@ module Summary
 
       # rubocop:disable Metrics/AbcSize
       def children_personal_details
-        c100.children.map do |child|
+        c100.children.map.with_index(1) do |child, index|
           [
+            Separator.new(:child_index_title, index: index),
             FreeTextAnswer.new(:child_full_name, child.full_name),
             DateAnswer.new(:child_dob, child.dob),
             FreeTextAnswer.new(:child_age_estimate, child.age_estimate), # This shows only if a value is present

--- a/app/presenters/summary/separator.rb
+++ b/app/presenters/summary/separator.rb
@@ -1,0 +1,18 @@
+module Summary
+  class Separator
+    attr_reader :title, :i18n_opts
+
+    def initialize(title, i18n_opts = {})
+      @title = title
+      @i18n_opts = i18n_opts
+    end
+
+    def show?
+      true
+    end
+
+    def to_partial_path
+      'shared/separator'
+    end
+  end
+end

--- a/app/views/steps/completion/shared/_separator.html.erb
+++ b/app/views/steps/completion/shared/_separator.html.erb
@@ -1,0 +1,2 @@
+<!-- HTML version to be implemented when needed for check your answers -->
+<p>Not implemented: <%= __FILE__ %></p>

--- a/app/views/steps/completion/shared/_separator.pdf.erb
+++ b/app/views/steps/completion/shared/_separator.pdf.erb
@@ -1,0 +1,5 @@
+<tr>
+  <td colspan="2" class="separator">
+    <%=t "check_answers.separators.#{separator.title}", separator.i18n_opts %>
+  </td>
+</tr>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -51,6 +51,7 @@ en:
       urgent_and_without_notice: 6. Urgent and without notice hearings
       international_element: 8. Cases with an international element
       litigation_capacity: 9. Factors affecting ability to participate in proceedings
+      applicants_details: 11. About you (the applicant(s))
     sections:
       help_with_fees: Help with fees
       applicant_respondent: Applicant and respondent
@@ -64,6 +65,8 @@ en:
     descriptions:
       risk_concerns: Are you alleging that the child(ren) named in Section 1 of this form have experienced, or are at risk of experiencing, harm from any of the following by any person who has had contact with the child?
       c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
+    separators:
+      applicant_index_title: Applicant %{index}
     hwf_reference_number:
       question: Reference number
       absence_answer: *not_applicable
@@ -258,3 +261,30 @@ en:
       question: Details of any referral to or assessment by the Adult Learning Disability team, and/or any adult health service, where known, together with the outcome
     participation_other_factors_details:
       question: Other factors which may affect the ability of the person concerned to take part in the proceedings?
+
+    person_full_name:
+      question: Full name
+    person_has_previous_name:
+      question: Previous name
+      answers:
+        <<: *YESNO
+    person_sex:
+      question: Sex
+      answers:
+        <<: *SEX_OPTIONS
+    person_dob:
+      question: Date of birth
+    person_birthplace:
+      question: Place of birth
+    person_address:
+      question: Address
+    person_residence_requirement_met:
+      question: Lived at this address for more than 5 years?
+      answers:
+        <<: *YESNO
+    person_home_phone:
+      question: Home telephone number
+    person_mobile_phone:
+      question: Mobile telephone number
+    person_email:
+      question: Email address

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -66,6 +66,7 @@ en:
       risk_concerns: Are you alleging that the child(ren) named in Section 1 of this form have experienced, or are at risk of experiencing, harm from any of the following by any person who has had contact with the child?
       c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
     separators:
+      child_index_title: Child %{index}
       applicant_index_title: Applicant %{index}
     hwf_reference_number:
       question: Reference number
@@ -152,7 +153,7 @@ en:
       answers:
         <<: *YESNO
     child_full_name:
-      question: Child full name
+      question: Full name
     child_dob:
       question: Date of birth
     child_age_estimate:

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -40,6 +40,8 @@ module Summary
           Sections::InternationalElement,
           Sections::SectionHeader,
           Sections::LitigationCapacity,
+          Sections::SectionHeader,
+          Sections::ApplicantsDetails,
         ])
       end
     end

--- a/spec/presenters/summary/sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/applicants_details_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::ApplicantsDetails do
+    let(:c100_application) { instance_double(C100Application, applicants: [applicant]) }
+
+    let(:applicant) {
+      instance_double(Applicant,
+        full_name: 'fullname',
+        has_previous_name: 'no',
+        dob: Date.new(2018, 1, 20),
+        gender: 'female',
+        birthplace: 'birthplace',
+        address: 'address',
+        residence_requirement_met: 'yes',
+        home_phone: 'home_phone',
+        mobile_phone: 'mobile_phone',
+        email: 'email'
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:applicants_details) }
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#answers' do
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(11)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Separator)
+        expect(answers[0].title).to eq(:applicant_index_title)
+        expect(answers[0].i18n_opts).to eq({index: 1})
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:person_full_name)
+        expect(answers[1].value).to eq('fullname')
+
+        expect(answers[2]).to be_an_instance_of(Answer)
+        expect(answers[2].question).to eq(:person_has_previous_name)
+        expect(answers[2].value).to eq('no')
+
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:person_sex)
+        expect(answers[3].value).to eq('female')
+
+        expect(answers[4]).to be_an_instance_of(DateAnswer)
+        expect(answers[4].question).to eq(:person_dob)
+        expect(answers[4].value).to eq(Date.new(2018, 1, 20))
+
+        expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[5].question).to eq(:person_birthplace)
+        expect(answers[5].value).to eq('birthplace')
+
+        expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[6].question).to eq(:person_address)
+        expect(answers[6].value).to eq('address')
+
+        expect(answers[7]).to be_an_instance_of(Answer)
+        expect(answers[7].question).to eq(:person_residence_requirement_met)
+        expect(answers[7].value).to eq('yes')
+
+        expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[8].question).to eq(:person_home_phone)
+        expect(answers[8].value).to eq('home_phone')
+
+        expect(answers[9]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[9].question).to eq(:person_mobile_phone)
+        expect(answers[9].value).to eq('mobile_phone')
+
+        expect(answers[10]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[10].question).to eq(:person_email)
+        expect(answers[10].value).to eq('email')
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/sections/children_details_spec.rb
+++ b/spec/presenters/summary/sections/children_details_spec.rb
@@ -45,46 +45,50 @@ module Summary
       end
 
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(9)
+        expect(answers.count).to eq(10)
       end
 
       it 'has the correct rows in the right order' do
-        expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[0].question).to eq(:child_full_name)
-        expect(answers[0].value).to eq('name')
+        expect(answers[0]).to be_an_instance_of(Separator)
+        expect(answers[0].title).to eq(:child_index_title)
+        expect(answers[0].i18n_opts).to eq({index: 1})
 
-        expect(answers[1]).to be_an_instance_of(DateAnswer)
-        expect(answers[1].question).to eq(:child_dob)
-        expect(answers[1].value).to eq(Date.new(2018, 1, 20))
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:child_full_name)
+        expect(answers[1].value).to eq('name')
 
-        expect(answers[2]).to be_an_instance_of(Answer)
-        expect(answers[2].question).to eq(:child_sex)
-        expect(answers[2].value).to eq('female')
+        expect(answers[2]).to be_an_instance_of(DateAnswer)
+        expect(answers[2].question).to eq(:child_dob)
+        expect(answers[2].value).to eq(Date.new(2018, 1, 20))
 
-        expect(answers[3]).to be_an_instance_of(MultiAnswer)
-        expect(answers[3].question).to eq(:child_applicants_relationship)
-        expect(answers[3].value).to eq(['mother'])
-        expect(c100_application).to have_received(:applicants)
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:child_sex)
+        expect(answers[3].value).to eq('female')
 
         expect(answers[4]).to be_an_instance_of(MultiAnswer)
-        expect(answers[4].question).to eq(:child_respondents_relationship)
+        expect(answers[4].question).to eq(:child_applicants_relationship)
         expect(answers[4].value).to eq(['mother'])
-        expect(c100_application).to have_received(:respondents)
+        expect(c100_application).to have_received(:applicants)
 
         expect(answers[5]).to be_an_instance_of(MultiAnswer)
-        expect(answers[5].question).to eq(:child_orders)
-        expect(answers[5].value).to eq(['an_order'])
+        expect(answers[5].question).to eq(:child_respondents_relationship)
+        expect(answers[5].value).to eq(['mother'])
+        expect(c100_application).to have_received(:respondents)
 
-        expect(answers[6]).to be_an_instance_of(Answer)
-        expect(answers[6].question).to eq(:children_known_to_authorities)
+        expect(answers[6]).to be_an_instance_of(MultiAnswer)
+        expect(answers[6].question).to eq(:child_orders)
+        expect(answers[6].value).to eq(['an_order'])
+
+        expect(answers[7]).to be_an_instance_of(Answer)
+        expect(answers[7].question).to eq(:children_known_to_authorities)
         expect(c100_application).to have_received(:children_known_to_authorities)
 
-        expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[7].question).to eq(:children_known_to_authorities_details)
+        expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[8].question).to eq(:children_known_to_authorities_details)
         expect(c100_application).to have_received(:children_known_to_authorities_details)
 
-        expect(answers[8]).to be_an_instance_of(Answer)
-        expect(answers[8].question).to eq(:children_protection_plan)
+        expect(answers[9]).to be_an_instance_of(Answer)
+        expect(answers[9].question).to eq(:children_protection_plan)
         expect(c100_application).to have_received(:children_protection_plan)
       end
 
@@ -93,9 +97,9 @@ module Summary
         let(:age_estimate) { 18 }
 
         it 'uses the age estimate' do
-          expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[1].question).to eq(:child_age_estimate)
-          expect(answers[1].value).to eq(18)
+          expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[2].question).to eq(:child_age_estimate)
+          expect(answers[2].value).to eq(18)
         end
       end
     end

--- a/spec/presenters/summary/separator_spec.rb
+++ b/spec/presenters/summary/separator_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Summary::Separator do
+  let(:title) { :whatever }
+
+  subject { described_class.new(title) }
+
+  describe '#show?' do
+    it { expect(subject.show?).to eq(true) }
+  end
+
+  describe '#to_partial_path' do
+    it { expect(subject.to_partial_path).to eq('shared/separator') }
+  end
+
+  describe 'can be given i18n options' do
+    context 'when there are no options' do
+      it 'returns the default value' do
+        expect(subject.i18n_opts).to eq({})
+      end
+    end
+
+    context 'when there are options' do
+      subject { described_class.new(title, index: 1) }
+
+      it 'returns the options' do
+        expect(subject.i18n_opts).to eq({index: 1})
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are some things missing that will be added as part of another PR to not grow this one too much.

The good news is, for respondents and 'other parties' is going to look very similar or identical and we may be able to share a lot of code.
 
<img width="903" alt="screen shot 2018-01-31 at 13 00 12" src="https://user-images.githubusercontent.com/687910/35624405-cdde9e8e-0686-11e8-8634-4fda1de8235b.png">
