### PR TITLE
C8 handling for `other parties` relationships

### DIFF
--- a/app/presenters/c8_confidentiality_presenter.rb
+++ b/app/presenters/c8_confidentiality_presenter.rb
@@ -7,6 +7,10 @@ class C8ConfidentialityPresenter < SimpleDelegator
     :email,
   ].freeze
 
+  def self.replacement_answer
+    I18n.translate!('shared.c8_confidential_answer')
+  end
+
   def method_missing(name, *args, &block)
     confidential_detail?(name, super) ? replacement_answer : super
   end
@@ -18,6 +22,6 @@ class C8ConfidentialityPresenter < SimpleDelegator
   end
 
   def replacement_answer
-    @_replacement_answer ||= I18n.translate!('shared.c8_confidential_answer')
+    @_replacement_answer ||= self.class.replacement_answer
   end
 end

--- a/app/presenters/relationships_presenter.rb
+++ b/app/presenters/relationships_presenter.rb
@@ -8,6 +8,8 @@ class RelationshipsPresenter
   end
 
   def relationship_to_children(person_or_people, show_person_name: true)
+    return C8ConfidentialityPresenter.replacement_answer if under_c8?(person_or_people)
+
     relationships.where(minor: minors, person: person_or_people).map do |relationship|
       show_person_name ? present_relation_with_person(relationship) : present_relation_without_person(relationship)
     end.join(PEOPLE_SEPARATOR)
@@ -21,6 +23,11 @@ class RelationshipsPresenter
 
   def relationships
     c100_application.relationships
+  end
+
+  # For other parties, we need to hide the relationships if C8 is triggered
+  def under_c8?(person_or_people)
+    c100_application.confidentiality_enabled? && Array(person_or_people).first.is_a?(OtherParty)
   end
 
   def i18n_relation(relationship)

--- a/app/presenters/summary/c100_form.rb
+++ b/app/presenters/summary/c100_form.rb
@@ -32,7 +32,8 @@ module Summary
       [
         Sections::SectionHeader.new(c100_application, name: :children),
         Sections::ChildrenDetails.new(c100_application),
-        Sections::ChildrenRelationships.new(c100_application)
+        Sections::ChildrenRelationships.new(c100_application),
+        Sections::ChildrenResidence.new(c100_application),
       ]
     end
 

--- a/app/presenters/summary/sections/children_relationships.rb
+++ b/app/presenters/summary/sections/children_relationships.rb
@@ -19,31 +19,8 @@ module Summary
             :other_parties_relationships,
             RelationshipsPresenter.new(c100_application).relationship_to_children(c100.other_parties)
           ),
-          FreeTextAnswer.new(:children_residence, children_residence)
         ].select(&:show?)
       end
-
-      private
-
-      def children
-        @_children ||= c100.children
-      end
-
-      def children_residence
-        ChildResidence.where(child: children).map do |residence|
-          residence_full_names(residence)
-        end.join('; ')
-      end
-
-      # TODO: we might need to separate which child lives with each of the parties
-      # For now it is not clear in the PDF mockup, so this is just a simple solution.
-      # :nocov:
-      def residence_full_names(residence)
-        names = c100.people.where(id: residence.person_ids).pluck(:full_name)
-        names << residence.other_full_name if residence.other?
-        names
-      end
-      # :nocov:
     end
   end
 end

--- a/app/presenters/summary/sections/children_residence.rb
+++ b/app/presenters/summary/sections/children_residence.rb
@@ -1,0 +1,38 @@
+module Summary
+  module Sections
+    class ChildrenResidence < BaseSectionPresenter
+      def name
+        :children_residence
+      end
+
+      def show_header?
+        false
+      end
+
+      def answers
+        [
+          FreeTextAnswer.new(:children_residence, children_residence),
+        ].select(&:show?)
+      end
+
+      private
+
+      def children_residence
+        ChildResidence.where(child: c100.children).map do |residence|
+          residence_full_names(residence)
+        end.join('; ')
+      end
+
+      # TODO: we might need to separate which child lives with each of the parties
+      # For now it is not clear in the PDF mockup, so this is just a simple solution.
+      # Also we will need to handle somehow the C8 for `other parties`. Awaiting design.
+      # :nocov:
+      def residence_full_names(residence)
+        names = c100.people.where(id: residence.person_ids).pluck(:full_name)
+        names << residence.other_full_name if residence.other?
+        names
+      end
+      # :nocov:
+    end
+  end
+end

--- a/spec/presenters/c8_confidentiality_presenter_spec.rb
+++ b/spec/presenters/c8_confidentiality_presenter_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe C8ConfidentialityPresenter do
     }
   end
 
+  describe '.replacement_answer' do
+    it { expect(described_class.replacement_answer).to eq('< See C8 attached >') }
+  end
+
   it 'returns the original answer if it is blank/nil' do
     expect(subject.residence_history).to eq(nil)
   end

--- a/spec/presenters/relationships_presenter_spec.rb
+++ b/spec/presenters/relationships_presenter_spec.rb
@@ -1,7 +1,16 @@
 require 'spec_helper'
 
 RSpec.describe RelationshipsPresenter do
