### PR TITLE
Add `respondents` section to PDF

### DIFF
--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -16,6 +16,7 @@ module Summary
         international_element_sections,
         litigation_capacity_sections,
         applicants_section,
+        respondents_section,
       ].flatten.select(&:show?)
     end
 
@@ -91,6 +92,13 @@ module Summary
       [
         Sections::SectionHeader.new(c100_application, name: :applicants_details),
         Sections::ApplicantsDetails.new(c100_application),
+      ]
+    end
+
+    def respondents_section
+      [
+        Sections::SectionHeader.new(c100_application, name: :respondents_details),
+        Sections::RespondentsDetails.new(c100_application),
       ]
     end
   end

--- a/app/presenters/summary/sections/applicants_details.rb
+++ b/app/presenters/summary/sections/applicants_details.rb
@@ -15,12 +15,13 @@ module Summary
           [
             Separator.new(:applicant_index_title, index: index),
             FreeTextAnswer.new(:person_full_name, applicant.full_name),
-            Answer.new(:person_has_previous_name, applicant.has_previous_name),
+            previous_name_answer(applicant),
             Answer.new(:person_sex, applicant.gender),
             DateAnswer.new(:person_dob, applicant.dob),
             FreeTextAnswer.new(:person_birthplace, applicant.birthplace),
             FreeTextAnswer.new(:person_address, applicant.address),
             Answer.new(:person_residence_requirement_met, applicant.residence_requirement_met),
+            FreeTextAnswer.new(:person_residence_history, applicant.residence_history),
             FreeTextAnswer.new(:person_home_phone, applicant.home_phone),
             FreeTextAnswer.new(:person_mobile_phone, applicant.mobile_phone),
             FreeTextAnswer.new(:person_email, applicant.email),
@@ -28,6 +29,16 @@ module Summary
         end.flatten.select(&:show?)
       end
       # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def previous_name_answer(applicant)
+        if applicant.has_previous_name.eql?(GenericYesNo::YES.to_s)
+          FreeTextAnswer.new(:person_previous_name, applicant.previous_name)
+        else
+          Answer.new(:person_previous_name, applicant.has_previous_name)
+        end
+      end
     end
   end
 end

--- a/app/presenters/summary/sections/people_details.rb
+++ b/app/presenters/summary/sections/people_details.rb
@@ -20,6 +20,7 @@ module Summary
             previous_name_answer(person),
             Answer.new(:person_sex, person.gender),
             DateAnswer.new(:person_dob, person.dob),
+            FreeTextAnswer.new(:person_age_estimate, person.age_estimate), # This shows only if a value is present
             FreeTextAnswer.new(:person_birthplace, person.birthplace),
             FreeTextAnswer.new(:person_address, person.address),
             Answer.new(:person_residence_requirement_met, person.residence_requirement_met),

--- a/app/presenters/summary/sections/people_details.rb
+++ b/app/presenters/summary/sections/people_details.rb
@@ -1,0 +1,46 @@
+module Summary
+  module Sections
+    class PeopleDetails < BaseSectionPresenter
+      def show_header?
+        false
+      end
+
+      # :nocov:
+      def record_collection
+        raise 'must be implemented in subclasses'
+      end
+      # :nocov:
+
+      # rubocop:disable Metrics/AbcSize
+      def answers
+        record_collection.map.with_index(1) do |person, index|
+          [
+            Separator.new("#{name}_index_title", index: index),
+            FreeTextAnswer.new(:person_full_name, person.full_name),
+            previous_name_answer(person),
+            Answer.new(:person_sex, person.gender),
+            DateAnswer.new(:person_dob, person.dob),
+            FreeTextAnswer.new(:person_birthplace, person.birthplace),
+            FreeTextAnswer.new(:person_address, person.address),
+            Answer.new(:person_residence_requirement_met, person.residence_requirement_met),
+            FreeTextAnswer.new(:person_residence_history, person.residence_history),
+            FreeTextAnswer.new(:person_home_phone, person.home_phone),
+            FreeTextAnswer.new(:person_mobile_phone, person.mobile_phone),
+            FreeTextAnswer.new(:person_email, person.email),
+          ]
+        end.flatten.select(&:show?)
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def previous_name_answer(person)
+        if person.has_previous_name.eql?(GenericYesNo::YES.to_s)
+          FreeTextAnswer.new(:person_previous_name, person.previous_name)
+        else
+          Answer.new(:person_previous_name, person.has_previous_name)
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/respondents_details.rb
+++ b/app/presenters/summary/sections/respondents_details.rb
@@ -1,12 +1,12 @@
 module Summary
   module Sections
-    class ApplicantsDetails < PeopleDetails
+    class RespondentsDetails < PeopleDetails
       def name
-        :applicants_details
+        :respondents_details
       end
 
       def record_collection
-        c100.applicants
+        c100.respondents
       end
     end
   end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -52,6 +52,7 @@ en:
       international_element: 8. Cases with an international element
       litigation_capacity: 9. Factors affecting ability to participate in proceedings
       applicants_details: 11. About you (the applicant(s))
+      respondents_details: 12. The respondent(s)
     sections:
       help_with_fees: Help with fees
       applicant_respondent: Applicant and respondent
@@ -67,7 +68,8 @@ en:
       c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
     separators:
       child_index_title: Child %{index}
-      applicant_index_title: Applicant %{index}
+      applicants_details_index_title: Applicant %{index}
+      respondents_details_index_title: Respondent %{index}
     hwf_reference_number:
       question: Reference number
       absence_answer: *not_applicable

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -265,7 +265,7 @@ en:
 
     person_full_name:
       question: Full name
-    person_has_previous_name:
+    person_previous_name:
       question: Previous name
       answers:
         <<: *YESNO
@@ -283,6 +283,8 @@ en:
       question: Lived at this address for more than 5 years?
       answers:
         <<: *YESNO
+    person_residence_history:
+      question: Previous addresses
     person_home_phone:
       question: Home telephone number
     person_mobile_phone:

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -277,6 +277,8 @@ en:
         <<: *SEX_OPTIONS
     person_dob:
       question: Date of birth
+    person_age_estimate:
+      question: Approximate age or year born
     person_birthplace:
       question: Place of birth
     person_address:

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -42,6 +42,8 @@ module Summary
           Sections::LitigationCapacity,
           Sections::SectionHeader,
           Sections::ApplicantsDetails,
+          Sections::SectionHeader,
+          Sections::RespondentsDetails,
         ])
       end
     end

