### PR TITLE
Implement `Other children` relationships

### DIFF
--- a/app/controllers/concerns/relationship_step.rb
+++ b/app/controllers/concerns/relationship_step.rb
@@ -18,12 +18,12 @@ module RelationshipStep
   private
 
   def child_record
-    current_c100_application.children.find(params[:child_id])
+    current_c100_application.minors.find(params[:child_id])
   end
 
   def relationship_record
     current_c100_application.relationships.find_or_initialize_by(
-      person: current_record, child: child_record
+      person: current_record, minor: child_record
     )
   end
 end

--- a/app/forms/steps/shared/relationship_form.rb
+++ b/app/forms/steps/shared/relationship_form.rb
@@ -22,7 +22,7 @@ module Steps
       end
 
       def other_value_needed?
-        relation_value.eql?(Relation::OTHER)
+        relation.eql?(Relation::OTHER.to_s)
       end
 
       def persist!

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -11,6 +11,7 @@ class C100Application < ApplicationRecord
 
   # Remember, we are using UUIDs as the record IDs, we can't rely on ID sequential ordering
   has_many :people,      -> { order(created_at: :asc) }
+  has_many :minors,      -> { order(created_at: :asc) }
   has_many :children,    -> { order(created_at: :asc) }, dependent: :destroy
   has_many :applicants,  -> { order(created_at: :asc) }, dependent: :destroy
   has_many :respondents, -> { order(created_at: :asc) }, dependent: :destroy

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,6 +1,4 @@
-class Child < Person
+class Child < Minor
   has_one :child_order, dependent: :destroy
   has_one :child_residence, dependent: :destroy
-
-  has_many :relationships, source: :child, dependent: :destroy
 end

--- a/app/models/minor.rb
+++ b/app/models/minor.rb
@@ -1,0 +1,3 @@
+class Minor < Person
+  has_many :relationships, source: :minor, dependent: :destroy
+end

--- a/app/models/other_child.rb
+++ b/app/models/other_child.rb
@@ -1,2 +1,2 @@
-class OtherChild < Person
+class OtherChild < Minor
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,4 @@
 class Person < ApplicationRecord
   belongs_to :c100_application
-  has_many :relationships, dependent: :destroy
+  has_many :relationships, source: :person, dependent: :destroy
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,6 +1,6 @@
 class Relationship < ApplicationRecord
   belongs_to :c100_application
 
-  belongs_to :child,  foreign_key: :child_id
-  belongs_to :person, foreign_key: :person_id
+  belongs_to :minor
+  belongs_to :person
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,9 +1,6 @@
 class Relationship < ApplicationRecord
   belongs_to :c100_application
 
-  belongs_to :child,       foreign_key: :child_id
-  belongs_to :person,      foreign_key: :person_id
-  belongs_to :applicant,   foreign_key: :person_id
-  belongs_to :respondent,  foreign_key: :person_id
-  belongs_to :other_party, foreign_key: :person_id
+  belongs_to :child,  foreign_key: :child_id
+  belongs_to :person, foreign_key: :person_id
 end

--- a/app/presenters/relationships_presenter.rb
+++ b/app/presenters/relationships_presenter.rb
@@ -9,9 +9,9 @@ class RelationshipsPresenter
   end
 
   def relationship_to_children(person_or_people, show_person_name: true)
-    relationships.where(child: children, person: person_or_people).map do |relationship|
+    relationships.where(minor: minors, person: person_or_people).map do |relationship|
       person_full_name = show_person_name ? relationship.person.full_name : nil
-      child_full_name  = relationship.child.full_name
+      child_full_name  = relationship.minor.full_name
       relation = i18n_relation(relationship)
 
       [person_full_name, relation, child_full_name].compact.join(RELATION_SEPARATOR)
@@ -20,8 +20,8 @@ class RelationshipsPresenter
 
   private
 
-  def children
-    c100_application.children
+  def minors
+    c100_application.minors
   end
 
   def relationships

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -15,7 +15,7 @@ module C100App
       when :under_age
         edit_first_child_relationships
       when :relationship
