### PR TITLE
Refactor petition orders to use value-object

### DIFF
--- a/app/controllers/steps/children/orders_controller.rb
+++ b/app/controllers/steps/children/orders_controller.rb
@@ -8,7 +8,7 @@ module Steps
         )
 
         @petition = PetitionPresenter.new(
-          current_c100_application.asking_order
+          current_c100_application
         )
       end
 

--- a/app/controllers/steps/petition/orders_controller.rb
+++ b/app/controllers/steps/petition/orders_controller.rb
@@ -2,9 +2,7 @@ module Steps
   module Petition
     class OrdersController < Steps::PetitionStepController
       def edit
-        @form_object = OrdersForm.build(
-          c100_application: current_c100_application
-        )
+        @form_object = OrdersForm.build(current_c100_application)
       end
 
       def update

--- a/app/controllers/steps/petition/playback_controller.rb
+++ b/app/controllers/steps/petition/playback_controller.rb
@@ -3,7 +3,7 @@ module Steps
     class PlaybackController < Steps::PetitionStepController
       def show
         @petition = PetitionPresenter.new(
-          current_c100_application.asking_order
+          current_c100_application
         )
       end
     end

--- a/app/forms/form_attribute_methods.rb
+++ b/app/forms/form_attribute_methods.rb
@@ -20,9 +20,10 @@ module FormAttributeMethods
       self.class.attributes_map(self)
     end
 
-    # Returns an array of attributes with a `true` value
+    # Returns an array of attributes with a `true` value (this is meant to
+    # be used to return an array of selected checkboxes, for example).
     def selected_options
-      attributes_map.select { |_name, selected| selected }.keys
+      attributes_map.select { |_name, selected| selected.is_a?(TrueClass) }.keys
     end
   end
 

--- a/app/forms/steps/petition/orders_form.rb
+++ b/app/forms/steps/petition/orders_form.rb
@@ -1,21 +1,28 @@
 module Steps
   module Petition
     class OrdersForm < BaseForm
-      include HasOneAssociationForm
-      has_one_association :asking_order
-
       attributes PetitionOrder.values, Boolean
-      attribute  :other_details, String
 
-      validates_presence_of :other_details, if: :other?
+      # We override the getter methods for each of the order attributes so we
+      # can retrieve their state (checked/unchecked) from the DB array column.
+      attribute_names.each do |name|
+        define_method(name) { c100_application.orders.include?(name.to_s) }
+      end
+
+      # We also need an attribute to hold details when `other_issue` checkbox
+      # is selected. This attribute should not have its getter overridden.
+      attribute :orders_additional_details, String
+
+      # TODO: validation
 
       private
 
       def persist!
         raise C100ApplicationNotFound unless c100_application
 
-        record_to_persist.update(
-          attributes_map
+        c100_application.update(
+          orders: selected_options,
+          orders_additional_details: orders_additional_details,
         )
       end
     end

--- a/app/models/asking_order.rb
+++ b/app/models/asking_order.rb
@@ -1,3 +1,0 @@
-class AskingOrder < ApplicationRecord
-  belongs_to :c100_application
-end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -2,7 +2,6 @@ class C100Application < ApplicationRecord
   belongs_to :user, optional: true, dependent: :destroy
 
   has_one  :abduction_detail, dependent: :destroy
-  has_one  :asking_order,     dependent: :destroy
   has_one  :court_order,      dependent: :destroy
   has_one  :court_proceeding, dependent: :destroy
   has_one  :miam_exemption,   dependent: :destroy

--- a/app/presenters/petition_presenter.rb
+++ b/app/presenters/petition_presenter.rb
@@ -11,6 +11,10 @@ class PetitionPresenter < SimpleDelegator
     selected_orders_from(PetitionOrder::PROHIBITED_STEPS)
   end
 
+  def orders_with_no_name
+    selected_orders_from(PetitionOrder::ORDERS_WITH_NO_NAME)
+  end
+
   def all_selected_orders
     selected_orders_from(PetitionOrder.values)
   end
@@ -21,6 +25,12 @@ class PetitionPresenter < SimpleDelegator
 
   def other_issue_details
     orders_additional_details
+  end
+
+  # This is just a little helper for the view to customise the copy based
+  # on number of orders selected (to know when to say 'you also want to...')
+  def count_for(*order_groups)
+    order_groups.sum { |group| public_send(group).count }
   end
 
   private

--- a/app/presenters/petition_presenter.rb
+++ b/app/presenters/petition_presenter.rb
@@ -15,14 +15,24 @@ class PetitionPresenter < SimpleDelegator
     selected_orders_from(PetitionOrder.values)
   end
 
-  def other_details
-    __getobj__&.other_details
+  def other_issue?
+    orders.include?(PetitionOrder::OTHER_ISSUE.to_s)
+  end
+
+  def other_issue_details
+    orders_additional_details
   end
 
   private
 
   def selected_orders_from(collection)
-    return [] if __getobj__.nil?
-    collection.select { |attrib| self[attrib] }
+    filtered(collection.map(&:to_s)) & orders
+  end
+
+  # We filter out `group_xxx` items, as the purpose of these are to present the orders
+  # in groups for the user to show/hide them, and are not really an order by itself.
+  #
+  def filtered(collection)
+    collection.grep_v(/^group_/)
   end
 end

--- a/app/presenters/summary/sections/nature_of_application.rb
+++ b/app/presenters/summary/sections/nature_of_application.rb
@@ -7,10 +7,11 @@ module Summary
 
       def answers
         [
+          MultiAnswer.new(:orders_with_no_name, petition.orders_with_no_name),
           MultiAnswer.new(:child_arrangements_orders, petition.child_arrangements_orders),
-          MultiAnswer.new(:specific_issues_orders, petition.specific_issues_orders),
           MultiAnswer.new(:prohibited_steps_orders, petition.prohibited_steps_orders),
-          FreeTextAnswer.new(:other_details, petition.other_issue_details),
+          MultiAnswer.new(:specific_issues_orders, petition.specific_issues_orders),
+          FreeTextAnswer.new(:other_issue_details, petition.other_issue_details),
         ].select(&:show?)
       end
 

--- a/app/presenters/summary/sections/nature_of_application.rb
+++ b/app/presenters/summary/sections/nature_of_application.rb
@@ -10,14 +10,14 @@ module Summary
           MultiAnswer.new(:child_arrangements_orders, petition.child_arrangements_orders),
           MultiAnswer.new(:specific_issues_orders, petition.specific_issues_orders),
           MultiAnswer.new(:prohibited_steps_orders, petition.prohibited_steps_orders),
-          FreeTextAnswer.new(:other_details, petition.other_details),
+          FreeTextAnswer.new(:other_details, petition.other_issue_details),
         ].select(&:show?)
       end
 
       private
 
       def petition
-        @_petition ||= PetitionPresenter.new(c100.asking_order)
+        @_petition ||= PetitionPresenter.new(c100)
       end
     end
   end

