### PR TITLE
Refactor of the PDF generation to combine multiple forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'uglifier'
 gem 'virtus'
 
 # PDF generation
+gem 'combine_pdf'
 gem 'wicked_pdf', '~> 1.1.0'
 gem 'wkhtmltopdf-binary'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     colored2 (3.1.2)
+    combine_pdf (1.0.9)
+      ruby-rc4 (>= 0.1.5)
     concord (0.1.5)
       adamantium (~> 0.2.0)
       equalizer (~> 0.0.9)
@@ -344,6 +346,7 @@ GEM
     rubocop-rspec (1.21.0)
       rubocop (>= 0.52.0)
     ruby-progressbar (1.9.0)
+    ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     sanitize (4.5.0)
@@ -431,6 +434,7 @@ DEPENDENCIES
   brakeman
   byebug
   capybara
+  combine_pdf
   cucumber
   database_cleaner
   devise

--- a/app/controllers/steps/completion/summary_controller.rb
+++ b/app/controllers/steps/completion/summary_controller.rb
@@ -8,8 +8,12 @@ module Steps
           end
 
           format.pdf do
-            @presenter = Summary::PdfPresenter.new(current_c100_application)
-            render @presenter.pdf_params
+            presenter = Summary::PdfPresenter.new(current_c100_application)
+            presenter.generate
+
+            # If we want to trigger a file download, instead of showing the PDF
+            # in the browser, we can use `send_data presenter.to_pdf`
+            render plain: presenter.to_pdf
           end
         end
       end

--- a/app/presenters/summary/answer.rb
+++ b/app/presenters/summary/answer.rb
@@ -1,7 +1,7 @@
 module Summary
   class Answer < BaseAnswer
     def to_partial_path
-      'shared/row'
+      'steps/completion/shared/row'
     end
   end
 end

--- a/app/presenters/summary/base_pdf_form.rb
+++ b/app/presenters/summary/base_pdf_form.rb
@@ -1,0 +1,19 @@
+module Summary
+  class BasePdfForm
+    attr_reader :c100_application
+
+    def initialize(c100_application)
+      @c100_application = c100_application
+    end
+
+    def template
+      'steps/completion/summary/show.pdf'
+    end
+
+    # :nocov:
+    def sections
+      raise 'implement in subclasses'
+    end
+    # :nocov:
+  end
+end

