### PR TITLE
Implement `children details` C1A section

### DIFF
--- a/app/presenters/summary/c1a_form.rb
+++ b/app/presenters/summary/c1a_form.rb
@@ -6,6 +6,8 @@ module Summary
         Sections::C1aCourtDetails.new(c100_application),
         Sections::SectionHeader.new(c100_application, name: :c1a_applicants_details),
         Sections::C1aApplicantDetails.new(c100_application),
+        Sections::C1aChildrenDetails.new(c100_application),
+        Sections::C1aSolicitorDetails.new(c100_application),
       ].flatten.select(&:show?)
     end
 

--- a/app/presenters/summary/sections/c1a_children_details.rb
+++ b/app/presenters/summary/sections/c1a_children_details.rb
@@ -1,0 +1,20 @@
+module Summary
+  module Sections
+    class C1aChildrenDetails < BaseChildrenDetails
+      def name
+        :c1a_children_details
+      end
+
+      def answers
+        c100.children.map.with_index(1) do |child, index|
+          [
+            Separator.new(:child_index_title, index: index),
+            personal_details(child),
+            MultiAnswer.new(:child_applicants_relationship, relation_to_child(child, c100.applicants)),
+            Partial.row_blank_space,
+          ]
+        end.flatten.select(&:show?)
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/c1a_solicitor_details.rb
+++ b/app/presenters/summary/sections/c1a_solicitor_details.rb
@@ -1,0 +1,15 @@
+module Summary
+  module Sections
+    class C1aSolicitorDetails < BaseSectionPresenter
+      def name
+        :c1a_solicitor_details
+      end
+
+      def answers
+        [
+          Answer.new(:c1a_has_solicitor, GenericYesNo::NO), # Always `NO` for pilot (we are screening)
+        ]
+      end
+    end
+  end
+end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -97,6 +97,8 @@ en:
       other_children_details: Other children not part of the application
       ### C1A ###
       c1a_court_details: *to_be_completed
+      c1a_children_details: Summary of children’s details
+      c1a_solicitor_details: Your solicitor’s details
       ### C8 ###
       c8_court_details: *to_be_completed
       c8_applicants_details: Applicant contact details to be kept private
@@ -413,6 +415,10 @@ en:
       answers:
         'yes': 'Yes'
         'no': *not_applicable
+    c1a_has_solicitor:
+      question: Is a solicitor acting for you?
+      answers:
+        <<: *YESNO
 
     ### C8 questions/answers ###
     #

--- a/spec/presenters/summary/c1a_form_spec.rb
+++ b/spec/presenters/summary/c1a_form_spec.rb
@@ -24,6 +24,8 @@ module Summary
           Sections::C1aCourtDetails,
           Sections::SectionHeader,
           Sections::C1aApplicantDetails,
+          Sections::C1aChildrenDetails,
+          Sections::C1aSolicitorDetails,
         ])
       end
     end

--- a/spec/presenters/summary/sections/c1a_children_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_children_details_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::C1aChildrenDetails do
+    let(:c100_application) {
+      instance_double(C100Application,
+        children: [child],
+        applicants: [],
+      )
+    }
+    let(:child) {
+      instance_double(Child,
+        full_name: 'name',
+        dob: Date.new(2018, 1, 20),
+        age_estimate: nil,
+        gender: 'female',
+        relationships: relationships,
+      )
+    }
+    let(:relationships) { double('relationships') }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:c1a_children_details)
+      end
+    end
+
+    # The following tests can be fragile, but on purpose. During the development phase
+    # we have to update the tests each time we introduce a new row or remove another.
+    # But once it is finished and stable, it will raise a red flag if it ever gets out
+    # of sync, which means a quite solid safety net for any maintainers in the future.
+    #
+    describe '#answers' do
+      before do
+        allow(relationships).to receive_message_chain(:where, :pluck).and_return(['mother'])
+      end
+
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(6)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Separator)
+        expect(answers[0].title).to eq(:child_index_title)
+        expect(answers[0].i18n_opts).to eq({index: 1})
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:child_full_name)
+        expect(answers[1].value).to eq('name')
+
+        expect(answers[2]).to be_an_instance_of(DateAnswer)
+        expect(answers[2].question).to eq(:child_dob)
+        expect(answers[2].value).to eq(Date.new(2018, 1, 20))
+
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:child_sex)
+        expect(answers[3].value).to eq('female')
+
+        expect(answers[4]).to be_an_instance_of(MultiAnswer)
+        expect(answers[4].question).to eq(:child_applicants_relationship)
+        expect(answers[4].value).to eq(['mother'])
+        expect(c100_application).to have_received(:applicants)
+
+        expect(answers[5]).to be_an_instance_of(Partial)
+        expect(answers[5].name).to eq(:row_blank_space)
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/sections/c1a_solicitor_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_solicitor_details_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::C1aSolicitorDetails do
+    let(:c100_application) {
+      instance_double(C100Application,
+    ) }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:c1a_solicitor_details) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:c1a_has_solicitor)
+        expect(answers[0].value).to eq(GenericYesNo::NO) # Always `NO` for pilot (we are screening)
+      end
+    end
+  end
+end


### PR DESCRIPTION
And also the solicitor section, which is always set to NO.

<img width="915" alt="screen shot 2018-02-22 at 15 08 51" src="https://user-images.githubusercontent.com/687910/36546073-51878e46-17e2-11e8-932d-c06bee0b92ef.png">
