### PR TITLE
Extend FormBuilder with custom continue button

### DIFF
--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -1,0 +1,31 @@
+module CustomFormHelpers
+  delegate :t,
+           :current_c100_application,
+           :user_signed_in?,
+           :new_user_registration_path, to: :@template
+
+  def continue_button
+    content_tag(:p, class: 'actions') do
+      if save_and_return_disabled?
+        submit_button(:continue)
+      elsif user_signed_in?
+        submit_button(:save_and_continue)
+      else
+        safe_concat [
+          submit_button(:continue),
+          content_tag(:a, t('helpers.submit.save_and_come_back_later'), href: new_user_registration_path)
+        ].join
+      end
+    end
+  end
+
+  private
+
+  def save_and_return_disabled?
+    current_c100_application.nil? || current_c100_application.screening?
+  end
+
+  def submit_button(i18n_key)
+    submit t("helpers.submit.#{i18n_key}"), class: 'button'
+  end
+end

--- a/app/services/c100_app/screener_decision_tree.rb
+++ b/app/services/c100_app/screener_decision_tree.rb
@@ -17,7 +17,7 @@ module C100App
       when :written_agreement
         after_written_agreement
       when :email_consent
-        after_email_consent
+        start_application_journey
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
@@ -82,8 +82,14 @@ module C100App
       end
     end
 
-    def after_email_consent
-      edit('/steps/miam/child_protection_cases')
+    # This is the very first step of the C100 application, once the screener
+    # has been successfully completed and the user is eligible.
+    #
+    # We might need to change it, but for now using this one. Whatever is the first
+    # step, make sure their controller includes the concern `SavepointStep`.
+    #
+    def start_application_journey
+      edit('/steps/miam/consent_order')
     end
   end
 end

--- a/app/views/steps/abduction/children_have_passport/edit.html.erb
+++ b/app/views/steps/abduction/children_have_passport/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :children_have_passport, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/abduction/international/edit.html.erb
+++ b/app/views/steps/abduction/international/edit.html.erb
@@ -18,7 +18,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/abduction/passport_details/edit.html.erb
+++ b/app/views/steps/abduction/passport_details/edit.html.erb
@@ -21,7 +21,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/abduction/previous_attempt/edit.html.erb
+++ b/app/views/steps/abduction/previous_attempt/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :previous_attempt, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/abduction/previous_attempt_details/edit.html.erb
+++ b/app/views/steps/abduction/previous_attempt_details/edit.html.erb
@@ -23,7 +23,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/abduction/risk_details/edit.html.erb
+++ b/app/views/steps/abduction/risk_details/edit.html.erb
@@ -14,7 +14,7 @@
       <span class="form-label-bold"><%=t '.children_location' %></span>
       <%= f.text_area :current_location, size: '40x4', class: 'form-control-3-4' %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/abuse_concerns/contact/edit.html.erb
+++ b/app/views/steps/abuse_concerns/contact/edit.html.erb
@@ -20,7 +20,7 @@
       <%= f.radio_button_fieldset :concerns_contact_other, inline: true,
           choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/abuse_concerns/details/edit.html.erb
+++ b/app/views/steps/abuse_concerns/details/edit.html.erb
@@ -32,7 +32,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/abuse_concerns/question/edit.html.erb
+++ b/app/views/steps/abuse_concerns/question/edit.html.erb
@@ -16,7 +16,7 @@
 
       <%= f.radio_button_fieldset :answer, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/alternatives/collaborative_law/edit.en.html.erb
+++ b/app/views/steps/alternatives/collaborative_law/edit.en.html.erb
@@ -50,7 +50,7 @@
 
         <%= step_form @form_object do |f| %>
             <%= f.radio_button_fieldset :alternative_collaborative_law, inline: true, choices: GenericYesNo.values %>
-            <%= f.submit class: 'button' %>
+            <%= f.continue_button %>
         <% end %>
       </div>
     </div>

