### PR TITLE
Implement draft reminder emails

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -47,6 +47,16 @@ class NotifyMailer < GovukNotifyRails::Mailer
     mail(to: c100_application.user.email)
   end
 
+  def draft_expire_reminder(c100_application, template_name)
+    set_template(template_name)
+
+    set_personalisation(
+      resume_draft_url: resume_users_draft_url(c100_application)
+    )
+
+    mail(to: c100_application.user.email)
+  end
+
   protected
 
   # rubocop:disable Naming/AccessorMethodName

--- a/app/services/c100_app/draft_reminders.rb
+++ b/app/services/c100_app/draft_reminders.rb
@@ -1,0 +1,35 @@
+module C100App
+  class DraftReminders
+    attr_reader :rule_set
+
+    def initialize(rule_set:)
+      @rule_set = rule_set
+    end
+
+    def run
+      rule_set.find_each do |c100_application|
+        send_reminder(c100_application)
+      end
+    end
+
+    private
+
+    # Note: the reminders are sent outside of the request-response cycle, via a
+    # rake task (lib/tasks/daily_tasks.rake) and thus using `deliver_later` will not
+    # work unless setting up a persistent queue.
+    #
+    # For this service this is not an issue as the number of emails that are likely
+    # to be sent is very low, and we can afford the rake task to take a bit longer to
+    # complete. But if this assumption ever changes, a persistent queue will be needed.
+    #
+    def send_reminder(c100_application)
+      NotifyMailer.draft_expire_reminder(
+        c100_application, rule_set.email_template_name
+      ).deliver_now
+
+      c100_application.update(
+        status: rule_set.status_transition_to
+      )
+    end
+  end
+end

--- a/app/services/c100_app/reminder_rule_set.rb
+++ b/app/services/c100_app/reminder_rule_set.rb
@@ -1,0 +1,44 @@
+module C100App
+  class ReminderRuleSet
+    attr_accessor :created_days_ago,
+                  :status,
+                  :status_transition_to,
+                  :email_template_name
+
+    delegate :find_each, :count, to: :rule_query
+
+    def initialize(created_days_ago:, status:, status_transition_to:, email_template_name:)
+      @created_days_ago = created_days_ago
+      @status = status
+      @status_transition_to = status_transition_to
+      @email_template_name = email_template_name
+    end
+
+    def self.first_reminder
+      new(
+        created_days_ago: 9,
+        status: :in_progress,
+        status_transition_to: :first_reminder_sent,
+        email_template_name: :draft_first_reminder
+      )
+    end
+
+    def self.last_reminder
+      new(
+        created_days_ago: 13,
+        status: :first_reminder_sent,
+        status_transition_to: :last_reminder_sent,
+        email_template_name: :draft_last_reminder
+      )
+    end
+
+    private
+
+    def rule_query
+      C100Application
+        .with_owner
+        .where(status: status)
+        .where('created_at <= ?', created_days_ago.days.ago)
+    end
+  end
+end

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -12,8 +12,12 @@ integration:
   reset_password: '73d0804a-2302-4307-a431-e4a0fd7087ec'
   change_password: '97ea3c24-0b40-4b8e-8fc6-a54f7f1718e9'
   application_saved: '1252b250-541c-456a-b98b-c568aef05e5f'
+  draft_first_reminder: 'fcd87b1c-a3a0-4a2a-9b4e-524857e3bf8c'
+  draft_last_reminder: '8e622f55-4be8-49cc-8a94-0ab3fd868067'
 
 live:
   reset_password: 'tbc'
   change_password: 'tbc'
   application_saved: 'tbc'
+  draft_first_reminder: 'tbc'
+  draft_last_reminder: 'tbc'

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -1,0 +1,30 @@
+task :daily_tasks do
+  log 'Starting daily tasks'
+
+  Rake::Task['draft_reminders:first_email'].invoke
+  Rake::Task['draft_reminders:last_email'].invoke
+
+  log 'Finished daily tasks'
+end
+
+namespace :draft_reminders do
+  task :first_email => :environment do |task_name|
+    rule_set = C100App::ReminderRuleSet.first_reminder
+
+    log "#{task_name} - Count: #{rule_set.count}"
+    C100App::DraftReminders.new(rule_set: rule_set).run
+  end
+
+  task :last_email => :environment do |task_name|
+    rule_set = C100App::ReminderRuleSet.last_reminder
+
+    log "#{task_name}  - Count: #{rule_set.count}"
+    C100App::DraftReminders.new(rule_set: rule_set).run
+  end
+end
+
+private
+
+def log(message)
+  puts "[#{Time.now}] #{message}"
+end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe NotifyMailer, type: :mailer do
       reset_password: 'reset_password_template_id',
       change_password: 'change_password_template_id',
       application_saved: 'application_saved_template_id',