--- a/app/value_objects/petition_order.rb
+++ b/app/value_objects/petition_order.rb
@@ -4,7 +4,6 @@ class PetitionOrder < ValueObject
       new(:child_arrangements_home),
       new(:child_arrangements_time),
       new(:child_arrangements_contact),
-      new(:child_arrangements_event),
       new(:child_arrangements_access),
     ].freeze,
 
@@ -12,15 +11,14 @@ class PetitionOrder < ValueObject
     PROHIBITED_STEPS = [
       new(:prohibited_steps_moving),
       new(:prohibited_steps_moving_abroad),
-      new(:prohibited_steps_moving_abduction),
-      new(:prohibited_steps_moving_names),
-      new(:prohibited_steps_moving_medical),
-      new(:prohibited_steps_moving_holiday),
+      new(:prohibited_steps_names),
+      new(:prohibited_steps_medical),
+      new(:prohibited_steps_holiday),
     ].freeze,
 
     GROUP_SPECIFIC_ISSUES = new(:group_specific_issues),
     SPECIFIC_ISSUES = [
-      new(:specific_issues_return),
+      new(:specific_issues_holiday),
       new(:specific_issues_school),
       new(:specific_issues_religion),
       new(:specific_issues_names),

--- a/app/value_objects/petition_order.rb
+++ b/app/value_objects/petition_order.rb
@@ -27,6 +27,12 @@ class PetitionOrder < ValueObject
       new(:specific_issues_moving_abroad),
     ].freeze,
 
+    # This is the exception to the rule. The values here (one for now),
+    # don't have a corresponding order name.
+    ORDERS_WITH_NO_NAME = [
+      new(:no_name_child_return),
+    ].freeze,
+
     OTHER_ISSUE = new(:other_issue),
   ].flatten.freeze
 

--- a/app/value_objects/petition_order.rb
+++ b/app/value_objects/petition_order.rb
@@ -1,28 +1,35 @@
 class PetitionOrder < ValueObject
   VALUES = [
     CHILD_ARRANGEMENTS = [
-      new(:child_home),
-      new(:child_times),
-      new(:child_contact),
-      new(:child_return)
+      new(:child_arrangements_home),
+      new(:child_arrangements_time),
+      new(:child_arrangements_contact),
+      new(:child_arrangements_event),
+      new(:child_arrangements_access),
     ].freeze,
 
+    GROUP_PROHIBITED_STEPS = new(:group_prohibited_steps),
     PROHIBITED_STEPS = [
-      new(:child_abduction),
-      new(:child_flight)
+      new(:prohibited_steps_moving),
+      new(:prohibited_steps_moving_abroad),
+      new(:prohibited_steps_moving_abduction),
+      new(:prohibited_steps_moving_names),
+      new(:prohibited_steps_moving_medical),
+      new(:prohibited_steps_moving_holiday),
     ].freeze,
 
+    GROUP_SPECIFIC_ISSUES = new(:group_specific_issues),
     SPECIFIC_ISSUES = [
-      new(:child_specific_issue_school),
-      new(:child_specific_issue_religion),
-      new(:child_specific_issue_name),
-      new(:child_specific_issue_medical),
-      new(:child_specific_issue_abroad),
+      new(:specific_issues_return),
+      new(:specific_issues_school),
+      new(:specific_issues_religion),
+      new(:specific_issues_names),
+      new(:specific_issues_medical),
+      new(:specific_issues_moving),
+      new(:specific_issues_moving_abroad),
     ].freeze,
 
-    OTHER = [
-      new(:other)
-    ].freeze
+    OTHER_ISSUE = new(:other_issue),
   ].flatten.freeze
 
   def self.values

--- a/app/views/steps/petition/orders/edit.html.erb
+++ b/app/views/steps/petition/orders/edit.html.erb
@@ -10,13 +10,31 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.check_box_fieldset :orders, PetitionOrder::CHILD_ARRANGEMENTS %>
-      <%= f.check_box_fieldset :orders, PetitionOrder::PROHIBITED_STEPS %>
-      <%= f.check_box_fieldset :orders, PetitionOrder::SPECIFIC_ISSUES %>
 
       <%=