--- a/app/views/steps/alternatives/court/edit.en.html.erb
+++ b/app/views/steps/alternatives/court/edit.en.html.erb
@@ -67,7 +67,7 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.check_box_fieldset :court_acknowledgement, [:court_acknowledgement] %>
-          <%= f.submit class: 'button' %>
+          <%= f.continue_button %>
         <% end %>
       </div>
     </div>

--- a/app/views/steps/alternatives/lawyer_negotiation/edit.en.html.erb
+++ b/app/views/steps/alternatives/lawyer_negotiation/edit.en.html.erb
@@ -49,7 +49,7 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.radio_button_fieldset :alternative_lawyer_negotiation, inline: true, choices: GenericYesNo.values %>
-          <%= f.submit class: 'button' %>
+          <%= f.continue_button %>
         <% end %>
       </div>
     </div>

--- a/app/views/steps/alternatives/mediation/edit.en.html.erb
+++ b/app/views/steps/alternatives/mediation/edit.en.html.erb
@@ -50,7 +50,7 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.radio_button_fieldset :alternative_mediation, inline: true, choices: GenericYesNo.values %>
-          <%= f.submit class: 'button' %>
+          <%= f.continue_button %>
         <% end %>
       </div>
     </div>

--- a/app/views/steps/alternatives/negotiation_tools/edit.en.html.erb
+++ b/app/views/steps/alternatives/negotiation_tools/edit.en.html.erb
@@ -50,7 +50,7 @@
 
         <%= step_form @form_object do |f| %>
             <%= f.radio_button_fieldset :alternative_negotiation_tools, inline: true, choices: GenericYesNo.values %>
-            <%= f.submit class: 'button' %>
+            <%= f.continue_button %>
         <% end %>
       </div>
     </div>

--- a/app/views/steps/applicant/contact_details/edit.html.erb
+++ b/app/views/steps/applicant/contact_details/edit.html.erb
@@ -20,7 +20,7 @@
       <%= f.text_field :mobile_phone %>
       <%= f.text_field :email %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/applicant/names/edit.html.erb
+++ b/app/views/steps/applicant/names/edit.html.erb
@@ -28,7 +28,7 @@
       <% end %>
 
       <div class="xform-group form-submit">
-        <%= f.submit class: 'button' %>
+        <%= f.continue_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/applicant/personal_details/edit.html.erb
+++ b/app/views/steps/applicant/personal_details/edit.html.erb
@@ -28,7 +28,7 @@
       <%= f.text_field :birthplace %>
 
       <div class="xform-group form-submit">
-        <%= f.submit class: 'button' %>
+        <%= f.continue_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/applicant/under_age/edit.html.erb
+++ b/app/views/steps/applicant/under_age/edit.html.erb
@@ -11,7 +11,7 @@
     <!-- TODO: prototype still needs to finish this view -->
 
     <%= step_form @form_object do |f| %>
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/applicant/user_type/edit.html.erb
+++ b/app/views/steps/applicant/user_type/edit.html.erb
@@ -10,7 +10,7 @@
       <%= f.radio_button_fieldset :user_type,
         choices: Steps::Applicant::UserTypeForm.choices %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/court_proceedings/edit.html.erb
+++ b/app/views/steps/application/court_proceedings/edit.html.erb
@@ -21,7 +21,7 @@
       <%= f.text_area :order_types, size: '40x4', class: 'form-control-3-4' %>
       <%= f.text_area :previous_details, size: '40x4', class: 'form-control-3-4' %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/details/edit.html.erb