--- a/app/presenters/summary/c100_form.rb
+++ b/app/presenters/summary/c100_form.rb
@@ -1,0 +1,98 @@
+module Summary
+  class C100Form < BasePdfForm
+    def sections
+      [
+        summary_sections,
+        children_form_sections,
+        miam_sections,
+        application_reasons_sections,
+        urgent_and_without_notice_sections,
+        international_element_sections,
+        litigation_capacity_sections,
+        attending_court_sections,
+        people_sections,
+      ].flatten.select(&:show?)
+    end
+
+    private
+
+    def summary_sections
+      [
+        Sections::FormHeader.new(c100_application, name: :c100_form),
+        Sections::HelpWithFees.new(c100_application),
+        Sections::ApplicantRespondent.new(c100_application),
+        Sections::NatureOfApplication.new(c100_application),
+        Sections::RiskConcerns.new(c100_application),
+        Sections::AdditionalInformation.new(c100_application)
+      ]
+    end
+
+    def children_form_sections
+      [
+        Sections::SectionHeader.new(c100_application, name: :children),
+        Sections::ChildrenDetails.new(c100_application),
+        Sections::ChildrenRelationships.new(c100_application)
+      ]
+    end
+
+    def miam_sections
+      [
+        Sections::SectionHeader.new(c100_application, name: :miam_requirement),
+        Sections::MiamRequirement.new(c100_application),
+        # TODO: exemptions (section 3)
+        Sections::SectionHeader.new(c100_application, name: :mediator_certification),
+        Sections::MediatorCertification.new(c100_application),
+      ]
+    end
+
+    def application_reasons_sections
+      [
+        Sections::SectionHeader.new(c100_application, name: :application_reasons),
+        Sections::ApplicationReasons.new(c100_application),
+      ]
+    end
+
+    def urgent_and_without_notice_sections
+      [
+        Sections::SectionHeader.new(c100_application, name: :urgent_and_without_notice),
+        Sections::UrgentHearing.new(c100_application),
+        Sections::WithoutNoticeHearing.new(c100_application),
+      ]
+    end
+
+    def international_element_sections
+      [
+        Sections::SectionHeader.new(c100_application, name: :international_element),
+        Sections::InternationalElement.new(c100_application)
+      ]
+    end
+
+    def litigation_capacity_sections
+      [
+        Sections::SectionHeader.new(c100_application, name: :litigation_capacity),
+        Sections::LitigationCapacity.new(c100_application),
+      ]
+    end
+
+    def attending_court_sections
+      [
+        Sections::SectionHeader.new(c100_application, name: :attending_court),
+        Sections::AttendingCourt.new(c100_application),
+      ]
+    end
+
+    def people_sections
+      [
+        Sections::SectionHeader.new(c100_application, name: :applicants_details),
+        Sections::ApplicantsDetails.new(c100_application),
+        Sections::SectionHeader.new(c100_application, name: :respondents_details),
+        Sections::RespondentsDetails.new(c100_application),
+        Sections::SectionHeader.new(c100_application, name: :other_parties_details),
+        Sections::OtherPartiesDetails.new(c100_application),
+        Sections::OtherChildrenDetails.new(c100_application),
+        Sections::SectionHeader.new(c100_application, name: :solicitor_details),
+        Sections::SolicitorDetails.new(c100_application),
+      ]
+    end
+  end
+end

--- a/app/presenters/summary/date_answer.rb
+++ b/app/presenters/summary/date_answer.rb
@@ -1,7 +1,7 @@
 module Summary
   class DateAnswer < BaseAnswer
     def to_partial_path
-      'shared/date_row'
+      'steps/completion/shared/date_row'
     end
   end
 end

--- a/app/presenters/summary/free_text_answer.rb
+++ b/app/presenters/summary/free_text_answer.rb
@@ -1,7 +1,7 @@
 module Summary
   class FreeTextAnswer < BaseAnswer
     def to_partial_path
-      'shared/free_text_row'
+      'steps/completion/shared/free_text_row'
     end
   end
 end

--- a/app/presenters/summary/multi_answer.rb
+++ b/app/presenters/summary/multi_answer.rb
@@ -1,7 +1,7 @@
 module Summary
   class MultiAnswer < BaseAnswer
     def to_partial_path
-      'shared/multi_answer_row'
+      'steps/completion/shared/multi_answer_row'
     end
   end
 end

--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -1,112 +1,35 @@
 module Summary
   class PdfPresenter
     attr_reader :c100_application
+    attr_reader :pdf_generator
 
-    def initialize(c100_application)
+    delegate :to_pdf, to: :pdf_generator
+
+    def initialize(c100_application, generator = C100App::PdfGenerator.new)
       @c100_application = c100_application
+      @pdf_generator = generator
     end
 
-    def sections
-      [
-        c100_form_sections,
-        children_form_sections,
-        miam_sections,
-        application_reasons_sections,
-        urgent_and_without_notice_sections,
-        international_element_sections,
-        litigation_capacity_sections,
-        attending_court_sections,
-        people_sections,
-      ].flatten.select(&:show?)
-    end
-
-    def pdf_params
-      { pdf: pdf_filename, footer: { right: '[page]' } }
+    def generate
+      pdf_generator.generate(c100_form, copies: 3)
     end
 
     private
 
-    def pdf_filename
-      'c100_application'.freeze # TODO: to be decided
+    def c100_form
+      Summary::C100Form.new(c100_application)
     end
 
