### PR TITLE
Update service name and titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,8 +39,12 @@ module ApplicationHelper
     ENV['GA_TRACKING_ID']
   end
 
+  def service_name
+    t('service.name')
+  end
+
   def title(page_title)
-    content_for :page_title, [page_title.presence, t('generic.page_title')].compact.join(' - ')
+    content_for :page_title, [page_title.presence, service_name, 'GOV.UK'].compact.join(' - ')
   end
 
   # We send a notification to Sentry to be alerted about any missing page titles.

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -2,7 +2,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
   rescue_from Exception, with: :log_errors
 
   before_action do
-    @service_name = I18n.translate!(:service_name, scope: 'dictionary')
+    @service_name = I18n.translate!('service.name')
     @template_ids = Rails.configuration.govuk_notify_templates
   end
 

--- a/app/views/application/_step_header.html.erb
+++ b/app/views/application/_step_header.html.erb
@@ -1,1 +1,1 @@
-<%= link_to t('generic.back_link'), path, class: 'link-back' %>
+<%= link_to t('shared.back_link'), path, class: 'link-back' %>

--- a/app/views/home/cookies.en.html.erb
+++ b/app/views/home/cookies.en.html.erb
@@ -5,7 +5,7 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge">Cookies</h1>
 
     <p>
-      C100 Children and the Family Courts puts small files (known as ‘cookies’) onto your computer to collect
+      <%= service_name -%> puts small files (known as ‘cookies’) onto your computer to collect
       information about how you browse the site.
     </p>
 
@@ -16,17 +16,17 @@
       <li>measure how you use the website so it can be updated and improved based on your needs</li>
     </ul>
 
-    <p>C100 Children and the Family Courts cookies aren't used to identify you personally.</p>
+    <p><%= service_name -%> cookies aren't used to identify you personally.</p>
 
     <p>You'll normally see a message on the site before we store a cookie on your computer.</p>
 
     <p>Find out more about <a rel="external" target="_blank" href="http://www.aboutcookies.org">how to manage cookies</a>.</p>
 
-    <h2 class="heading-medium">How cookies are used on C100 Children and the Family Courts</h2>
+    <h2 class="heading-medium">How cookies are used on <%= service_name -%></h2>
 
     <p><strong>Our introductory message</strong></p>
 
-    <p>You may see a pop-up welcome message when you first visit C100 Children and the Family Courts. We'll store a cookie so that your computer knows you've seen it and knows not to show it again.</p>
+    <p>You may see a pop-up welcome message when you first visit <%= service_name -%>. We'll store a cookie so that your computer knows you've seen it and knows not to show it again.</p>
 
     <table>
       <thead>
@@ -68,15 +68,15 @@
 
     <p><strong>Measuring website usage (Google Analytics)</strong></p>
 
-    <p>We use Google Analytics software to collect information about how you use C100 Children and the Family Courts. We do this
+    <p>We use Google Analytics software to collect information about how you use <%= service_name -%>. We do this
       to help make sure the site is meeting the needs of its users and to help us make improvements, for example
       <a rel="external" target="_blank" href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/">improving site search</a>.</p>
 
     <p>Google Analytics stores information about:</p>
 
     <ul class="list list-bullet">
-      <li>the pages you visit on C100 Children and the Family Courts</li>
-      <li>how long you spend on each C100 Children and the Family Courts page </li>
+      <li>the pages you visit on <%= service_name -%></li>
+      <li>how long you spend on each <%= service_name -%> page </li>
       <li>how you got to the site  </li>
       <li>what you click on while you’re visiting the site</li>
     </ul>
@@ -101,13 +101,13 @@
       <tbody>
       <tr>
         <td>_ga</td>
-        <td>This helps us count how many people visit C100 Children and the Family Courts by tracking if you've visited before
+        <td>This helps us count how many people visit <%= service_name -%> by tracking if you've visited before
         </td>
         <td>2 years</td>
       </tr>
       <tr>
         <td>_gid</td>
-        <td>This helps us count how many people visit C100 Children and the Family Courts by tracking if you've visited before
+        <td>This helps us count how many people visit <%= service_name -%> by tracking if you've visited before
         </td>
         <td>24 hours</td>
       </tr>
@@ -133,13 +133,13 @@
       <tr>
         <td>_utma</td>
         <td>Like _ga, this lets us know if you've visited before, so we can count how many of our visitors are new to
-          C100 Children and the Family Courts or to a certain page
+          <%= service_name -%> or to a certain page
         </td>
         <td>2 years</td>
       </tr>
       <tr>
         <td>_utmb</td>
-        <td>This works with _utmc to calculate the average length of time you spend on C100 Children and the Family Courts</td>
+        <td>This works with _utmc to calculate the average length of time you spend on <%= service_name -%></td>
         <td>30 minutes</td>
       </tr>
       <tr>
@@ -149,7 +149,7 @@
       </tr>
       <tr>
         <td>_utmz</td>
-        <td>This tells us how you reached C100 Children and the Family Courts (for example from another website or a search engine)
+        <td>This tells us how you reached <%= service_name -%> (for example from another website or a search engine)
         </td>
         <td>6 months</td>
       </tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
         <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
       <% end %>
       <nav id="proposition-menu">
-        <%= link_to 'C100 Children and the Family Courts', Rails.configuration.gds_service_homepage_url, id: 'proposition-name' %>
+        <%= link_to service_name, Rails.configuration.gds_service_homepage_url, id: 'proposition-name' %>
         <%= render partial: 'layouts/current_user_menu' if user_signed_in? %>
       </nav>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,8 @@
 en:
+  service:
+    name: Apply to court about child arrangements
+
   dictionary:
-    service_name: &service_name "Apply to court about child arrangements"
-    default_service_title: &default_service_title "C100 Children and the Family Courts - GOV.UK"
     dont_know: &dont_know "Don't know"
     birthplace_hint: &birthplace_hint "For example, town or city"
     address_hint: &address_hint "Court documents will be sent here. Include the postcode if you have it"
@@ -878,10 +879,6 @@ en:
       change_password: Change password
       your_drafts: Your drafts
 
-  generic:
-    page_title: *default_service_title
-    back_link: Back
-
   errors:
     attributes:
       email_address:
@@ -1399,6 +1396,7 @@ en:
 
   shared:
     <<: *START_FINISH
+    back_link: Back
     password_toggle:
       show_password: Show password
       hide_password: Hide password

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -109,12 +109,12 @@ RSpec.describe ApplicationHelper do
 
     context 'for a blank value' do
       let(:value) { '' }
-      it { expect(title).to eq('C100 Children and the Family Courts - GOV.UK') }
+      it { expect(title).to eq('Apply to court about child arrangements - GOV.UK') }
     end
 
     context 'for a provided value' do
       let(:value) { 'Test page' }
-      it { expect(title).to eq('Test page - C100 Children and the Family Courts - GOV.UK') }
+      it { expect(title).to eq('Test page - Apply to court about child arrangements - GOV.UK') }
     end
   end
 


### PR DESCRIPTION
Sort out the mess with the service name and titles, and unify it in a
sensible way to ever touch in one place if we need to change it again.