+      draft_first_reminder: 'draft_first_reminder_template_id',
+      draft_last_reminder: 'draft_last_reminder_template_id',
     )
   end
 
@@ -33,6 +35,40 @@ RSpec.describe NotifyMailer, type: :mailer do
         resume_draft_url: 'https://c100.justice.uk/users/drafts/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume',
         draft_expire_in_days: 14,
       })
+    end
+  end
+
+  describe 'draft_first_reminder' do
+    let(:mail) { described_class.draft_expire_reminder(c100_application, :draft_first_reminder) }
+
+    it_behaves_like 'a Notify mail', template_id: 'draft_first_reminder_template_id'
+
+    it { expect(mail.to).to eq(['test@example.com']) }
+
+    context 'personalisation' do
+      it 'sets the personalisation' do
+        expect(mail.govuk_notify_personalisation).to eq({
+          service_name: 'Apply to court about child arrangements',
+          resume_draft_url: 'https://c100.justice.uk/users/drafts/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume',
+        })
+      end
+    end
+  end
+
+  describe 'draft_last_reminder' do
+    let(:mail) { described_class.draft_expire_reminder(c100_application, :draft_last_reminder) }
+
+    it_behaves_like 'a Notify mail', template_id: 'draft_last_reminder_template_id'
+
+    it { expect(mail.to).to eq(['test@example.com']) }
+
+    context 'personalisation' do
+      it 'sets the personalisation' do
+        expect(mail.govuk_notify_personalisation).to eq({
+          service_name: 'Apply to court about child arrangements',
+          resume_draft_url: 'https://c100.justice.uk/users/drafts/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume',
+        })
+      end
     end
   end
 

--- a/spec/services/c100_app/draft_reminders_spec.rb
+++ b/spec/services/c100_app/draft_reminders_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe C100App::DraftReminders do
+  subject { described_class.new(rule_set: rule_set) }
+
+  let(:rule_set) {
+    instance_double(
+      C100App::ReminderRuleSet,
+      email_template_name: :template_name,
+      status_transition_to: :another_status
+    )
+  }
+  let(:c100_application) { instance_double(C100Application) }
+
+  describe '#run' do
+    let(:mailer_double) { double.as_null_object }
+
+    before do
+      allow(rule_set).to receive(:find_each).and_yield(c100_application)
+      allow(NotifyMailer).to receive(:draft_expire_reminder).with(c100_application, :template_name).and_return(mailer_double)
+    end
+
+    it 'should send the email and update the C100 application status' do
+      expect(mailer_double).to receive(:deliver_now)
+      expect(c100_application).to receive(:update).with(status: :another_status)
+      subject.run
+    end
+  end
+end

--- a/spec/services/c100_app/reminder_rule_set_spec.rb
+++ b/spec/services/c100_app/reminder_rule_set_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe C100App::ReminderRuleSet do
+  describe '.first_reminder' do
+    subject { described_class.first_reminder }
+
+    it { expect(subject.created_days_ago).to eq(9) }
+    it { expect(subject.status).to eq(:in_progress) }
+    it { expect(subject.status_transition_to).to eq(:first_reminder_sent) }
+    it { expect(subject.email_template_name).to eq(:draft_first_reminder) }
+  end
+
+  describe '.last_reminder' do
+    subject { described_class.last_reminder }
+
+    it { expect(subject.created_days_ago).to eq(13) }
+    it { expect(subject.status).to eq(:first_reminder_sent) }
+    it { expect(subject.status_transition_to).to eq(:last_reminder_sent) }
+    it { expect(subject.email_template_name).to eq(:draft_last_reminder) }
+  end
+
+  describe '#find_each' do
+    let(:dummy_config) do
+      {
+        created_days_ago: 3,
+        status: :test_status,
+        status_transition_to: :another_status,
+        email_template_name: :template_name
+      }
+    end
+    let(:finder_double) { double.as_null_object }
+
+    subject { described_class.new(dummy_config) }
+
+    before do
+      travel_to Time.now
+    end
+
+    it 'filters the c100 applications' do
+      expect(C100Application).to receive(:with_owner).and_return(finder_double)
+      expect(finder_double).to receive(:where).with(status: :test_status).and_return(finder_double)
+      expect(finder_double).to receive(:where).with('created_at <= ?', 3.days.ago).and_return(finder_double)
+      subject.find_each
+    end
+
+    it 'it returns an enumerator' do
+      expect(subject.find_each).to be_an(Enumerator)
+    end
+  end
+end


### PR DESCRIPTION
This will be triggered by a daily task.

We setup 2 draft expire reminders, one to be sent when 5 days left and another one to be sent when 1 day left.

The mechanism is flexible enough to setup as many reminders as we want to trigger at specific moments in time.