--- a/spec/presenters/summary/sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/applicants_details_spec.rb
@@ -10,6 +10,7 @@ module Summary
         has_previous_name: has_previous_name,
         previous_name: previous_name,
         dob: Date.new(2018, 1, 20),
+        age_estimate: nil,
         gender: 'female',
         birthplace: 'birthplace',
         address: 'address',

--- a/spec/presenters/summary/sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/applicants_details_spec.rb
@@ -7,12 +7,14 @@ module Summary
     let(:applicant) {
       instance_double(Applicant,
         full_name: 'fullname',
-        has_previous_name: 'no',
+        has_previous_name: has_previous_name,
+        previous_name: previous_name,
         dob: Date.new(2018, 1, 20),
         gender: 'female',
         birthplace: 'birthplace',
         address: 'address',
         residence_requirement_met: 'yes',
+        residence_history: 'history',
         home_phone: 'home_phone',
         mobile_phone: 'mobile_phone',
         email: 'email'
@@ -20,6 +22,9 @@ module Summary
     }
 
     subject { described_class.new(c100_application) }
+
+    let(:has_previous_name) { 'no' }
+    let(:previous_name) { nil }
 
     let(:answers) { subject.answers }
 
@@ -33,7 +38,7 @@ module Summary
 
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(11)
+        expect(answers.count).to eq(12)
       end
 
       it 'has the correct rows in the right order' do
@@ -46,7 +51,7 @@ module Summary
         expect(answers[1].value).to eq('fullname')
 
         expect(answers[2]).to be_an_instance_of(Answer)
-        expect(answers[2].question).to eq(:person_has_previous_name)
+        expect(answers[2].question).to eq(:person_previous_name)
         expect(answers[2].value).to eq('no')
 
         expect(answers[3]).to be_an_instance_of(Answer)
@@ -70,16 +75,35 @@ module Summary
         expect(answers[7].value).to eq('yes')
 
         expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[8].question).to eq(:person_home_phone)
