### PR TITLE
Add `other children` section to PDF

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -115,4 +115,10 @@
       text-align: right;
     }
   }
+
+  #children_known_to_authorities {
+    td {
+      padding-top: 15px;
+    }
+  }
 }

--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -95,6 +95,7 @@ module Summary
         Sections::RespondentsDetails.new(c100_application),
         Sections::SectionHeader.new(c100_application, name: :other_parties_details),
         Sections::OtherPartiesDetails.new(c100_application),
+        Sections::OtherChildrenDetails.new(c100_application),
       ]
     end
   end

--- a/app/presenters/summary/sections/base_children_details.rb
+++ b/app/presenters/summary/sections/base_children_details.rb
@@ -1,0 +1,29 @@
+module Summary
+  module Sections
+    class BaseChildrenDetails < BaseSectionPresenter
+      protected
+
+      def personal_details(child)
+        [
+          FreeTextAnswer.new(:child_full_name, child.full_name),
+          DateAnswer.new(:child_dob, child.dob),
+          FreeTextAnswer.new(:child_age_estimate, child.age_estimate), # This shows only if a value is present
+          Answer.new(:child_sex, child.gender),
+        ]
+      end
+
+      def relationships(child)
+        [
+          MultiAnswer.new(:child_applicants_relationship,  relation_to_child(child, c100.applicants)),
+          MultiAnswer.new(:child_respondents_relationship, relation_to_child(child, c100.respondents)),
+        ]
+      end
+
+      private
+
+      def relation_to_child(child, people)
+        child.relationships.where(person: people).pluck(:relation)
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/children_details.rb
+++ b/app/presenters/summary/sections/children_details.rb
@@ -1,40 +1,34 @@
 module Summary
   module Sections
-    class ChildrenDetails < BaseSectionPresenter
+    class ChildrenDetails < BaseChildrenDetails
       def name
         :children_details
       end
 
       def answers
         [
-          *children_personal_details,
+          children_details,
           Answer.new(:children_known_to_authorities, c100.children_known_to_authorities),
           FreeTextAnswer.new(:children_known_to_authorities_details, c100.children_known_to_authorities_details),
           Answer.new(:children_protection_plan, c100.children_protection_plan),
-        ].select(&:show?)
+        ].flatten.select(&:show?)
       end
 
       private
 
-      # rubocop:disable Metrics/AbcSize
-      def children_personal_details
-        c100.children.map.with_index(1) do |child, index|
+      def children_details
+        children.map.with_index(1) do |child, index|
           [
             Separator.new(:child_index_title, index: index),
-            FreeTextAnswer.new(:child_full_name, child.full_name),
-            DateAnswer.new(:child_dob, child.dob),
-            FreeTextAnswer.new(:child_age_estimate, child.age_estimate), # This shows only if a value is present
-            Answer.new(:child_sex, child.gender),
-            MultiAnswer.new(:child_applicants_relationship, relation_to_child(child, c100.applicants)),
-            MultiAnswer.new(:child_respondents_relationship, relation_to_child(child, c100.respondents)),
-            MultiAnswer.new(:child_orders, child.child_order&.orders),
+            personal_details(child),
+            relationships(child),
+            MultiAnswer.new(:child_orders, child.child_order&.orders)
           ]
-        end.flatten
+        end
       end
-      # rubocop:enable Metrics/AbcSize
 
-      def relation_to_child(child, people)
-        child.relationships.where(person: people).pluck(:relation)
+      def children
+        @_children ||= c100.children
       end
     end
   end

--- a/app/presenters/summary/sections/other_children_details.rb
+++ b/app/presenters/summary/sections/other_children_details.rb
@@ -1,0 +1,33 @@
+module Summary
+  module Sections
+    class OtherChildrenDetails < BaseChildrenDetails
+      def name
+        :other_children_details
+      end
+
+      def answers
+        return [Separator.new(:not_applicable)] if children.empty?
+
+        [
+          children_details
+        ].flatten.select(&:show?)
+      end
+
+      private
+
+      def children_details
+        children.map.with_index(1) do |child, index|
+          [
+            Separator.new(:child_index_title, index: index),
+            personal_details(child),
+            relationships(child),
+          ]
+        end
+      end
+
+      def children
+        @_children ||= c100.other_children
+      end
+    end
+  end
+end

--- a/app/views/steps/completion/shared/_date_row.pdf.erb
+++ b/app/views/steps/completion/shared/_date_row.pdf.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr id="<%= date_row.question %>">
   <td class="question">
     <%=t "check_answers.#{date_row.question}.question" %>
   </td>

