### PR TITLE
Implement C8 - Part I

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -12,6 +12,19 @@
     }
   }
 
+  tr.answer-box {
+    td {
+      border-bottom: none;
+      vertical-align: middle;
+    }
+
+    div.box-to-fill {
+      border: 1px solid #6f777b;
+      background-color: #fff;
+      padding: 9px;
+    }
+  }
+
   h2.main-section-header {
     font-size: 90%;
     font-weight: 700;
@@ -119,6 +132,15 @@
   #children_known_to_authorities {
     td {
       padding-top: 15px;
+    }
+  }
+
+  #c8_court_details {
+    background-color: #eee;
+    padding: 10px;
+
+    td {
+      border-bottom: none;
     }
   }
 }

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -26,4 +26,8 @@ class C100Application < ApplicationRecord
   has_value_object :concerns_contact_other,        class_name: 'GenericYesNo'
   has_value_object :children_previous_proceedings, class_name: 'GenericYesNo'
   has_value_object :emergency_proceedings,         class_name: 'GenericYesNo'
+
+  def confidentiality_enabled?
+    address_confidentiality.eql?(GenericYesNo::YES.to_s)
+  end
 end

--- a/app/presenters/c8_confidentiality_presenter.rb
+++ b/app/presenters/c8_confidentiality_presenter.rb
@@ -32,7 +32,7 @@ class C8ConfidentialityPresenter < SimpleDelegator
   def confidentiality_enabled?
     @_confidentiality_enabled ||= begin
       PEOPLE_UNDER_C8.include?(__getobj__.class) &&
-        c100_application.address_confidentiality.eql?(GenericYesNo::YES.to_s)
+        c100_application.confidentiality_enabled?
     end
   end
 

--- a/app/presenters/summary/answer_box.rb
+++ b/app/presenters/summary/answer_box.rb
@@ -1,0 +1,11 @@
+module Summary
+  class AnswerBox < BaseAnswer
+    def initialize(name)
+      super(name, nil, show: true)
+    end
+
+    def to_partial_path
+      'steps/completion/shared/answer_box'
+    end
+  end
+end

--- a/app/presenters/summary/c8_form.rb
+++ b/app/presenters/summary/c8_form.rb
@@ -1,0 +1,10 @@
+module Summary
+  class C8Form < BasePdfForm
+    def sections
+      [
+        Sections::FormHeader.new(c100_application, name: :c8_form),
+        Sections::C8CourtDetails.new(c100_application),
+      ].flatten.select(&:show?)
+    end
+  end
+end

--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -12,6 +12,7 @@ module Summary
 
     def generate
       pdf_generator.generate(c100_form, copies: 3)
+      pdf_generator.generate(c8_form,   copies: 1) if c100_application.confidentiality_enabled?
     end
 
     private
@@ -25,7 +26,7 @@ module Summary
     end
 
     def c8_form
-      # TODO
+      Summary::C8Form.new(c100_application)
     end
 
     def cover_letter

--- a/app/presenters/summary/sections/c8_court_details.rb
+++ b/app/presenters/summary/sections/c8_court_details.rb
@@ -1,0 +1,27 @@
+module Summary
+  module Sections
+    class C8CourtDetails < BaseSectionPresenter
+      def name
+        :c8_court_details
+      end
+
+      def answers
+        [
+          AnswerBox.new(:c8_family_court),
+          AnswerBox.new(:c8_case_number),
+          Separator.new(:blank_space),
+          Answer.new(:c8_children_names, :c8_children_numbers),
+          *children_boxes
+        ].select(&:show?)
+      end
+
+      private
+
+      def children_boxes
+        c100.children.map do |child|
+          AnswerBox.new(child.full_name)
+        end
+      end
+    end
+  end
+end

--- a/app/views/steps/completion/shared/_answer_box.pdf.erb
+++ b/app/views/steps/completion/shared/_answer_box.pdf.erb
@@ -1,0 +1,9 @@
+<tr class="answer-box">
+  <td class="question">
+    <%= answer_box.question.is_a?(Symbol) ? t("check_answers.#{answer_box.question}.question") : answer_box.question %>
+  </td>
+
+  <td class="answer answer-value">
+    <div class="box-to-fill"></div>
+  </td>
+</tr>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -47,6 +47,9 @@ en:
       c100_form:
         title: C100
         details: Application under section 8 of the Children Act 1989 for a child arrangements, prohibited steps, specific issue order or to vary or discharge or ask permission to make a section 8 order.
+      c8_form:
+        title: C8
+        details: Confidential contact details - Family Procedure Rules 2010 Rule 29.1
     section_headers:
       children: 1. The Child(ren)
       miam_requirement: 2. Requirement to attend a Mediation, Information and Assessment Meeting (MIAM)
@@ -71,10 +74,13 @@ en:
       urgent_hearing: Urgent hearing
       without_notice_hearing: Without notice hearing
       other_children_details: Other children not part of the application
+      ### C8 ###
+      c8_court_details: To be completed by the court
     descriptions:
       risk_concerns: Are you alleging that the child(ren) named in Section 1 of this form have experienced, or are at risk of experiencing, harm from any of the following by any person who has had contact with the child?
       c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
     separators:
+      blank_space: ""
       not_applicable: Not applicable
       language_assistance: Language assistance
       intermediary: Intermediary
