### PR TITLE
Implement Save & Return basics

### DIFF
--- a/app/controllers/users/drafts_controller.rb
+++ b/app/controllers/users/drafts_controller.rb
@@ -1,0 +1,9 @@
+module Users
+  class DraftsController < ApplicationController
+    before_action :authenticate_user!
+
+    def index
+      @drafts = []
+    end
+  end
+end

--- a/app/controllers/users/logins_controller.rb
+++ b/app/controllers/users/logins_controller.rb
@@ -10,7 +10,7 @@ module Users
 
     def sign_in(_resource_name, user)
       super
-      save_for_later = TaxTribs::SaveCaseForLater.new(current_c100_application, user)
+      save_for_later = C100App::SaveApplicationForLater.new(current_c100_application, user)
       save_for_later.save
       session[:confirmation_email_address] = user.email if save_for_later.email_sent?
     end
@@ -18,7 +18,7 @@ module Users
     # Devise will try to return to a previously login-protected page if available,
     # otherwise this is the fallback route to redirect the user after login
     def signed_in_root_path(_)
-      current_c100_application ? users_login_save_confirmation_path : users_cases_path
+      current_c100_application ? users_login_save_confirmation_path : users_drafts_path
     end
 
     def after_sign_out_path_for(_)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class RegistrationsController < Devise::RegistrationsController
-    # We are allowing to create new accounts only as part of saving a case in progress
+    # We are allowing to create new accounts only as part of saving an application in progress
     before_action :check_c100_application_presence, only: [:new, :create, :save_confirmation]
 
     # Using an after filter so we maintain the session for analytics purposes when rendering the view
@@ -16,7 +16,7 @@ module Users
 
     # We want, on purpose, to not sign in the user after registration, so not calling `super` here.
     def sign_up(_resource_name, user)
-      TaxTribs::SaveCaseForLater.new(current_c100_application, user).save
+      C100App::SaveApplicationForLater.new(current_c100_application, user).save
     end
 
     # Devise will not give an error when leaving blank the new password, it will just ignore the update,

--- a/app/forms/steps/screener/email_consent_form.rb
+++ b/app/forms/steps/screener/email_consent_form.rb
@@ -6,7 +6,7 @@ module Steps
 
       has_one_association   :screener_answers
       yes_no_attribute      :email_consent, reset_when_no: [:email_address]
-      attribute             :email_address, String
+      attribute             :email_address, NormalisedEmailType
       validates             :email_address, email: true, if: -> { email_consent&.yes? }
 
       private

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,37 +1,63 @@
 class NotifyMailer < GovukNotifyRails::Mailer
   rescue_from Exception, with: :log_errors
 
+  before_action do
+    @service_name = I18n.translate!(:service_name, scope: 'dictionary')
+    @template_ids = Rails.configuration.govuk_notify_templates
+  end
+
   # When logging exceptions, filter the following keys from the personalisation hash
   FILTERED = '[FILTERED]'.freeze
   PERSONALISATION_ERROR_FILTER = [
-    :recipient_name,
-    :reset_url
+    :reset_password_url
   ].freeze
 
-  # Define methods as usual, and set the template and personalisation, if needed,
-  # then just use mail() as with any other ActionMailer, with the recipient email
-
-  # Triggered automatically by Devise when the user resets its password
+  # Triggered automatically by Devise when the user resets its password.
+  # Do not change the method name unless you configure Devise with the new name.
   def reset_password_instructions(user, token, _opts = {})
-    set_template(ENV.fetch('NOTIFY_RESET_PASSWORD_TEMPLATE_ID'))
+    set_template(:reset_password)
 
     set_personalisation(
-      reset_url: edit_user_password_url(reset_password_token: token)
+      reset_password_url: edit_user_password_url(reset_password_token: token),
     )
 
     mail(to: user.email)
   end
 
-  # Triggered automatically by Devise when the user changes its password
+  # Triggered automatically by Devise when the user changes its password.
+  # Do not change the method name unless you configure Devise with the new name.
   def password_change(user, _opts = {})
-    set_template(ENV.fetch('NOTIFY_CHANGE_PASSWORD_TEMPLATE_ID'))
+    set_template(:change_password)
 
-    # set_personalisation(
-    #   portfolio_url: users_cases_url
-    # )
+    set_personalisation(
+      drafts_url: users_drafts_url,
+    )
 
     mail(to: user.email)
   end