-        f.check_box_fieldset :orders, [:other] do |fieldset|
-          fieldset.check_box_input(:other) {
-            f.text_area :other_details, size: '40x4', class: 'form-control-3-4'
+        f.check_box_fieldset :orders, [
+          PetitionOrder::PROHIBITED_STEPS,
+        ] do |fieldset|
+          fieldset.check_box_input(PetitionOrder::GROUP_PROHIBITED_STEPS) {
+            f.check_box_fieldset :orders_prohibited_steps, PetitionOrder::PROHIBITED_STEPS
+          }
+        end
+      %>
+
+      <%=
+        f.check_box_fieldset :orders, [
+          PetitionOrder::SPECIFIC_ISSUES,
+        ] do |fieldset|
+          fieldset.check_box_input(PetitionOrder::GROUP_SPECIFIC_ISSUES) {
+            f.check_box_fieldset :orders_specific_issues, PetitionOrder::SPECIFIC_ISSUES
+          }
+        end
+      %>
+
+      <%=
+        f.check_box_fieldset :orders, [PetitionOrder::OTHER_ISSUE] do |fieldset|
+          fieldset.check_box_input(:other_issue) {
+            f.text_area :orders_additional_details, size: '40x4', class: 'form-control-3-4'
           }
         end
       %>

--- a/app/views/steps/petition/orders/edit.html.erb
+++ b/app/views/steps/petition/orders/edit.html.erb
@@ -9,7 +9,8 @@
     <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.check_box_fieldset :orders, PetitionOrder::CHILD_ARRANGEMENTS %>
+      <%= f.check_box_fieldset :orders,
+          PetitionOrder::CHILD_ARRANGEMENTS + PetitionOrder::ORDERS_WITH_NO_NAME %>
 
       <%=
         f.check_box_fieldset :orders, [

--- a/app/views/steps/petition/playback/show.html.erb
+++ b/app/views/steps/petition/playback/show.html.erb
@@ -16,8 +16,20 @@
       <p><%= t('.aka.child_arrangements_order') %></p>
     <% end %>
 
+    <% @petition.orders_with_no_name.each do |order| %>
+      <p class="lede">
+        <%=t ".orders_with_no_name.#{order}", count: @petition.count_for(
+          :child_arrangements_orders
+        ) %>
+      </p>
+    <% end %>
+
     <% if @petition.prohibited_steps_orders.any? %>
-      <p class="lede"><%=t '.lead_text_stop', count: @petition.child_arrangements_orders.count %></p>
+      <p class="lede">
+        <%=t '.lead_text_stop', count: @petition.count_for(
+          :child_arrangements_orders, :orders_with_no_name
+        ) %>
+      </p>
       <ul class="list list-bullet">
         <% @petition.prohibited_steps_orders.each do |order| %>
           <%= content_tag :li, t(".#{order}_html") %>
@@ -27,7 +39,11 @@
     <% end %>
 
     <% if @petition.specific_issues_orders.any? %>
-        <p class="lede"><%=t '.lead_text_issues', count: @petition.child_arrangements_orders.count + @petition.prohibited_steps_orders.count %></p>
+        <p class="lede">
+          <%=t '.lead_text_issues', count: @petition.count_for(
+            :child_arrangements_orders, :orders_with_no_name, :prohibited_steps_orders
+          ) %>
+        </p>
         <ul class="list list-bullet">
           <% @petition.specific_issues_orders.each do |order| %>
               <%= content_tag :li, t(".#{order}_html") %>
@@ -37,7 +53,11 @@
     <% end %>
 
     <% if @petition.other_issue? %>
-      <p class="lede"><%=t '.lead_text_other', count: @petition.child_arrangements_orders.count + @petition.specific_issues_orders.count %></p>
+      <p class="lede">
+        <%=t '.lead_text_other', count: @petition.count_for(
+          :child_arrangements_orders, :orders_with_no_name, :prohibited_steps_orders, :specific_issues_orders
+        ) %>
+      </p>
       <div class="panel">
         <%= @petition.other_issue_details %>
       </div>

--- a/app/views/steps/petition/playback/show.html.erb
+++ b/app/views/steps/petition/playback/show.html.erb
@@ -36,10 +36,10 @@
       <p><%= t('.aka.prohibited_steps_order') %></p>
     <% end %>
 
-    <% if @petition.other? %>
+    <% if @petition.other_issue? %>
       <p class="lede"><%=t '.lead_text_other', count: @petition.child_arrangements_orders.count + @petition.specific_issues_orders.count %></p>
       <div class="panel">
-        <%= @petition.other_details %>
+        <%= @petition.other_issue_details %>
       </div>
     <% end %>
 

--- a/app/views/steps/petition/playback/show.html.erb
+++ b/app/views/steps/petition/playback/show.html.erb
@@ -10,30 +10,30 @@
       <p class="lede"><%=t '.lead_text', count: 0 %></p>
       <ul class="list list-bullet">
         <% @petition.child_arrangements_orders.each do |order| %>
-          <%= content_tag :li, t(".#{order}") %>
+          <%= content_tag :li, t(".#{order}_html") %>
         <% end %>
       </ul>
       <p><%= t('.aka.child_arrangements_order') %></p>
     <% end %>
 
-    <% if @petition.specific_issues_orders.any? %>
-      <p class="lede"><%=t '.lead_text_issues', count: @petition.child_arrangements_orders.count %></p>
-      <ul class="list list-bullet">
-        <% @petition.specific_issues_orders.each do |order| %>
-          <%= content_tag :li, t(".#{order}") %>
-        <% end %>
-      </ul>
-      <p><%= t('.aka.specific_issues_order') %></p>
-    <% end %>
-
     <% if @petition.prohibited_steps_orders.any? %>
-      <p class="lede"><%=t '.lead_text', count: @petition.child_arrangements_orders.count + @petition.specific_issues_orders.count %></p>
+      <p class="lede"><%=t '.lead_text_stop', count: @petition.child_arrangements_orders.count %></p>
       <ul class="list list-bullet">
         <% @petition.prohibited_steps_orders.each do |order| %>
-          <%= content_tag :li, t(".#{order}") %>
+          <%= content_tag :li, t(".#{order}_html") %>
         <% end %>
       </ul>
       <p><%= t('.aka.prohibited_steps_order') %></p>
+    <% end %>
+
+    <% if @petition.specific_issues_orders.any? %>
+        <p class="lede"><%=t '.lead_text_issues', count: @petition.child_arrangements_orders.count + @petition.prohibited_steps_orders.count %></p>
+        <ul class="list list-bullet">
+          <% @petition.specific_issues_orders.each do |order| %>
+              <%= content_tag :li, t(".#{order}_html") %>
+          <% end %>
+        </ul>
+        <p><%= t('.aka.specific_issues_order') %></p>
     <% end %>
 
     <% if @petition.other_issue? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,20 +34,25 @@ en:
       other: Other
 
     PETITION_ORDERS: &PETITION_ORDERS
-      child_home: Arrange where they live
-      child_times: Arrange how much time they spend with each parent
-      child_contact: Confirm when and what other types of contact will take place with them
-      child_specific_issue: Resolve a dispute over a specific issue (For example, what school they’ll go to)
-      child_specific_issue_school: Which school they go to
-      child_specific_issue_religion: A religious issue
-      child_specific_issue_name: Changing their names
-      child_specific_issue_medical: Medical treatment
-      child_specific_issue_abroad: Moving location
-      child_return: Return them to your care
-      child_abduction: Stop the other parent abducting them
-      child_flight: Stop the other parent taking them abroad or moving location without your permission
-      other: Another issue
-      other_details: *provide_details
+      child_arrangements_home: Decide where they live
+      child_arrangements_time: Decide how much time they spend with each person
+      child_arrangements_contact: Decide what types of contact will take place and when
+      child_arrangements_event: Decide on a specific holiday or arrangement
+      child_arrangements_access: Make the other person grant you access to them
+      prohibited_steps_moving: Moving them to a different area
+      prohibited_steps_moving_abroad: Moving abroad
+      prohibited_steps_moving_abduction: Abducting them
+      prohibited_steps_moving_names: Changing their names
+      prohibited_steps_moving_medical: Having medical treatment carried out on them
+      prohibited_steps_moving_holiday: Taking them on holiday
+      specific_issues_return: Make the other person return them to your care
+      specific_issues_school: What school they go to
+      specific_issues_religion: A religious issue
+      specific_issues_names: Changing their names
+      specific_issues_medical: Medical treatment
+      specific_issues_moving: Moving them to a different area
+      specific_issues_moving_abroad: Moving abroad
+      other_issue: Deal with another issue not listed
 
     # Note: this is duplicated in `locales/summary/en.yml`, due to the way locales work
     # (they don't see each other when they are in different files). If you change copy here,
@@ -978,6 +983,8 @@ en:
         exemptions_group_html: ""
       steps_petition_orders_form:
         orders_html: ""
+        orders_prohibited_steps_html: ""
+        orders_specific_issues_html: ""
       steps_safety_questions_address_confidentiality_form:
         address_confidentiality_html: "Do you want to keep your contact details private from the other person?"
       steps_safety_questions_risk_of_abduction_form:
@@ -1132,9 +1139,40 @@ en:
         miam_certification_service_name: Family mediation service name
         miam_certification_sole_trader_name: Sole trader name
       steps_petition_orders_form:
-        <<: *PETITION_ORDERS
-        child_contact: Confirm when and what other types of contact will take place with them (for example, phone calls)
-        child_specific_issue_abroad: Moving location (including moving abroad)
+        child_arrangements_home_html: Decide where they live
+        child_arrangements_time_html: Decide how much time they spend with each person
+        child_arrangements_contact_html: |
+          <span class="gv-u-heading-small">Decide what types of contact will take place and when</span><br>
+          <span class="form-hint">For example, phone calls</span>
+        child_arrangements_event_html: |
+          <span class="gv-u-heading-small">Decide on a specific holiday or arrangement</span><br>
+          <span class="form-hint">For example, you’re in dispute over a one-off event</span>
+        child_arrangements_access_html: |
+          <span class="gv-u-heading-small">Make the other person grant you access to them</span><br>
+          <span class="form-hint">If you’re currently not being allowed to see your children</span>
+        group_prohibited_steps_html: |
+          <span class="gv-u-heading-small">Stop the other person doing something</span><br>
+          <span class="form-hint">For example, moving abroad or abducting your children</span>
+        prohibited_steps_moving_html: Moving them to a different area
+        prohibited_steps_moving_abroad_html: Moving abroad
+        prohibited_steps_moving_abduction_html: Abducting them
+        prohibited_steps_moving_names_html: Changing their names
+        prohibited_steps_moving_medical_html: Having medical treatment carried out on them
+        prohibited_steps_moving_holiday_html: Taking them on holiday
+        group_specific_issues_html: |
+          <span class="gv-u-heading-small">Resolve any other dispute</span><br>
+          <span class="form-hint">For example, what school they’ll go to</span>
+        specific_issues_return_html: |
+          <span class="gv-u-heading-small">Make the other person return them to your care</span><br>
+          <span class="form-hint">If your children have been abducted</span>
+        specific_issues_school_html: What school they go to
+        specific_issues_religion_html: A religious issue
+        specific_issues_names_html: Changing their names
+        specific_issues_medical_html: Medical treatment
+        specific_issues_moving_html: Moving them to a different area
+        specific_issues_moving_abroad_html: Moving abroad
+        other_issue_html: Deal with another issue not listed
+        orders_additional_details: Briefly provide more details
       steps_abduction_passport_details_form:
         passport_possession_mother: Mother
         passport_possession_father: Father
@@ -1267,6 +1305,10 @@ en:
         passport_possesion: Select all that apply
       steps_abduction_previous_attempt_details_form:
         previous_attempt_agency_involved: Including in the UK or abroad
+      steps_petition_orders_form:
+        orders_prohibited_steps: Select all that apply
+        orders_specific_issues: Select all that apply
+        orders_additional_details: No more than 2 sentences
       steps_applicant_personal_details_form:
         birthplace: *birthplace_hint
       steps_applicant_contact_details_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,25 +34,23 @@ en:
       other: Other
 
     PETITION_ORDERS: &PETITION_ORDERS
-      child_arrangements_home: Decide where they live
-      child_arrangements_time: Decide how much time they spend with each person
-      child_arrangements_contact: Decide what types of contact will take place and when
-      child_arrangements_event: Decide on a specific holiday or arrangement
-      child_arrangements_access: Make the other person grant you access to them
-      prohibited_steps_moving: Moving them to a different area
-      prohibited_steps_moving_abroad: Moving abroad
-      prohibited_steps_moving_abduction: Abducting them
-      prohibited_steps_moving_names: Changing their names
-      prohibited_steps_moving_medical: Having medical treatment carried out on them
-      prohibited_steps_moving_holiday: Taking them on holiday
-      specific_issues_return: Make the other person return them to your care
-      specific_issues_school: What school they go to
-      specific_issues_religion: A religious issue
-      specific_issues_names: Changing their names
-      specific_issues_medical: Medical treatment
-      specific_issues_moving: Moving them to a different area
-      specific_issues_moving_abroad: Moving abroad
-      other_issue: Deal with another issue not listed
+      child_arrangements_home_html: Decide who they live with and when
+      child_arrangements_time_html: Decide how much time they spend with each person
+      child_arrangements_contact_html: Decide how and when each person can spend time with the children
+      child_arrangements_access_html: Allow you to spend time with the children
+      prohibited_steps_moving_html: Relocating the children to a different area in England and Wales
+      prohibited_steps_moving_abroad_html: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
+      prohibited_steps_names_html: Changing their names or surname
+      prohibited_steps_medical_html: Allowing medical treatment to be carried out on them
+      prohibited_steps_holiday_html: Taking them on holiday
+      specific_issues_holiday_html: A specific holiday or arrangement
+      specific_issues_school_html: What school they’ll go to
+      specific_issues_religion_html: A religious issue
+      specific_issues_names_html: Changing their names or surname
+      specific_issues_medical_html: Medical treatment
+      specific_issues_moving_html: Relocating the children to a different area in England and Wales
+      specific_issues_moving_abroad_html: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
+      other_issue_html: Deal with another issue not listed
 
     # Note: this is duplicated in `locales/summary/en.yml`, due to the way locales work
     # (they don't see each other when they are in different files). If you change copy here,
@@ -534,17 +532,19 @@ en:
           page_title: What you are asking the court to do
           heading: What you’re asking the court to do about your children
           lead_text:
-            zero: You’d like the court to
-            one: You’d also like the court to
-            other: You’d also like the court to
+            zero: 'You would like the court to:'
+          lead_text_stop:
+            zero: 'You would like the court to stop the other person:'
+            one: 'You would also like the court to stop the other person:'
+            other: 'You would also like the court to stop the other person:'
           lead_text_issues:
-            zero: You’d like the court to resolve a dispute about
-            one: You’d also like the court to resolve a dispute about
-            other: You’d also like the court to resolve a dispute about
+            zero: 'You would like the court to resolve an issue about:'
+            one: 'You would also like the court to resolve an issue about:'
+            other: 'You would also like the court to resolve an issue about:'
           lead_text_other:
-            zero: "You told us that you need help with this issue:"
-            one: "You also told us that you need help with this issue:"
-            other: "You also told us that you need help with this issue:"
+            zero: "You told us that you need help with this dispute:"
+            one: "You also told us that you need help with this dispute:"
+            other: "You also told us that you need help with this dispute:"
           continue: Continue
           <<: *PETITION_ORDERS
           aka:
@@ -1139,39 +1139,20 @@ en:
         miam_certification_service_name: Family mediation service name
         miam_certification_sole_trader_name: Sole trader name
       steps_petition_orders_form:
-        child_arrangements_home_html: Decide where they live
-        child_arrangements_time_html: Decide how much time they spend with each person
+        <<: *PETITION_ORDERS
+        # We override only those that have hint text or are different to the playback here.
         child_arrangements_contact_html: |
-          <span class="gv-u-heading-small">Decide what types of contact will take place and when</span><br>
-          <span class="form-hint">For example, phone calls</span>
-        child_arrangements_event_html: |
-          <span class="gv-u-heading-small">Decide on a specific holiday or arrangement</span><br>
-          <span class="form-hint">For example, you’re in dispute over a one-off event</span>
+          <span class="gv-u-heading-small">Decide how and when each person can spend time with the children</span><br>
+          <span class="form-hint">For example, in person, or phone calls and emails</span>
         child_arrangements_access_html: |
-          <span class="gv-u-heading-small">Make the other person grant you access to them</span><br>
-          <span class="form-hint">If you’re currently not being allowed to see your children</span>
+          <span class="gv-u-heading-small">Allow you to spend time with the children</span><br>
+          <span class="form-hint">If you’re currently not being allowed to</span>
         group_prohibited_steps_html: |
           <span class="gv-u-heading-small">Stop the other person doing something</span><br>
           <span class="form-hint">For example, moving abroad or abducting your children</span>
-        prohibited_steps_moving_html: Moving them to a different area
-        prohibited_steps_moving_abroad_html: Moving abroad
-        prohibited_steps_moving_abduction_html: Abducting them
-        prohibited_steps_moving_names_html: Changing their names
-        prohibited_steps_moving_medical_html: Having medical treatment carried out on them
-        prohibited_steps_moving_holiday_html: Taking them on holiday
         group_specific_issues_html: |
-          <span class="gv-u-heading-small">Resolve any other dispute</span><br>
+          <span class="gv-u-heading-small">Resolve a specific issue</span><br>
           <span class="form-hint">For example, what school they’ll go to</span>
-        specific_issues_return_html: |
-          <span class="gv-u-heading-small">Make the other person return them to your care</span><br>
-          <span class="form-hint">If your children have been abducted</span>
-        specific_issues_school_html: What school they go to
-        specific_issues_religion_html: A religious issue
-        specific_issues_names_html: Changing their names
-        specific_issues_medical_html: Medical treatment
-        specific_issues_moving_html: Moving them to a different area
-        specific_issues_moving_abroad_html: Moving abroad
-        other_issue_html: Deal with another issue not listed
         orders_additional_details: Briefly provide more details
       steps_abduction_passport_details_form:
         passport_possession_mother: Mother
@@ -1308,7 +1289,6 @@ en:
       steps_petition_orders_form:
         orders_prohibited_steps: Select all that apply
         orders_specific_issues: Select all that apply
-        orders_additional_details: No more than 2 sentences
       steps_applicant_personal_details_form:
         birthplace: *birthplace_hint
       steps_applicant_contact_details_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
       child_arrangements_time_html: Decide how much time they spend with each person
       child_arrangements_contact_html: Decide how and when each person can spend time with the children
       child_arrangements_access_html: Allow you to spend time with the children
+      no_name_child_return_html: Return the children to your care
       prohibited_steps_moving_html: Relocating the children to a different area in England and Wales
       prohibited_steps_moving_abroad_html: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
       prohibited_steps_names_html: Changing their names or surname
@@ -545,6 +546,11 @@ en:
             zero: "You told us that you need help with this dispute:"
             one: "You also told us that you need help with this dispute:"
             other: "You also told us that you need help with this dispute:"
+          orders_with_no_name:
+            no_name_child_return:
+              zero: 'You would like the children to be returned to your care.'
+              one: 'You would also like the children to be returned to your care.'
+              other: 'You would also like the children to be returned to your care.'
           continue: Continue
           <<: *PETITION_ORDERS
           aka:
@@ -1147,6 +1153,9 @@ en:
         child_arrangements_access_html: |
           <span class="gv-u-heading-small">Allow you to spend time with the children</span><br>
           <span class="form-hint">If you’re currently not being allowed to</span>
+        no_name_child_return_html: |
+          <span class="gv-u-heading-small">Return the children to your care</span><br>
+          <span class="form-hint">If your children have been abducted, unlawfully removed or unlawfully retained</span>
         group_prohibited_steps_html: |
           <span class="gv-u-heading-small">Stop the other person doing something</span><br>
           <span class="form-hint">For example, moving abroad or abducting your children</span>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -25,21 +25,28 @@ en:
       other: Other
 
     ARRANGEMENT_ORDERS: &ARRANGEMENT_ORDERS
-      child_home: Arrange where they live
-      child_times: Arrange how much time they spend with each parent
-      child_contact: Confirm when and what other types of contact will take place with them
-      child_return: Return them to your care
-    SPECIFIC_ISSUE_ORDERS: &SPECIFIC_ISSUE_ORDERS
-      child_specific_issue_school: Which school they go to
-      child_specific_issue_religion: A religious issue
-      child_specific_issue_name: Changing their names
-      child_specific_issue_medical: Medical treatment
-      child_specific_issue_abroad: Moving location
+      child_arrangements_home: Decide where they live
+      child_arrangements_time: Decide how much time they spend with each person
+      child_arrangements_contact: Decide what types of contact will take place and when
+      child_arrangements_event: Decide on a specific holiday or arrangement
+      child_arrangements_access: Make the other person grant you access to them
     PROHIBITED_STEPS_ORDERS: &PROHIBITED_STEPS_ORDERS
-      child_abduction: Stop the other parent abducting them
-      child_flight: Stop the other parent taking them abroad or moving location without your permission
+      prohibited_steps_moving: Moving them to a different area
+      prohibited_steps_moving_abroad: Moving abroad
+      prohibited_steps_moving_abduction: Abducting them
+      prohibited_steps_moving_names: Changing their names
+      prohibited_steps_moving_medical: Having medical treatment carried out on them
+      prohibited_steps_moving_holiday: Taking them on holiday
+    SPECIFIC_ISSUE_ORDERS: &SPECIFIC_ISSUE_ORDERS
+      specific_issues_return: Make the other person return them to your care
+      specific_issues_school: What school they go to
+      specific_issues_religion: A religious issue
+      specific_issues_names: Changing their names
+      specific_issues_medical: Medical treatment
+      specific_issues_moving: Moving them to a different area
+      specific_issues_moving_abroad: Moving abroad
     OTHER_ORDER: &OTHER_ORDER
-      other: Other
+      other_issue: Deal with another issue not listed
 
     # Note: this is duplicated in `locales/en.yml`, due to the way locales work
     # (they don't see each other when they are in different files). If you change copy here,

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -43,6 +43,8 @@ en:
       specific_issues_medical: Medical treatment
       specific_issues_moving: Relocating the children to a different area in England and Wales
       specific_issues_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
+    ORDERS_WITH_NO_NAME: &ORDERS_WITH_NO_NAME
+      no_name_child_return: Return the children to your care
     OTHER_ORDER: &OTHER_ORDER
       other_issue: Deal with another issue not listed
 
@@ -164,8 +166,12 @@ en:
       question: 'Prohibited steps order(s):'
       answers:
         <<: *PROHIBITED_STEPS_ORDERS
-    other_details:
-      question: 'Other:'
+    orders_with_no_name:
+      question: ""
+      answers:
+        <<: *ORDERS_WITH_NO_NAME
+    other_issue_details:
+      question: 'Other issue:'
     domestic_abuse:
       question: Any form of domestic abuse?
       answers:
@@ -254,6 +260,7 @@ en:
         <<: *ARRANGEMENT_ORDERS
         <<: *SPECIFIC_ISSUE_ORDERS
         <<: *PROHIBITED_STEPS_ORDERS
+        <<: *ORDERS_WITH_NO_NAME
         <<: *OTHER_ORDER
     children_known_to_authorities:
       question: Are any of the children known to the local authority children’s services?

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -25,26 +25,24 @@ en:
       other: Other
 
     ARRANGEMENT_ORDERS: &ARRANGEMENT_ORDERS
-      child_arrangements_home: Decide where they live
+      child_arrangements_home: Decide who they live with and when
       child_arrangements_time: Decide how much time they spend with each person
-      child_arrangements_contact: Decide what types of contact will take place and when
-      child_arrangements_event: Decide on a specific holiday or arrangement
-      child_arrangements_access: Make the other person grant you access to them
+      child_arrangements_contact: Decide how and when each person can spend time with the children
+      child_arrangements_access: Allow you to spend time with the children
     PROHIBITED_STEPS_ORDERS: &PROHIBITED_STEPS_ORDERS
-      prohibited_steps_moving: Moving them to a different area
-      prohibited_steps_moving_abroad: Moving abroad
-      prohibited_steps_moving_abduction: Abducting them
-      prohibited_steps_moving_names: Changing their names
-      prohibited_steps_moving_medical: Having medical treatment carried out on them
-      prohibited_steps_moving_holiday: Taking them on holiday
+      prohibited_steps_moving: Relocating the children to a different area in England and Wales
+      prohibited_steps_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
+      prohibited_steps_names: Changing their names or surname
+      prohibited_steps_medical: Allowing medical treatment to be carried out on them
+      prohibited_steps_holiday: Taking them on holiday
     SPECIFIC_ISSUE_ORDERS: &SPECIFIC_ISSUE_ORDERS
-      specific_issues_return: Make the other person return them to your care
-      specific_issues_school: What school they go to
+      specific_issues_holiday: A specific holiday or arrangement
+      specific_issues_school: What school they’ll go to
       specific_issues_religion: A religious issue
-      specific_issues_names: Changing their names
+      specific_issues_names: Changing their names or surname
       specific_issues_medical: Medical treatment
-      specific_issues_moving: Moving them to a different area
-      specific_issues_moving_abroad: Moving abroad
+      specific_issues_moving: Relocating the children to a different area in England and Wales
+      specific_issues_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
     OTHER_ORDER: &OTHER_ORDER
       other_issue: Deal with another issue not listed
 

--- a/db/migrate/20180227130146_add_orders_fields.rb
+++ b/db/migrate/20180227130146_add_orders_fields.rb
@@ -1,0 +1,6 @@
+class AddOrdersFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :c100_applications, :orders, :string, array: true, default: []
+    add_column :c100_applications, :orders_additional_details, :text
+  end
+end

--- a/db/migrate/20180228111024_drop_asking_orders_table.rb
+++ b/db/migrate/20180228111024_drop_asking_orders_table.rb
@@ -1,0 +1,10 @@
+class DropAskingOrdersTable < ActiveRecord::Migration[5.1]
+  #
+  # Note: this is a one-way migration, so no rollback is provided.
+  # This is safe as we are in the development phase yet and the service is
+  # yet to be deployed, so we don't have existing data to care about, etc.
+  #
+  def up
+    drop_table :asking_orders
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180226132148) do
+ActiveRecord::Schema.define(version: 20180227130146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,8 @@ ActiveRecord::Schema.define(version: 20180226132148) do
     t.string "miam_certification_service_name"
     t.string "miam_certification_sole_trader_name"
     t.string "miam_exemption_claim"
+    t.string "orders", default: [], array: true
+    t.text "orders_additional_details"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227130146) do
+ActiveRecord::Schema.define(version: 20180228111024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,28 +50,6 @@ ActiveRecord::Schema.define(version: 20180227130146) do
     t.text "help_description"
     t.uuid "c100_application_id"
     t.index ["c100_application_id"], name: "index_abuse_concerns_on_c100_application_id"
-  end
-
-  create_table "asking_orders", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.boolean "child_home"
-    t.boolean "child_times"
-    t.boolean "child_contact"
-    t.boolean "child_specific_issue"
-    t.boolean "child_specific_issue_school"
-    t.boolean "child_specific_issue_religion"
-    t.boolean "child_specific_issue_name"
-    t.boolean "child_specific_issue_medical"
-    t.boolean "child_specific_issue_abroad"
-    t.boolean "child_return"
-    t.boolean "child_abduction"
-    t.boolean "child_flight"
-    t.boolean "other"
-    t.text "other_details"
-    t.boolean "child_arrangements_order"
-    t.boolean "prohibited_steps_order"
-    t.boolean "specific_issue_order"
-    t.uuid "c100_application_id"
-    t.index ["c100_application_id"], name: "index_asking_orders_on_c100_application_id"
   end
 
   create_table "c100_applications", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -284,7 +262,6 @@ ActiveRecord::Schema.define(version: 20180227130146) do
 
   add_foreign_key "abduction_details", "c100_applications"
   add_foreign_key "abuse_concerns", "c100_applications"
-  add_foreign_key "asking_orders", "c100_applications"
   add_foreign_key "c100_applications", "users"
   add_foreign_key "child_orders", "people", column: "child_id"
   add_foreign_key "child_residences", "people", column: "child_id"

--- a/spec/controllers/steps/petition/playback_controller_spec.rb
+++ b/spec/controllers/steps/petition/playback_controller_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe Steps::Petition::PlaybackController, type: :controller do
   it_behaves_like 'a show step controller'
 
   describe '#show' do
-    let(:c100_application) { instance_double(C100Application, asking_order: asking_order) }
-    let(:asking_order) { double('asking_order').as_null_object }
+    let(:c100_application) { instance_double(C100Application) }
 
     before do
       allow(controller).to receive(:current_c100_application).and_return(c100_application)
@@ -13,7 +12,7 @@ RSpec.describe Steps::Petition::PlaybackController, type: :controller do
     end
 
     it 'assigns the presenter' do
-      expect(PetitionPresenter).to receive(:new).with(asking_order).and_call_original
+      expect(PetitionPresenter).to receive(:new).with(c100_application).and_call_original
 
       get :show
 

--- a/spec/forms/steps/children/orders_form_spec.rb
+++ b/spec/forms/steps/children/orders_form_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Steps::Children::OrdersForm do
     child_arrangements_home: '1',
     specific_issues_school: '0',
     specific_issues_medical: '1',
-    prohibited_steps_moving_abduction: '0',
   } }
 
   let(:c100_application) { instance_double(C100Application) }