-    def c100_form_sections
-      [
-        Sections::FormHeader.new(c100_application, name: :c100_form),
-        Sections::HelpWithFees.new(c100_application),
-        Sections::ApplicantRespondent.new(c100_application),
-        Sections::NatureOfApplication.new(c100_application),
-        Sections::RiskConcerns.new(c100_application),
-        Sections::AdditionalInformation.new(c100_application)
-      ]
+    def c1a_form
+      # TODO
     end
 
-    def children_form_sections
-      [
-        Sections::SectionHeader.new(c100_application, name: :children),
-        Sections::ChildrenDetails.new(c100_application),
-        Sections::ChildrenRelationships.new(c100_application)
-      ]
+    def c8_form
+      # TODO
     end
 
-    def miam_sections
-      [
-        Sections::SectionHeader.new(c100_application, name: :miam_requirement),
-        Sections::MiamRequirement.new(c100_application),
-        # TODO: exemptions (section 3)
-        Sections::SectionHeader.new(c100_application, name: :mediator_certification),
-        Sections::MediatorCertification.new(c100_application),
-      ]
-    end
-
-    def application_reasons_sections
-      [
-        Sections::SectionHeader.new(c100_application, name: :application_reasons),
-        Sections::ApplicationReasons.new(c100_application),
-      ]
-    end
-
-    def urgent_and_without_notice_sections
-      [
-        Sections::SectionHeader.new(c100_application, name: :urgent_and_without_notice),
-        Sections::UrgentHearing.new(c100_application),
-        Sections::WithoutNoticeHearing.new(c100_application),
-      ]
-    end
-
-    def international_element_sections
-      [
-        Sections::SectionHeader.new(c100_application, name: :international_element),
-        Sections::InternationalElement.new(c100_application)
-      ]
-    end
-
-    def litigation_capacity_sections
-      [
-        Sections::SectionHeader.new(c100_application, name: :litigation_capacity),
-        Sections::LitigationCapacity.new(c100_application),
-      ]
-    end
-
-    def attending_court_sections
-      [
-        Sections::SectionHeader.new(c100_application, name: :attending_court),
-        Sections::AttendingCourt.new(c100_application),
-      ]
-    end
-
-    def people_sections
-      [
-        Sections::SectionHeader.new(c100_application, name: :applicants_details),
-        Sections::ApplicantsDetails.new(c100_application),
-        Sections::SectionHeader.new(c100_application, name: :respondents_details),
-        Sections::RespondentsDetails.new(c100_application),
-        Sections::SectionHeader.new(c100_application, name: :other_parties_details),
-        Sections::OtherPartiesDetails.new(c100_application),
-        Sections::OtherChildrenDetails.new(c100_application),
-        Sections::SectionHeader.new(c100_application, name: :solicitor_details),
-        Sections::SolicitorDetails.new(c100_application),
-      ]
+    def cover_letter
+      # TODO
     end
   end
 end

--- a/app/presenters/summary/sections/base_section_presenter.rb
+++ b/app/presenters/summary/sections/base_section_presenter.rb
@@ -15,7 +15,7 @@ module Summary
 
       # Used by Rails to determine which partial to render. May be overridden in subclasses
       def to_partial_path
-        'shared/section'
+        'steps/completion/shared/section'
       end
 
       # May be overridden in subclasses to hide/show if appropriate

--- a/app/presenters/summary/sections/form_header.rb
+++ b/app/presenters/summary/sections/form_header.rb
@@ -2,7 +2,7 @@ module Summary
   module Sections
     class FormHeader < BaseSectionPresenter
       def to_partial_path
-        'shared/form_header'
+        'steps/completion/shared/form_header'
       end
 
       def show?

--- a/app/presenters/summary/sections/risk_concerns.rb
+++ b/app/presenters/summary/sections/risk_concerns.rb
@@ -6,7 +6,7 @@ module Summary
       end
 
       def to_partial_path
-        'shared/risk_concerns'
+        'steps/completion/shared/risk_concerns'
       end
 
       def answers