+
+  def application_saved_confirmation(c100_application)
+    set_template(:application_saved)
+
+    set_personalisation(
+      resume_draft_link: resume_users_draft_url(c100_application),
+      draft_expire_in_days: Rails.configuration.x.drafts.expire_in_days,
+    )
+
+    mail(to: c100_application.user.email)
+  end
+
+  protected
+
+  # rubocop:disable Naming/AccessorMethodName
+  def set_template(name)
+    super(@template_ids.fetch(name))
+  end
+
+  def set_personalisation(personalisation)
+    super({ service_name: @service_name }.merge(personalisation))
+  end
+  # rubocop:enable Naming/AccessorMethodName
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, :registerable, :validatable, :trackable
 
-  has_one :c100_application, dependent: :destroy
+  has_many :c100_application, dependent: :destroy
 
   attribute :email, NormalisedEmailType.new
 
@@ -13,6 +13,6 @@ class User < ApplicationRecord
     # Using `#created_at` as the secondary criteria because `#last_sign_in_at`
     # does not get set until after the first time they have actually signed in.
     # This does *not* automatically happen when they create their account.
-    where(["last_sign_in_at <= :date OR (created_at <= :date AND last_sign_in_at IS NULL)", date: date]).destroy_all
+    where('last_sign_in_at <= :date OR (created_at <= :date AND last_sign_in_at IS NULL)', date: date).destroy_all
   end
 end

--- a/app/services/c100_app/save_application_for_later.rb
+++ b/app/services/c100_app/save_application_for_later.rb
@@ -1,0 +1,30 @@
+module C100App
+  class SaveApplicationForLater
+    attr_reader :c100_application, :user
+
+    def initialize(c100_application, user)
+      @c100_application = c100_application
+      @user = user
+      @email_sent = false
+    end
+
+    def save
+      c100_application.nil? || c100_application.user.present? || claim_ownership!
+    end
+
+    def email_sent?
+      @email_sent
+    end
+
+    private
+
+    def claim_ownership!
+      c100_application.update(user: user) && send_confirmation_email
+    end
+
+    def send_confirmation_email
+      NotifyMailer.application_saved_confirmation(c100_application).deliver_later
+      @email_sent = true
+    end
+  end
+end

--- a/app/views/layouts/_current_user_menu.html.erb
+++ b/app/views/layouts/_current_user_menu.html.erb
@@ -1,4 +1,5 @@
 <ul id="proposition-links">
+  <li><%= link_to t('.your_drafts'), users_drafts_path %></li>
   <li><%= link_to t('.change_password'), edit_user_registration_path %></li>
   <li><%= current_user.email %></li>
   <li><%= button_to t('.logout'), destroy_user_session_path, method: :delete %></li>

--- a/app/views/users/drafts/index.html.erb
+++ b/app/views/users/drafts/index.html.erb
@@ -1,0 +1,7 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">TODO</h1>
+  </div>
+</div>

--- a/app/views/users/logins/logged_out.html.erb
+++ b/app/views/users/logins/logged_out.html.erb
@@ -6,7 +6,7 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <p class="lede"><%= t('.more_text_html', expire_in_days: Rails.configuration.x.cases.expire_in_days) %></p>
+    <p class="lede"><%= t('.more_text_html', expire_in_days: Rails.configuration.x.drafts.expire_in_days) %></p>
 
     <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.start_again'), show_survey: false} %>
 

--- a/app/views/users/logins/save_confirmation.html.erb
+++ b/app/views/users/logins/save_confirmation.html.erb
@@ -1,0 +1,11 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <%= render partial: 'users/shared/application_saved', locals: {email_address: @email_address} %>
+
+    <p><%= link_to t('.your_drafts'), users_drafts_path %></p>
+  </div>
+</div>

--- a/app/views/users/registrations/save_confirmation.html.erb
+++ b/app/views/users/registrations/save_confirmation.html.erb
@@ -1,0 +1,11 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <%= render partial: 'users/shared/application_saved', locals: {email_address: @email_address} %>
+
+    <p><%= link_to t('.sign_in'), user_session_path %></p>
+  </div>
+</div>

--- a/app/views/users/registrations/update_confirmation.html.erb
+++ b/app/views/users/registrations/update_confirmation.html.erb
@@ -1,0 +1,11 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <p><%= link_to t('.your_drafts'), users_drafts_path %></p>
+  </div>
+</div>