--- a/spec/forms/steps/children/orders_form_spec.rb
+++ b/spec/forms/steps/children/orders_form_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Steps::Children::OrdersForm do
   let(:arguments) { {
     c100_application: c100_application,
     record: child,
-    child_home: '1',
-    child_specific_issue_school: '0',
-    child_specific_issue_medical: '1',
-    child_abduction: '0'
+    child_arrangements_home: '1',
+    specific_issues_school: '0',
+    specific_issues_medical: '1',
+    prohibited_steps_moving_abduction: '0',
   } }
 
   let(:c100_application) { instance_double(C100Application) }
@@ -17,14 +17,14 @@ RSpec.describe Steps::Children::OrdersForm do
   subject { described_class.new(arguments) }
 
   describe 'custom getters override' do
-    let(:child_order) { double('child_order', orders: ['child_home']) }
+    let(:child_order) { double('child_order', orders: ['child_arrangements_home']) }
 
-    it 'returns true if the exemption is in the list' do
-      expect(subject.child_home).to eq(true)
+    it 'returns true if the order is in the list' do
+      expect(subject.child_arrangements_home).to eq(true)
     end
 
-    it 'returns false if the exemption is not in the list' do
-      expect(subject.child_specific_issue_school).to eq(false)
+    it 'returns false if the order is not in the list' do
+      expect(subject.specific_issues_school).to eq(false)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe Steps::Children::OrdersForm do
     end
 
     context 'for valid details' do