--- a/app/presenters/summary/sections/section_header.rb
+++ b/app/presenters/summary/sections/section_header.rb
@@ -2,7 +2,7 @@ module Summary
   module Sections
     class SectionHeader < BaseSectionPresenter
       def to_partial_path
-        'shared/section_header'
+        'steps/completion/shared/section_header'
       end
 
       def show?

--- a/app/presenters/summary/separator.rb
+++ b/app/presenters/summary/separator.rb
@@ -12,7 +12,7 @@ module Summary
     end
 
     def to_partial_path
-      'shared/separator'
+      'steps/completion/shared/separator'
     end
   end
 end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -22,7 +22,7 @@ module C100App
       when :special_assistance
         edit(:special_arrangements)
       when :special_arrangements
-        start_international_journey # TODO: change when we have 'statement of truth'
+        show('/steps/completion/summary') # TODO: change when we have 'statement of truth'
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/services/c100_app/pdf_generator.rb
+++ b/app/services/c100_app/pdf_generator.rb
@@ -1,0 +1,34 @@
+module C100App
+  class PdfGenerator
+    delegate :to_pdf, to: :combiner
+
+    def generate(presenter, copies:)
+      doc = pdf_from_presenter(presenter)
+
+      copies.times do
+        combiner << CombinePDF.parse(doc)
+      end
+    end
+
+    private
+
+    def pdf_from_presenter(presenter)
+      WickedPdf.new.pdf_from_string(render(presenter), pdf_options)
+    end
+
+    def render(presenter)
+      ApplicationController.renderer.render(
+        template: presenter.template,
+        locals: { presenter: presenter }
+      )
+    end
+
+    def combiner
+      @_combiner ||= CombinePDF.new
+    end
+
+    def pdf_options
+      { footer: { right: '[page]/[topage]' } }
+    end
+  end
+end

--- a/app/services/c100_app/pdf_generator.rb
+++ b/app/services/c100_app/pdf_generator.rb
@@ -17,7 +17,7 @@ module C100App
     end
 
     def render(presenter)
