### PR TITLE
Implement `applicant details` C1A section

### DIFF
--- a/app/presenters/summary/c1a_form.rb
+++ b/app/presenters/summary/c1a_form.rb
@@ -4,6 +4,8 @@ module Summary
       [
         Sections::FormHeader.new(c100_application, name: :c1a_form),
         Sections::C1aCourtDetails.new(c100_application),
+        Sections::SectionHeader.new(c100_application, name: :c1a_applicants_details),
+        Sections::C1aApplicantDetails.new(c100_application),
       ].flatten.select(&:show?)
     end
 

--- a/app/presenters/summary/sections/c1a_applicant_details.rb
+++ b/app/presenters/summary/sections/c1a_applicant_details.rb
@@ -1,0 +1,38 @@
+module Summary
+  module Sections
+    class C1aApplicantDetails < BaseSectionPresenter
+      def name
+        :c1a_applicant_details
+      end
+
+      def show_header?
+        false
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def answers
+        return [] if applicant.nil?
+
+        [
+          FreeTextAnswer.new(:c1a_full_name, applicant.full_name),
+          Answer.new(:person_sex, applicant.gender),
+          Answer.new(:c1a_person_type, :applicant), # Always going to be `applicant` in our digital form
+          Partial.row_blank_space,
+          Separator.new(:contact_details),
+          FreeTextAnswer.new(:person_home_phone, applicant.home_phone),
+          FreeTextAnswer.new(:person_mobile_phone, applicant.mobile_phone),
+          FreeTextAnswer.new(:person_email, applicant.email),
+          Partial.row_blank_space,
+          Answer.new(:c1a_address_confidentiality, c100.address_confidentiality, default: GenericYesNo::NO),
+        ].select(&:show?)
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def applicant
+        @_applicant ||= c100.applicants.first
+      end
+    end
+  end
+end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -80,6 +80,8 @@ en:
       other_parties_details: 13. Others who should be given notice
       solicitor_details: 14. Solicitor’s details
       statement_of_truth: 16. Statement of truth
+      ### C1A ###
+      c1a_applicants_details: Section 1 - About you (the person completing this form)
     sections:
       ### C100 ###
       c100_court_details: *to_be_completed
@@ -105,6 +107,7 @@ en:
     separators:
       c8_attached: See C8 attached
       not_applicable: Not applicable
+      contact_details: Contact details
       language_assistance: Language assistance
       intermediary: Intermediary
       special_assistance: Special assistance / facilities
@@ -396,6 +399,20 @@ en:
       question: Type of proceedings - if known
     court_proceeding_previous_details:
       question: Details of any other previous family case
+
+    ### C1A questions/answers ###
+    #
+    c1a_full_name:
+      question: Your full name
+    c1a_person_type:
+      question: Are you the
+      answers:
+        applicant: Applicant
+    c1a_address_confidentiality:
+      question: C8 form completed?
+      answers:
+        'yes': 'Yes'
+        'no': *not_applicable
 
     ### C8 questions/answers ###
     #

--- a/spec/presenters/summary/c1a_form_spec.rb
+++ b/spec/presenters/summary/c1a_form_spec.rb
@@ -22,6 +22,8 @@ module Summary
         expect(subject.sections).to match_instances_array([
           Sections::FormHeader,
           Sections::C1aCourtDetails,
+          Sections::SectionHeader,
+          Sections::C1aApplicantDetails,
         ])
       end
     end

--- a/spec/presenters/summary/sections/c1a_applicant_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_applicant_details_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::C1aApplicantDetails do
+    let(:c100_application) {
+      instance_double(
+        C100Application,
+        address_confidentiality: address_confidentiality,
+        applicants: [applicant]
+      )
+    }
+
+    let(:applicant) {
+      instance_double(Applicant,
+        full_name: 'fullname',
+        gender: 'female',
+        home_phone: 'home_phone',
+        mobile_phone: 'mobile_phone',
+        email: 'email'
+      )
+    }
+
+    let(:address_confidentiality) { nil }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:c1a_applicant_details) }
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    # The following tests can be fragile, but on purpose. During the development phase
+    # we have to update the tests each time we introduce a new row or remove another.
+    # But once it is finished and stable, it will raise a red flag if it ever gets out
+    # of sync, which means a quite solid safety net for any maintainers in the future.
+    #
+    describe '#answers' do
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(10)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[0].question).to eq(:c1a_full_name)
+        expect(answers[0].value).to eq('fullname')
+
+        expect(answers[1]).to be_an_instance_of(Answer)
+        expect(answers[1].question).to eq(:person_sex)
+        expect(answers[1].value).to eq('female')
+
+        expect(answers[2]).to be_an_instance_of(Answer)
+        expect(answers[2].question).to eq(:c1a_person_type)
+        expect(answers[2].value).to eq(:applicant)
+
+        expect(answers[3]).to be_an_instance_of(Partial)
+        expect(answers[3].name).to eq(:row_blank_space)
+
+        expect(answers[4]).to be_an_instance_of(Separator)
+        expect(answers[4].title).to eq(:contact_details)
+
+        expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[5].question).to eq(:person_home_phone)
+        expect(answers[5].value).to eq('home_phone')
+
+        expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[6].question).to eq(:person_mobile_phone)
+        expect(answers[6].value).to eq('mobile_phone')
+
+        expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[7].question).to eq(:person_email)
+        expect(answers[7].value).to eq('email')
+
+        expect(answers[8]).to be_an_instance_of(Partial)
+        expect(answers[8].name).to eq(:row_blank_space)
+
+        expect(answers[9]).to be_an_instance_of(Answer)
+        expect(answers[9].question).to eq(:c1a_address_confidentiality)
+        expect(answers[9].value).to eq(GenericYesNo::NO)
+      end
+
+      context 'when no applicant present' do
+        let(:applicant) { nil }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(0)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A few details related to the (first) applicant.

<img width="954" alt="screen shot 2018-02-22 at 13 32 42" src="https://user-images.githubusercontent.com/687910/36541150-e41e2d04-17d4-11e8-8e83-cb2763602ee9.png">