-      let(:expected_attributes) { { orders: [:child_home, :child_specific_issue_medical] } }
+      let(:expected_attributes) { { orders: [:child_arrangements_home, :specific_issues_medical] } }
 
       context 'when child_order does not exist' do
         let(:child_order) { nil }

--- a/spec/forms/steps/petition/orders_form_spec.rb
+++ b/spec/forms/steps/petition/orders_form_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Steps::Petition::OrdersForm do
     child_arrangements_home: '1',
     specific_issues_school: '0',
     specific_issues_medical: '1',
-    prohibited_steps_moving_abduction: '0',
     orders_additional_details: orders_additional_details,
   } }
 

--- a/spec/presenters/petition_presenter_spec.rb
+++ b/spec/presenters/petition_presenter_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe PetitionPresenter do
         child_arrangements_home
         child_arrangements_time
         child_arrangements_contact
-        child_arrangements_event
         child_arrangements_access
       ))
     end
@@ -27,10 +26,9 @@ RSpec.describe PetitionPresenter do
       expect(subject.prohibited_steps_orders).to eq(%w(
         prohibited_steps_moving
         prohibited_steps_moving_abroad
-        prohibited_steps_moving_abduction
-        prohibited_steps_moving_names
-        prohibited_steps_moving_medical
-        prohibited_steps_moving_holiday
+        prohibited_steps_names
+        prohibited_steps_medical
+        prohibited_steps_holiday
       ))
     end
   end
