### PR TITLE
Implement C8 details confidentiality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -498,4 +498,9 @@ AbcSize:
   Max: 22
 
 CyclomaticComplexity:
-  Enabled: false
+  Enabled: true
+  Max: 15
+
+MethodMissing:
+  Exclude:
+    - app/presenters/c8_confidentiality_presenter.rb

--- a/app/presenters/c8_confidentiality_presenter.rb
+++ b/app/presenters/c8_confidentiality_presenter.rb
@@ -1,0 +1,42 @@
+class C8ConfidentialityPresenter < SimpleDelegator
+  attr_reader :c100_application
+
+  PEOPLE_UNDER_C8 = [
+    Applicant,
+    OtherParty,
+  ].freeze
+
+  DETAILS_UNDER_C8 = [
+    :address,
+    :residence_history,
+    :home_phone,
+    :mobile_phone,
+    :email,
+  ].freeze
+
+  def initialize(person, c100_application)
+    @c100_application = c100_application
+    super(person)
+  end
+
+  def method_missing(name, *args, &block)
+    confidential_detail?(name, super) ? replacement_answer : super
+  end
+
+  private
+
+  def confidential_detail?(attribute, value)
+    DETAILS_UNDER_C8.include?(attribute) && value.present? && confidentiality_enabled?
+  end
+
+  def confidentiality_enabled?
+    @_confidentiality_enabled ||= begin
+      PEOPLE_UNDER_C8.include?(__getobj__.class) &&
+        c100_application.address_confidentiality.eql?(GenericYesNo::YES.to_s)
+    end
+  end
+
+  def replacement_answer
+    @_replacement_answer ||= I18n.translate!('shared.c8_confidential_answer')
+  end
+end

--- a/app/presenters/summary/sections/people_details.rb
+++ b/app/presenters/summary/sections/people_details.rb
@@ -16,6 +16,8 @@ module Summary
         return [Separator.new(:not_applicable)] if record_collection.empty?
 
         record_collection.map.with_index(1) do |person, index|
+          person = C8ConfidentialityPresenter.new(person, c100)
+
           [
             Separator.new("#{name}_index_title", index: index),
             FreeTextAnswer.new(:person_full_name, person.full_name),

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -39,6 +39,9 @@ en:
     OTHER_ORDER: &OTHER_ORDER
       other: Other
 
+  shared:
+    c8_confidential_answer: < See C8 attached >
+
   check_answers:
     headers:
       c100_form:

--- a/spec/presenters/c8_confidentiality_presenter_spec.rb
+++ b/spec/presenters/c8_confidentiality_presenter_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+RSpec.describe C8ConfidentialityPresenter do
+  let(:c100_application) {
+    instance_double(
+      C100Application,
+      address_confidentiality: address_confidentiality
+    )
+  }
+
+  let(:person) {
+    Applicant.new(address: 'real address', residence_history: nil, gender: 'male')
+  }
+
+  describe 'constants' do
+    it {
+      expect(
+        described_class::PEOPLE_UNDER_C8
+      ).to contain_exactly(
+        Applicant,
+        OtherParty,
+      )
+    }
+
+    it {
+      expect(
+        described_class::DETAILS_UNDER_C8
+      ).to contain_exactly(
+        :address,
+        :residence_history,
+        :home_phone,
+        :mobile_phone,
+        :email,
+      )
+    }
+  end
+
+  subject { described_class.new(person, c100_application) }
+
+  describe 'Address confidentiality is enabled' do
+    let(:address_confidentiality) { 'yes' }
+
+    context 'for a person subject to C8' do
+      it 'returns the replacement answer' do
+        expect(subject.address).to eq('< See C8 attached >')
+      end
+
+      it 'returns the original answer if it is blank/nil' do
+        expect(subject.residence_history).to eq(nil)
+      end
+
+      it 'returns the original answer when confidentiality does not apply' do
+        expect(subject.gender).to eq('male')
+      end
+    end
+
+    context 'for a person not subject to C8' do
+      let(:person) { Respondent.new(address: 'real address') }
+
+      it 'returns the original answer' do
+        expect(subject.address).to eq('real address')
+      end
+    end
+  end
+
+  describe 'Address confidentiality is not enabled' do
+    let(:address_confidentiality) { 'no' }
+
+    it 'returns the original answer' do
+      expect(subject.address).to eq('real address')
+    end
+
+    it 'returns the original answer if it is blank/nil' do
+      expect(subject.residence_history).to eq(nil)
+    end
+  end
+end

--- a/spec/presenters/summary/sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/applicants_details_spec.rb
@@ -123,6 +123,13 @@ module Summary
           expect(answers[2].value).to eq('previous_name')
         end
       end
+
+      context 'C8 confidentiality' do
+        it 'uses the confidentiality presenter' do
+          expect(C8ConfidentialityPresenter).to receive(:new).with(applicant, c100_application).and_call_original
+          answers
+        end
+      end
     end
   end
 end

--- a/spec/presenters/summary/sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/sections/other_parties_details_spec.rb
@@ -129,6 +129,13 @@ module Summary
           expect(answers[0].title).to eq(:not_applicable)
         end
       end
+
+      context 'C8 confidentiality' do
+        it 'uses the confidentiality presenter' do
+          expect(C8ConfidentialityPresenter).to receive(:new).with(other_party, c100_application).and_call_original
+          answers
+        end
+      end
     end
   end
 end

--- a/spec/presenters/summary/sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/sections/respondents_details_spec.rb
@@ -140,6 +140,13 @@ module Summary
           expect(answers[4].value).to eq(18)
         end
       end
+
+      context 'C8 confidentiality' do
+        it 'uses the confidentiality presenter' do
+          expect(C8ConfidentialityPresenter).to receive(:new).with(respondent, c100_application).and_call_original
+          answers
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If the applicant enables the confidentiality of personal details,
then the C100 PDF form will hide a limited set of details and will
generate an extra C8 form with the omitted details.

This PR only implements the 'hiding' of details in a flexible way,
but not yet the output of the C8 form.

<img width="894" alt="screen shot 2018-02-07 at 12 20 10" src="https://user-images.githubusercontent.com/687910/35917440-102b52bc-0c06-11e8-8a51-90af00616673.png">
