### PR TITLE
 Add `other parties` details to PDF

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -495,7 +495,7 @@ MethodLength:
 
 AbcSize:
   Enabled: true
-  Max: 20
+  Max: 22
 
 CyclomaticComplexity:
   Enabled: false

--- a/app/presenters/relationships_presenter.rb
+++ b/app/presenters/relationships_presenter.rb
@@ -1,0 +1,35 @@
+class RelationshipsPresenter
+  RELATION_SEPARATOR = ' - '.freeze
+  PEOPLE_SEPARATOR = '; '.freeze
+
+  attr_reader :c100_application
+
+  def initialize(c100_application)
+    @c100_application = c100_application
+  end
+
+  def relationship_to_children(person_or_people, show_person_name: true)
+    relationships.where(child: children, person: person_or_people).map do |relationship|
+      person_full_name = show_person_name ? relationship.person.full_name : nil
+      child_full_name  = relationship.child.full_name
+      relation = i18n_relation(relationship)
+
+      [person_full_name, relation, child_full_name].compact.join(RELATION_SEPARATOR)
+    end.join(PEOPLE_SEPARATOR)
+  end
+
+  private
+
+  def children
+    c100_application.children
+  end
+
+  def relationships
+    c100_application.relationships
+  end
+
+  def i18n_relation(relationship)
+    return relationship.relation_other_value if relationship.relation.eql?(Relation::OTHER.to_s)
+    I18n.translate!(relationship.relation, scope: 'dictionary.RELATIONS')
+  end
+end

--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -15,8 +15,7 @@ module Summary
         urgent_and_without_notice_sections,
         international_element_sections,
         litigation_capacity_sections,
-        applicants_section,
-        respondents_section,
+        people_sections,
       ].flatten.select(&:show?)
     end
 
@@ -88,17 +87,14 @@ module Summary
       ]
     end
 
-    def applicants_section
+    def people_sections
       [
         Sections::SectionHeader.new(c100_application, name: :applicants_details),
         Sections::ApplicantsDetails.new(c100_application),
-      ]
-    end
-
-    def respondents_section
-      [
         Sections::SectionHeader.new(c100_application, name: :respondents_details),
         Sections::RespondentsDetails.new(c100_application),
+        Sections::SectionHeader.new(c100_application, name: :other_parties_details),
+        Sections::OtherPartiesDetails.new(c100_application),
       ]
     end
   end

--- a/app/presenters/summary/sections/children_relationships.rb
+++ b/app/presenters/summary/sections/children_relationships.rb
@@ -7,10 +7,19 @@ module Summary
 
       def answers
         [
-          FreeTextAnswer.new(:applicants_relationships,    relationships_with(c100.applicants)),
-          FreeTextAnswer.new(:respondents_relationships,   relationships_with(c100.respondents)),
-          FreeTextAnswer.new(:other_parties_relationships, relationships_with(c100.other_parties)),
-          FreeTextAnswer.new(:children_residence,          children_residence)
+          FreeTextAnswer.new(
+            :applicants_relationships,
+            RelationshipsPresenter.new(c100_application).relationship_to_children(c100.applicants)
+          ),
+          FreeTextAnswer.new(
+            :respondents_relationships,
+            RelationshipsPresenter.new(c100_application).relationship_to_children(c100.respondents)
+          ),
+          FreeTextAnswer.new(
+            :other_parties_relationships,
+            RelationshipsPresenter.new(c100_application).relationship_to_children(c100.other_parties)
+          ),
+          FreeTextAnswer.new(:children_residence, children_residence)
         ].select(&:show?)
       end
 
@@ -24,21 +33,6 @@ module Summary
         ChildResidence.where(child: children).map do |residence|
           residence_full_names(residence)
         end.join('; ')
-      end
-
-      def relationships_with(people)
-        c100.relationships.where(child: children, person: people).map do |relationship|
-          [
-            relationship.person.full_name,
-            i18n_relation(relationship),
-            relationship.child.full_name
-          ].join(' - ')
-        end.join('; ')
-      end
-
-      def i18n_relation(relationship)
-        return relationship.relation_other_value if relationship.relation.eql?(Relation::OTHER.to_s)
-        t(relationship.relation, scope: 'dictionary.RELATIONS')
       end
 
       # TODO: we might need to separate which child lives with each of the parties