-  let(:c100_application) { instance_double(C100Application, minors: minors, relationships: relationships) }
+  let(:c100_application) {
+    instance_double(
+      C100Application,
+      confidentiality_enabled?: confidentiality_enabled,
+      minors: minors,
+      relationships: relationships,
+    )
+  }
+
+  let(:confidentiality_enabled) { false }
 
   let(:minors) { [] }
   let(:relationships) { double('relationships') }
@@ -47,6 +56,26 @@ RSpec.describe RelationshipsPresenter do
       context 'hiding the person name' do
         it 'returns a string describing the relationships' do
           expect(subject.relationship_to_children(person, show_person_name: false)).to eq('A friend to Child name')
+        end
+      end
+    end
+
+    context 'for a collection under C8 confidentiality' do
+      let(:person) { OtherParty.new }
+
+      context 'and confidentiality is enabled' do
+        let(:confidentiality_enabled) { true }
+
+        it 'returns the C8 replacement string' do
+          expect(subject.relationship_to_children(person)).to eq('< See C8 attached >')
+        end
+      end
+
+      context 'and confidentiality is disabled' do
+        let(:confidentiality_enabled) { false }
+
+        it 'returns the C8 replacement string' do
+          expect(subject.relationship_to_children(person)).to eq('Person name - Father to Child name')
         end
       end
     end

--- a/spec/presenters/summary/c100_form_spec.rb
+++ b/spec/presenters/summary/c100_form_spec.rb
@@ -26,6 +26,7 @@ module Summary
           Sections::SectionHeader,
           Sections::ChildrenDetails,
           Sections::ChildrenRelationships,
+          Sections::ChildrenResidence,
           Sections::SectionHeader,
           Sections::MiamRequirement,
           Sections::SectionHeader,

--- a/spec/presenters/summary/sections/children_relationships_spec.rb
+++ b/spec/presenters/summary/sections/children_relationships_spec.rb
@@ -4,7 +4,6 @@ module Summary
   describe Sections::ChildrenRelationships do
     let(:c100_application) {
       instance_double(C100Application,
-        children: [],
         applicants: applicants,
         respondents: respondents,
         other_parties: other_parties,
@@ -14,7 +13,6 @@ module Summary
     let(:applicants) { double('applicants') }
     let(:respondents) { double('respondents') }
     let(:other_parties) { double('other_parties') }
-    let(:residence) { instance_double(ChildResidence) }
 
     subject { described_class.new(c100_application) }
 
@@ -39,20 +37,13 @@ module Summary
         allow_any_instance_of(
           RelationshipsPresenter
         ).to receive(:relationship_to_children).with(other_parties).and_return('other_parties_relationships')
-
-        # This is a quick smoke test, not in deep, as we are probably need to change the
-        # implementation of the residence_full_names method once the PDF mockup is finished.
-        allow(ChildResidence).to receive(:where).and_return([residence])
-        allow(subject).to receive(:residence_full_names).with(residence).and_return('Full name')
       end
 
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(3)
       end
 
       it 'has the correct rows in the right order' do
-        expect(c100_application).to receive(:children)
-
         expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
         expect(answers[0].question).to eq(:applicants_relationships)
         expect(answers[0].value).to eq('applicants_relationships')
@@ -64,11 +55,6 @@ module Summary
         expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
         expect(answers[2].question).to eq(:other_parties_relationships)
         expect(answers[2].value).to eq('other_parties_relationships')
-
-        expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[3].question).to eq(:children_residence)
-        expect(answers[3].value).to eq('Full name')
-        expect(subject).to have_received(:residence_full_names)
       end
     end
   end

--- a/spec/presenters/summary/sections/children_residence_spec.rb
+++ b/spec/presenters/summary/sections/children_residence_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::ChildrenResidence do
+    let(:c100_application) {
+      instance_double(C100Application,
+        children: [],
+      )
+    }
+
+    let(:residence) { instance_double(ChildResidence) }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:children_residence)
+      end
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#answers' do
+      before do
+        # This is a quick smoke test, not in deep, as we will probably need to change the
+        # implementation of the residence_full_names method once the PDF mockup is finished.
+        allow(ChildResidence).to receive(:where).and_return([residence])
+        allow(subject).to receive(:residence_full_names).with(residence).and_return('Full name')
+      end
+
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(1)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(c100_application).to receive(:children)
+
+        expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[0].question).to eq(:children_residence)
+        expect(answers[0].value).to eq('Full name')
+        expect(subject).to have_received(:residence_full_names)
+      end
+    end
+  end
+end


### PR DESCRIPTION
If confidentiality has been triggered, then we need to completely
hide `other parties` relationships, if there are any other parties.

Also eventually we will need to do a similar thing for the residence
details, but leaving it for now until I have confirmation.

A bit of refactor to split into two separate section presenters the
relationships and the residence.

<img width="906" alt="screen shot 2018-02-12 at 16 32 23" src="https://user-images.githubusercontent.com/687910/36107569-5eaf81aa-1012-11e8-8214-9a1e6f6bf03f.png">