-        expect(answers[8].value).to eq('home_phone')
+        expect(answers[8].question).to eq(:person_residence_history)
+        expect(answers[8].value).to eq('history')
 
         expect(answers[9]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[9].question).to eq(:person_mobile_phone)
-        expect(answers[9].value).to eq('mobile_phone')
+        expect(answers[9].question).to eq(:person_home_phone)
+        expect(answers[9].value).to eq('home_phone')
 
         expect(answers[10]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[10].question).to eq(:person_email)
-        expect(answers[10].value).to eq('email')
+        expect(answers[10].question).to eq(:person_mobile_phone)
+        expect(answers[10].value).to eq('mobile_phone')
+
+        expect(answers[11]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[11].question).to eq(:person_email)
+        expect(answers[11].value).to eq('email')
+      end
+
+      context 'for existing previous name' do
+        let(:has_previous_name) { 'yes' }
+        let(:previous_name) { 'previous_name' }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(12)
+        end
+
+        it 'renders the previous name' do
+          expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[2].question).to eq(:person_previous_name)
+          expect(answers[2].value).to eq('previous_name')
+        end
       end
     end
   end

--- a/spec/presenters/summary/sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/sections/respondents_details_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 module Summary
-  describe Sections::ApplicantsDetails do
-    let(:c100_application) { instance_double(C100Application, applicants: [applicant]) }
+  describe Sections::RespondentsDetails do
+    let(:c100_application) { instance_double(C100Application, respondents: [respondent]) }
 
-    let(:applicant) {
-      instance_double(Applicant,
+    let(:respondent) {
+      instance_double(Respondent,
         full_name: 'fullname',
         has_previous_name: has_previous_name,
         previous_name: previous_name,
@@ -29,7 +29,7 @@ module Summary
     let(:answers) { subject.answers }
 
     describe '#name' do
-      it { expect(subject.name).to eq(:applicants_details) }
+      it { expect(subject.name).to eq(:respondents_details) }
     end
 
     describe '#show_header?' do
@@ -38,7 +38,7 @@ module Summary
 
     describe '#record_collection' do
       it {
-        expect(c100_application).to receive(:applicants)
+        expect(c100_application).to receive(:respondents)
         subject.record_collection
       }
     end
@@ -50,7 +50,7 @@ module Summary
 
       it 'has the correct rows in the right order' do
         expect(answers[0]).to be_an_instance_of(Separator)
-        expect(answers[0].title).to eq('applicants_details_index_title')
+        expect(answers[0].title).to eq('respondents_details_index_title')
         expect(answers[0].i18n_opts).to eq({index: 1})
 
         expect(answers[1]).to be_an_instance_of(FreeTextAnswer)

--- a/spec/presenters/summary/sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/sections/respondents_details_spec.rb
@@ -9,7 +9,8 @@ module Summary
         full_name: 'fullname',
         has_previous_name: has_previous_name,
         previous_name: previous_name,
-        dob: Date.new(2018, 1, 20),
+        dob: dob,
+        age_estimate: age_estimate,
         gender: 'female',
         birthplace: 'birthplace',
         address: 'address',
@@ -25,6 +26,8 @@ module Summary
 
     let(:has_previous_name) { 'no' }
     let(:previous_name) { nil }
+    let(:dob) { Date.new(2018, 1, 20) }
+    let(:age_estimate) { nil }
 
     let(:answers) { subject.answers }
 
@@ -110,6 +113,21 @@ module Summary
           expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
           expect(answers[2].question).to eq(:person_previous_name)
           expect(answers[2].value).to eq('previous_name')
+        end
+      end
+
+      context 'when `dob` is nil' do
+        let(:dob) { nil }
+        let(:age_estimate) { 18 }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(12)
+        end
+
+        it 'uses the age estimate' do
+          expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[4].question).to eq(:person_age_estimate)
+          expect(answers[4].value).to eq(18)
         end
       end
     end


### PR DESCRIPTION
This was done reusing/refactoring the code we had for applicants. I expect to be able to use it for 'other parties' too, which is very similar.

<img width="904" alt="screen shot 2018-01-31 at 16 41 10" src="https://user-images.githubusercontent.com/687910/35635312-e3da07a4-06a5-11e8-80c5-28af14489eb8.png">