-        children_relationships(record.applicant)
+        children_relationships
       when :contact_details
         after_contact_details
       else

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -1,5 +1,5 @@
 module C100App
-  class ApplicantDecisionTree < BaseDecisionTree
+  class ApplicantDecisionTree < PeopleDecisionTree
     def destination
       return next_step if next_step
 
@@ -15,7 +15,7 @@ module C100App
       when :under_age
         edit_first_child_relationships
       when :relationship
-        children_relationships
+        children_relationships(record.applicant)
       when :contact_details
         after_contact_details
       else
@@ -25,14 +25,6 @@ module C100App
 
     private
 
-    def after_personal_details
-      if dob_under_age?
-        edit(:under_age, id: record)
-      else
-        edit_first_child_relationships
-      end
-    end
-
     def after_contact_details
       if next_applicant_id
         edit(:personal_details, id: next_applicant_id)
@@ -41,32 +33,8 @@ module C100App
       end
     end
 
-    def children_relationships
-      if next_child_id
-        edit(:relationship, id: record.applicant, child_id: next_child_id)
-      else
-        edit(:contact_details, id: record.applicant)
-      end
-    end
-
-    def dob_under_age?
-      record.reload.dob > 18.years.ago
-    end
-
-    def edit_first_child_relationships
-      edit(:relationship, id: record, child_id: first_child_id)
-    end
-
     def next_applicant_id
       next_record_id(c100_application.applicant_ids)
-    end
-
-    def next_child_id
-      next_record_id(c100_application.child_ids, current: record.child)
-    end
-
-    def first_child_id
-      c100_application.child_ids.first
     end
   end
 end

--- a/app/services/c100_app/other_parties_decision_tree.rb
+++ b/app/services/c100_app/other_parties_decision_tree.rb
@@ -11,7 +11,7 @@ module C100App
       when :personal_details
         after_personal_details(age_check: false)
       when :relationship
-        children_relationships(record.other_party)
+        children_relationships
       when :contact_details
         after_contact_details
       else

--- a/app/services/c100_app/other_parties_decision_tree.rb
+++ b/app/services/c100_app/other_parties_decision_tree.rb
@@ -1,5 +1,5 @@
 module C100App
-  class OtherPartiesDecisionTree < BaseDecisionTree
+  class OtherPartiesDecisionTree < PeopleDecisionTree
     def destination
       return next_step if next_step
 
@@ -9,9 +9,9 @@ module C100App
       when :names_finished
         edit(:personal_details, id: next_party_id)
       when :personal_details
-        edit(:relationship, id: record, child_id: first_child_id)
+        after_personal_details(age_check: false)
       when :relationship
-        children_relationships
+        children_relationships(record.other_party)
       when :contact_details
         after_contact_details
       else
@@ -29,24 +29,8 @@ module C100App
       end
     end
 
-    def children_relationships
-      if next_child_id
-        edit(:relationship, id: record.other_party, child_id: next_child_id)
-      else
-        edit(:contact_details, id: record.other_party)
-      end
-    end
-
     def next_party_id
       next_record_id(c100_application.other_party_ids)
-    end
-
-    def next_child_id
-      next_record_id(c100_application.child_ids, current: record.child)
-    end
-
-    def first_child_id
-      c100_application.child_ids.first
     end
   end
 end

--- a/app/services/c100_app/respondent_decision_tree.rb
+++ b/app/services/c100_app/respondent_decision_tree.rb
@@ -1,5 +1,5 @@
 module C100App
-  class RespondentDecisionTree < BaseDecisionTree
+  class RespondentDecisionTree < PeopleDecisionTree
     def destination
       return next_step if next_step
 
@@ -13,7 +13,7 @@ module C100App
       when :under_age
         edit_first_child_relationships
       when :relationship
-        children_relationships
+        children_relationships(record.respondent)
       when :contact_details
         after_contact_details
       when :has_other_parties