--- a/app/views/users/shared/_application_saved.html.erb
+++ b/app/views/users/shared/_application_saved.html.erb
@@ -1,0 +1,7 @@
+<% if email_address %>
+  <p class="lede"><%= t '.lead_text_html', email_address: email_address %></p>
+<% end %>
+
+<p><%=t('.expire_warning_html', expire_in_days: Rails.configuration.x.drafts.expire_in_days) %></p>
+
+<p><%=t '.return_info' %></p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,10 +37,15 @@ class Application < Rails::Application
   # This is the GDS-hosted homepage for our service, and the one with a `start` button
   config.gds_service_homepage_url = '/'.freeze  # TODO: replace this with the correct gov.uk URL, when we have one
 
+  # Load the templates set (refer to `config/govuk_notify_templates.yml` for details)
+  config.govuk_notify_templates = config_for(
+    :govuk_notify_templates, env: ENV.fetch('GOVUK_NOTIFY_ENV', 'integration')
+  ).symbolize_keys
+
   config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 30).to_i
   config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 
-  config.x.cases.expire_in_days = ENV.fetch('EXPIRE_AFTER', 14).to_i
+  config.x.drafts.expire_in_days = ENV.fetch('EXPIRE_AFTER', 14).to_i
   config.x.users.expire_in_days = ENV.fetch('USERS_EXPIRE_AFTER', 30).to_i
 
   config.action_mailer.default_url_options = {host: ENV.fetch('EXTERNAL_URL')}

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -1,0 +1,19 @@
+# We use 2 different GOV.UK Notify services, one for development/integration
+# purposes and another one for production. This is so we can test changes
+# to the templates in a controlled environment, before these changes make their
+# way to production (and real users can see them).
+#
+# As these are 2 separate services in GOV.UK Notify, the template IDs are also
+# different, so we declare them in this file. We use the value of the variable
+# ENV['GOVUK_NOTIFY_ENV'] if defined to know which group to load, otherwise
+# we default to 'integration' group.
+#
+integration:
+  reset_password: '73d0804a-2302-4307-a431-e4a0fd7087ec'
+  change_password: '97ea3c24-0b40-4b8e-8fc6-a54f7f1718e9'
+  application_saved: '1252b250-541c-456a-b98b-c568aef05e5f'
+
+live:
+  reset_password: 'tbc'
+  change_password: 'tbc'
+  application_saved: 'tbc'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -873,6 +873,10 @@ en:
     phase_banner:
       phase_info_email_html: |
         This is a new service. <a href="mailto:family_justice_helpdesk@digital.justice.gov.uk?subject=Feedback">Report a problem</a> and help improve it for others.
+    current_user_menu:
+      logout: Sign out
+      change_password: Change password
+      your_drafts: Your drafts
 
   generic:
     page_title: *default_service_title
@@ -894,7 +898,7 @@ en:
     invalid_session:
       heading: Sorry, you'll have to start again
       <<: *START_FINISH
-      lead_text: Your session automatically ends if you don't use the service for %{session_timeout} minutes or after you submit your case.
+      lead_text: Your session automatically ends if you don't use the service for %{session_timeout} minutes or after you complete your application.
       more_text: We do this for your security. Any unsaved details will be deleted.
       page_title: Invalid session
     unhandled:
@@ -935,6 +939,28 @@ en:
         steps/other_parties/contact_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
+
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: Please enter your email address
+              invalid: Please enter a valid email address
+              taken: You already have a draft saved with this email address. Try signing in.
+            password:
+              blank: Please enter a password
+              too_short: Your password must be at least %{count} characters
+              too_long: Your password must be no longer than %{count} characters
+            password_confirmation:
+              blank: Please enter the password again
+              too_short: Your password must be at least %{count} characters
+              too_long: Your password must be no longer than %{count} characters
+              confirmation: The password confirmation doesn't match
+            current_password:
+              blank: Please enter your current password
+              invalid: The password is not valid
 
   helpers:
     fieldset:
@@ -1366,11 +1392,13 @@ en:
       short: '%d/%m/%Y'
       long: '%e %B %Y'
   time:
-    case_expires_in:
+    draft_expires_in:
       zero: Today
       one: '%{count} day'
       other: '%{count} days'