@@ -38,7 +36,7 @@ RSpec.describe PetitionPresenter do
   describe '#specific_issues_orders' do
     it 'only returns the orders set to true' do
       expect(subject.specific_issues_orders).to eq(%w(
-        specific_issues_return
+        specific_issues_holiday
         specific_issues_school
         specific_issues_religion
         specific_issues_names
@@ -55,15 +53,13 @@ RSpec.describe PetitionPresenter do
         child_arrangements_home
         child_arrangements_time
         child_arrangements_contact
-        child_arrangements_event
         child_arrangements_access
         prohibited_steps_moving
         prohibited_steps_moving_abroad
-        prohibited_steps_moving_abduction
-        prohibited_steps_moving_names
-        prohibited_steps_moving_medical
-        prohibited_steps_moving_holiday
-        specific_issues_return
+        prohibited_steps_names
+        prohibited_steps_medical
+        prohibited_steps_holiday
+        specific_issues_holiday
         specific_issues_school
         specific_issues_religion
         specific_issues_names

--- a/spec/presenters/petition_presenter_spec.rb
+++ b/spec/presenters/petition_presenter_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe PetitionPresenter do
     end
   end
 
+  describe '#orders_with_no_name' do
+    it 'only returns the orders set to true' do
+      expect(subject.orders_with_no_name).to eq(%w(
+        no_name_child_return
+      ))
+    end
+  end
+
   describe '#all_selected_orders' do
     it 'only returns the orders set to true' do
       expect(subject.all_selected_orders).to eq(%w(
@@ -66,6 +74,7 @@ RSpec.describe PetitionPresenter do
         specific_issues_medical
         specific_issues_moving
         specific_issues_moving_abroad
+        no_name_child_return
         other_issue
       ))
     end
@@ -106,6 +115,22 @@ RSpec.describe PetitionPresenter do
 
       it { expect(subject.other_issue?).to eq(false) }
       it { expect(subject.other_issue_details).to eq(nil) }
+    end
+  end
+
+  describe '#count_for' do
+    context 'for a single group' do
+      let(:orders) { ['child_arrangements_home'] }
+      let(:count)  { subject.count_for(:child_arrangements_orders) }
+
+      it { expect(count).to eq(1) }
+    end
+
+    context 'for multiple groups' do
+      let(:orders) {%w(child_arrangements_home specific_issues_religion)}
+      let(:count)  { subject.count_for(:child_arrangements_orders, :specific_issues_orders) }
+
+      it { expect(count).to eq(2) }
     end
   end
 end

--- a/spec/presenters/summary/sections/nature_of_application_spec.rb
+++ b/spec/presenters/summary/sections/nature_of_application_spec.rb
@@ -2,10 +2,14 @@ require 'spec_helper'
 
 module Summary
   describe Sections::NatureOfApplication do
-    let(:c100_application) { instance_double(C100Application, asking_order: asking_order) }
+    let(:c100_application) {
+      instance_double(
+        C100Application,
+        orders: %w(child_arrangements_home prohibited_steps_moving specific_issues_school other_issue),
+        orders_additional_details: 'details'
+      )
+    }
     subject { described_class.new(c100_application) }
-
-    let(:asking_order) { double('asking_order').as_null_object }
 
     let(:answers) { subject.answers }
 
@@ -16,10 +20,6 @@ module Summary
     end
 
     describe '#answers' do
-      before do
-        allow(asking_order).to receive(:other_details).and_return('description')
-      end
-
       it 'has the correct number of rows' do
         expect(answers.count).to eq(4)
       end

--- a/spec/presenters/summary/sections/nature_of_application_spec.rb
+++ b/spec/presenters/summary/sections/nature_of_application_spec.rb
@@ -5,7 +5,13 @@ module Summary
     let(:c100_application) {
       instance_double(
         C100Application,
-        orders: %w(child_arrangements_home prohibited_steps_moving specific_issues_school other_issue),
+        orders: %w(
+          child_arrangements_home
+          prohibited_steps_moving
+          specific_issues_school
+          no_name_child_return
+          other_issue
+        ),
         orders_additional_details: 'details'
       )
     }
@@ -21,21 +27,24 @@ module Summary
 
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(5)
       end
 
       it 'has the correct rows in the right order' do
         expect(answers[0]).to be_an_instance_of(MultiAnswer)
-        expect(answers[0].question).to eq(:child_arrangements_orders)
+        expect(answers[0].question).to eq(:orders_with_no_name)
 
         expect(answers[1]).to be_an_instance_of(MultiAnswer)
-        expect(answers[1].question).to eq(:specific_issues_orders)
+        expect(answers[1].question).to eq(:child_arrangements_orders)
 
         expect(answers[2]).to be_an_instance_of(MultiAnswer)
         expect(answers[2].question).to eq(:prohibited_steps_orders)
 
-        expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[3].question).to eq(:other_details)
+        expect(answers[3]).to be_an_instance_of(MultiAnswer)
+        expect(answers[3].question).to eq(:specific_issues_orders)
+
+        expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[4].question).to eq(:other_issue_details)
       end
     end
   end