@@ -24,14 +24,6 @@ module C100App
     end
 
     private
-
-    def after_personal_details
-      if dob_under_age?
-        edit(:under_age, id: record)
-      else
-        edit_first_child_relationships
-      end
-    end
 
     def after_contact_details
       if next_respondent_id
@@ -49,14 +41,6 @@ module C100App
       end
     end
 
-    def children_relationships
-      if next_child_id
-        edit(:relationship, id: record.respondent, child_id: next_child_id)
-      else
-        edit(:contact_details, id: record.respondent)
-      end
-    end
-
     def dob_under_age?
       # Respondents, unlike Applicants, can have an 'unknown' DoB and they can fill
       # an 'approximate age or year born' free input text. The prototype does some fancy
@@ -65,20 +49,8 @@ module C100App
       record.reload.dob.present? && (record.dob > 18.years.ago)
     end
 
-    def edit_first_child_relationships
-      edit(:relationship, id: record, child_id: first_child_id)
-    end
-
     def next_respondent_id
       next_record_id(c100_application.respondent_ids)
-    end
-
-    def next_child_id
-      next_record_id(c100_application.child_ids, current: record.child)
-    end
-
-    def first_child_id
-      c100_application.child_ids.first
     end
   end
 end

--- a/app/services/c100_app/respondent_decision_tree.rb
+++ b/app/services/c100_app/respondent_decision_tree.rb
@@ -13,7 +13,7 @@ module C100App
       when :under_age
         edit_first_child_relationships
       when :relationship
-        children_relationships(record.respondent)
+        children_relationships
       when :contact_details
         after_contact_details
       when :has_other_parties

--- a/app/services/people_decision_tree.rb
+++ b/app/services/people_decision_tree.rb
@@ -17,11 +17,11 @@ class PeopleDecisionTree < BaseDecisionTree
     edit(:relationship, id: record, child_id: first_child_id)
   end
 
-  def children_relationships(subject_record)
+  def children_relationships
     if next_child_id
-      edit(:relationship, id: subject_record, child_id: next_child_id)
+      edit(:relationship, id: record.person, child_id: next_child_id)
     else
-      edit(:contact_details, id: subject_record)
+      edit(:contact_details, id: record.person)
     end
   end
 

--- a/app/services/people_decision_tree.rb
+++ b/app/services/people_decision_tree.rb
@@ -26,10 +26,10 @@ class PeopleDecisionTree < BaseDecisionTree
   end
 
   def next_child_id
-    next_record_id(c100_application.child_ids, current: record.child)
+    next_record_id(c100_application.minor_ids, current: record.minor)
   end
 
   def first_child_id
-    c100_application.child_ids.first
+    c100_application.minor_ids.first
   end
 end

--- a/app/services/people_decision_tree.rb
+++ b/app/services/people_decision_tree.rb
@@ -1,0 +1,35 @@
+class PeopleDecisionTree < BaseDecisionTree
+  private
+
+  def after_personal_details(age_check: true)
+    if age_check && dob_under_age?
+      edit(:under_age, id: record)
+    else
+      edit_first_child_relationships
+    end
+  end
+
+  def dob_under_age?
+    record.reload.dob > 18.years.ago
+  end
+
+  def edit_first_child_relationships
+    edit(:relationship, id: record, child_id: first_child_id)
+  end
+
+  def children_relationships(subject_record)
+    if next_child_id
+      edit(:relationship, id: subject_record, child_id: next_child_id)
+    else
+      edit(:contact_details, id: subject_record)
+    end
+  end
+
+  def next_child_id
+    next_record_id(c100_application.child_ids, current: record.child)
+  end
+
+  def first_child_id
+    c100_application.child_ids.first
+  end
+end