+
   shared:
+    <<: *START_FINISH
     password_toggle:
       show_password: Show password
       hide_password: Hide password
@@ -1404,13 +1432,12 @@ en:
       destroy: No, end session
     expired:
       title: Session expired
-      heading: Your case has been cancelled
-      description: For your security, the information you’ve entered has automatically
-        been deleted.
+      heading: Your application has been cancelled
+      description: For your security, the information you’ve entered has automatically been deleted.
       restart: You can start again below.
       restart_button: Start again
-    canceled_message: Your case has been deleted. Please start again.
-    expired_message: You've been inactive for 30 minutes. Your case has been
+    canceled_message: Your application has been deleted. Please start again.
+    expired_message: You've been inactive for 30 minutes. Your application has been
       automatically deleted. Please start again.
     minute_single: minute
     second_single: second
@@ -1453,18 +1480,19 @@ en:
         page_title: Sign in
       logged_out:
         heading: You have signed out
-        lead_text: You can return to a saved case using the link sent in the email or by returning to the start of the service.
+        lead_text: You can return to a saved draft using the link sent in the email or by returning to the start of the service.
+        more_text_html: A draft expires %{expire_in_days} days after it was created or when you complete the application.
         page_title: Signed out
       save_confirmation:
-        heading: Your case has been saved
-        your_cases: Go to your saved cases
-        page_title: Case saved
+        heading: Your application has been saved
+        your_drafts: Go to your saved drafts
+        page_title: Application draft saved
     registrations:
       new:
         heading: Save your application
         existing_account: Sign into an existing account
         account_warning_html: |
-          <p>Choose an email address and password so you can sign in and complete your case later.</p>
+          <p>Choose an email address and password so you can sign in and complete your application later.</p>
         email_confirmation: "An email will be sent to:"
         page_title: Sign up
       save_confirmation:
@@ -1475,9 +1503,9 @@ en:
         heading: Change your password
         page_title: Update password
       update_confirmation:
-        heading: "Your password has been changed"
+        heading: Your password has been changed
         lead_text: Your password has been updated successfully.
-        your_cases: Return to your saved cases
+        your_drafts: Return to your saved drafts
         page_title: Password updated
     passwords:
       new:
@@ -1497,8 +1525,18 @@ en:
       reset_confirmation:
         heading: Your password has been changed
         lead_text: You have set a new password successfully.
-        sign_in: Sign in to see your saved cases
+        sign_in: Sign in to see your saved drafts
         page_title: Password changed
+    drafts:
+      index:
+        page_title: Draft applications
+    shared:
+      application_saved:
+        lead_text_html: A confirmation email has been sent to:<br><strong>%{email_address}</strong>
+        expire_warning_html: We will keep a draft for <strong>%{expire_in_days} days</strong> or until
+          you complete your application. Any information will be automatically deleted for your security after this time.
+        return_info: You can return to continue entering details at any time.
+
   surveys:
     feedback:
       new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   dictionary:
+    service_name: &service_name "Apply to court about child arrangements"
     default_service_title: &default_service_title "C100 Children and the Family Courts - GOV.UK"
     dont_know: &dont_know "Don't know"
     birthplace_hint: &birthplace_hint "For example, town or city"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,23 @@ Rails.application.routes.draw do
                sign_out: 'logout'
              }
 
+  namespace :users do
+    devise_scope :user do
+      get 'login/logged_out',        to: 'logins#logged_out'
+      get 'login/save_confirmation', to: 'logins#save_confirmation'
+
+      get 'password/reset_sent',         to: 'passwords#reset_sent'
+      get 'password/reset_confirmation', to: 'passwords#reset_confirmation'
+
+      get 'registration/save_confirmation',   to: 'registrations#save_confirmation'
+      get 'registration/update_confirmation', to: 'registrations#update_confirmation'
+    end
+
+    resources :drafts, only: [:index, :destroy] do
+      get :resume, on: :member
+    end
+  end
+
   namespace :steps do
     namespace :screener do
       edit_step :postcode

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -2,7 +2,7 @@
 # on classes that match. Example: `rake mutant TaxTribs::ZendeskSender`
 #
 task :mutant => :environment do