--- a/spec/value_objects/petition_order_spec.rb
+++ b/spec/value_objects/petition_order_spec.rb
@@ -7,18 +7,27 @@ RSpec.describe PetitionOrder do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(%w(
-        child_home
-        child_times
-        child_contact
-        child_return
-        child_abduction
-        child_flight
-        child_specific_issue_school
-        child_specific_issue_religion
-        child_specific_issue_name
-        child_specific_issue_medical
-        child_specific_issue_abroad
-        other
+        child_arrangements_home
+        child_arrangements_time
+        child_arrangements_contact
+        child_arrangements_event
+        child_arrangements_access
+        group_prohibited_steps
+        prohibited_steps_moving
+        prohibited_steps_moving_abroad
+        prohibited_steps_moving_abduction
+        prohibited_steps_moving_names
+        prohibited_steps_moving_medical
+        prohibited_steps_moving_holiday
+        group_specific_issues
+        specific_issues_return
+        specific_issues_school
+        specific_issues_religion
+        specific_issues_names
+        specific_issues_medical
+        specific_issues_moving
+        specific_issues_moving_abroad
+        other_issue
       ))
     end
   end
@@ -26,22 +35,11 @@ RSpec.describe PetitionOrder do
   describe 'CHILD_ARRANGEMENTS' do
     it 'returns the expected values' do
       expect(described_class::CHILD_ARRANGEMENTS.map(&:to_s)).to eq(%w(
-        child_home
-        child_times
-        child_contact
-        child_return
-      ))
-    end
-  end
-
-  describe 'SPECIFIC_ISSUES' do
-    it 'returns the expected values' do
-      expect(described_class::SPECIFIC_ISSUES.map(&:to_s)).to eq(%w(
-        child_specific_issue_school
-        child_specific_issue_religion
-        child_specific_issue_name
-        child_specific_issue_medical
-        child_specific_issue_abroad
+        child_arrangements_home
+        child_arrangements_time
+        child_arrangements_contact
+        child_arrangements_event
+        child_arrangements_access
       ))
     end
   end