--- a/app/presenters/summary/sections/other_parties_details.rb
+++ b/app/presenters/summary/sections/other_parties_details.rb
@@ -1,0 +1,13 @@
+module Summary
+  module Sections
+    class OtherPartiesDetails < PeopleDetails
+      def name
+        :other_parties_details
+      end
+
+      def record_collection
+        c100.other_parties
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/people_details.rb
+++ b/app/presenters/summary/sections/people_details.rb
@@ -11,8 +11,10 @@ module Summary
       end
       # :nocov:
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def answers
+        return [Separator.new(:not_applicable)] if record_collection.empty?
+
         record_collection.map.with_index(1) do |person, index|
           [
             Separator.new("#{name}_index_title", index: index),
@@ -28,10 +30,14 @@ module Summary
             FreeTextAnswer.new(:person_home_phone, person.home_phone),
             FreeTextAnswer.new(:person_mobile_phone, person.mobile_phone),
             FreeTextAnswer.new(:person_email, person.email),
+            FreeTextAnswer.new(
+              :person_relationship_to_children,
+              RelationshipsPresenter.new(c100_application).relationship_to_children(person, show_person_name: false)
+            ),
           ]
         end.flatten.select(&:show?)
       end
-      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       private
 

--- a/app/presenters/summary/sections/people_details.rb
+++ b/app/presenters/summary/sections/people_details.rb
@@ -22,7 +22,7 @@ module Summary
             DateAnswer.new(:person_dob, person.dob),
             FreeTextAnswer.new(:person_age_estimate, person.age_estimate), # This shows only if a value is present
             FreeTextAnswer.new(:person_birthplace, person.birthplace),
-            FreeTextAnswer.new(:person_address, person.address),
+            FreeTextAnswer.new(:person_address, person.address, show: true),
             Answer.new(:person_residence_requirement_met, person.residence_requirement_met),
             FreeTextAnswer.new(:person_residence_history, person.residence_history),
             FreeTextAnswer.new(:person_home_phone, person.home_phone),

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -1,11 +1,12 @@
 en:
   dictionary:
     not_applicable: &not_applicable "Not applicable"
+    unknown: &unknown "Don't know"
 
     YESNO: &YESNO
       'yes': 'Yes'
       'no': 'No'
-      unknown: "Don't know"
+      unknown: *unknown
 
     SEX_OPTIONS: &SEX_OPTIONS
       female: Female
@@ -53,6 +54,7 @@ en:
       litigation_capacity: 9. Factors affecting ability to participate in proceedings
       applicants_details: 11. About you (the applicant(s))
       respondents_details: 12. The respondent(s)
+      other_parties_details: 13. Others who should be given notice
     sections:
       help_with_fees: Help with fees
       applicant_respondent: Applicant and respondent
@@ -70,6 +72,7 @@ en:
       child_index_title: Child %{index}
       applicants_details_index_title: Applicant %{index}
       respondents_details_index_title: Respondent %{index}
+      other_parties_details_index_title: Person %{index}
     hwf_reference_number:
       question: Reference number
       absence_answer: *not_applicable
@@ -283,6 +286,7 @@ en:
       question: Place of birth
     person_address:
       question: Address
+      absence_answer: *unknown
     person_residence_requirement_met:
       question: Lived at this address for more than 5 years?
       answers:

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -69,6 +69,7 @@ en:
       risk_concerns: Are you alleging that the child(ren) named in Section 1 of this form have experienced, or are at risk of experiencing, harm from any of the following by any person who has had contact with the child?
       c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
     separators:
+      not_applicable: Not applicable
       child_index_title: Child %{index}
       applicants_details_index_title: Applicant %{index}
       respondents_details_index_title: Respondent %{index}
@@ -299,3 +300,5 @@ en:
       question: Mobile telephone number
     person_email:
       question: Email address
+    person_relationship_to_children:
+      question: Relationship to children listed in this application

