### PR TITLE
Simplify contact details form

### DIFF
--- a/app/forms/steps/applicant/contact_details_form.rb
+++ b/app/forms/steps/applicant/contact_details_form.rb
@@ -13,6 +13,8 @@ module Steps
       validates_inclusion_of :residence_requirement_met, in: GenericYesNo.values
       validates_presence_of  :residence_history, if: -> { residence_requirement_met&.no? }
 
+      validates :email, email: true, allow_blank: true
+
       private
 
       def persist!

--- a/app/forms/steps/respondent/contact_details_form.rb
+++ b/app/forms/steps/respondent/contact_details_form.rb
@@ -5,18 +5,16 @@ module Steps
       attribute :address_unknown, Boolean
       attribute :home_phone, StrippedString
       attribute :mobile_phone, StrippedString
-      attribute :mobile_phone_unknown, Boolean
       attribute :email, NormalisedEmail
-      attribute :email_unknown, Boolean
       attribute :residence_requirement_met, YesNoUnknown
       attribute :residence_history, String
 
-      validates_presence_of :address,      unless: :address_unknown?
-      validates_presence_of :mobile_phone, unless: :mobile_phone_unknown?
-      validates_presence_of :email,        unless: :email_unknown?
+      validates_presence_of :address, unless: :address_unknown?
 
       validates_inclusion_of :residence_requirement_met, in: GenericYesNoUnknown.values
       validates_presence_of  :residence_history, if: -> { residence_requirement_met&.no? }
+
+      validates :email, email: true, allow_blank: true
 
       private
 

--- a/app/views/steps/respondent/contact_details/edit.html.erb
+++ b/app/views/steps/respondent/contact_details/edit.html.erb
@@ -6,6 +6,10 @@
 
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
 
+    <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
+      <p><%=t '.body_info' %></p>
+    </div>
+
     <%= step_form @form_object do |f| %>
       <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
       <%= f.check_box_fieldset :address_unknown, [:address_unknown] %>
@@ -20,12 +24,8 @@
       %>
 
       <%= f.text_field :home_phone %>
-
       <%= f.text_field :mobile_phone %>
-      <%= f.check_box_fieldset :mobile_phone_unknown, [:mobile_phone_unknown] %>
-
       <%= f.text_field :email %>
-      <%= f.check_box_fieldset :email_unknown, [:email_unknown] %>
 
       <%= f.submit class: 'button' %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     default_service_title: &default_service_title "C100 Children and the Family Courts - GOV.UK"
     dont_know: &dont_know "Don't know"
     birthplace_hint: &birthplace_hint "For example, town or city"
+    address_hint: &address_hint "Court documents will be sent here. Include the postcode if you have it"
     name_instructions: &name_instructions "This should be the full legal name (including any middle names)"
     order_current: &order_current "Is the order current?"
     order_current_error: &order_current_error "Please answer if the order is current"
@@ -65,7 +66,7 @@ en:
     # This is a compilation of all possible fields shared between Applicants and Respondents (maybe others later)
     PERSONAL_CONTACT_FIELDS: &PERSONAL_CONTACT_FIELDS
       address: Address
-      address_unknown: *dont_know
+      address_unknown: I don’t know where they currently live
       home_phone: Home phone
       mobile_phone: Mobile phone
       mobile_phone_unknown: *dont_know
@@ -176,6 +177,7 @@ en:
         edit:
           page_title: Respondent contact details
           heading: "Contact details of %{name}"
+          body_info: Include as much detail as you can. This will help us process your application more quickly.
       has_other_parties:
         edit:
           page_title: Other parties required
@@ -1235,9 +1237,9 @@ en:
       steps_respondent_personal_details_form:
         birthplace: *birthplace_hint
       steps_respondent_contact_details_form:
-        address: Documents for this application will be sent here. Include the postcode
+        address: *address_hint
       steps_other_parties_contact_details_form:
-        address: Enter the full address including postcode
+        address: *address_hint
       steps_children_names_form:
         new_name_html: *name_instructions
       steps_children_additional_details_form:

--- a/spec/forms/steps/applicant/contact_details_form_spec.rb
+++ b/spec/forms/steps/applicant/contact_details_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
   let(:address) { 'address' }
   let(:home_phone) { nil }
   let(:mobile_phone) { nil }
-  let(:email) { nil }
+  let(:email) { 'test@test.com' }
   let(:residence_requirement_met) { 'no' }
   let(:residence_history) { 'history' }
 
@@ -69,13 +69,28 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
       end
     end
 
+    context 'email validation' do
+      context 'email is not validated if not present' do
+        let(:email) { nil }
+        it { expect(subject).to be_valid }
+      end
+
+      context 'email is validated if present' do
+        let(:email) { 'xxx' }
+        it {
+          expect(subject).not_to be_valid
+          expect(subject.errors[:email]).to_not be_empty
+        }
+      end
+    end
+
     context 'for valid details' do
       let(:expected_attributes) {
         {
           address: 'address',
           home_phone: '',
           mobile_phone: '',
-          email: '',
+          email: 'test@test.com',
           residence_requirement_met: GenericYesNo::NO,
           residence_history: 'history'
         }

--- a/spec/forms/steps/respondent/contact_details_form_spec.rb
+++ b/spec/forms/steps/respondent/contact_details_form_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
     address_unknown: address_unknown,
     home_phone: home_phone,
     mobile_phone: mobile_phone,
-    mobile_phone_unknown: mobile_phone_unknown,
     email: email,
-    email_unknown: email_unknown,
     residence_requirement_met: residence_requirement_met,
     residence_history: residence_history
   } }
@@ -24,9 +22,7 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
   let(:address_unknown) { false }
   let(:home_phone) { nil }
   let(:mobile_phone) { nil }
-  let(:mobile_phone_unknown) { true }
-  let(:email) { nil }
-  let(:email_unknown) { true }
+  let(:email) { 'test@test.com' }
   let(:residence_requirement_met) { 'no' }
   let(:residence_history) { 'history' }
 
@@ -77,8 +73,21 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
 
     context 'validations on field presence unless `unknown`' do
       it { should validate_presence_unless_unknown_of(:address) }
-      it { should validate_presence_unless_unknown_of(:mobile_phone) }
-      it { should validate_presence_unless_unknown_of(:email) }
+    end
+
+    context 'email validation' do
+      context 'email is not validated if not present' do
+        let(:email) { nil }
+        it { expect(subject).to be_valid }
+      end
+
+      context 'email is validated if present' do
+        let(:email) { 'xxx' }
+        it {
+          expect(subject).not_to be_valid
+          expect(subject.errors[:email]).to_not be_empty
+        }
+      end
     end
 
     context 'for valid details' do
@@ -88,9 +97,7 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
           address_unknown: false,
           home_phone: '',
           mobile_phone: '',
-          mobile_phone_unknown: true,
-          email: '',
-          email_unknown: true,
+          email: 'test@test.com',
           residence_requirement_met: GenericYesNoUnknown::NO,
           residence_history: 'history'
         }


### PR DESCRIPTION
Remove the `I don't know` checkboxes for mobile and email, and also
validate the email only if present, for both applicant and respondent.

Some minor copy changes.

Fixes #200 #201

<img width="574" alt="screen shot 2018-02-21 at 11 30 27" src="https://user-images.githubusercontent.com/687910/36478980-e20a7904-16fe-11e8-9133-b6c5d4957fb6.png">
 