### PR TITLE
Add `solicitor details` section to PDF

### DIFF
--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -104,6 +104,8 @@ module Summary
         Sections::SectionHeader.new(c100_application, name: :other_parties_details),
         Sections::OtherPartiesDetails.new(c100_application),
         Sections::OtherChildrenDetails.new(c100_application),
+        Sections::SectionHeader.new(c100_application, name: :solicitor_details),
+        Sections::SolicitorDetails.new(c100_application),
       ]
     end
   end

--- a/app/presenters/summary/sections/solicitor_details.rb
+++ b/app/presenters/summary/sections/solicitor_details.rb
@@ -1,0 +1,19 @@
+module Summary
+  module Sections
+    class SolicitorDetails < BaseSectionPresenter
+      def name
+        :solicitor_details
+      end
+
+      def show_header?
+        false
+      end
+
+      def answers
+        [
+          Answer.new(:has_solicitor, GenericYesNo::NO), # Always `NO` for pilot (we are screening)
+        ].select(&:show?)
+      end
+    end
+  end
+end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -56,6 +56,7 @@ en:
       applicants_details: 11. About you (the applicant(s))
       respondents_details: 12. The respondent(s)
       other_parties_details: 13. Others who should be given notice
+      solicitor_details: 14. Solicitor’s details
     sections:
       help_with_fees: Help with fees
       applicant_respondent: Applicant and respondent
@@ -320,3 +321,7 @@ en:
       question: Email address
     person_relationship_to_children:
       question: Relationship to children listed in this application
+    has_solicitor:
+      question: Is a solicitor acting for you?
+      answers:
+        <<: *YESNO

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -49,6 +49,8 @@ module Summary
           Sections::SectionHeader,
           Sections::OtherPartiesDetails,
           Sections::OtherChildrenDetails,
+          Sections::SectionHeader,
+          Sections::SolicitorDetails,
         ])
       end
     end

--- a/spec/presenters/summary/sections/solicitor_details_spec.rb
+++ b/spec/presenters/summary/sections/solicitor_details_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::SolicitorDetails do
+    let(:c100_application) {
+      instance_double(C100Application,
+    ) }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:solicitor_details) }
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:has_solicitor)
+        expect(answers[0].value).to eq(GenericYesNo::NO) # Always `NO` for pilot (we are screening)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is always a hardcoded `NO` answer, for pilot, as we are screening
out people with a solicitor.

<img width="912" alt="screen shot 2018-02-05 at 15 31 59" src="https://user-images.githubusercontent.com/687910/35812744-beca4e1e-0a89-11e8-8f90-cfacffde1208.png">