+++ b/app/views/steps/application/details/edit.html.erb
@@ -13,7 +13,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.text_area :application_details, size: '40x4', class: 'form-control-3-4' %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/help_paying/edit.html.erb
+++ b/app/views/steps/application/help_paying/edit.html.erb
@@ -19,7 +19,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/intermediary/edit.html.erb
+++ b/app/views/steps/application/intermediary/edit.html.erb
@@ -19,7 +19,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/language/edit.html.erb
+++ b/app/views/steps/application/language/edit.html.erb
@@ -17,7 +17,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/litigation_capacity/edit.html.erb
+++ b/app/views/steps/application/litigation_capacity/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :reduced_litigation_capacity, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/litigation_capacity_details/edit.html.erb
+++ b/app/views/steps/application/litigation_capacity_details/edit.html.erb
@@ -11,7 +11,7 @@
       <%= f.text_area :participation_referral_or_assessment_details, size: '40x4', class: 'form-control-3-4' %>
       <%= f.text_area :participation_other_factors_details, size: '40x4', class: 'form-control-3-4' %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/previous_proceedings/edit.html.erb
+++ b/app/views/steps/application/previous_proceedings/edit.html.erb
@@ -11,7 +11,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :children_previous_proceedings, inline: true, choices: GenericYesNo.values %>
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/special_arrangements/edit.html.erb
+++ b/app/views/steps/application/special_arrangements/edit.html.erb
@@ -19,7 +19,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/special_assistance/edit.html.erb
+++ b/app/views/steps/application/special_assistance/edit.html.erb
@@ -19,7 +19,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/without_notice/edit.html.erb
+++ b/app/views/steps/application/without_notice/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :without_notice, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/application/without_notice_details/edit.html.erb
+++ b/app/views/steps/application/without_notice_details/edit.html.erb
@@ -29,7 +29,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/children/additional_details/edit.html.erb
+++ b/app/views/steps/children/additional_details/edit.html.erb
@@ -20,7 +20,7 @@
 
       <%= f.radio_button_fieldset :children_protection_plan, inline: true, choices: GenericYesNoUnknown.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/children/has_other_children/edit.html.erb
+++ b/app/views/steps/children/has_other_children/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :has_other_children, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/children/names/edit.html.erb
+++ b/app/views/steps/children/names/edit.html.erb
@@ -28,7 +28,7 @@
       <% end %>
 
       <div class="xform-group form-submit">
-        <%= f.submit class: 'button' %>
+        <%= f.continue_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/children/orders/edit.html.erb
+++ b/app/views/steps/children/orders/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.check_box_fieldset :orders, @petition.all_selected_orders %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/children/personal_details/edit.html.erb
+++ b/app/views/steps/children/personal_details/edit.html.erb
@@ -23,7 +23,7 @@
 
       <%= f.radio_button_fieldset :gender, choices: Gender.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/children/residence/edit.html.erb
+++ b/app/views/steps/children/residence/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.collection_check_boxes :person_ids, @form_object.people, :id, :full_name %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/court_orders/details/edit.html.erb
+++ b/app/views/steps/court_orders/details/edit.html.erb
@@ -24,7 +24,7 @@
         %>
       <% end %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/court_orders/has_orders/edit.html.erb
+++ b/app/views/steps/court_orders/has_orders/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object, inline: true do |f| %>
       <%= f.radio_button_fieldset :has_court_orders, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/international/jurisdiction/edit.html.erb
+++ b/app/views/steps/international/jurisdiction/edit.html.erb
@@ -17,7 +17,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/international/request/edit.html.erb
+++ b/app/views/steps/international/request/edit.html.erb
@@ -17,7 +17,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/international/resident/edit.html.erb
+++ b/app/views/steps/international/resident/edit.html.erb
@@ -19,7 +19,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
 
     <%=t '.why_we_ask_this_html' %>

--- a/app/views/steps/miam/acknowledgement/edit.en.html.erb
+++ b/app/views/steps/miam/acknowledgement/edit.en.html.erb
@@ -35,7 +35,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.check_box_fieldset :miam_acknowledgement, [:miam_acknowledgement] %>
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/miam/attended/edit.html.erb
+++ b/app/views/steps/miam/attended/edit.html.erb
@@ -13,7 +13,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :miam_attended, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/miam/certification/edit.html.erb
+++ b/app/views/steps/miam/certification/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :miam_certification, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/miam/certification_date/edit.html.erb
+++ b/app/views/steps/miam/certification_date/edit.html.erb
@@ -15,7 +15,7 @@
         <%= f.gov_uk_date_field :miam_certification_date, placeholders: true, legend_text: nil, form_hint_text: '' %>
       </div>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/miam/certification_details/edit.html.erb
