### PR TITLE
Implement the basics of the C1A form

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -163,6 +163,7 @@
   }
 
   #c100_court_details,
+  #c1a_court_details,
   #c8_court_details {
     background-color: #eee;
     padding: 10px;

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -27,4 +27,14 @@ class C100Application < ApplicationRecord
   def confidentiality_enabled?
     address_confidentiality.eql?(GenericYesNo::YES.to_s)
   end
+
+  def has_safety_concerns?
+    [
+      domestic_abuse,
+      risk_of_abduction,
+      children_abuse,
+      substance_abuse,
+      other_abuse
+    ].any? { |concern| concern.eql?(GenericYesNo::YES.to_s) }
+  end
 end

--- a/app/presenters/summary/c1a_form.rb
+++ b/app/presenters/summary/c1a_form.rb
@@ -1,0 +1,10 @@
+module Summary
+  class C1aForm < BasePdfForm
+    def sections
+      [
+        Sections::FormHeader.new(c100_application, name: :c1a_form),
+        Sections::C1aCourtDetails.new(c100_application),
+      ].flatten.select(&:show?)
+    end
+  end
+end

--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -12,6 +12,7 @@ module Summary
 
     def generate
       pdf_generator.generate(c100_form, copies: 3)
+      pdf_generator.generate(c1a_form,  copies: 3) if c100_application.has_safety_concerns?
       pdf_generator.generate(c8_form,   copies: 1) if c100_application.confidentiality_enabled?
     end
 
@@ -22,7 +23,7 @@ module Summary
     end
 
     def c1a_form
-      # TODO
+      Summary::C1aForm.new(c100_application)
     end
 
     def c8_form

--- a/app/presenters/summary/sections/c100_court_details.rb
+++ b/app/presenters/summary/sections/c100_court_details.rb
@@ -9,7 +9,6 @@ module Summary
         [
           Partial.new(:admin_court_and_case_number),
           Partial.new(:admin_date_issued),
-          Partial.new(:admin_orders_applied_for),
         ]
       end
     end

--- a/app/presenters/summary/sections/c1a_court_details.rb
+++ b/app/presenters/summary/sections/c1a_court_details.rb
@@ -1,0 +1,17 @@
+module Summary
+  module Sections
+    class C1aCourtDetails < BaseSectionPresenter
+      def name
+        :c1a_court_details
+      end
+
+      def answers
+        [
+          Partial.new(:admin_court_and_case_number),
+          Partial.new(:admin_date_issued),
+          Partial.new(:admin_orders_applied_for),
+        ]
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/risk_concerns.rb
+++ b/app/presenters/summary/sections/risk_concerns.rb
@@ -20,13 +20,7 @@ module Summary
       end
 
       def any?
-        [
-          c100.domestic_abuse,
-          c100.risk_of_abduction,
-          c100.children_abuse,
-          c100.substance_abuse,
-          c100.other_abuse
-        ].any? { |abuse| abuse.eql?(GenericYesNo::YES.to_s) }
+        c100.has_safety_concerns?
       end
 
       private

--- a/app/services/c100_app/miam_exemptions_decision_tree.rb
+++ b/app/services/c100_app/miam_exemptions_decision_tree.rb
@@ -38,9 +38,7 @@ module C100App
     end
 
     def has_safety_concerns?
-      SafetyConcernsPresenter.new(
-        c100_application
-      ).concerns.any?
+      c100_application.has_safety_concerns?
     end
   end
 end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -1,5 +1,6 @@
 en:
   dictionary:
+    to_be_completed: &to_be_completed "To be completed by the court"
     not_applicable: &not_applicable "Not applicable"
     unknown: &unknown "Don't know"
 
@@ -57,6 +58,9 @@ en:
       c100_form:
         title: C100
         details: Application under section 8 of the Children Act 1989 for a child arrangements, prohibited steps, specific issue order or to vary or discharge or ask permission to make a section 8 order
+      c1a_form:
+        title: C1A
+        details: Allegations of harm and domestic violence (Supplemental information form)
       c8_form:
         title: C8
         details: Confidential contact details - Family Procedure Rules 2010 Rule 29.1
@@ -78,7 +82,7 @@ en:
       statement_of_truth: 16. Statement of truth
     sections:
       ### C100 ###
-      c100_court_details: To be completed by the court
+      c100_court_details: *to_be_completed
       help_with_fees: Help with fees
       applicant_respondent: Applicant and respondent
       nature_of_application: Nature of application
@@ -89,8 +93,10 @@ en:
       urgent_hearing: Urgent hearing
       without_notice_hearing: Without notice hearing
       other_children_details: Other children not part of the application
+      ### C1A ###
+      c1a_court_details: *to_be_completed
       ### C8 ###
-      c8_court_details: To be completed by the court
+      c8_court_details: *to_be_completed
       c8_applicants_details: Applicant contact details to be kept private
       c8_other_parties_details: Other parties contact details to be kept private
     descriptions:

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -15,4 +15,24 @@ RSpec.describe C100Application, type: :model do
       it { expect(subject.confidentiality_enabled?).to eq(false) }
     end
   end
+
+  describe '#has_safety_concerns?' do
+    let(:attributes) { {
+      domestic_abuse: domestic_abuse,
+      risk_of_abduction: 'no',
+      children_abuse: 'no',
+      substance_abuse: 'no',
+      other_abuse: 'no'
+    } }
+
+    context 'at least one concern was answered as `YES`' do
+      let(:domestic_abuse) { 'yes' }
+      it { expect(subject.has_safety_concerns?).to eq(true) }
+    end
+
+    context 'there are no concerns' do
+      let(:domestic_abuse) { 'no' }
+      it { expect(subject.has_safety_concerns?).to eq(false) }
+    end
+  end
 end

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe C100Application, type: :model do
     context 'there are no concerns' do
       let(:domestic_abuse) { 'no' }
       it { expect(subject.has_safety_concerns?).to eq(false) }