--- a/spec/presenters/relationships_presenter_spec.rb
+++ b/spec/presenters/relationships_presenter_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe RelationshipsPresenter do
+  let(:c100_application) { instance_double(C100Application, children: children, relationships: relationships) }
+
+  let(:children) { [] }
+  let(:relationships) { double('relationships') }
+  let(:child_relationship) { double(Relationship) }
+
+  subject { described_class.new(c100_application) }
+
+  describe '#relationship_to_children' do
+    let(:person) { instance_double(Person, relationships: relationships) }
+
+    before do
+      allow(relationships).to receive(:where).with(child: children, person: person).and_return([child_relationship])
+
+      allow(child_relationship).to receive(:relation).and_return('father')
+      allow(child_relationship).to receive(:child).and_return(double(full_name: 'Child name'))
+      allow(child_relationship).to receive(:person).and_return(double(full_name: 'Person name'))
+    end
+
+    context 'showing the person name' do
+      it 'returns a string describing the relationships' do
+        expect(subject.relationship_to_children(person, show_person_name: true)).to eq('Person name - Father - Child name')
+      end
+    end
+
+    context 'hiding the person name' do
+      it 'returns a string describing the relationships' do
+        expect(subject.relationship_to_children(person, show_person_name: false)).to eq('Father - Child name')
+      end
+    end
+
+    context 'for `other` relationship' do
+      before do
+        allow(child_relationship).to receive(:relation).and_return('other')
+        allow(child_relationship).to receive(:relation_other_value).and_return('A friend')
+      end
+
+      context 'showing the person name' do
+        it 'returns a string describing the relationships' do
+          expect(subject.relationship_to_children(person, show_person_name: true)).to eq('Person name - A friend - Child name')
+        end
+      end
+
+      context 'hiding the person name' do
+        it 'returns a string describing the relationships' do
+          expect(subject.relationship_to_children(person, show_person_name: false)).to eq('A friend - Child name')
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -44,6 +44,8 @@ module Summary
           Sections::ApplicantsDetails,
           Sections::SectionHeader,
           Sections::RespondentsDetails,
+          Sections::SectionHeader,
+          Sections::OtherPartiesDetails,
         ])
       end
     end

--- a/spec/presenters/summary/sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/applicants_details_spec.rb
@@ -45,8 +45,14 @@ module Summary
     end
 
     describe '#answers' do
+      before do
+        allow_any_instance_of(
+          RelationshipsPresenter
+        ).to receive(:relationship_to_children).with(applicant, show_person_name: false).and_return('relationships')
+      end
+
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(12)
+        expect(answers.count).to eq(13)
       end
 
       it 'has the correct rows in the right order' do
@@ -97,6 +103,10 @@ module Summary
         expect(answers[11]).to be_an_instance_of(FreeTextAnswer)
         expect(answers[11].question).to eq(:person_email)
         expect(answers[11].value).to eq('email')
+
+        expect(answers[12]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[12].question).to eq(:person_relationship_to_children)
+        expect(answers[12].value).to eq('relationships')
       end
 
       context 'for existing previous name' do
@@ -104,7 +114,7 @@ module Summary
         let(:previous_name) { 'previous_name' }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(12)
+          expect(answers.count).to eq(13)
         end
 
         it 'renders the previous name' do

--- a/spec/presenters/summary/sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/sections/other_parties_details_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::OtherPartiesDetails do
+    let(:c100_application) { instance_double(C100Application, other_parties: [other_party]) }
+
+    let(:other_party) {
+      instance_double(OtherParty,
+        full_name: 'fullname',
+        has_previous_name: has_previous_name,
+        previous_name: previous_name,
+        dob: dob,
+        age_estimate: age_estimate,
+        gender: 'female',
+        birthplace: nil,
+        address: 'address',
+        residence_requirement_met: nil,
+        residence_history: nil,
+        home_phone: nil,
+        mobile_phone: nil,
+        email: nil,
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:has_previous_name) { 'no' }
+    let(:previous_name) { nil }
+    let(:dob) { Date.new(2018, 1, 20) }
+    let(:age_estimate) { nil }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:other_parties_details) }
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#record_collection' do
+      it {
+        expect(c100_application).to receive(:other_parties)
+        subject.record_collection
+      }
+    end
+
+    describe '#answers' do
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(6)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Separator)
+        expect(answers[0].title).to eq('other_parties_details_index_title')
+        expect(answers[0].i18n_opts).to eq({index: 1})
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:person_full_name)
+        expect(answers[1].value).to eq('fullname')
+
+        expect(answers[2]).to be_an_instance_of(Answer)
+        expect(answers[2].question).to eq(:person_previous_name)
+        expect(answers[2].value).to eq('no')
+
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:person_sex)
+        expect(answers[3].value).to eq('female')
+
+        expect(answers[4]).to be_an_instance_of(DateAnswer)
+        expect(answers[4].question).to eq(:person_dob)
+        expect(answers[4].value).to eq(Date.new(2018, 1, 20))
+
+        expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[5].question).to eq(:person_address)
+        expect(answers[5].value).to eq('address')
+      end
+
+      context 'for existing previous name' do
+        let(:has_previous_name) { 'yes' }
+        let(:previous_name) { 'previous_name' }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(6)
+        end
+
+        it 'renders the previous name' do
+          expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[2].question).to eq(:person_previous_name)
+          expect(answers[2].value).to eq('previous_name')
+        end
+      end
+
+      context 'when `dob` is nil' do
+        let(:dob) { nil }
+        let(:age_estimate) { 18 }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(6)
+        end
+
+        it 'uses the age estimate' do
+          expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[4].question).to eq(:person_age_estimate)
+          expect(answers[4].value).to eq(18)
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/sections/other_parties_details_spec.rb
@@ -47,8 +47,14 @@ module Summary
     end
 
     describe '#answers' do