+++ b/app/views/steps/miam/certification_details/edit.html.erb
@@ -15,7 +15,7 @@
       <%= f.text_field :miam_certification_service_name %>
       <%= f.text_field :miam_certification_sole_trader_name %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/miam/child_protection_cases/edit.html.erb
+++ b/app/views/steps/miam/child_protection_cases/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :child_protection_cases, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
 
     <%=t 'shared.why_we_use_children_html' %>

--- a/app/views/steps/miam/consent_order/edit.html.erb
+++ b/app/views/steps/miam/consent_order/edit.html.erb
@@ -7,13 +7,15 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <p class="lede gv-u-text-lede"><%=t '.lead_text_html' %></p>
+
     <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
-        <p><%=t '.info_notice' %></p>
+      <p><%=t '.info_notice' %></p>
     </div>
+
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :consent_order, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/miam/exemption_claim/edit.html.erb
+++ b/app/views/steps/miam/exemption_claim/edit.html.erb
@@ -13,7 +13,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :miam_exemption_claim, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/miam_exemptions/adr/edit.html.erb
+++ b/app/views/steps/miam_exemptions/adr/edit.html.erb
@@ -27,7 +27,7 @@
 
       <%= f.check_box_fieldset :exemptions_group, [AdrExemptions::ADR_NONE] %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
     </div>
   </div>

--- a/app/views/steps/miam_exemptions/domestic/edit.html.erb
+++ b/app/views/steps/miam_exemptions/domestic/edit.html.erb
@@ -47,7 +47,7 @@
 
       <%= f.check_box_fieldset :exemptions_group, [DomesticExemptions::DOMESTIC_NONE] %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
     </div>
   </div>

--- a/app/views/steps/miam_exemptions/misc/edit.html.erb
+++ b/app/views/steps/miam_exemptions/misc/edit.html.erb
@@ -33,7 +33,7 @@
 
       <%= f.check_box_fieldset :exemptions_group, [MiscExemptions::MISC_NONE] %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
     </div>
   </div>

--- a/app/views/steps/miam_exemptions/protection/edit.html.erb
+++ b/app/views/steps/miam_exemptions/protection/edit.html.erb
@@ -15,7 +15,7 @@
 
       <%= f.check_box_fieldset :exemptions_group, [ProtectionExemptions::PROTECTION_NONE] %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
     </div>
   </div>

--- a/app/views/steps/miam_exemptions/urgency/edit.html.erb
+++ b/app/views/steps/miam_exemptions/urgency/edit.html.erb
@@ -33,7 +33,7 @@
 
       <%= f.check_box_fieldset :exemptions_group, [UrgencyExemptions::URGENCY_NONE] %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
     </div
   </div>

--- a/app/views/steps/other_children/names/edit.html.erb
+++ b/app/views/steps/other_children/names/edit.html.erb
@@ -24,7 +24,7 @@
       <% end %>
 
       <div class="xform-group form-submit">
-        <%= f.submit class: 'button' %>
+        <%= f.continue_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/other_children/personal_details/edit.html.erb
+++ b/app/views/steps/other_children/personal_details/edit.html.erb
@@ -25,7 +25,7 @@
 
       <%= f.radio_button_fieldset :gender, choices: Gender.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/other_parties/contact_details/edit.html.erb
+++ b/app/views/steps/other_parties/contact_details/edit.html.erb
@@ -10,7 +10,7 @@
       <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
       <%= f.check_box_fieldset :address_unknown, [:address_unknown] %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/other_parties/names/edit.html.erb
+++ b/app/views/steps/other_parties/names/edit.html.erb
@@ -24,7 +24,7 @@
       <% end %>
 
       <div class="xform-group form-submit">
