### PR TITLE
Add `children other abuse` section

### DIFF
--- a/app/presenters/summary/c1a_form.rb
+++ b/app/presenters/summary/c1a_form.rb
@@ -8,6 +8,7 @@ module Summary
         *abuse_summary,
         *abuse_details,
         *abduction_details,
+        *children_other_abuse,
         *statement_of_truth,
       ].flatten.select(&:show?)
     end
@@ -50,6 +51,13 @@ module Summary
       [
         Sections::SectionHeader.new(c100_application, name: :c1a_abduction),
         Sections::C1aAbductionDetails.new(c100_application),
+      ]
+    end
+
+    def children_other_abuse
+      [
+        Sections::SectionHeader.new(c100_application, name: :c1a_children_other_abuse),
+        Sections::C1aChildrenOtherAbuseDetails.new(c100_application),
       ]
     end
 

--- a/app/presenters/summary/sections/c1a_children_other_abuse_details.rb
+++ b/app/presenters/summary/sections/c1a_children_other_abuse_details.rb
@@ -1,0 +1,22 @@
+module Summary
+  module Sections
+    class C1aChildrenOtherAbuseDetails < C1aBaseAbuseDetails
+      def name
+        :c1a_children_other_abuse_details
+      end
+
+      def show_header?
+        false
+      end
+
+      # Filter everything but `other`
+      def filtered_abuses
+        AbuseType.values - [AbuseType::OTHER]
+      end
+
+      def subject
+        AbuseSubject::CHILDREN
+      end
+    end
+  end
+end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -95,6 +95,7 @@ en:
       c1a_applicants_details: Section 1 - About you (the person completing this form)
       c1a_abuse_details: Section 2 - Details of domestic violence / abuse
       c1a_abduction: Section 3 - Abduction
+      c1a_children_other_abuse: Section 4 - Other concerns about your child(ren)
       c1a_statement_of_truth: Section 6 - Statement of truth
     sections:
       ### C100 ###
@@ -468,6 +469,7 @@ en:
           psychological: Children - Psychological
           sexual: Children - Sexual
           financial: Children - Financial
+          other: Children - Other
         applicant:
           physical: Applicant - Physical
           emotional: Applicant - Emotional

--- a/spec/presenters/summary/c1a_form_spec.rb
+++ b/spec/presenters/summary/c1a_form_spec.rb
@@ -36,6 +36,8 @@ module Summary
           Sections::SectionHeader,
           Sections::C1aAbductionDetails,
           Sections::SectionHeader,
+          Sections::C1aChildrenOtherAbuseDetails,
+          Sections::SectionHeader,
           Sections::StatementOfTruth,
         ])
       end

--- a/spec/presenters/summary/sections/c1a_children_other_abuse_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_children_other_abuse_details_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::C1aChildrenOtherAbuseDetails do
+    let(:c100_application) { instance_double(C100Application, abuse_concerns: abuse_concerns_resultset) }
+    let(:abuse_concerns_resultset) { double('abuse_concerns_resultset') }
+
+    let(:abuse_concern) {
+      instance_double(
+        AbuseConcern,
+        subject: 'children',
+        kind: 'other',
+        behaviour_description: 'behaviour_description',
+        behaviour_start: '2001',
+        behaviour_ongoing: 'no',
+        behaviour_stop: '2010',
+        asked_for_help: 'yes',
+        help_party: 'friend',
+        help_provided: 'yes',
+        help_description: 'help_description'
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:c1a_children_other_abuse_details)
+      end
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#answers' do
+      let(:found_abuses_resultset) { double('found_abuses_resultset') }
+      let(:filtered_abuses_resultset) { double('filtered_abuses_resultset') }
+      let(:final_resultset) { [abuse_concern] }
+
+      before do
+        allow(
+          abuse_concerns_resultset
+        ).to receive(:where).with(
+          answer: GenericYesNo::YES, subject: AbuseSubject::CHILDREN
+        ).and_return(found_abuses_resultset)
+
+        allow(
+          found_abuses_resultset
+        ).to receive_message_chain(:where, :not).with(
+          kind: %w(physical emotional psychological sexual financial)
+        ).and_return(filtered_abuses_resultset)
+
+        allow(filtered_abuses_resultset).to receive(:reverse).and_return(final_resultset)
+      end
+
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(10)
+      end
+
+      it 'has the correct rows in the right order' do
+        #
+        # NOTE: this presenter uses exactly the same code as
+        # `C1aChildrenAbuseDetails`, but for abuse kind `other`.
+        # Refer to the above presenter spec for a full test.
+        #
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:c1a_abuse_type)
+        expect(answers[0].value).to eq('children.other')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the same as the previously implemented abuse concerns, but
only for kind `other` and only for children.
<img width="617" alt="screen shot 2018-02-27 at 10 28 57" src="https://user-images.githubusercontent.com/687910/36723750-09d708b8-1ba9-11e8-829a-611b2aef4c4c.png">