+
+      it 'checks all the neccessary attributes' do
+        expect(subject).to receive(:domestic_abuse)
+        expect(subject).to receive(:risk_of_abduction)
+        expect(subject).to receive(:children_abuse)
+        expect(subject).to receive(:substance_abuse)
+        expect(subject).to receive(:other_abuse)
+
+        subject.has_safety_concerns?
+      end
     end
   end
 end

--- a/spec/presenters/summary/c100_form_spec.rb
+++ b/spec/presenters/summary/c100_form_spec.rb
@@ -5,7 +5,7 @@ module Summary
     let(:c100_application) { instance_double(C100Application) }
     subject { described_class.new(c100_application) }
 
-    describe '#tempate' do
+    describe '#template' do
       it { expect(subject.template).to eq('steps/completion/summary/show.pdf') }
     end
 

--- a/spec/presenters/summary/c1a_form_spec.rb
+++ b/spec/presenters/summary/c1a_form_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Summary
-  describe C8Form do
+  describe C1aForm do
     let(:c100_application) { instance_double(C100Application) }
     subject { described_class.new(c100_application) }
 
@@ -17,10 +17,7 @@ module Summary
       it 'has the right sections in the right order' do
         expect(subject.sections).to match_instances_array([
           Sections::FormHeader,
-          Sections::C8CourtDetails,
-          Partial,
-          Sections::C8ApplicantsDetails,
-          Sections::C8OtherPartiesDetails,
+          Sections::C1aCourtDetails,
         ])
       end
     end

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
 describe Summary::PdfPresenter do
-  let(:c100_application) { C100Application.new(address_confidentiality: address_confidentiality) }
+  let(:c100_application) { C100Application.new(address_confidentiality: address_confidentiality, domestic_abuse: domestic_abuse) }
   let(:generator) { double('Generator') }
 
   let(:address_confidentiality) { 'no' }
+  let(:domestic_abuse) { 'no' }
 
   subject { described_class.new(c100_application, generator) }
 
@@ -15,6 +16,22 @@ describe Summary::PdfPresenter do
       )
 
       subject.generate
+    end
+
+    context 'when C1A is triggered' do
+      let(:domestic_abuse) { 'yes' }
+
+      it 'generates the C100 form and the C1A' do
+        expect(generator).to receive(:generate).with(
+          an_instance_of(Summary::C100Form), copies: 3
+        )
+
+        expect(generator).to receive(:generate).with(
+          an_instance_of(Summary::C1aForm), copies: 3
+        )
+
+        subject.generate
+      end
     end
 
     context 'when C8 is triggered' do

--- a/spec/presenters/summary/sections/c100_court_details_spec.rb
+++ b/spec/presenters/summary/sections/c100_court_details_spec.rb
@@ -15,16 +15,13 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(3)
+        expect(answers.count).to eq(2)
 
         expect(answers[0]).to be_an_instance_of(Partial)
         expect(answers[0].name).to eq(:admin_court_and_case_number)
 
         expect(answers[1]).to be_an_instance_of(Partial)
         expect(answers[1].name).to eq(:admin_date_issued)
-
-        expect(answers[2]).to be_an_instance_of(Partial)
-        expect(answers[2].name).to eq(:admin_orders_applied_for)
       end
     end
   end

--- a/spec/presenters/summary/sections/c1a_court_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_court_details_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::C1aCourtDetails do
+    let(:c100_application) { instance_double(C100Application) }
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:c1a_court_details)
+      end
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(3)
+
+        expect(answers[0]).to be_an_instance_of(Partial)
+        expect(answers[0].name).to eq(:admin_court_and_case_number)
+
+        expect(answers[1]).to be_an_instance_of(Partial)
+        expect(answers[1].name).to eq(:admin_date_issued)
+
+        expect(answers[2]).to be_an_instance_of(Partial)
+        expect(answers[2].name).to eq(:admin_orders_applied_for)
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/sections/risk_concerns_spec.rb
+++ b/spec/presenters/summary/sections/risk_concerns_spec.rb
@@ -46,30 +46,9 @@ module Summary
     end
 
     describe '#any?' do
-      let(:c100_application) {
-        instance_double(C100Application,
-          domestic_abuse: domestic_abuse,
-          risk_of_abduction: 'no',
-          children_abuse: 'no',
-          substance_abuse: 'no',
-          other_abuse: 'no'
-        )
-      }
-
-      context 'at least one concern was answered as `YES`' do
-        let(:domestic_abuse) { 'yes' }
-
-        it 'returns true' do
-          expect(subject.any?).to eq(true)
-        end
-      end
-
-      context 'there are no concerns' do
-        let(:domestic_abuse) { 'no' }
-
-        it 'returns false' do
-          expect(subject.any?).to eq(false)
-        end
+      it 'delegates the implementation to the c100 application' do
+        expect(c100_application).to receive(:has_safety_concerns?).and_return(true)
+        expect(subject.any?).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Individual commits with more contextual details to make it easier to see what is going on.

This will just render (if safety concerns triggered) a small portion of the C1A, the admin section.
It is a start.

<img width="927" alt="screen shot 2018-02-21 at 14 47 57" src="https://user-images.githubusercontent.com/687910/36486435-65a503f8-1716-11e8-8ec6-9ea125ed7b61.png">