@@ -49,17 +47,33 @@ RSpec.describe PetitionOrder do
   describe 'PROHIBITED_STEPS' do
     it 'returns the expected values' do
       expect(described_class::PROHIBITED_STEPS.map(&:to_s)).to eq(%w(
-        child_abduction
-        child_flight
+        prohibited_steps_moving
+        prohibited_steps_moving_abroad
+        prohibited_steps_moving_abduction
+        prohibited_steps_moving_names
+        prohibited_steps_moving_medical
+        prohibited_steps_moving_holiday
       ))
     end
   end
 
-  describe 'OTHER' do
+  describe 'SPECIFIC_ISSUES' do
     it 'returns the expected values' do
-      expect(described_class::OTHER.map(&:to_s)).to eq(%w(
-        other
+      expect(described_class::SPECIFIC_ISSUES.map(&:to_s)).to eq(%w(
+        specific_issues_return
+        specific_issues_school
+        specific_issues_religion
+        specific_issues_names
+        specific_issues_medical
+        specific_issues_moving
+        specific_issues_moving_abroad
       ))
+    end
+  end
+
+  describe 'OTHER_ISSUE' do
+    it 'returns the expected values' do
+      expect(described_class::OTHER_ISSUE.to_s).to eq('other_issue')
     end
   end
 end

--- a/spec/value_objects/petition_order_spec.rb
+++ b/spec/value_objects/petition_order_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe PetitionOrder do
         specific_issues_medical
         specific_issues_moving
         specific_issues_moving_abroad
+        no_name_child_return
         other_issue
       ))
     end
@@ -63,6 +64,14 @@ RSpec.describe PetitionOrder do
         specific_issues_medical
         specific_issues_moving
         specific_issues_moving_abroad
+      ))
+    end
+  end
+
+  describe 'ORDERS_WITH_NO_NAME' do
+    it 'returns the expected values' do
+      expect(described_class::ORDERS_WITH_NO_NAME.map(&:to_s)).to eq(%w(
+        no_name_child_return
       ))
     end
   end

--- a/spec/value_objects/petition_order_spec.rb
+++ b/spec/value_objects/petition_order_spec.rb
@@ -10,17 +10,15 @@ RSpec.describe PetitionOrder do
         child_arrangements_home
         child_arrangements_time
         child_arrangements_contact
-        child_arrangements_event
         child_arrangements_access
         group_prohibited_steps
         prohibited_steps_moving
         prohibited_steps_moving_abroad
-        prohibited_steps_moving_abduction
-        prohibited_steps_moving_names
-        prohibited_steps_moving_medical
-        prohibited_steps_moving_holiday
+        prohibited_steps_names
+        prohibited_steps_medical
+        prohibited_steps_holiday
         group_specific_issues
-        specific_issues_return
+        specific_issues_holiday
         specific_issues_school
         specific_issues_religion
         specific_issues_names
@@ -38,7 +36,6 @@ RSpec.describe PetitionOrder do
         child_arrangements_home
         child_arrangements_time
         child_arrangements_contact
-        child_arrangements_event
         child_arrangements_access
       ))
     end
@@ -49,10 +46,9 @@ RSpec.describe PetitionOrder do
       expect(described_class::PROHIBITED_STEPS.map(&:to_s)).to eq(%w(
         prohibited_steps_moving
         prohibited_steps_moving_abroad
-        prohibited_steps_moving_abduction
-        prohibited_steps_moving_names
-        prohibited_steps_moving_medical
-        prohibited_steps_moving_holiday
+        prohibited_steps_names
+        prohibited_steps_medical
+        prohibited_steps_holiday
       ))
     end
   end
@@ -60,7 +56,7 @@ RSpec.describe PetitionOrder do
   describe 'SPECIFIC_ISSUES' do
     it 'returns the expected values' do
       expect(described_class::SPECIFIC_ISSUES.map(&:to_s)).to eq(%w(
-        specific_issues_return
+        specific_issues_holiday
         specific_issues_school
         specific_issues_religion
         specific_issues_names


### PR DESCRIPTION
This follows the same mechanism as the MIAM exemptions, so we don’t
need to create dozens of DB fields, just we use a value-object to hold
the different values and can be grouped and extended/modified more
easily.

Lots of copy changes.

<img width="342" alt="screen shot 2018-03-01 at 10 15 25" src="https://user-images.githubusercontent.com/687910/36839278-8aa60fe8-1d39-11e8-985e-d7080b068d63.png">
