### PR TITLE
Add HMCTS instructions sentence

### DIFF
--- a/app/presenters/summary/sections/mediator_certification.rb
+++ b/app/presenters/summary/sections/mediator_certification.rb
@@ -10,12 +10,16 @@ module Summary
       end
 
       def answers
+        return [
+          Separator.not_applicable
+        ] unless c100.miam_certification.eql?(GenericYesNo::YES.to_s)
+
         [
-          Answer.new(:miam_certification_details, c100.miam_certification, default: GenericYesNo::NO),
           FreeTextAnswer.new(:miam_certification_number, c100.miam_certification_number),
           FreeTextAnswer.new(:miam_certification_service_name, c100.miam_certification_service_name),
           FreeTextAnswer.new(:miam_certification_sole_trader_name, c100.miam_certification_sole_trader_name),
           DateAnswer.new(:miam_certification_date, c100.miam_certification_date),
+          Separator.new(:hmcts_instructions),
         ].select(&:show?)
       end
     end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -144,6 +144,7 @@ en:
       applicants_details_index_title: Applicant %{index}
       respondents_details_index_title: Respondent %{index}
       other_parties_details_index_title: Person %{index}
+      hmcts_instructions: Certificate to be provided at first court hearing
       ### C8 ###
       c8_applicants_details_index_title: Applicant %{index}
       c8_other_parties_details_index_title: Person %{index}
@@ -300,11 +301,6 @@ en:
       question: Have you attended a MIAM?
       answers:
         <<: *YESNO
-    miam_certification_details:
-      question: 'Details:'
-      answers:
-        'yes': ''
-        'no': *not_applicable
     miam_certification_number:
       question: FMC registration no
     miam_certification_service_name:

--- a/spec/presenters/summary/sections/mediator_certification_spec.rb
+++ b/spec/presenters/summary/sections/mediator_certification_spec.rb
@@ -33,40 +33,34 @@ module Summary
       it 'has the correct rows' do
         expect(answers.count).to eq(5)
 
-        expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:miam_certification_details)
-        expect(c100_application).to have_received(:miam_certification)
-
-        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[1].question).to eq(:miam_certification_number)
+        expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[0].question).to eq(:miam_certification_number)
         expect(c100_application).to have_received(:miam_certification_number)
 
-        expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[2].question).to eq(:miam_certification_service_name)
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:miam_certification_service_name)
         expect(c100_application).to have_received(:miam_certification_service_name)
 
-        expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[3].question).to eq(:miam_certification_sole_trader_name)
+        expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[2].question).to eq(:miam_certification_sole_trader_name)
         expect(c100_application).to have_received(:miam_certification_sole_trader_name)
 
-        expect(answers[4]).to be_an_instance_of(DateAnswer)
-        expect(answers[4].question).to eq(:miam_certification_date)
+        expect(answers[3]).to be_an_instance_of(DateAnswer)
+        expect(answers[3].question).to eq(:miam_certification_date)
         expect(c100_application).to have_received(:miam_certification_date)
+
+        expect(answers[4]).to be_an_instance_of(Separator)
+        expect(answers[4].title).to eq(:hmcts_instructions)
       end
 
       context 'when no certification received' do
-        let(:miam_certification) { nil }
-        let(:miam_certification_number) { nil }
-        let(:miam_certification_service_name) { nil }
-        let(:miam_certification_sole_trader_name) { nil }
-        let(:miam_certification_date) { nil }
+        let(:miam_certification) { 'no' }
 
         it 'has the correct rows' do
           expect(answers.count).to eq(1)
 
-          expect(answers[0]).to be_an_instance_of(Answer)
-          expect(answers[0].question).to eq(:miam_certification_details)
-          expect(answers[0].value).to eq(GenericYesNo::NO)
+          expect(answers[0]).to be_an_instance_of(Separator)
+          expect(answers[0].title).to eq(:not_applicable)
         end
       end
     end


### PR DESCRIPTION
Just a static sentence, if there is certification details. If no
certification we return `non applicable`.

<img width="903" alt="screen shot 2018-03-01 at 10 50 24" src="https://user-images.githubusercontent.com/687910/36840852-62514af8-1d3e-11e8-84ad-3822b88ab417.png">
