### PR TITLE
Add C8 form instructions

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -4,6 +4,10 @@
   width: 70%;
   margin: 0 auto;
 
+  p {
+    font-size: 70%;
+  }
+
   .form-header {
     h1 {
       font-size: 110%;

--- a/app/presenters/summary/c8_form.rb
+++ b/app/presenters/summary/c8_form.rb
@@ -4,6 +4,7 @@ module Summary
       [
         Sections::FormHeader.new(c100_application, name: :c8_form),
         Sections::C8CourtDetails.new(c100_application),
+        Partial.new(:c8_instructions),
       ].flatten.select(&:show?)
     end
   end

--- a/app/presenters/summary/partial.rb
+++ b/app/presenters/summary/partial.rb
@@ -1,0 +1,17 @@
+module Summary
+  class Partial
+    attr_reader :name
+
+    def initialize(name)
+      @name = name
+    end
+
+    def show?
+      true
+    end
+
+    def to_partial_path
+      "steps/completion/shared/#{name}"
+    end
+  end
+end

--- a/app/presenters/summary/sections/c8_court_details.rb
+++ b/app/presenters/summary/sections/c8_court_details.rb
@@ -9,7 +9,7 @@ module Summary
         [
           AnswerBox.new(:c8_family_court),
           AnswerBox.new(:c8_case_number),
-          Separator.new(:blank_space),
+          Partial.new(:blank_space),
           Answer.new(:c8_children_names, :c8_children_numbers),
           *children_boxes
         ].select(&:show?)

--- a/app/views/steps/completion/shared/_blank_space.pdf.erb
+++ b/app/views/steps/completion/shared/_blank_space.pdf.erb
@@ -1,0 +1,5 @@
+<tr class="blank-space">
+  <td colspan="2">
+    <br/>
+  </td>
+</tr>

--- a/app/views/steps/completion/shared/_c8_instructions.en.pdf.erb
+++ b/app/views/steps/completion/shared/_c8_instructions.en.pdf.erb
@@ -1,0 +1,23 @@
+<br/>
+
+<h3 class="section-header">The omitted contact details</h3>
+
+<p>
+  This form is to be used by any party in Family Proceedings who does not wish to reveal their contact details - such as
+  the contact details of any child, the address of the party, telephone number, email address etc. These details will be
+  kept for use by the court and Cafcass or CAFCASS Cymru and will not be revealed to any other person except by Order of
+  the Court.
+</p>
+
+<p>
+  <strong>Please note:</strong> you will need to make sure that any form or document, either completed by you now, or at
+  a later date, for use in court does not contain the information you wish to keep private. This includes documents
+  received from other people e.g. medical reports or financial statements etc.
+</p>
+
+<p>
+  <strong>
+    The court staff are not able to check the documents you submit to the court for any unintentional disclosure of your
+    contact details.
+  </strong>
+</p>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -80,7 +80,6 @@ en:
       risk_concerns: Are you alleging that the child(ren) named in Section 1 of this form have experienced, or are at risk of experiencing, harm from any of the following by any person who has had contact with the child?
       c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
     separators:
-      blank_space: ""
       not_applicable: Not applicable
       language_assistance: Language assistance
       intermediary: Intermediary

--- a/spec/presenters/summary/c8_form_spec.rb
+++ b/spec/presenters/summary/c8_form_spec.rb
@@ -18,6 +18,7 @@ module Summary
         expect(subject.sections).to match_instances_array([
           Sections::FormHeader,
           Sections::C8CourtDetails,
+          Partial
         ])
       end
     end

--- a/spec/presenters/summary/partial_spec.rb
+++ b/spec/presenters/summary/partial_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Summary::Partial do
+  let(:name) { 'anything' }
+
+  subject { described_class.new(name) }
+
+  describe '#to_partial_path' do
+    it { expect(subject.to_partial_path).to eq('steps/completion/shared/anything') }
+  end
+
+  describe '#show?' do
+    it { expect(subject.show?).to eq(true) }
+  end
+end

--- a/spec/presenters/summary/sections/c8_court_details_spec.rb
+++ b/spec/presenters/summary/sections/c8_court_details_spec.rb
@@ -25,8 +25,8 @@ module Summary
         expect(answers[1]).to be_an_instance_of(AnswerBox)
         expect(answers[1].question).to eq(:c8_case_number)
 
-        expect(answers[2]).to be_an_instance_of(Separator)
-        expect(answers[2].title).to eq(:blank_space)
+        expect(answers[2]).to be_an_instance_of(Partial)
+        expect(answers[2].name).to eq(:blank_space)
 
         expect(answers[3]).to be_an_instance_of(Answer)
         expect(answers[3].question).to eq(:c8_children_names)


### PR DESCRIPTION
Using  localised partial (`_c8_instructions.en.pdf.erb`)
Also changed the previous 'blank_space' to be a partial too, for consistency.

<img width="800" alt="screen shot 2018-02-09 at 10 30 57" src="https://user-images.githubusercontent.com/687910/36023453-6610f572-0d84-11e8-8a57-af7f92b26e67.png">