--- a/app/views/steps/shared/_relationship_step.html.erb
+++ b/app/views/steps/shared/_relationship_step.html.erb
@@ -1,7 +1,7 @@
 <h1 class="heading-xlarge gv-u-heading-xxlarge">
   <%= t('.heading',
     person_name: form_object.record.person.full_name,
-    child_name:  form_object.record.child.full_name) %>
+    child_name:  form_object.record.minor.full_name) %>
 </h1>
 
 <%= step_form form_object do |f| %>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -170,11 +170,11 @@ en:
       answers:
         <<: *SEX_OPTIONS
     child_applicants_relationship:
-      question: Relationship to applicant(s)
+      question: Applicant(s) relationship to child
       answers:
         <<: *RELATIONS
     child_respondents_relationship:
-      question: Relationship to respondent(s)
+      question: Respondent(s) relationship to child
       answers:
         <<: *RELATIONS
     child_orders:

--- a/db/migrate/20180205101502_rename_relationships_foreign_key.rb
+++ b/db/migrate/20180205101502_rename_relationships_foreign_key.rb
@@ -1,0 +1,5 @@
+class RenameRelationshipsForeignKey < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :relationships, :child_id, :minor_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180123123759) do
+ActiveRecord::Schema.define(version: 20180205101502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -257,11 +257,11 @@ ActiveRecord::Schema.define(version: 20180123123759) do
   create_table "relationships", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "relation"
     t.string "relation_other_value"
-    t.uuid "child_id", null: false
+    t.uuid "minor_id", null: false
     t.uuid "person_id", null: false
     t.uuid "c100_application_id"
     t.index ["c100_application_id"], name: "index_relationships_on_c100_application_id"
-    t.index ["child_id", "person_id"], name: "index_relationships_on_child_id_and_person_id", unique: true
+    t.index ["minor_id", "person_id"], name: "index_relationships_on_minor_id_and_person_id", unique: true
   end
 
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -289,5 +289,5 @@ ActiveRecord::Schema.define(version: 20180123123759) do
   add_foreign_key "people", "c100_applications"
   add_foreign_key "relationships", "c100_applications"
   add_foreign_key "relationships", "people"
-  add_foreign_key "relationships", "people", column: "child_id"
+  add_foreign_key "relationships", "people", column: "minor_id"
 end

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -21,25 +21,40 @@ private
 def classes_to_mutate
   Rails.application.eager_load!
 
-  # As the current models are just empty shells for ActiveRecord relationships,
-  # and we don't even have corresponding spec tests for those, there is no point
-  # in including these in the mutation test, and thus we can save some time.
-  # Only include in this collection the models that matter and have specs.
-  model_classes = %w(C100Application User).freeze
-
   case ARGV[1]
     when nil
       # Quicker run, reduced testing scope (random sample), default option
       puts '> running quick sample mutant testing'
-      BaseForm.descendants.map(&:name).grep(/^Steps::/).sample(10) +
-        BaseDecisionTree.descendants.map(&:name).sample(5) +
-        model_classes
+      form_objects.sample(10) + decision_trees_and_services.sample(5) + models
     when 'all'
       # Complete coverage, very long run time
       puts '> running complete mutant testing'
-      BaseForm.descendants.map(&:name).grep(/^Steps::/) + ['C100App*'] + model_classes
+      form_objects + decision_trees_and_services + models
     else
       # Individual class testing, very quick
       Array(ARGV[1])
   end
+end
+
+# As the current models are just empty shells for ActiveRecord relationships,
+# and we don't even have corresponding spec tests for those, there is no point
+# in including these in the mutation test, and thus we can save some time.
+# Only include in this collection the models that matter and have specs.
+#
+def models
+  %w(C100Application User).freeze
+end
+
+# Everything inheriting from `BaseForm` and inside namespace `Steps`
+# i.e. all classes in `/app/forms/steps/**/*`
+#
+def form_objects
+  BaseForm.descendants.map(&:name).grep(/^Steps::/)
+end
+
+# Everything inside `C100App` namespace
+# i.e. all classes in `/app/services/c100_app/*`
+#
+def decision_trees_and_services
+  C100App.constants.map { |symbol| C100App.const_get(symbol) }
 end

--- a/spec/presenters/relationships_presenter_spec.rb
+++ b/spec/presenters/relationships_presenter_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe RelationshipsPresenter do
-  let(:c100_application) { instance_double(C100Application, children: children, relationships: relationships) }
+  let(:c100_application) { instance_double(C100Application, minors: minors, relationships: relationships) }
 
-  let(:children) { [] }
+  let(:minors) { [] }
   let(:relationships) { double('relationships') }
   let(:child_relationship) { double(Relationship) }
 
@@ -13,10 +13,10 @@ RSpec.describe RelationshipsPresenter do
     let(:person) { instance_double(Person, relationships: relationships) }
 
     before do
-      allow(relationships).to receive(:where).with(child: children, person: person).and_return([child_relationship])
+      allow(relationships).to receive(:where).with(minor: minors, person: person).and_return([child_relationship])
 
       allow(child_relationship).to receive(:relation).and_return('father')
-      allow(child_relationship).to receive(:child).and_return(double(full_name: 'Child name'))
+      allow(child_relationship).to receive(:minor).and_return(double(full_name: 'Child name'))
       allow(child_relationship).to receive(:person).and_return(double(full_name: 'Person name'))
     end
 

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe C100App::ApplicantDecisionTree do
 
   context 'when the step is `relationship`' do
     let(:step_params) {{'relationship' => 'anything'}}
-    let(:record) { double('Relationship', applicant: applicant, child: child) }
+    let(:record) { double('Relationship', person: applicant, child: child) }
 
     let(:applicant) { double('Applicant', id: 1) }
 

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe C100App::ApplicantDecisionTree do
   let(:as)               { nil }
   let(:record)           { nil }
 
-  let(:c100_application) { instance_double(C100Application, applicant_ids: [1, 2, 3], child_ids: [1, 2, 3]) }
+  let(:c100_application) { instance_double(C100Application, applicant_ids: [1, 2, 3], minor_ids: [1, 2, 3]) }
 
   subject {
     described_class.new(
@@ -85,7 +85,7 @@ RSpec.describe C100App::ApplicantDecisionTree do
 
   context 'when the step is `relationship`' do
     let(:step_params) {{'relationship' => 'anything'}}
-    let(:record) { double('Relationship', person: applicant, child: child) }
+    let(:record) { double('Relationship', person: applicant, minor: child) }
 
     let(:applicant) { double('Applicant', id: 1) }
 

--- a/spec/services/c100_app/other_parties_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_parties_decision_tree_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
   let(:as)               { nil }
   let(:record)           { nil }
 
-  let(:c100_application) { instance_double(C100Application, other_party_ids: [1, 2, 3], child_ids: [1, 2, 3]) }
+  let(:c100_application) { instance_double(C100Application, other_party_ids: [1, 2, 3], minor_ids: [1, 2, 3]) }
 
   subject {
     described_class.new(
@@ -50,7 +50,7 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
 
   context 'when the step is `relationship`' do
     let(:step_params) {{'relationship' => 'anything'}}
-    let(:record) { double('Relationship', person: other_party, child: child) }
+    let(:record) { double('Relationship', person: other_party, minor: child) }
 
     let(:other_party) { double('OtherParty', id: 1) }
 

--- a/spec/services/c100_app/other_parties_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_parties_decision_tree_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
     let(:step_params) {{'personal_details' => 'anything'}}
     let(:record) {double('OtherParty', id: 1)}
 
+    it 'does not run the age check' do
+      expect(subject).to receive(:after_personal_details).with(age_check: false)
+      subject.destination
+    end
+
     it 'goes to edit the first child relationship for the current record' do
       expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
     end

--- a/spec/services/c100_app/other_parties_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_parties_decision_tree_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
 
   context 'when the step is `relationship`' do
     let(:step_params) {{'relationship' => 'anything'}}
-    let(:record) { double('Relationship', other_party: other_party, child: child) }
+    let(:record) { double('Relationship', person: other_party, child: child) }
 
     let(:other_party) { double('OtherParty', id: 1) }
 

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe C100App::RespondentDecisionTree do
 
   context 'when the step is `relationship`' do
     let(:step_params) {{'relationship' => 'anything'}}
-    let(:record) { double('Relationship', respondent: respondent, child: child) }
+    let(:record) { double('Relationship', person: respondent, child: child) }
 
     let(:respondent) { double('Respondent', id: 1) }
 

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe C100App::RespondentDecisionTree do
   let(:as)               { nil }
   let(:record)           { nil }
 
-  let(:c100_application) { instance_double(C100Application, respondent_ids: [1, 2, 3], child_ids: [1, 2, 3]) }
+  let(:c100_application) { instance_double(C100Application, respondent_ids: [1, 2, 3], minor_ids: [1, 2, 3]) }
 
   subject {
     described_class.new(
@@ -87,7 +87,7 @@ RSpec.describe C100App::RespondentDecisionTree do
 
   context 'when the step is `relationship`' do
     let(:step_params) {{'relationship' => 'anything'}}
-    let(:record) { double('Relationship', person: respondent, child: child) }
+    let(:record) { double('Relationship', person: respondent, minor: child) }
 
     let(:respondent) { double('Respondent', id: 1) }
 

--- a/spec/support/relationship_step_controller_shared_examples.rb
+++ b/spec/support/relationship_step_controller_shared_examples.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.shared_examples 'a relationship step controller' do |form_class, decision_tree_class|
   let(:relationships) { double('relationships').as_null_object }
-  let(:children)      { double('children').as_null_object }
+  let(:minors)        { double('minors').as_null_object }
   let(:person)        { double('Person') }
   let(:child)         { double('Child') }
 
-  let(:existing_case) { instance_double(C100Application, relationships: relationships, children: children) }
+  let(:existing_case) { instance_double(C100Application, relationships: relationships, minors: minors) }
 
   # This is a side effect of everything being a double, we have to do a lot of 'setup', but all this
   # is not part of these tests and we don't need to test the functionality, just trust it.
@@ -37,9 +37,9 @@ RSpec.shared_examples 'a relationship step controller' do |form_class, decision_
       before do
         allow(form_class).to receive(:new).and_return(form_object)
         allow(controller).to receive(:current_record).and_return(person)
-        allow(children).to receive(:find).with('123').and_return(child)
+        allow(minors).to receive(:find).with('123').and_return(child)
 
-        expect(relationships).to receive(:find_or_initialize_by).with(person: person, child: child)
+        expect(relationships).to receive(:find_or_initialize_by).with(person: person, minor: child)
       end
 
       context 'when the form saves successfully' do
@@ -86,8 +86,8 @@ RSpec.shared_examples 'a relationship step controller' do |form_class, decision_
     context 'when a case exists in the session' do
       before do
         allow(controller).to receive(:current_record).and_return(person)
-        allow(children).to receive(:find).with('123').and_return(child)
-        expect(relationships).to receive(:find_or_initialize_by).with(person: person, child: child)
+        allow(minors).to receive(:find).with('123').and_return(child)
+        expect(relationships).to receive(:find_or_initialize_by).with(person: person, minor: child)
       end
 
       it 'responds with HTTP success' do


### PR DESCRIPTION
This was missing from the rails app (and I think also the prototype) but was confirmed with Andy it is needed.

Due to this oversight we didn't model properly the Child and OtherChild in first place and now a substantial refactor had to be made, introducing an intermediate model called `Minor` (inheriting from `Person`) and then our current models `Child` and `OtherChild` can inherit from `Minor`.
This allows us to create relationships between a 'person' (being these applicant, respondent or other party) and a 'minor' (being these child or other child). And to retrieve all kind of children using `#minors`.

<img width="905" alt="screen shot 2018-02-05 at 11 45 53" src="https://user-images.githubusercontent.com/687910/35803250-ed40f474-0a6a-11e8-900e-59c09181282c.png">