-      ApplicationController.renderer.render(
+      ApplicationController.render(
         template: presenter.template,
         locals: { presenter: presenter }
       )

--- a/app/views/steps/completion/summary/show.pdf.erb
+++ b/app/views/steps/completion/summary/show.pdf.erb
@@ -2,11 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <title><%= t '.pdf.heading' %> <%= t 'shared.language' %></title>
     <%= stylesheet_link_tag wicked_pdf_asset_base64('local/pdf_summary') -%>
   </head>
 
   <body id="application-details-pdf">
-    <%= render @presenter.sections %>
+    <%= render presenter.sections %>
   </body>
 </html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -671,8 +671,6 @@ en:
           heading: Check your answers
           lead_text: Please review your answers before submitting your application
           confirm: Confirm and continue
-          pdf:
-            heading: C100 Application
 
   home:
     index:
@@ -1118,7 +1116,6 @@ en:
       one: '%{count} day'
       other: '%{count} days'
   shared:
-    language: (English)
     password_toggle:
       show_password: Show password
       hide_password: Hide password

--- a/spec/presenters/summary/answer_spec.rb
+++ b/spec/presenters/summary/answer_spec.rb
@@ -8,7 +8,7 @@ describe Summary::Answer do
 
   describe '#to_partial_path' do
     it 'returns the correct partial path' do
-      expect(subject.to_partial_path).to eq('shared/row')
+      expect(subject.to_partial_path).to eq('steps/completion/shared/row')
     end
   end
 end

--- a/spec/presenters/summary/c100_form_spec.rb
+++ b/spec/presenters/summary/c100_form_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+module Summary
+  describe C100Form do
+    let(:c100_application) { instance_double(C100Application) }
+    subject { described_class.new(c100_application) }
+
+    describe '#tempate' do
+      it { expect(subject.template).to eq('steps/completion/summary/show.pdf') }
+    end
+
+    describe '#sections' do
+      before do
+        allow_any_instance_of(Summary::Sections::BaseSectionPresenter).to receive(:show?).and_return(true)
+      end
+
+      it 'has the right sections in the right order' do
+        expect(subject.sections).to match_instances_array([
+          Sections::FormHeader,
+          Sections::HelpWithFees,
+          Sections::ApplicantRespondent,
+          Sections::NatureOfApplication,
+          Sections::RiskConcerns,
+          Sections::AdditionalInformation,
+          Sections::SectionHeader,
+          Sections::ChildrenDetails,
+          Sections::ChildrenRelationships,
+          Sections::SectionHeader,
+          Sections::MiamRequirement,
+          Sections::SectionHeader,
+          Sections::MediatorCertification,
+          Sections::SectionHeader,
+          Sections::ApplicationReasons,
+          Sections::SectionHeader,
+          Sections::UrgentHearing,
+          Sections::WithoutNoticeHearing,
+          Sections::SectionHeader,
+          Sections::InternationalElement,
+          Sections::SectionHeader,
+          Sections::LitigationCapacity,
+          Sections::SectionHeader,
+          Sections::AttendingCourt,
+          Sections::SectionHeader,
+          Sections::ApplicantsDetails,
+          Sections::SectionHeader,
+          Sections::RespondentsDetails,
+          Sections::SectionHeader,
+          Sections::OtherPartiesDetails,
+          Sections::OtherChildrenDetails,
+          Sections::SectionHeader,
+          Sections::SolicitorDetails,
+        ])
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/date_answer_spec.rb
+++ b/spec/presenters/summary/date_answer_spec.rb
@@ -8,7 +8,7 @@ describe Summary::DateAnswer do
 
   describe '#to_partial_path' do
     it 'returns the correct partial path' do
-      expect(subject.to_partial_path).to eq('shared/date_row')
+      expect(subject.to_partial_path).to eq('steps/completion/shared/date_row')
     end
   end
 end

--- a/spec/presenters/summary/free_text_answer_spec.rb
+++ b/spec/presenters/summary/free_text_answer_spec.rb
@@ -8,7 +8,7 @@ describe Summary::FreeTextAnswer do
 
   describe '#to_partial_path' do
     it 'returns the correct partial path' do
-      expect(subject.to_partial_path).to eq('shared/free_text_row')
+      expect(subject.to_partial_path).to eq('steps/completion/shared/free_text_row')
     end
   end
 end

--- a/spec/presenters/summary/multi_answer_spec.rb
+++ b/spec/presenters/summary/multi_answer_spec.rb
@@ -8,7 +8,7 @@ describe Summary::MultiAnswer do
 
   describe '#to_partial_path' do
     it 'returns the correct partial path' do
-      expect(subject.to_partial_path).to eq('shared/multi_answer_row')
+      expect(subject.to_partial_path).to eq('steps/completion/shared/multi_answer_row')
     end
   end
 end

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -1,58 +1,25 @@
 require 'spec_helper'
 
-module Summary
-  describe PdfPresenter do
-    let(:c100_application) { instance_double(C100Application) }
-    subject { described_class.new(c100_application) }
+describe Summary::PdfPresenter do
+  let(:c100_application) { instance_double(C100Application) }
+  let(:generator) { double('Generator') }
 
-    describe '#pdf_params' do
-      it 'should have the expected parameters' do
-        expect(subject.pdf_params).to eq({pdf: 'c100_application', footer: {right: '[page]'}})
-      end
+  subject { described_class.new(c100_application, generator) }
+
+  describe '#generate' do
+    it 'generates the different form documents needed' do
+      expect(generator).to receive(:generate).with(
+        an_instance_of(Summary::C100Form), copies: 3
+      )
+
+      subject.generate
     end
+  end
 
-    describe '#sections' do
-      before do
-        allow_any_instance_of(Summary::Sections::BaseSectionPresenter).to receive(:show?).and_return(true)
-      end
-
-      it 'has the right sections in the right order' do
-        expect(subject.sections).to match_instances_array([
-          Sections::FormHeader,
-          Sections::HelpWithFees,
-          Sections::ApplicantRespondent,
-          Sections::NatureOfApplication,
-          Sections::RiskConcerns,
-          Sections::AdditionalInformation,
-          Sections::SectionHeader,
-          Sections::ChildrenDetails,
-          Sections::ChildrenRelationships,
-          Sections::SectionHeader,
-          Sections::MiamRequirement,
-          Sections::SectionHeader,
-          Sections::MediatorCertification,
-          Sections::SectionHeader,
-          Sections::ApplicationReasons,
-          Sections::SectionHeader,
-          Sections::UrgentHearing,
-          Sections::WithoutNoticeHearing,
-          Sections::SectionHeader,
-          Sections::InternationalElement,
-          Sections::SectionHeader,
-          Sections::LitigationCapacity,
-          Sections::SectionHeader,
-          Sections::AttendingCourt,
-          Sections::SectionHeader,
-          Sections::ApplicantsDetails,
-          Sections::SectionHeader,
-          Sections::RespondentsDetails,
-          Sections::SectionHeader,
-          Sections::OtherPartiesDetails,
-          Sections::OtherChildrenDetails,
-          Sections::SectionHeader,
-          Sections::SolicitorDetails,
-        ])
-      end
+  describe '#to_pdf' do
+    it 'delegates method to the generator' do
+      expect(generator).to receive(:to_pdf)
+      subject.to_pdf
     end
   end
 end

--- a/spec/presenters/summary/sections/base_section_presenter_spec.rb
+++ b/spec/presenters/summary/sections/base_section_presenter_spec.rb
@@ -7,7 +7,7 @@ module Summary
 
     describe '#to_partial_path' do
       it 'returns the partial path' do
-        expect(subject.to_partial_path).to eq('shared/section')
+        expect(subject.to_partial_path).to eq('steps/completion/shared/section')
       end
     end
 

--- a/spec/presenters/summary/sections/form_header_spec.rb
+++ b/spec/presenters/summary/sections/form_header_spec.rb
@@ -10,7 +10,7 @@ module Summary
     end
 
     describe '#to_partial_path' do
-      it { expect(subject.to_partial_path).to eq('shared/form_header') }
+      it { expect(subject.to_partial_path).to eq('steps/completion/shared/form_header') }
     end
 
     describe '#show?' do

--- a/spec/presenters/summary/sections/risk_concerns_spec.rb
+++ b/spec/presenters/summary/sections/risk_concerns_spec.rb
@@ -14,7 +14,7 @@ module Summary
     end
 
     describe '#to_partial_path' do
-      it { expect(subject.to_partial_path).to eq('shared/risk_concerns') }
+      it { expect(subject.to_partial_path).to eq('steps/completion/shared/risk_concerns') }
     end
 
     describe '#answers' do

--- a/spec/presenters/summary/sections/section_header_spec.rb
+++ b/spec/presenters/summary/sections/section_header_spec.rb
@@ -10,7 +10,7 @@ module Summary
     end
 
     describe '#to_partial_path' do
-      it { expect(subject.to_partial_path).to eq('shared/section_header') }
+      it { expect(subject.to_partial_path).to eq('steps/completion/shared/section_header') }
     end
 
     describe '#show?' do

--- a/spec/presenters/summary/separator_spec.rb
+++ b/spec/presenters/summary/separator_spec.rb
@@ -10,7 +10,7 @@ describe Summary::Separator do
   end
 
   describe '#to_partial_path' do
-    it { expect(subject.to_partial_path).to eq('shared/separator') }
+    it { expect(subject.to_partial_path).to eq('steps/completion/shared/separator') }
   end
 
   describe 'can be given i18n options' do

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -72,6 +72,6 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
   context 'when the step is `special_arrangements`' do
     let(:step_params) { { special_arrangements: 'anything' } }
-    it { is_expected.to have_destination('/steps/international/resident', :edit) }
+    it { is_expected.to have_destination('/steps/completion/summary', :show) }
   end
 end

--- a/spec/services/c100_app/pdf_generator_spec.rb
+++ b/spec/services/c100_app/pdf_generator_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe C100App::PdfGenerator do
-  let(:renderer)   { ApplicationController.renderer }
   let(:wicked_pdf) { instance_double(WickedPdf) }
   let(:combiner)   { [] }
 
@@ -15,7 +14,7 @@ RSpec.describe C100App::PdfGenerator do
     let(:document)  { 'a form document' }
 
     it 'renders a form using a presenter' do
-      expect(renderer).to receive(:render).with(
+      expect(ApplicationController).to receive(:render).with(
         template: 'path/to/template', locals: { presenter: presenter }
       ).and_return(document)
 

--- a/spec/services/c100_app/pdf_generator_spec.rb
+++ b/spec/services/c100_app/pdf_generator_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe C100App::PdfGenerator do
+  let(:renderer)   { ApplicationController.renderer }
+  let(:wicked_pdf) { instance_double(WickedPdf) }
+  let(:combiner)   { [] }
+
+  before do
+    allow(WickedPdf).to receive(:new).and_return(wicked_pdf)
+    allow(CombinePDF).to receive(:new).and_return(combiner)
+  end
+
+  describe '#generate' do
+    let(:presenter) { double('Presenter', template: 'path/to/template') }
+    let(:document)  { 'a form document' }
+
+    it 'renders a form using a presenter' do
+      expect(renderer).to receive(:render).with(
+        template: 'path/to/template', locals: { presenter: presenter }
+      ).and_return(document)
+
+      expect(wicked_pdf).to receive(:pdf_from_string).with(
+        document, { footer: { right: '[page]/[topage]' } }
+      ).and_return(document)
+
+      # Using 0 copies just to make this test scenario simpler to mock,
+      # as we want to test here only the call to `pdf_from_presenter`
+      subject.generate(presenter, copies: 0)
+    end
+
+    it 'generates a PDF document with N copies' do
+      expect(subject).to receive(:pdf_from_presenter).with(presenter).and_return(document)
+      expect(CombinePDF).to receive(:parse).twice.with(document).and_return(document)
+
+      subject.generate(presenter, copies: 2)
+
+      expect(combiner).to match_array([document, document])
+    end
+  end
+
+  describe '#to_pdf' do
+    let(:combiner) { double.as_null_object }
+
+    it 'delegates method to combiner' do
+      expect(combiner).to receive(:to_pdf)
+      subject.to_pdf
+    end
+  end
+end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -299,12 +299,16 @@ RSpec.shared_examples 'a summary step controller' do
       end
 
       context 'PDF format' do
-        it 'generates and sends the case details PDF' do
+        let(:pdf_presenter) { instance_double(Summary::PdfPresenter, generate: nil, to_pdf: 'a majestic pdf') }
+
+        before do
+          allow(Summary::PdfPresenter).to receive(:new).and_return(pdf_presenter)
+        end
+
+        it 'generates and renders the PDF' do
           get :show, format: :pdf, session: { c100_application_id: existing_case.id }
 
-          expect(subject).to render_template(:show)
-          expect(assigns[:presenter]).to be_an_instance_of(Summary::PdfPresenter)
-          expect(response.headers['Content-Disposition']).to eq('inline; filename="c100_application.pdf"')
+          expect(response.body).to eq('a majestic pdf')
         end
       end
     end


### PR DESCRIPTION
We have to generate the `C100 x 3 times`, but also if triggered, the
`C1A x 3 times`, and if triggered, the `C8 x 1 time`. Also, `1 cover letter`.

Lots of documents, that need to be paginated 1/X correctly, and need to
support custom headers and footers.
Also for efficiency it is much better to generate the C100 once, and
copy it 3 times, (and the same with the C1A).

Individual documents can still be generated, so for example we can still
send by email 1 copy of the C100 (instead of the whole bundle with all
contained inside). If needed.