-        <%= f.submit class: 'button' %>
+        <%= f.continue_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/other_parties/personal_details/edit.html.erb
+++ b/app/views/steps/other_parties/personal_details/edit.html.erb
@@ -33,7 +33,7 @@
       %>
 
       <div class="xform-group form-submit">
-        <%= f.submit class: 'button' %>
+        <%= f.continue_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/petition/orders/edit.html.erb
+++ b/app/views/steps/petition/orders/edit.html.erb
@@ -40,7 +40,7 @@
         end
       %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/respondent/contact_details/edit.html.erb
+++ b/app/views/steps/respondent/contact_details/edit.html.erb
@@ -27,7 +27,7 @@
       <%= f.text_field :mobile_phone %>
       <%= f.text_field :email %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/respondent/has_other_parties/edit.html.erb
+++ b/app/views/steps/respondent/has_other_parties/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :has_other_parties, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/respondent/names/edit.html.erb
+++ b/app/views/steps/respondent/names/edit.html.erb
@@ -28,7 +28,7 @@
       <% end %>
 
       <div class="xform-group form-submit">
-        <%= f.submit class: 'button' %>
+        <%= f.continue_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/respondent/personal_details/edit.html.erb
+++ b/app/views/steps/respondent/personal_details/edit.html.erb
@@ -35,7 +35,7 @@
       <%= f.text_field :birthplace %>
 
       <div class="xform-group form-submit">
-        <%= f.submit class: 'button' %>
+        <%= f.continue_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/respondent/under_age/edit.html.erb
+++ b/app/views/steps/respondent/under_age/edit.html.erb
@@ -11,7 +11,7 @@
     <!-- TODO: prototype still needs to finish this view -->
 
     <%= step_form @form_object do |f| %>
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/safety_questions/address_confidentiality/edit.html.erb
+++ b/app/views/steps/safety_questions/address_confidentiality/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :address_confidentiality, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/safety_questions/children_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/children_abuse/edit.html.erb
@@ -16,7 +16,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :children_abuse, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/safety_questions/domestic_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/domestic_abuse/edit.html.erb
@@ -15,7 +15,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :domestic_abuse, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/safety_questions/other_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/other_abuse/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :other_abuse, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/safety_questions/risk_of_abduction/edit.html.erb
+++ b/app/views/steps/safety_questions/risk_of_abduction/edit.html.erb
@@ -16,7 +16,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :risk_of_abduction, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/safety_questions/substance_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/substance_abuse/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :substance_abuse, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/safety_questions/substance_abuse_details/edit.html.erb
+++ b/app/views/steps/safety_questions/substance_abuse_details/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.text_area :substance_abuse_details, size: '40x4', class: 'form-control-3-4' %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/screener/children_postcodes/edit.html.erb
+++ b/app/views/steps/screener/children_postcodes/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.text_area :children_postcodes, size: '40x4', class: 'form-control-3-4' %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/screener/email_consent/edit.html.erb
+++ b/app/views/steps/screener/email_consent/edit.html.erb
@@ -18,7 +18,7 @@
         end
         %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/screener/legal_representation/edit.html.erb
+++ b/app/views/steps/screener/legal_representation/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :legal_representation, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/screener/over18/edit.html.erb
+++ b/app/views/steps/screener/over18/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :over18, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/screener/parent/edit.html.erb
+++ b/app/views/steps/screener/parent/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :parent, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/screener/postcode/edit.html.erb
+++ b/app/views/steps/screener/postcode/edit.html.erb
@@ -11,7 +11,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.text_area :children_postcodes, size: '40x4', class: 'form-control-3-4' %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/screener/urgency/edit.html.erb
+++ b/app/views/steps/screener/urgency/edit.html.erb
@@ -19,7 +19,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :urgent, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/screener/written_agreement/edit.html.erb
+++ b/app/views/steps/screener/written_agreement/edit.html.erb
@@ -14,7 +14,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :written_agreement, inline: true, choices: GenericYesNo.values %>
 
