### PR TITLE
Screener reordering

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,6 +47,7 @@
 @import 'local/utilities';
 @import 'local/timeout_modal';
 @import 'local/spinner';
+@import 'local/developer_tools';
 
 @import 'local/check_answers';
 @import 'local/pdf_summary';

--- a/app/assets/stylesheets/local/developer_tools.scss
+++ b/app/assets/stylesheets/local/developer_tools.scss
@@ -1,0 +1,23 @@
+#footer .developer_tools {
+  margin: 0;
+
+  h4 {
+    font-size: 16px;
+    font-weight: bold;
+  }
+
+  .details {
+    color: $secondary-text-colour;
+    margin: 0;
+  }
+
+  .button-destroy_session {
+    background-color: $mellow-red;
+    color: $page-colour;
+  }
+
+  .button-create_session {
+    background-color: $mauve;
+    color: $page-colour;
+  }
+}

--- a/app/controllers/concerns/savepoint_step.rb
+++ b/app/controllers/concerns/savepoint_step.rb
@@ -9,9 +9,9 @@ module SavepointStep
   private
 
   def update_navigation_stack
-    # Reset the navigation_stack to clear the screening steps as these
-    # are no longer needed.
-    current_c100_application.navigation_stack = []
+    # Points the navigation stack to the first page after the screener, so if the user
+    # clicks the `back` link, they are not taken to start of the screener again.
+    current_c100_application.navigation_stack = [entrypoint_v1_path]
     super
   end
 

--- a/app/controllers/entrypoint_controller.rb
+++ b/app/controllers/entrypoint_controller.rb
@@ -1,6 +1,4 @@
 class EntrypointController < ApplicationController
-  before_action :reset_c100_application_session
-
   def v1; end
 
   def v2; end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,4 +14,23 @@ class SessionsController < ApplicationController
       format.json { render json: {} }
     end
   end
+
+  # :nocov:
+  def bypass_screener
+    raise 'For development use only' unless Rails.env.development? || ENV['DEV_TOOLS_ENABLED']
+
+    c100_application.update(status: 1)
+    redirect_to edit_steps_miam_child_protection_cases_path
+  end
+  # :nocov:
+
+  private
+
+  # :nocov:
+  def c100_application
+    @_c100_application ||= C100Application.create.tap do |c100_application|
+      session[:c100_application_id] = c100_application.id
+    end
+  end
+  # :nocov:
 end

--- a/app/controllers/steps/miam/child_protection_cases_controller.rb
+++ b/app/controllers/steps/miam/child_protection_cases_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   module Miam
     class ChildProtectionCasesController < Steps::MiamStepController
