### PR TITLE
Implement the drafts portfolio functionality

### DIFF
--- a/app/assets/stylesheets/local/tables.scss
+++ b/app/assets/stylesheets/local/tables.scss
@@ -58,7 +58,7 @@ table.check-your-answers {
   }
 }
 
-table.saved-appeals {
+table.saved-drafts {
   th {
     @include bold-16;
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,8 @@ class ApplicationController < ActionController::Base
     case exception
     when Errors::InvalidSession, ActionController::InvalidAuthenticityToken
       redirect_to invalid_session_errors_path
+    when Errors::ApplicationNotFound
+      redirect_to application_not_found_errors_path
     else
       raise if Rails.application.config.consider_all_requests_local
 

--- a/app/controllers/concerns/savepoint_step.rb
+++ b/app/controllers/concerns/savepoint_step.rb
@@ -1,0 +1,29 @@
+module SavepointStep
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :mark_in_progress, only: [:update]
+    before_action :save_application_for_later, if: :user_signed_in?, only: [:update]
+  end
+
+  private
+
+  def update_navigation_stack
+    # Reset the navigation_stack to clear the screening steps as these
+    # are no longer needed.
+    current_c100_application.navigation_stack = []
+    super
+  end
+
+  def mark_in_progress
+    # The step including this concern will mark the current application
+    # as `in progress`, meaning it has passed the screening and can be drafted.
+    current_c100_application.in_progress!
+  end
+
+  def save_application_for_later
+    C100App::SaveApplicationForLater.new(
+      current_c100_application, current_user
+    ).save
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -5,6 +5,10 @@ class ErrorsController < ApplicationController
     respond_with_status(:not_found)
   end
 
+  def application_not_found
+    respond_with_status(:not_found)
+  end
+
   def unhandled
     respond_with_status(:internal_server_error)
   end

--- a/app/controllers/steps/miam/consent_order_controller.rb
+++ b/app/controllers/steps/miam/consent_order_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   module Miam
     class ConsentOrderController < Steps::MiamStepController
+      include SavepointStep
+
       def edit
         @form_object = ConsentOrderForm.new(
           c100_application: current_c100_application,

--- a/app/controllers/users/drafts_controller.rb
+++ b/app/controllers/users/drafts_controller.rb
@@ -3,7 +3,28 @@ module Users
     before_action :authenticate_user!
 
     def index
-      @drafts = []
+      @drafts = drafts.order(created_at: :asc)
+    end
+
+    def resume
+      c100_application = draft_from_params
+      session[:c100_application_id] = c100_application.id
+      redirect_to c100_application.navigation_stack.last
+    end
+
+    def destroy
+      draft_from_params.destroy
+      redirect_to users_drafts_path
+    end
+
+    private
+
+    def drafts
+      current_user.drafts
+    end
+
+    def draft_from_params
+      drafts.find_by(id: params[:id]) || (raise Errors::ApplicationNotFound)
     end
   end
 end

--- a/app/errors/errors.rb
+++ b/app/errors/errors.rb
@@ -1,3 +1,4 @@
 module Errors
   class InvalidSession < StandardError; end
+  class ApplicationNotFound < StandardError; end
 end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -40,7 +40,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
     set_template(:application_saved)
 
     set_personalisation(
-      resume_draft_link: resume_users_draft_url(c100_application),
+      resume_draft_url: resume_users_draft_url(c100_application),
       draft_expire_in_days: Rails.configuration.x.drafts.expire_in_days,
     )
 

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -1,5 +1,13 @@
 class C100Application < ApplicationRecord
-  belongs_to :user, optional: true, dependent: :destroy
+  enum status: {
+    screening: 0,
+    in_progress: 1,
+    first_reminder_sent: 5,
+    last_reminder_sent: 6,
+    completed: 10,
+  }
+
+  belongs_to :user, optional: true
 
   has_one  :abduction_detail, dependent: :destroy
   has_one  :court_order,      dependent: :destroy
@@ -19,6 +27,9 @@ class C100Application < ApplicationRecord
 
   has_many :other_children, -> { order(created_at: :asc) }, dependent: :destroy
   has_many :other_parties,  -> { order(created_at: :asc) }, dependent: :destroy
+
+  scope :not_completed, -> { where.not(status: :completed) }
+  scope :with_owner,    -> { where.not(user: nil) }
 
   has_value_object :user_type
   has_value_object :concerns_contact_type

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, :registerable, :validatable, :trackable
 
-  has_many :c100_application, dependent: :destroy
+  has_many :c100_applications, dependent: :destroy
+  has_many :drafts, -> { not_completed }, class_name: 'C100Application'
 
   attribute :email, NormalisedEmailType.new
 

--- a/app/presenters/draft_presenter.rb
+++ b/app/presenters/draft_presenter.rb
@@ -1,0 +1,27 @@
+class DraftPresenter < SimpleDelegator
+  def expires_in
+    I18n.translate!(:draft_expires_in, scope: 'time', count: remaining_days)
+  end
+
+  def expires_in_class
+    case remaining_days
+    when 0
+      'expires-today'
+    when 1..5
+      'expires-soon'
+    else
+      ''
+    end
+  end
+
+  def applicant_name
+    applicants.first&.full_name
+  end
+
+  private
+
+  def remaining_days
+    expiration_date = created_at.days_since(Rails.configuration.x.drafts.expire_in_days).to_date
+    (Date.today...expiration_date).count
+  end
+end

--- a/app/views/errors/application_not_found.html.erb
+++ b/app/views/errors/application_not_found.html.erb
@@ -1,0 +1,14 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t '.heading' %></h1>
+
+    <p class="lede"><%=t('.lead_text', session_timeout: Rails.configuration.x.session.expires_in_minutes) %></p>
+    <p class="lede"><%=t('.more_text', expire_in_days: Rails.configuration.x.drafts.expire_in_days) %></p>
+
+    <div class="form-group">
+      <%= link_to t('.start_again'), root_path, class: 'button' %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/drafts/_draft_row.html.erb
+++ b/app/views/users/drafts/_draft_row.html.erb
@@ -1,0 +1,18 @@
+<tr class="<%= draft.expires_in_class %>">
+  <td class="timeliness">
+    <%= content_tag(:span, draft.expires_in) %>
+  </td>
+
+  <% if draft.applicant_name.present? %>
+    <td><%= draft.applicant_name %></td>
+  <% else %>
+    <td class="not-entered"><%=t '.name_not_entered' %></td>
+  <% end %>
+
+  <td class="right">
+    <span class="right actions actions-tight">
+      <%= button_to t('.delete'), users_draft_path(draft), method: :delete, data: {confirm: t('.delete_confirmation')}, class: 'button button-secondary' %>
+      <%= link_to t('.resume'), resume_users_draft_path(draft), class: 'button ga-pageLink', data: {ga_category: 'save and return', ga_label: 'resume application'} %>
+    </span>
+  </td>
+</tr>

--- a/app/views/users/drafts/index.html.erb
+++ b/app/views/users/drafts/index.html.erb
@@ -1,7 +1,0 @@
-<% title t('.page_title') %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-large">TODO</h1>
-  </div>
-</div>

--- a/app/views/users/drafts/index.html.erb
+++ b/app/views/users/drafts/index.html.erb
@@ -1,0 +1,35 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">
+      <%=t '.heading' %>
+    </h1>
+    <p class="lede"><%=t '.drafts_intro' %></p>
+  </div>
+</div>
+
+<table class="saved-drafts">
+  <caption class="visuallyhidden"><%=t '.table.caption' %></caption>
+  <thead>
+  <tr>
+    <th><%=t '.table.heading.expires_in' %></th>
+    <th><%=t '.table.heading.applicant_name' %></th>
+    <th width="25%"><span class="visuallyhidden"><%=t '.table.heading.actions' %></span>&nbsp;</th>
+  </tr>
+  </thead>
+
+  <tbody>
+    <% @drafts.present_each(DraftPresenter) do |draft| %>
+      <%= render partial: 'draft_row', locals: {draft: draft} %>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <p>
+      <%= link_to t('.new_application'), root_path %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1534,6 +1534,20 @@ en:
     drafts:
       index:
         page_title: Draft applications
+        heading: Your saved drafts
+        drafts_intro: Resume an application you haven't yet completed.
+        new_application: Start a new application
+        table:
+          caption: Table of saved drafts
+          heading:
+            expires_in: Expires in
+            applicant_name: Applicant name
+            actions: Draft actions
+      draft_row:
+        name_not_entered: Not entered yet
+        resume: Resume
+        delete: Delete
+        delete_confirmation: Are you sure you want to delete this draft?
     shared:
       application_saved:
         lead_text_html: A confirmation email has been sent to:<br><strong>%{email_address}</strong>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -904,6 +904,12 @@ en:
       lead_text: To keep this service secure, any information you have entered hasn't been saved.
       more_text: You'll need to start again.
       page_title: Unexpected error
+    application_not_found:
+      page_title: Application not found
+      heading: Sorry, this application can't be found
+      lead_text: If you copied a web address, please check it’s correct.
+      more_text: "Please note: a draft application expires %{expire_in_days} days after it was created or when you complete it."
+      <<: *START_FINISH
 
   activemodel:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,6 +220,7 @@ Rails.application.routes.draw do
 
   resource :errors, only: [] do
     get :invalid_session
+    get :application_not_found
     get :unhandled
   end
 

--- a/db/migrate/20180305101934_add_application_status_field.rb
+++ b/db/migrate/20180305101934_add_application_status_field.rb
@@ -1,0 +1,6 @@
+class AddApplicationStatusField < ActiveRecord::Migration[5.1]
+  def change
+    add_column :c100_applications, :status, :integer, default: 0
+    add_index  :c100_applications, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180228111024) do
+ActiveRecord::Schema.define(version: 20180305101934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,8 @@ ActiveRecord::Schema.define(version: 20180228111024) do
     t.string "miam_exemption_claim"
     t.string "orders", default: [], array: true
     t.text "orders_additional_details"
+    t.integer "status", default: 0
+    t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe ApplicationController do
   controller do
     def invalid_session; raise Errors::InvalidSession; end
+    def application_not_found; raise Errors::ApplicationNotFound; end
     def another_exception; raise Exception; end
   end
 
@@ -19,6 +20,17 @@ RSpec.describe ApplicationController do
 
         get :invalid_session
         expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'Errors::ApplicationNotFound' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'application_not_found' => 'anonymous#application_not_found' }
+
+        expect(Raven).not_to receive(:capture_exception)
+
+        get :application_not_found
+        expect(response).to redirect_to(application_not_found_errors_path)
       end
     end
 

--- a/spec/controllers/steps/miam/consent_order_controller_spec.rb
+++ b/spec/controllers/steps/miam/consent_order_controller_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Miam::ConsentOrderController, type: :controller do
+  it_behaves_like 'a savepoint step controller'
   it_behaves_like 'an intermediate step controller', Steps::Miam::ConsentOrderForm, C100App::MiamDecisionTree
 end

--- a/spec/controllers/users/drafts_controller_spec.rb
+++ b/spec/controllers/users/drafts_controller_spec.rb
@@ -12,14 +12,108 @@ RSpec.describe Users::DraftsController, type: :controller do
     end
 
     context 'when user is logged in' do
+      let(:finder_double) { double.as_null_object }
+
       before do
         sign_in(user)
+        expect(user).to receive(:drafts).and_return(finder_double)
       end
 
       it 'renders the drafts page' do
         get :index
         expect(assigns[:drafts]).not_to be_nil
         expect(response).to render_template(:index)
+      end
+
+      it 'sorts the resulting drafts by ascending `created_at`' do
+        expect(finder_double).to receive(:order).with(created_at: :asc)
+        get :index
+      end
+    end
+  end
+
+  describe '#resume' do
+    context 'when user is logged out' do
+      it 'redirects to the sign-in page' do
+        get :resume, params: { id: 'any' }
+        expect(response).to redirect_to(user_session_path)
+      end
+    end
+
+    context 'when user is logged in' do
+      before do
+        sign_in(user)
+      end
+
+      context 'when c100 application does not exist' do
+        it 'redirects to the application not found error page' do
+          get :resume, params: {id: '123'}
+          expect(response).to redirect_to(application_not_found_errors_path)
+        end
+      end
+
+      context 'when c100 application exists' do
+        let!(:c100_application) { C100Application.create(navigation_stack: %w(/step/1 /step/2)) }
+        let(:scoped_result) { double('result') }
+
+        before do
+          expect(user).to receive(:drafts).and_return(scoped_result)
+          expect(scoped_result).to receive(:find_by).with(id: c100_application.id).and_return(c100_application)
+        end
+
+        it 'assigns the chosen c100 application to the current session' do
+          expect(session[:c100_application_id]).to be_nil
+          get :resume, params: { id: c100_application.id }
+          expect(session[:c100_application_id]).to eq(c100_application.id)
+        end
+
+        it 'redirects to the last recorded step' do
+          get :resume, params: { id: c100_application.id }
+          expect(response).to redirect_to('/step/2')
+        end
+      end
+    end
+  end
+
+  describe '#destroy' do
+    context 'when user is logged out' do
+      it 'redirects to the sign-in page' do
+        delete :destroy, params: { id: 'any' }
+        expect(response).to redirect_to(user_session_path)
+      end
+    end
+
+    context 'when user is logged in' do
+      before do
+        sign_in(user)
+      end
+
+      context 'when c100 application does not exist' do
+        it 'redirects to the application not found error page' do
+          delete :destroy, params: { id: '123' }
+          expect(response).to redirect_to(application_not_found_errors_path)
+        end
+      end
+
+      context 'when c100 application exists' do
+        let!(:c100_application) { C100Application.create }
+        let(:scoped_result) { double('result') }
+
+        before do
+          allow(user).to receive(:drafts).and_return(scoped_result)
+          allow(scoped_result).to receive(:find_by).with(id: c100_application.id).and_return(c100_application)
+        end
+
+        it 'deletes the c100 application by ID' do
+          expect {
+            delete :destroy, params: { id: c100_application.id }
+          }.to change { C100Application.count }.by(-1)
+        end
+
+        it 'redirects back to the drafts page' do
+          delete :destroy, params: { id: c100_application.id }
+          expect(response).to redirect_to(users_drafts_path)
+        end
       end
     end
   end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe NotifyMailer, type: :mailer do
     it 'has the right personalisation' do
       expect(mail.govuk_notify_personalisation).to eq({
         service_name: 'Apply to court about child arrangements',
-        resume_draft_link: 'https://c100.justice.uk/users/drafts/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume',
+        resume_draft_url: 'https://c100.justice.uk/users/drafts/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume',
         draft_expire_in_days: 14,
       })
     end

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -4,6 +4,20 @@ RSpec.describe C100Application, type: :model do
   subject { described_class.new(attributes) }
   let(:attributes) { {} }
 
+  describe 'status enum' do
+    it 'has the right values' do
+      expect(
+        described_class.statuses
+      ).to eq(
+        'screening' => 0,
+        'in_progress' => 1,
+        'first_reminder_sent' => 5,
+        'last_reminder_sent' => 6,
+        'completed' => 10,
+      )
+    end
+  end
+
   describe '#confidentiality_enabled?' do
     context 'for `yes` values' do
       let(:attributes) { {address_confidentiality: 'yes'} }

--- a/spec/presenters/draft_presenter_spec.rb
+++ b/spec/presenters/draft_presenter_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+RSpec.describe DraftPresenter do
+  subject { described_class.new(c100_application) }
+
+  let(:c100_application) { instance_double(C100Application, c100_application_attributes) }
+  let(:c100_application_attributes) {
+    {
+      created_at: created_at,
+    }
+  }
+
+  let(:created_at) { DateTime.now }
+  let(:applicant) { instance_double(Applicant, full_name: 'John Harrison') }
+
+  before do
+    travel_to Time.at(0)
+  end
+
+  describe '#expires_in' do
+    context 'draft created today' do
+      let(:created_at) { DateTime.now }
+      it { expect(subject.expires_in).to eq('14 days') }
+    end
+
+    context 'draft created 7 days ago' do
+      let(:created_at) { 7.days.ago }
+      it { expect(subject.expires_in).to eq('7 days') }
+    end
+
+    context 'draft created 13 days ago' do
+      let(:created_at) { 13.days.ago }
+      it { expect(subject.expires_in).to eq('1 day') }
+    end
+
+    context 'draft created 14 days ago' do
+      let(:created_at) { 14.days.ago }
+      it { expect(subject.expires_in).to eq('Today') }
+    end
+
+    # This is to ensure even if we don't purge the draft on time for whatever reason,
+    # the user will not see weird data (better to continue saying 'Today').
+    context 'draft created 15 days ago' do
+      let(:created_at) { 15.days.ago }
+      it { expect(subject.expires_in).to eq('Today') }
+    end
+  end
+
+  describe '#expires_in_class' do
+    context 'draft created today' do
+      let(:created_at) { DateTime.now }
+      it { expect(subject.expires_in_class).to eq('') }
+    end
+
+    context 'draft created 7 days ago' do
+      let(:created_at) { 7.days.ago }
+      it { expect(subject.expires_in_class).to eq('') }
+    end
+
+    context 'draft created 9 days ago' do
+      let(:created_at) { 9.days.ago }
+      it { expect(subject.expires_in_class).to eq('expires-soon') }
+    end
+
+    context 'draft created 14 days ago' do
+      let(:created_at) { 14.days.ago }
+      it { expect(subject.expires_in_class).to eq('expires-today') }
+    end
+  end
+
+  describe '#applicant_name' do
+    before do
+      allow(c100_application).to receive(:applicants).and_return(applicants)
+    end
+
+    context 'there are applicants' do
+      let(:applicants) { [applicant] }
+      it { expect(subject.applicant_name).to eq('John Harrison') }
+    end
+
+    context 'there are no applicants yet' do
+      let(:applicants) { [] }
+      it { expect(subject.applicant_name).to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Renders the current user drafts and allows to delete or resume any of them.
Still we don’t know if we will limit this to only 1 draft, but for now, it mimics very much TaxTribs.

More context in separate commits.

<img width="1019" alt="screen shot 2018-03-05 at 13 39 00" src="https://user-images.githubusercontent.com/687910/36977932-c5a15924-207a-11e8-8aa7-ee1ae1fde845.png">