-      <%= f.submit class: 'button' %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/app/views/steps/shared/_continue_or_save.html.erb
+++ b/app/views/steps/shared/_continue_or_save.html.erb
@@ -1,8 +1,0 @@
-<p class="actions">
-  <% if user_signed_in? %>
-    <%= f.submit t('helpers.submit.save_and_continue'), class: 'button' %>
-  <% else %>
-    <%= f.submit class: 'button' %>
-    <%= link_to t('helpers.submit.save_and_come_back_later'), new_user_registration_path %>
-  <% end %>
-</p>

--- a/app/views/steps/shared/_relationship_step.html.erb
+++ b/app/views/steps/shared/_relationship_step.html.erb
@@ -18,5 +18,5 @@
     end
   %>
 
-  <%= f.submit class: 'button' %>
+  <%= f.continue_button %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,8 +22,6 @@ end
 Bundler.require *Rails.groups(assets: %w(development test))
 
 class Application < Rails::Application
-  ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
-
   # This automatically adds id: :uuid to create_table in all future migrations
   config.generators do |g|
     g.orm :active_record, primary_key_type: :uuid

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -1,0 +1,5 @@
+ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
+
+ActionView::Base.default_form_builder.class_eval do
+  include CustomFormHelpers
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1374,6 +1374,7 @@ en:
         children_postcodes: Please enter one postcode per line. Only include postcodes that you are sure of - if you don't know any postcodes, leave this box blank. Please only enter full postcodes (like "SW1H 9AJ").
 
     submit:
+      continue: Continue
       create: Continue
       update: Continue
       cancel: Cancel
@@ -1382,7 +1383,7 @@ en:
       sign_in: Sign in
       reset_password: Reset password
       change_password: Change my password
-      save_and_continue: "Save and continue"
+      save_and_continue: Save and continue
 
   number:
     currency:

--- a/lib/generators/step/templates/edit/edit.html.erb
+++ b/lib/generators/step/templates/edit/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%%= step_form @form_object do |f| %>
       <!-- TODO: Add form fields here -->
-      <%%= f.submit class: 'button' %>
+      <%%= f.continue_button %>
     <%% end %>
   </div>
 </div>

--- a/lib/generators/step/templates/question/edit.html.erb
+++ b/lib/generators/step/templates/question/edit.html.erb
@@ -10,8 +10,7 @@
 
     <%%= step_form @form_object do |f| %>
       <%%= f.radio_button_fieldset :<%= step_name.underscore %>, inline: true, choices: GenericYesNo.values %>