+      include SavepointStep
+
       def edit
         @form_object = ChildProtectionCasesForm.new(
           c100_application: current_c100_application,

--- a/app/controllers/steps/miam/consent_order_controller.rb
+++ b/app/controllers/steps/miam/consent_order_controller.rb
@@ -1,8 +1,11 @@
 module Steps
   module Miam
     class ConsentOrderController < Steps::MiamStepController
-      include SavepointStep
-
+      #
+      # NOTE: this step is not used for now, as we are screening out people,
+      # but we don't want to remove it as it is valid and will be activated
+      # as soon as we can.
+      #
       def edit
         @form_object = ConsentOrderForm.new(
           c100_application: current_c100_application,

--- a/app/controllers/steps/screener/done_controller.rb
+++ b/app/controllers/steps/screener/done_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Screener
+    class DoneController < Steps::ScreenerStepController
+      def show; end
+    end
+  end
+end

--- a/app/controllers/steps/screener/start_controller.rb
+++ b/app/controllers/steps/screener/start_controller.rb
@@ -1,0 +1,10 @@
+module Steps
+  module Screener
+    class StartController < Steps::ScreenerStepController
+      skip_before_action :check_c100_application_presence
+      before_action :reset_c100_application_session
+
+      def show; end
+    end
+  end
+end

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -28,11 +28,6 @@ class BaseDecisionTree
     step_params.fetch(attribute_name).eql?(value)
   end
 
-  # Enable again when needed. Coverage complains otherwise.
-  # def root_path
-  #   { controller: '/entrypoint', action: :v1 }
-  # end
-
   def show(step_controller)
     {controller: step_controller, action: :show}
   end

--- a/app/services/c100_app/screener_decision_tree.rb
+++ b/app/services/c100_app/screener_decision_tree.rb
@@ -17,7 +17,7 @@ module C100App
       when :written_agreement
         after_written_agreement
       when :email_consent
-        start_application_journey
+        show(:done)
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
@@ -80,16 +80,6 @@ module C100App
       else
         show(:written_agreement_exit)
       end
-    end
-
-    # This is the very first step of the C100 application, once the screener
-    # has been successfully completed and the user is eligible.
-    #
-    # We might need to change it, but for now using this one. Whatever is the first
-    # step, make sure their controller includes the concern `SavepointStep`.
-    #
-    def start_application_journey
-      edit('/steps/miam/consent_order')
     end
   end
 end

--- a/app/views/application/_developer_tools.html.erb
+++ b/app/views/application/_developer_tools.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:footer_top) do %>
+  <details class="developer_tools">
+    <summary><span class="summary">Developer Tools</span></summary>
+
+    <div class="panel panel-border-narrow">
+      <% if current_c100_application %>
+        <h4 class="heading-small">Current Application ID</h4>
+        <p><%= current_c100_application.id %></p>
+      <% end %>
+
+      <h4>Destroy session</h4>
+      <p class="details">Deletes all data entered in this session and lets you start a new application from scratch.</p>
+      <p><%= link_to 'Destroy session', session_path, method: :delete, class: 'button button-destroy_session', data: { confirm: 'Are you sure?' } %></p>
+
+      <h4>Bypass screener</h4>
+      <p class="details">Bypass the screener and starts from the first application step.</p>
+      <p>
+        <%= link_to 'Bypass screener', bypass_screener_session_path, method: :post, class: 'button button-create_session' %>
+      </p>
+    </div>
+  </details>
+<% end %>

--- a/app/views/entrypoint/how_long.en.html.erb
+++ b/app/views/entrypoint/how_long.en.html.erb
@@ -23,7 +23,7 @@
       </div>
 
       <div class="xform-group form-submit">
-        <%= link_to 'Continue', edit_steps_screener_postcode_path, class: 'button', role: 'button' %>
+        <%= link_to 'Continue', edit_steps_miam_child_protection_cases_path, class: 'button', role: 'button' %>
       </div>
     </div>
   </div>

--- a/app/views/entrypoint/how_long.en.html.erb
+++ b/app/views/entrypoint/how_long.en.html.erb
@@ -1,6 +1,7 @@
 <% title 'How long it takes' %>
 
 <a class="link-back" href="/entrypoint/what_is_needed">Back</a>
+
 <main data-block-name="route:application-requirements">
   <div class=" grid-row gv-o-grid-row">
     <div class=" column-two-thirds gv-o-grid-item gv-u-two-thirds">

--- a/app/views/entrypoint/what_is_needed.en.html.erb
+++ b/app/views/entrypoint/what_is_needed.en.html.erb
@@ -1,6 +1,7 @@
 <% title 'What is required' %>
 
-<a class="link-back" href="/">Back</a>
+<a class="link-back" href="/entrypoint/v1">Back</a>
+
 <main data-block-name="route:application-requirements">
   <div class=" grid-row gv-o-grid-row">
     <div class=" column-two-thirds gv-o-grid-item gv-u-two-thirds">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,4 +70,8 @@
   <%= render partial: 'layouts/footer_links' %>
 <% end %>
 
+<% if Rails.env.development? || ENV['DEV_TOOLS_ENABLED'] %>
+  <%= render partial: 'developer_tools' %>
+<% end %>
+
 <%= render template: "layouts/govuk_template" %>

--- a/app/views/steps/screener/done/show.html.erb
+++ b/app/views/steps/screener/done/show.html.erb
@@ -1,0 +1,15 @@
+<% title 'Screener completed' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">You are eligible</h1>
+
+    <p class="lede">COPY TBD</p>
+
+    <div class="xform-group form-submit">
+      <%= link_to 'Continue', entrypoint_v1_path, class: 'button', role: 'button' %>
+    </div>
+  </div>
+</div>

--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -1,0 +1,24 @@
+<% title 'Screener' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">
+      You’ll need to meet the following criteria to try our new service:
+    </h1>
+
+    <div class=" govuk-govspeak gv-s-prose">
+      <ul class="list list-bullet">
+        <li>Your child must live in the [jurisdiction] court area (you’ll be able to check this on the next page)</li>
+        <li>You are not making an urgent application</li>
+        <li>You are a parent of the child</li>
+        <li>You and the respondent are both over 18</li>
+        <li>You do not have a written agreement you want the court to make legally binding</li>
+        <li>You do not have legal representation</li>
+      </ul>
+    </div>
+
+    <div class="xform-group form-submit">
+      <%= link_to 'Start now', edit_steps_screener_postcode_path, class: 'button', role: 'button' %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
       edit_step :written_agreement
       show_step :written_agreement_exit
       edit_step :email_consent
+      show_step :done
     end
     namespace :application do
       edit_step :previous_proceedings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,6 +215,7 @@ Rails.application.routes.draw do
   resource :session, only: [:destroy] do
     member do
       get :ping
+      post :bypass_screener
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
 
   namespace :steps do
     namespace :screener do
+      show_step :start
       edit_step :postcode
       show_step :error_but_continue
       show_step :no_court_found
@@ -224,7 +225,7 @@ Rails.application.routes.draw do
     get :unhandled
   end
 
-  root to: 'entrypoint#v1'
+  root 'steps/screener/start#show'
 
   get 'entrypoint/v1'
   get 'entrypoint/v2'

--- a/spec/controllers/entrypoint_controller_spec.rb
+++ b/spec/controllers/entrypoint_controller_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe EntrypointController do
-  before do
-    expect(subject).to receive(:reset_c100_application_session)
-  end
-
   describe '#v1' do
     it 'renders the expected page' do
       get :v1

--- a/spec/controllers/steps/miam/child_protection_cases_controller_spec.rb
+++ b/spec/controllers/steps/miam/child_protection_cases_controller_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Miam::ChildProtectionCasesController, type: :controller do
+  it_behaves_like 'a savepoint step controller'
   it_behaves_like 'an intermediate step controller', Steps::Miam::ChildProtectionCasesForm, C100App::MiamDecisionTree
 end

--- a/spec/controllers/steps/miam/consent_order_controller_spec.rb
+++ b/spec/controllers/steps/miam/consent_order_controller_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Miam::ConsentOrderController, type: :controller do
-  it_behaves_like 'a savepoint step controller'
   it_behaves_like 'an intermediate step controller', Steps::Miam::ConsentOrderForm, C100App::MiamDecisionTree
 end

--- a/spec/controllers/steps/screener/done_controller_spec.rb
+++ b/spec/controllers/steps/screener/done_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Screener::DoneController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/controllers/steps/screener/start_controller_spec.rb
+++ b/spec/controllers/steps/screener/start_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Screener::StartController, type: :controller do
+  before do
+    expect(subject).to receive(:reset_c100_application_session)
+  end
+
+  describe '#show' do
+    it 'responds with HTTP success' do
+      get :show
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/services/c100_app/screener_decision_tree_spec.rb
+++ b/spec/services/c100_app/screener_decision_tree_spec.rb
@@ -153,6 +153,6 @@ RSpec.describe C100App::ScreenerDecisionTree do
 
   context 'when the step is `email_consent`' do
     let(:step_params) { { email_consent: 'anything' } }
-    it { is_expected.to have_destination('/steps/miam/consent_order', :edit) }
+    it { is_expected.to have_destination(:done, :show) }
   end
 end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -124,9 +124,9 @@ RSpec.shared_examples 'a savepoint step controller' do
       allow(controller).to receive(:current_c100_application).and_return(existing_c100)
     end
 
-    it 'clears the navigation stack in the session' do
+    it 'initialises the navigation stack in the session introducing the entrypoint' do
       get :edit
-      expect(existing_c100.reload.navigation_stack).to eq([controller.request.fullpath])
+      expect(existing_c100.reload.navigation_stack).to eq(['/entrypoint/v1', controller.request.fullpath])
     end
 
     it 'does not change the status on edit' do


### PR DESCRIPTION
Reorganise the screener steps, introduce a start and done steps, and make sure back links, etc. are consistent.

Also, to simplify some repetitive tasks, added a developer tools section in the footer to bypass the screener or reset the session.

<img width="777" alt="screen shot 2018-03-09 at 12 03 39" src="https://user-images.githubusercontent.com/687910/37206767-eb85dcfe-2391-11e8-87f8-eb7021987d8c.png">