@@ -344,3 +350,14 @@ en:
       question: Is a solicitor acting for you?
       answers:
         <<: *YESNO
+
+    ### C8 questions/answers ###
+    #
+    c8_family_court:
+      question: The family court sitting at
+    c8_case_number:
+      question: Case number
+    c8_children_names:
+      question: Child(ren)’s names
+      answers:
+        c8_children_numbers: Child(ren)’s numbers

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -3,4 +3,16 @@ require 'rails_helper'
 RSpec.describe C100Application, type: :model do
   subject { described_class.new(attributes) }
   let(:attributes) { {} }
+
+  describe '#confidentiality_enabled?' do
+    context 'for `yes` values' do
+      let(:attributes) { {address_confidentiality: 'yes'} }
+      it { expect(subject.confidentiality_enabled?).to eq(true) }
+    end
+
+    context 'for `no` values' do
+      let(:attributes) { {address_confidentiality: 'no'} }
+      it { expect(subject.confidentiality_enabled?).to eq(false) }
+    end
+  end
 end

--- a/spec/presenters/c8_confidentiality_presenter_spec.rb
+++ b/spec/presenters/c8_confidentiality_presenter_spec.rb
@@ -2,10 +2,7 @@ require 'spec_helper'
 
 RSpec.describe C8ConfidentialityPresenter do
   let(:c100_application) {
-    instance_double(
-      C100Application,
-      address_confidentiality: address_confidentiality
-    )
+    C100Application.new(address_confidentiality: address_confidentiality)
   }
 
   let(:person) {

--- a/spec/presenters/summary/answer_box_spec.rb
+++ b/spec/presenters/summary/answer_box_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Summary::AnswerBox do
+  let(:question) {'Question?'}
+
+  subject { described_class.new(question) }
+
+  describe '#to_partial_path' do
+    it { expect(subject.to_partial_path).to eq('steps/completion/shared/answer_box') }
+  end
+
+  describe '#show?' do
+    it { expect(subject.show?).to eq(true) }
+  end
+
+  describe '#value' do
+    it { expect(subject.value).to be_nil }
+  end
+end

--- a/spec/presenters/summary/c8_form_spec.rb
+++ b/spec/presenters/summary/c8_form_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module Summary
+  describe C8Form do
+    let(:c100_application) { instance_double(C100Application) }
+    subject { described_class.new(c100_application) }
+
+    describe '#tempate' do
+      it { expect(subject.template).to eq('steps/completion/summary/show.pdf') }
+    end
+
+    describe '#sections' do
+      before do
+        allow_any_instance_of(Summary::Sections::BaseSectionPresenter).to receive(:show?).and_return(true)
+      end
+
+      it 'has the right sections in the right order' do
+        expect(subject.sections).to match_instances_array([
+          Sections::FormHeader,
+          Sections::C8CourtDetails,
+        ])
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -1,18 +1,36 @@
 require 'spec_helper'
 
 describe Summary::PdfPresenter do
-  let(:c100_application) { instance_double(C100Application) }
+  let(:c100_application) { C100Application.new(address_confidentiality: address_confidentiality) }
   let(:generator) { double('Generator') }
+
+  let(:address_confidentiality) { 'no' }
 
   subject { described_class.new(c100_application, generator) }
 
   describe '#generate' do
-    it 'generates the different form documents needed' do
+    it 'generates the C100 form' do
       expect(generator).to receive(:generate).with(
         an_instance_of(Summary::C100Form), copies: 3
       )
 
       subject.generate
+    end
+
+    context 'when C8 is triggered' do
+      let(:address_confidentiality) { 'yes' }
+
+      it 'generates the C100 form and the C8' do
+        expect(generator).to receive(:generate).with(
+          an_instance_of(Summary::C100Form), copies: 3
+        )
+
+        expect(generator).to receive(:generate).with(
+          an_instance_of(Summary::C8Form), copies: 1
+        )
+
+        subject.generate
+      end
     end
   end
 

--- a/spec/presenters/summary/sections/c8_court_details_spec.rb
+++ b/spec/presenters/summary/sections/c8_court_details_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::C8CourtDetails do
+    let(:c100_application) { instance_double(C100Application, children: [child]) }
+    subject { described_class.new(c100_application) }
+
+    let(:child) { instance_double(Child, full_name: 'John Doe') }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:c8_court_details)
+      end
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(5)
+
+        expect(answers[0]).to be_an_instance_of(AnswerBox)
+        expect(answers[0].question).to eq(:c8_family_court)
+
+        expect(answers[1]).to be_an_instance_of(AnswerBox)
+        expect(answers[1].question).to eq(:c8_case_number)
+
+        expect(answers[2]).to be_an_instance_of(Separator)
+        expect(answers[2].title).to eq(:blank_space)
+
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:c8_children_names)
+        expect(answers[3].value).to eq(:c8_children_numbers)
+
+        expect(answers[4]).to be_an_instance_of(AnswerBox)
+        expect(answers[4].question).to eq('John Doe')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR generates a C8 form if required based on address confidentiality question, and append it to the PDF bundle together with the 3 copies of the C100.

Only a small section of the first page has been implemented for now. Following PRs will implement more sections.

<img width="925" alt="screen shot 2018-02-08 at 17 05 37" src="https://user-images.githubusercontent.com/687910/35987495-b6b501ee-0cf3-11e8-8cc4-4d363cd393f9.png">