-  vars = 'NOCOVERAGE=true'
+  vars = 'RAILS_ENV=test NOCOVERAGE=true'
   flags = '--use rspec --fail-fast'
 
   unless system("#{vars} mutant #{flags} #{classes_to_mutate.join(' ')}")
@@ -40,7 +40,7 @@ end
 # Only include in this collection the models that matter and have specs.
 #
 def models
-  %w(C100Application Court).freeze
+  %w(C100Application Court User).freeze
 end
 
 # Everything inheriting from `BaseForm` and inside namespace `Steps`

--- a/spec/controllers/users/drafts_controller_spec.rb
+++ b/spec/controllers/users/drafts_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Users::DraftsController, type: :controller do
+  let(:user) { User.new }
+
+  describe '#index' do
+    context 'when user is logged out' do
+      it 'redirects to the sign-in page' do
+        get :index
+        expect(response).to redirect_to(user_session_path)
+      end
+    end
+
+    context 'when user is logged in' do
+      before do
+        sign_in(user)
+      end
+
+      it 'renders the drafts page' do
+        get :index
+        expect(assigns[:drafts]).not_to be_nil
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+end

--- a/spec/controllers/users/logins_controller_spec.rb
+++ b/spec/controllers/users/logins_controller_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe Users::LoginsController do
+  let(:c100_application) { double.as_null_object }
+
+  before do
+    allow(subject).to receive(:current_c100_application).and_return(c100_application)
+    request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  describe '#new' do
+    it 'responds with HTTP success' do
+      get :new
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#create' do
+    let(:user) { User.new(email: 'foo@bar.com') }
+
+    def do_post
+      post :create, params: { 'user' => {
+        email: 'foo@bar.com',
+        password: 'passw0rd'
+      } }
+    end
+
+    context 'when the authentication was successful' do
+      let(:c100_application) { instance_double(C100Application, user: user) }
+
+      before do
+        expect(warden).to receive(:authenticate!).and_return(user)
+      end
+
+      it 'signs the user in and redirects to the confirmation page' do
+        do_post
+        expect(response.location).to eq(users_login_save_confirmation_path)
+      end
+
+      it 'records #last_sign_in_at' do
+        expect { do_post }.to change(user, :last_sign_in_at)
+      end
+
+      context 'when the case already belongs to the user (we do not send an email)' do
+        it 'does not store the signed in email address in the session' do
+          do_post
+          expect(session[:confirmation_email_address]).to be_nil
+        end
+      end
+
+      context 'when the case is new and we are linking it to the user (we send an email)' do
+        before do
+          expect(
+            C100App::SaveApplicationForLater
+          ).to receive(:new).with(
+            c100_application, user
+          ).and_return(double(save: true, email_sent?: true))
+        end
+
+        it 'it stores the signed in email address in the session' do
+          do_post
+          expect(session[:confirmation_email_address]).to eq('foo@bar.com')
+        end
+      end
+    end
+
+    context 'when the authentication was unsuccessful' do
+      before do
+        expect(warden).to receive(:authenticate!).and_call_original
+        expect(C100App::SaveApplicationForLater).not_to receive(:new)
+      end
+
+      it 'does not sign a user in and re-renders the page' do
+        do_post
+        expect(subject).to render_template(:new)
+      end
+    end
+  end
+
+  describe '#destroy' do
+    it 'redirects to the logged out page' do
+      delete :destroy
+      expect(subject).to redirect_to(users_login_logged_out_path)
+    end
+  end
+
+  describe '#logged_out' do
+    it 'renders the expected page' do
+      get :logged_out
+      expect(response).to render_template(:logged_out)
+    end
+  end
+
+  describe '#save_confirmation' do
+    it 'renders the expected page' do
+      get :save_confirmation
+      expect(response).to render_template(:save_confirmation)
+    end
+  end
+end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Users::PasswordsController do
+  before do
+    request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  describe '#new' do
+    it 'responds with HTTP success' do
+      get :new
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#create' do
+    def do_post
+      post :create, params: {'user' => {
+        email: email
+      }}
+    end
+
+    context 'when email field is not left empty' do
+      let(:email) { 'foo@bar.com' }
+
+      it 'redirects to the confirmation path' do
+        do_post
+        expect(response).to redirect_to(users_password_reset_sent_path)
+      end
+    end
+
+    context 'when email field is left empty' do
+      let(:email) { '' }
+
+      it 're-renders the page' do
+        do_post
+        expect(subject).to render_template(:new)
+      end
+    end
+  end
+
+  describe '#update' do
+    def do_update
+      put :update, params: { 'user' => {
+        password: 'foo@bar.com',
+        password_confirmation: 'passw0rd',
+        reset_password_token: 'whatever'
+      }}
+    end
+
+    context 'when the parameters are valid' do
+      let(:user) { User.new }
+
+      before do
+        allow(User).to receive(:reset_password_by_token).and_return(user)
+      end
+
+      it 'redirects to the reset confirmation page' do
+        do_update
+        expect(response).to redirect_to(users_password_reset_confirmation_path)
+      end
+    end
+
+    context 'when the parameters are not valid' do
+      it 're-renders the page' do
+        do_update
+        expect(response).to redirect_to(new_user_password_path)
+      end
+    end
+  end
+
+  describe '#reset_sent' do
+    it 'renders the expected page' do
+      get :reset_sent
+      expect(response).to render_template(:reset_sent)
+    end
+  end
+
+  describe '#reset_sent' do
+    it 'renders the expected page' do
+      get :reset_confirmation
+      expect(response).to render_template(:reset_confirmation)
+    end
+  end
+end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -1,0 +1,165 @@
+require 'rails_helper'
+
+RSpec.describe Users::RegistrationsController do
+  let(:c100_application) { double.as_null_object }
+
+  before do
+    allow(subject).to receive(:current_c100_application).and_return(c100_application)
+    request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  describe '#new' do
+    context 'when there is no c100 application in the session' do
+      let(:c100_application) { nil }
+
+      it 'redirects to the invalid session error page' do
+        get :new
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when there is a c100 application in the session' do
+      it 'responds with HTTP success' do
+        get :new
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'when there is no c100 application in the session' do
+      let(:c100_application) { nil }
+
+      it 'redirects to the invalid session error page' do
+        post :create, params: { doesnt: 'matter' }
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when there is a c100 application in the session' do
+      def do_post
+        post :create, params: { 'user' => {
+          'email' => 'foo@bar.com',
+          'password' => 'passw0rd'
+        } }
+      end
+
+      context 'when the registration was successful' do
+        before do
+          expect(
+            C100App::SaveApplicationForLater
+          ).to receive(:new).with(
+            c100_application, an_instance_of(User)
+          ).and_return(double.as_null_object)
+        end
+
+        it 'creates the user and redirects to the confirmation page' do
+          expect { do_post }.to change{ User.count }.by(1)
+          expect(response).to redirect_to(users_registration_save_confirmation_path)
+        end
+      end
+
+      context 'when the registration was unsuccessful' do
+        before do
+          expect(C100App::SaveApplicationForLater).not_to receive(:new)
+        end
+
+        it 'does not create the user and re-renders the page' do
+          post :create, params: { 'user' => {
+            'email' => 'foo@bar.com',
+            'password' => 'short'
+          } }
+          expect(subject).to render_template(:new)
+        end
+      end
+    end
+  end
+
+  describe '#save_confirmation' do
+    context 'when there is no c100 application in the session' do
+      let(:c100_application) { nil }
+
+      it 'redirects to the invalid session error page' do
+        get :save_confirmation
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when there is a c100 application in the session' do
+      it 'renders the expected page' do
+        get :save_confirmation
+        expect(response).to render_template(:save_confirmation)
+      end
+
+      it 'resets the session after rendering the page' do
+        expect(subject).to receive(:reset_c100_application_session)
+        get :save_confirmation
+      end
+    end
+  end
+
+  describe '#update_confirmation' do
+    it 'renders the expected page' do
+      get :update_confirmation
+      expect(response).to render_template(:update_confirmation)
+    end
+  end
+
+  describe '#edit' do
+    let(:user) { User.new }
+
+    before do
+      sign_in(user)
+    end
+
+    it 'responds with HTTP success' do
+      get :edit
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#update' do
+    let(:user) { User.new }
+
+    before do
+      sign_in(user)
+      # Bypass Devise database find() so we don't need to persist the test user
+      allow(User.to_adapter).to receive(:get!).and_return(user)
+    end
+
+    def do_update
+      put :update, params: { 'user' => {
+        current_password: 'passw0rd',
+        password: new_password
+      }}
+    end
+
+    context 'when the parameters are valid' do
+      let(:new_password) { 'passw0rd' }
+
+      before do
+        expect(user).to receive(:update_with_password).with(
+          hash_including(password: 'passw0rd')
+        ).and_return(true)
+      end
+
+      it 'redirects to the update confirmation page' do
+        do_update
+        expect(response).to redirect_to(users_registration_update_confirmation_path)
+      end
+    end
+
+    context 'when the parameters are not valid' do
+      let(:new_password) { '' }
+
+      before do
+        expect(user).to receive(:update_with_password).with(hash_including(password: '*')).and_call_original
+      end
+
+      it 'renders to the update page' do
+        do_update
+        expect(subject).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/helpers/authentication_helpers_spec.rb
+++ b/spec/helpers/authentication_helpers_spec.rb
@@ -1,0 +1,6 @@
+module AuthenticationHelpers
+  def sign_in(user = double('user'))
+    allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+RSpec.describe NotifyMailer, type: :mailer do
+  let(:c100_application) {
+    C100Application.new(
+      id: '4a362e1c-48eb-40e3-9458-a31ead3f30a4',
+    )
+  }
+  let(:user) { instance_double(User, email: 'test@example.com') }
+
+  before do
+    allow(c100_application).to receive(:user).and_return(user)
+
+    allow(
+      Rails.configuration
+    ).to receive(:govuk_notify_templates).and_return(
+      reset_password: 'reset_password_template_id',
+      change_password: 'change_password_template_id',
+      application_saved: 'application_saved_template_id',
+    )
+  end
+
+  describe '#application_saved_confirmation' do
+    let(:mail) { described_class.application_saved_confirmation(c100_application) }
+
+    it_behaves_like 'a Notify mail', template_id: 'application_saved_template_id'
+
+    it { expect(mail.to).to eq(['test@example.com']) }
+
+    it 'has the right personalisation' do
+      expect(mail.govuk_notify_personalisation).to eq({
+        service_name: 'Apply to court about child arrangements',
+        resume_draft_link: 'https://c100.justice.uk/users/drafts/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume',
+        draft_expire_in_days: 14,
+      })
+    end
+  end
+
+  describe '#reset_password_instructions' do
+    let(:mail)  { described_class.reset_password_instructions(user, token) }
+    let(:token) { '0xDEADBEEF' }
+
+    it_behaves_like 'a Notify mail', template_id: 'reset_password_template_id'
+
+    it { expect(mail.to).to eq(['test@example.com']) }
+
+    it 'has the right keys' do
+      expect(mail.govuk_notify_personalisation).to eq({
+        service_name: 'Apply to court about child arrangements',
+        reset_password_url: 'https://c100.justice.uk/users/password/edit?reset_password_token=0xDEADBEEF',
+      })
+    end
+  end
+
+  describe '#password_change' do
+    let(:mail) { described_class.password_change(user) }
+
+    it_behaves_like 'a Notify mail', template_id: 'change_password_template_id'
+
+    it { expect(mail.to).to eq(['test@example.com']) }
+
+    it 'has the right keys' do
+      expect(mail.govuk_notify_personalisation).to eq({
+        service_name: 'Apply to court about child arrangements',
+        drafts_url: 'https://c100.justice.uk/users/drafts',
+      })
+    end
+  end
+
+  context 'capturing unexpected errors' do
+    let(:mail) { described_class.reset_password_instructions(nil, 'token') }
+
+    it 'should report the exception' do
+      expect(Rails.logger).to receive(:info)
+      expect(Raven).to receive(:capture_exception)
+      expect(Raven).to receive(:extra_context).with(
+        {
+          template_id: 'reset_password_template_id',
+          personalisation: {
+            service_name: 'Apply to court about child arrangements',
+            reset_password_url: '[FILTERED]',
+          }
+        }
+      )
+
+      mail.deliver_now
+    end
+  end
+
+  describe 'personalisation logging filter' do
+    it {
+      expect(
+        described_class::PERSONALISATION_ERROR_FILTER
+      ).to match_array([:reset_password_url])
+    }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe User, type: :model do
 
     it 'picks records equal to or older than the passed-in date' do
       expect(described_class).to receive(:where).with(
-        ["last_sign_in_at <= :date OR (created_at <= :date AND last_sign_in_at IS NULL)", date: 30.days.ago]
+        'last_sign_in_at <= :date OR (created_at <= :date AND last_sign_in_at IS NULL)', date: 30.days.ago
       ).and_return(user_class.as_null_object)
 
       described_class.purge!(30.days.ago)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require_relative '../spec/support/view_spec_helpers'