+      before do
+        allow_any_instance_of(
+          RelationshipsPresenter
+        ).to receive(:relationship_to_children).with(other_party, show_person_name: false).and_return('relationships')
+      end
+
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(6)
+        expect(answers.count).to eq(7)
       end
 
       it 'has the correct rows in the right order' do
@@ -75,6 +81,10 @@ module Summary
         expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
         expect(answers[5].question).to eq(:person_address)
         expect(answers[5].value).to eq('address')
+
+        expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[6].question).to eq(:person_relationship_to_children)
+        expect(answers[6].value).to eq('relationships')
       end
 
       context 'for existing previous name' do
@@ -82,7 +92,7 @@ module Summary
         let(:previous_name) { 'previous_name' }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(6)
+          expect(answers.count).to eq(7)
         end
 
         it 'renders the previous name' do
@@ -97,13 +107,26 @@ module Summary
         let(:age_estimate) { 18 }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(6)
+          expect(answers.count).to eq(7)
         end
 
         it 'uses the age estimate' do
           expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
           expect(answers[4].question).to eq(:person_age_estimate)
           expect(answers[4].value).to eq(18)
+        end
+      end
+
+      context 'when no other parties present' do
+        let(:c100_application) { instance_double(C100Application, other_parties: []) }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(1)
+        end
+
+        it 'has the correct rows in the right order' do
+          expect(answers[0]).to be_an_instance_of(Separator)
+          expect(answers[0].title).to eq(:not_applicable)
         end
       end
     end

--- a/spec/presenters/summary/sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/sections/respondents_details_spec.rb
@@ -47,8 +47,14 @@ module Summary
     end
 
     describe '#answers' do
+      before do
+        allow_any_instance_of(
+          RelationshipsPresenter
+        ).to receive(:relationship_to_children).with(respondent, show_person_name: false).and_return('relationships')
+      end
+
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(12)
+        expect(answers.count).to eq(13)
       end
 
       it 'has the correct rows in the right order' do
@@ -99,6 +105,10 @@ module Summary
         expect(answers[11]).to be_an_instance_of(FreeTextAnswer)
         expect(answers[11].question).to eq(:person_email)
         expect(answers[11].value).to eq('email')
+
+        expect(answers[12]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[12].question).to eq(:person_relationship_to_children)
+        expect(answers[12].value).to eq('relationships')
       end
 
       context 'for existing previous name' do
@@ -106,7 +116,7 @@ module Summary
         let(:previous_name) { 'previous_name' }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(12)
+          expect(answers.count).to eq(13)
         end
 
         it 'renders the previous name' do
@@ -121,7 +131,7 @@ module Summary
         let(:age_estimate) { 18 }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(12)
+          expect(answers.count).to eq(13)
         end
 
         it 'uses the age estimate' do


### PR DESCRIPTION
Including a bit of refactor of the relationships to a presenter to be reused in several of the sections.

<img width="903" alt="screen shot 2018-02-01 at 12 52 15" src="https://user-images.githubusercontent.com/687910/35679415-dce2aaba-074e-11e8-8a00-f4e22dc86c14.png">
