### PR TITLE
Remove `other` from the Residence step

### DIFF
--- a/app/forms/steps/children/residence_form.rb
+++ b/app/forms/steps/children/residence_form.rb
@@ -2,10 +2,6 @@ module Steps
   module Children
     class ResidenceForm < BaseForm
       attribute :person_ids, Array[String]
-      attribute :other, Boolean
-      attribute :other_full_name, StrippedString
-
-      validates_presence_of :other_full_name, if: :other?
 
       # These are all the parties available to choose from
       def people
@@ -23,8 +19,6 @@ module Steps
 
         record.update(
           person_ids: person_ids,
-          other: other,
-          other_full_name: (other_full_name if other)
         )
       end
     end

--- a/app/presenters/summary/sections/children_residence.rb
+++ b/app/presenters/summary/sections/children_residence.rb
@@ -11,28 +11,26 @@ module Summary
 
       def answers
         [
-          FreeTextAnswer.new(:children_residence, children_residence),
+          MultiAnswer.new(:children_residence, children_residence),
         ].select(&:show?)
       end
 
       private
 
+      # This will return an array of type of people, for example it may be
+      # ["OtherParty", "OtherParty", "Applicant", "Respondent", "Applicant"]
+      # We remove duplicates, and sort alphabetically.
       def children_residence
-        ChildResidence.where(child: c100.children).map do |residence|
-          residence_full_names(residence)
-        end.join('; ')
+        host_people.pluck(:type).uniq.sort
       end
 
-      # TODO: we might need to separate which child lives with each of the parties
-      # For now it is not clear in the PDF mockup, so this is just a simple solution.
-      # Also we will need to handle somehow the C8 for `other parties`. Awaiting design.
-      # :nocov:
-      def residence_full_names(residence)
-        names = c100.people.where(id: residence.person_ids).pluck(:full_name)
-        names << residence.other_full_name if residence.other?
-        names
+      def host_people
+        Person.where(id: host_person_ids)
       end
-      # :nocov:
+
+      def host_person_ids
+        ChildResidence.where(child: c100.children).pluck(:person_ids).flatten
+      end
     end
   end
 end

--- a/app/views/steps/children/residence/edit.html.erb
+++ b/app/views/steps/children/residence/edit.html.erb
@@ -11,14 +11,6 @@
     <%= step_form @form_object do |f| %>
       <%= f.collection_check_boxes :person_ids, @form_object.people, :id, :full_name %>
 
-      <p class="form-block or-block"><%=t '.or' %></p>
-
-      <%=
-        f.check_box_fieldset :other, [:other] do |fieldset|
-          fieldset.check_box_input(:other) { f.text_field :other_full_name }
-        end
-      %>
-
       <%= f.submit class: 'button' %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1116,9 +1116,6 @@ en:
         children_protection_plan:
           <<: *YESNO
         children_known_to_authorities_details: State which child and the name of the local authority and social worker (if known)
-      steps_children_residence_form:
-        other: Other
-        other_full_name: Enter full name
       steps_safety_questions_substance_abuse_details_form:
         substance_abuse_details:
       steps_abuse_concerns_details_form:

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -232,6 +232,10 @@ en:
       question: Other parties
     children_residence:
       question: Who do the children currently live with?
+      answers:
+        Applicant: Applicant
+        Respondent: Respondent
+        OtherParty: Other
     miam_child_protection:
       question: "Current or previous proceedings: are/were any of those cases about an emergency protection, care or supervision order?"
       answers:

--- a/db/migrate/20180219161354_remove_other_residence_field.rb
+++ b/db/migrate/20180219161354_remove_other_residence_field.rb
@@ -1,0 +1,6 @@
+class RemoveOtherResidenceField < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :child_residences, :other, :boolean
+    remove_column :child_residences, :other_full_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,9 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema.define(version: 20180219114253) do
+
+ActiveRecord::Schema.define(version: 20180219161354) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -149,8 +151,6 @@ ActiveRecord::Schema.define(version: 20180219114253) do
   create_table "child_residences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "child_id"
     t.string "person_ids", default: [], array: true
-    t.boolean "other"
-    t.string "other_full_name"
     t.index ["child_id"], name: "index_child_residences_on_child_id"
   end
 

--- a/spec/forms/steps/children/residence_form_spec.rb
+++ b/spec/forms/steps/children/residence_form_spec.rb
@@ -5,16 +5,12 @@ RSpec.describe Steps::Children::ResidenceForm do
     c100_application: c100_application,
     record: record,
     person_ids: person_ids,
-    other: other,
-    other_full_name: other_full_name
   } }
 
   let(:c100_application) { instance_double(C100Application) }
 
   let(:record) { double('Residence') }
   let(:person_ids) { %w(1 2) }
-  let(:other) { true }
-  let(:other_full_name) { 'John Doe' }
 
   subject { described_class.new(arguments) }
 
@@ -37,55 +33,13 @@ RSpec.describe Steps::Children::ResidenceForm do
       end
     end
 
-    context 'validations on `other_full_name`' do
-      context 'when residence is `other` and `other_full_name` is not provided' do
-        let(:other) { true }
-        let(:other_full_name) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the `other_full_name` field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:other_full_name]).to_not be_empty
-        end
-      end
-
-      context 'when residence is `other` and `other_full_name` is provided' do
-        let(:other) { true }
-        let(:other_full_name) { 'John Doe' }
-
-        it 'has no validation errors' do
-          expect(subject).to be_valid
-        end
-      end
-    end
-
     context 'for valid details' do
       it 'updates the record' do
         expect(record).to receive(:update).with(
           person_ids: %w(1 2),
-          other: true,
-          other_full_name: 'John Doe'
         ).and_return(true)
 
         expect(subject.save).to be(true)
-      end
-
-      context 'reset values' do
-        let(:other) { false }
-        let(:other_full_name) { 'John Doe' }
-
-        it 'reset `other_full_name` when no needed' do
-          expect(record).to receive(:update).with(
-            person_ids: %w(1 2),
-            other: false,
-            other_full_name: nil
-          ).and_return(true)
-
-          expect(subject.save).to be(true)
-        end
       end
     end
   end


### PR DESCRIPTION
This removes the `other` checkbox and its associated text field input, as
it is not neccessary for pilot.

C100 pdf form updated to not show the names but just the 'type' of
the person, i.e. Applicant, Respondent or Other.

<img width="924" alt="screen shot 2018-02-19 at 17 17 38" src="https://user-images.githubusercontent.com/687910/36389899-d1c3e6a0-1598-11e8-9133-6be872a0bd15.png">

Fixes #202