--- a/app/views/steps/completion/shared/_free_text_row.pdf.erb
+++ b/app/views/steps/completion/shared/_free_text_row.pdf.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr id="<%= free_text_row.question %>">
   <td class="question">
     <%=t "check_answers.#{free_text_row.question}.question" %>
   </td>

--- a/app/views/steps/completion/shared/_multi_answer_row.pdf.erb
+++ b/app/views/steps/completion/shared/_multi_answer_row.pdf.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr id="<%= multi_answer_row.question %>">
   <td class="question">
     <%=t "check_answers.#{multi_answer_row.question}.question" %>
   </td>

--- a/app/views/steps/completion/shared/_row.pdf.erb
+++ b/app/views/steps/completion/shared/_row.pdf.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr id="<%= row.question %>">
   <td class="question">
     <%=t "check_answers.#{row.question}.question" %>
   </td>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -65,6 +65,7 @@ en:
       children_relationships: Children’s relationship with parties
       urgent_hearing: Urgent hearing
       without_notice_hearing: Without notice hearing
+      other_children_details: Other children not part of the application
     descriptions:
       risk_concerns: Are you alleging that the child(ren) named in Section 1 of this form have experienced, or are at risk of experiencing, harm from any of the following by any person who has had contact with the child?
       c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
@@ -169,11 +170,11 @@ en:
       answers:
         <<: *SEX_OPTIONS
     child_applicants_relationship:
-      question: Applicant(s) relationship to child
+      question: Relationship to applicant(s)
       answers:
         <<: *RELATIONS
     child_respondents_relationship:
-      question: Respondent(s) relationship to child
+      question: Relationship to respondent(s)
       answers:
         <<: *RELATIONS
     child_orders:

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -46,6 +46,7 @@ module Summary
           Sections::RespondentsDetails,
           Sections::SectionHeader,
           Sections::OtherPartiesDetails,
+          Sections::OtherChildrenDetails,
         ])
       end
     end

--- a/spec/presenters/summary/sections/other_children_details_spec.rb
+++ b/spec/presenters/summary/sections/other_children_details_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::OtherChildrenDetails do
+    let(:c100_application) {
+      instance_double(C100Application,
+        other_children: [other_child],
+        applicants: [],
+        respondents: [],
+      )
+    }
+
+    let(:other_child) {
+      instance_double(OtherChild,
+        full_name: 'name',
+        dob: dob,
+        age_estimate: age_estimate,
+        gender: 'female',
+        relationships: relationships,
+      )
+    }
+
+    let(:dob) { Date.new(2018, 1, 20) }
+    let(:age_estimate) { nil }
+    let(:relationships) { double('relationships') }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:other_children_details)
+      end
+    end
+
+    describe '#answers' do
+      before do
+        allow(relationships).to receive_message_chain(:where, :pluck).and_return(['mother'])
+      end
+
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(6)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Separator)
+        expect(answers[0].title).to eq(:child_index_title)
+        expect(answers[0].i18n_opts).to eq({index: 1})
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:child_full_name)
+        expect(answers[1].value).to eq('name')
+
+        expect(answers[2]).to be_an_instance_of(DateAnswer)
+        expect(answers[2].question).to eq(:child_dob)
+        expect(answers[2].value).to eq(Date.new(2018, 1, 20))
+
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:child_sex)
+        expect(answers[3].value).to eq('female')
+
+        expect(answers[4]).to be_an_instance_of(MultiAnswer)
+        expect(answers[4].question).to eq(:child_applicants_relationship)
+        expect(answers[4].value).to eq(['mother'])
+        expect(c100_application).to have_received(:applicants)
+
+        expect(answers[5]).to be_an_instance_of(MultiAnswer)
+        expect(answers[5].question).to eq(:child_respondents_relationship)
+        expect(answers[5].value).to eq(['mother'])
+        expect(c100_application).to have_received(:respondents)
+      end
+
+      context 'when `dob` is nil' do
+        let(:dob) { nil }
+        let(:age_estimate) { 18 }
+
+        it 'uses the age estimate' do
+          expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[2].question).to eq(:child_age_estimate)
+          expect(answers[2].value).to eq(18)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Small refactor to reuse as much as possible between `children` and `other children` sections, as they are quite similar.

Also, this is prepared to show the relationships, but we are not asking for them in the case of 'other children' (we do only for 'children' - main ones). So next PR will modify the steps to ask for this.

<img width="906" alt="screen shot 2018-02-02 at 10 31 04" src="https://user-images.githubusercontent.com/687910/35728694-54620922-0804-11e8-86e9-7f5af21921e2.png">