-
-      <%%= f.submit class: 'button' %>
+      <%%= f.continue_button %>
     <%% end %>
   </div>
 </div>

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+class TestHelper < ActionView::Base
+  def user_signed_in?
+    false
+  end
+
+  def new_user_registration_path
+    '/test/sign_up'
+  end
+end
+
+# The module `CustomFormHelpers` gets mixed in and extends the helpers already
+# provided by `GovukElementsFormBuilder`. Refer to: `config/initializers/form_builder.rb`
+#
+RSpec.describe GovukElementsFormBuilder::FormBuilder do
+  let(:helper) { TestHelper.new }
+  let(:resource) { Applicant.new }
+  let(:builder) { described_class.new :applicant, resource, helper, {} }
+
+  describe '#continue_button' do
+    let(:c100_application) { C100Application.new(status: :in_progress) }
+    let(:html_output) { builder.continue_button }
+
+    before do
+      allow(helper).to receive(:current_c100_application).and_return(c100_application)
+    end
+
+    context 'no c100 application yet' do
+      let(:c100_application) { nil }
+
+      it 'outputs the continue button' do
+        expect(
+          html_output
+        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /></p>')
+      end
+    end
+
+    context 'for an application in screening' do
+      let(:c100_application) { C100Application.new(status: :screening) }
+
+      it 'outputs the continue button' do
+        expect(
+          html_output
+        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /></p>')
+      end
+    end
+
+    context 'for a logged in user' do
+      before do
+        allow(helper).to receive(:user_signed_in?).and_return(true)
+      end
+
+      it 'outputs the save and continue button' do
+        expect(
+          html_output
+        ).to eq('<p class="actions"><input type="submit" name="commit" value="Save and continue" class="button" data-disable-with="Save and continue" /></p>')
+      end
+    end
+
+    context 'for a logged out user' do
+      it 'outputs the continue button with a link to sign-up' do
+        expect(
+          html_output
+        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /><a href="/test/sign_up">Save and come back later</a></p>')
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/screener_decision_tree_spec.rb
+++ b/spec/services/c100_app/screener_decision_tree_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe C100App::ScreenerDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-
   context 'when the step is `children_postcodes`' do
     let(:step_params) { { children_postcodes: postcodes } }
 
@@ -71,7 +70,6 @@ RSpec.describe C100App::ScreenerDecisionTree do
     let(:step_params){ {urgent: urgent} }
     let(:screener_answers) { double('screener_answers', urgent: urgent) }
 
-
     context 'and urgent is "yes"' do
       let(:urgent){ GenericYesNo::YES }
 
@@ -88,7 +86,6 @@ RSpec.describe C100App::ScreenerDecisionTree do
   context 'when the step is `parent`' do
     let(:step_params){ {parent: parent} }
     let(:screener_answers) { double('screener_answers', parent: parent) }
-
 
     context 'and parent is "yes"' do
       let(:parent){ GenericYesNo::YES }
@@ -107,7 +104,6 @@ RSpec.describe C100App::ScreenerDecisionTree do
     let(:step_params){ {over18: over18} }
     let(:screener_answers) { double('screener_answers', over18: over18) }
 
-
     context 'and over18 is "yes"' do
       let(:over18){ GenericYesNo::YES }
 
@@ -124,7 +120,6 @@ RSpec.describe C100App::ScreenerDecisionTree do
   context 'when the step is `legal_representation`' do
     let(:step_params){ {legal_representation: legal_representation} }
     let(:screener_answers) { double('screener_answers', legal_representation: legal_representation) }
-
 
     context 'and legal_representation is "no"' do
       let(:legal_representation){ GenericYesNo::NO }
@@ -143,7 +138,6 @@ RSpec.describe C100App::ScreenerDecisionTree do
     let(:step_params){ {written_agreement: written_agreement} }
     let(:screener_answers) { double('screener_answers', written_agreement: written_agreement) }
 
-
     context 'and written_agreement is "no"' do
       let(:written_agreement){ GenericYesNo::NO }
 
@@ -158,20 +152,7 @@ RSpec.describe C100App::ScreenerDecisionTree do
   end
 
   context 'when the step is `email_consent`' do
-    let(:step_params){ {email_consent: email_consent} }
-    let(:screener_answers) { double('screener_answers', email_consent: email_consent) }
-
-
-    context 'and email_consent is "no"' do
-      let(:email_consent){ GenericYesNo::NO }
-
-      it { is_expected.to have_destination('/steps/miam/child_protection_cases', :edit) }
-    end
-
-    context 'and email_consent is "yes"' do
-      let(:email_consent){ GenericYesNo::YES }
-
-      it { is_expected.to have_destination('/steps/miam/child_protection_cases', :edit) }
-    end
+    let(:step_params) { { email_consent: 'anything' } }
+    it { is_expected.to have_destination('/steps/miam/consent_order', :edit) }
   end
 end


### PR DESCRIPTION
Centralise in the default FormBuilder
(`GovukElementsFormBuilder::FormBuilder`) the logic around the
`continue` button to support the save and return functionality.

* If the C100 application is still in screening, or for whatever reason
is nil, we just show a `continue` button.

* If we are logged in, we show a `Save and continue` button.

* Otherwise we show the `continue` button with a link to sign up next
to it.

We will use this form helper to render all the steps buttons.

<img width="454" alt="screen shot 2018-03-06 at 11 38 42" src="https://user-images.githubusercontent.com/687910/37030455-f2569188-2132-11e8-84d5-0f7c48cd7f02.png">