+require_relative '../spec/helpers/authentication_helpers_spec'
 require 'database_cleaner'
 
 ActiveRecord::Migration.maintain_test_schema!
@@ -18,8 +19,10 @@ RSpec.configure do |config|
   config.include(ActiveSupport::Testing::TimeHelpers)
 
   config.include(ViewSpecHelpers, type: :helper)
+
   config.include(Devise::Test::ControllerHelpers, type: :view)
   config.include(Devise::Test::ControllerHelpers, type: :controller)
+  config.include(AuthenticationHelpers, type: :controller)
 
   config.before(:each, type: :helper) { initialize_view_helpers(helper) }
 

--- a/spec/services/c100_app/save_application_for_later_spec.rb
+++ b/spec/services/c100_app/save_application_for_later_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe C100App::SaveApplicationForLater do
+  subject { described_class.new(c100_application, user) }
+
+  let(:user) { instance_double(User) }
+
+  describe '#save' do
+    context 'for a `nil` c100 application' do
+      let(:c100_application) { nil }
+
+      it 'returns true' do
+        expect(subject.save).to eq(true)
+      end
+
+      it 'does not send any email' do
+        expect(NotifyMailer).not_to receive(:application_saved_confirmation)
+        subject.save
+      end
+
+      it 'email_sent? is false' do
+        subject.save
+        expect(subject.email_sent?).to eq(false)
+      end
+    end
+
+    context 'for a c100 application already saved before (belongs to a user)' do
+      let(:c100_application) { instance_double(C100Application, user: user) }
+
+      it 'returns true' do
+        expect(subject.save).to eq(true)
+      end
+
+      it 'does not trigger any update in the c100 application' do
+        expect(c100_application).not_to receive(:update)
+        subject.save
+      end
+
+      it 'does not send any email' do
+        expect(NotifyMailer).not_to receive(:application_saved_confirmation)
+        subject.save
+      end
+
+      it 'email_sent? is false' do
+        subject.save
+        expect(subject.email_sent?).to eq(false)
+      end
+    end
+
+    context 'for a never saved before c100 application' do
+      let(:c100_application) { instance_double(C100Application, user: nil, update: true) }
+      let(:mailer_double) { double.as_null_object }
+
+      before do
+        allow(
+          NotifyMailer
+        ).to receive(:application_saved_confirmation).with(
+          c100_application
+        ).and_return(mailer_double)
+      end
+
+      it 'returns true' do
+        expect(subject.save).to eq(true)
+      end
+
+      it 'links the c100 application to the user' do
+        expect(c100_application).to receive(:update).with(user: user)
+        subject.save
+      end
+
+      it 'sends a confirmation email' do
+        subject.save
+        expect(mailer_double).to have_received(:deliver_later)
+      end
+
+      it 'email_sent? is true' do
+        subject.save
+        expect(subject.email_sent?).to eq(true)
+      end
+
+      context 'if the update fails' do
+        let(:c100_application) { instance_double(C100Application, user: nil, update: false) }
+
+        it 'does not send any email' do
+          expect(NotifyMailer).not_to receive(:application_saved_confirmation)
+          subject.save
+        end
+
+        it 'email_sent? is false' do
+          subject.save
+          expect(subject.email_sent?).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/notify_mailer_shared_examples.rb
+++ b/spec/support/notify_mailer_shared_examples.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'a Notify mail' do |options|
+  let(:template_id) { options.fetch(:template_id) }
+
+  it 'is a govuk_notify delivery' do
+    expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
+  end
+
+  it 'sets the template' do
+    expect(mail.govuk_notify_template).to eq(template_id)
+  end
+
+  # This is just internal, as the real subject gets set in the template at Notify website
+  it 'sets the subject' do
+    expect(mail.body).to match("This is a GOV.UK Notify email with template #{template_id}")
+  end
+end


### PR DESCRIPTION
Individual commits for more context.

Most of the code came from https://github.com/ministryofjustice/tax-tribunals-datacapture and we can use it "as it is" without any change, which is great.

Some other code will need to change to cater to the requirements of this service, but for now this PR will sets the basics.