### PR TITLE
Add `Other court cases` section to C100 PDF

### DIFF
--- a/app/presenters/summary/c100_form.rb
+++ b/app/presenters/summary/c100_form.rb
@@ -7,6 +7,7 @@ module Summary
         miam_sections,
         application_reasons_sections,
         urgent_and_without_notice_sections,
+        other_court_cases_section,
         international_element_sections,
         litigation_capacity_sections,
         attending_court_sections,
@@ -59,6 +60,13 @@ module Summary
         Sections::SectionHeader.new(c100_application, name: :urgent_and_without_notice),
         Sections::UrgentHearing.new(c100_application),
         Sections::WithoutNoticeHearing.new(c100_application),
+      ]
+    end
+
+    def other_court_cases_section
+      [
+        Sections::SectionHeader.new(c100_application, name: :other_court_cases),
+        Sections::OtherCourtCases.new(c100_application),
       ]
     end
 

--- a/app/presenters/summary/sections/other_court_cases.rb
+++ b/app/presenters/summary/sections/other_court_cases.rb
@@ -1,0 +1,39 @@
+module Summary
+  module Sections
+    class OtherCourtCases < BaseSectionPresenter
+      def name
+        :other_court_cases
+      end
+
+      def show_header?
+        false
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def answers
+        return [Separator.new(:not_applicable)] unless previous_proceedings?
+
+        [
+          FreeTextAnswer.new(:court_proceeding_children_names,   court_proceeding.children_names),
+          FreeTextAnswer.new(:court_proceeding_court_name,       court_proceeding.court_name),
+          FreeTextAnswer.new(:court_proceeding_case_number,      court_proceeding.case_number),
+          FreeTextAnswer.new(:court_proceeding_proceedings_date, court_proceeding.proceedings_date),
+          FreeTextAnswer.new(:court_proceeding_cafcass_details,  court_proceeding.cafcass_details),
+          FreeTextAnswer.new(:court_proceeding_order_types,      court_proceeding.order_types),
+          FreeTextAnswer.new(:court_proceeding_previous_details, court_proceeding.previous_details),
+        ].select(&:show?)
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def court_proceeding
+        @_court_proceeding ||= c100.court_proceeding
+      end
+
+      def previous_proceedings?
+        c100.children_previous_proceedings.eql?(GenericYesNo::YES.to_s)
+      end
+    end
+  end
+end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -63,6 +63,7 @@ en:
       mediator_certification: 4. Mediator certifies that the prospective applicant is exempt from attendance at Mediation Information and Assessment Meeting (MIAM) or confirms MIAM attendance
       application_reasons: 5. Why are you making this application?
       urgent_and_without_notice: 6. Urgent and without notice hearings
+      other_court_cases: 7. Other court cases which concern the child(ren) listed in Section 1
       international_element: 8. Cases with an international element
       litigation_capacity: 9. Factors affecting ability to participate in proceedings
       attending_court: 10. Attending the court
@@ -366,6 +367,20 @@ en:
       question: Is a solicitor acting for you?
       answers:
         <<: *YESNO
+    court_proceeding_children_names:
+      question: Name of child(ren)
+    court_proceeding_court_name:
+      question: Name of court where proceedings were heard
+    court_proceeding_case_number:
+      question: Case number
+    court_proceeding_proceedings_date:
+      question: Date/year
+    court_proceeding_cafcass_details:
+      question: Name and office of Cafcass/CAFCASS CYMRU officer
+    court_proceeding_order_types:
+      question: Type of proceedings - if known
+    court_proceeding_previous_details:
+      question: Details of any other previous family case
 
     ### C8 questions/answers ###
     #

--- a/spec/presenters/summary/c100_form_spec.rb
+++ b/spec/presenters/summary/c100_form_spec.rb
@@ -37,6 +37,8 @@ module Summary
           Sections::UrgentHearing,
           Sections::WithoutNoticeHearing,
           Sections::SectionHeader,
+          Sections::OtherCourtCases,
+          Sections::SectionHeader,
           Sections::InternationalElement,
           Sections::SectionHeader,
           Sections::LitigationCapacity,

--- a/spec/presenters/summary/sections/other_court_cases_spec.rb
+++ b/spec/presenters/summary/sections/other_court_cases_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::OtherCourtCases do
+    let(:c100_application) {
+      instance_double(C100Application,
+        children_previous_proceedings: children_previous_proceedings,
+        court_proceeding: court_proceeding,
+    ) }
+
+    let(:court_proceeding) {
+      instance_double(CourtProceeding,
+        children_names: 'children_names',
+        court_name: 'court_name',
+        case_number: 'case_number',
+        proceedings_date: 'proceedings_date',
+        cafcass_details: 'cafcass_details',
+        order_types: 'order_types',
+        previous_details: 'previous_details',
+    ) }
+
+    let(:children_previous_proceedings) { 'yes' }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:other_court_cases) }
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(7)
+
+        expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[0].question).to eq(:court_proceeding_children_names)
+        expect(answers[0].value).to eq('children_names')
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:court_proceeding_court_name)
+        expect(answers[1].value).to eq('court_name')
+
+        expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[2].question).to eq(:court_proceeding_case_number)
+        expect(answers[2].value).to eq('case_number')
+
+        expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[3].question).to eq(:court_proceeding_proceedings_date)
+        expect(answers[3].value).to eq('proceedings_date')
+
+        expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[4].question).to eq(:court_proceeding_cafcass_details)
+        expect(answers[4].value).to eq('cafcass_details')
+
+        expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[5].question).to eq(:court_proceeding_order_types)
+        expect(answers[5].value).to eq('order_types')
+
+        expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[6].question).to eq(:court_proceeding_previous_details)
+        expect(answers[6].value).to eq('previous_details')
+      end
+
+      context 'when there are no previous proceedings' do
+        let(:children_previous_proceedings) { 'no' }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(1)
+
+          expect(answers[0]).to be_an_instance_of(Separator)
+          expect(answers[0].title).to eq(:not_applicable)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As we have now the corresponding step, we can finish this section in
the C100 PDF.

<img width="910" alt="screen shot 2018-02-13 at 15 07 52" src="https://user-images.githubusercontent.com/687910/36158020-2e5b0a9e-10d3-11e8-8f70-b26011ddb8a0.png">
