### PR TITLE
Fix for C8 Other Party relationships

### DIFF
--- a/app/presenters/relationships_presenter.rb
+++ b/app/presenters/relationships_presenter.rb
@@ -7,8 +7,10 @@ class RelationshipsPresenter
     @c100_application = c100_application
   end
 
-  def relationship_to_children(person_or_people, show_person_name: true)
-    return C8ConfidentialityPresenter.replacement_answer if under_c8?(person_or_people)
+  def relationship_to_children(person_or_people, show_person_name: true, bypass_c8: false)
+    unless bypass_c8
+      return C8ConfidentialityPresenter.replacement_answer if under_c8?(person_or_people)
+    end
 
     relationships.where(minor: minors, person: person_or_people).map do |relationship|
       show_person_name ? present_relation_with_person(relationship) : present_relation_without_person(relationship)

--- a/app/presenters/summary/sections/c8_other_parties_details.rb
+++ b/app/presenters/summary/sections/c8_other_parties_details.rb
@@ -9,6 +9,11 @@ module Summary
         true
       end
 
+      # Always show the relationships in the C8 form, as opposite to the C100
+      def bypass_relationships_c8?
+        true
+      end
+
       def record_collection
         c100.other_parties
       end

--- a/app/presenters/summary/sections/people_details.rb
+++ b/app/presenters/summary/sections/people_details.rb
@@ -11,6 +11,12 @@ module Summary
       end
       # :nocov:
 
+      # Override in subclasses to disable the hiding of relationships.
+      # Right now, this is only needed in `sections/c8_other_parties_details.rb`
+      def bypass_relationships_c8?
+        false
+      end
+
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def answers
         record_collection.map.with_index(1) do |person, index|
@@ -30,7 +36,9 @@ module Summary
             FreeTextAnswer.new(:person_email, person.email),
             FreeTextAnswer.new(
               :person_relationship_to_children,
-              RelationshipsPresenter.new(c100_application).relationship_to_children(person, show_person_name: false)
+              RelationshipsPresenter.new(c100_application).relationship_to_children(
+                person, show_person_name: false, bypass_c8: bypass_relationships_c8?
+              )
             ),
             Partial.row_blank_space,
           ]

--- a/spec/presenters/relationships_presenter_spec.rb
+++ b/spec/presenters/relationships_presenter_spec.rb
@@ -69,12 +69,18 @@ RSpec.describe RelationshipsPresenter do
         it 'returns the C8 replacement string' do
           expect(subject.relationship_to_children(person)).to eq('See C8 attached')
         end
+
+        context 'but the bypass is activated' do
+          it 'returns the relationship details' do
+            expect(subject.relationship_to_children(person, bypass_c8: true)).to eq('Person name - Father to Child name')
+          end
+        end
       end
 
       context 'and confidentiality is disabled' do
         let(:confidentiality_enabled) { false }
 
-        it 'returns the C8 replacement string' do
+        it 'returns the relationship details' do
           expect(subject.relationship_to_children(person)).to eq('Person name - Father to Child name')
         end
       end

--- a/spec/presenters/summary/sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/applicants_details_spec.rb
@@ -54,6 +54,10 @@ module Summary
       }
     end
 
+    describe '#bypass_relationships_c8?' do
+      it { expect(subject.bypass_relationships_c8?).to eq(false) }
+    end
+
     # The following tests can be fragile, but on purpose. During the development phase
     # we have to update the tests each time we introduce a new row or remove another.
     # But once it is finished and stable, it will raise a red flag if it ever gets out
@@ -63,7 +67,9 @@ module Summary
       before do
         allow_any_instance_of(
           RelationshipsPresenter
-        ).to receive(:relationship_to_children).with(applicant, show_person_name: false).and_return('relationships')
+        ).to receive(:relationship_to_children).with(
+          applicant, show_person_name: false, bypass_c8: false
+        ).and_return('relationships')
       end
 
       it 'has the correct number of rows' do

--- a/spec/presenters/summary/sections/c8_applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/c8_applicants_details_spec.rb
@@ -39,6 +39,10 @@ module Summary
       }
     end
 
+    describe '#bypass_relationships_c8?' do
+      it { expect(subject.bypass_relationships_c8?).to eq(false) }
+    end
+
     describe '#answers' do
       it 'has the correct number of rows' do
         expect(answers.count).to eq(8)

--- a/spec/presenters/summary/sections/c8_other_parties_details_spec.rb
+++ b/spec/presenters/summary/sections/c8_other_parties_details_spec.rb
@@ -44,6 +44,10 @@ module Summary
       it { expect(subject.show_header?).to eq(true) }
     end
 
+    describe '#bypass_relationships_c8?' do
+      it { expect(subject.bypass_relationships_c8?).to eq(true) }
+    end
+
     describe '#record_collection' do
       it {
         expect(c100_application).to receive(:other_parties)
@@ -55,7 +59,9 @@ module Summary
       before do
         allow_any_instance_of(
           RelationshipsPresenter
-        ).to receive(:relationship_to_children).with(other_party, show_person_name: false).and_return('relationships')
+        ).to receive(:relationship_to_children).with(
+          other_party, show_person_name: false, bypass_c8: true
+        ).and_return('relationships')
       end
 
       it 'has the correct number of rows' do

--- a/spec/presenters/summary/sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/sections/other_parties_details_spec.rb
@@ -58,6 +58,10 @@ module Summary
       }
     end
 
+    describe '#bypass_relationships_c8?' do
+      it { expect(subject.bypass_relationships_c8?).to eq(false) }
+    end
+
     # The following tests can be fragile, but on purpose. During the development phase
     # we have to update the tests each time we introduce a new row or remove another.
     # But once it is finished and stable, it will raise a red flag if it ever gets out
@@ -67,7 +71,9 @@ module Summary
       before do
         allow_any_instance_of(
           RelationshipsPresenter
-        ).to receive(:relationship_to_children).with(other_party, show_person_name: false).and_return('relationships')
+        ).to receive(:relationship_to_children).with(
+          other_party, show_person_name: false, bypass_c8: false
+        ).and_return('relationships')
       end
 
       it 'has the correct number of rows' do

--- a/spec/presenters/summary/sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/sections/respondents_details_spec.rb
@@ -50,6 +50,10 @@ module Summary
       }
     end
 
+    describe '#bypass_relationships_c8?' do
+      it { expect(subject.bypass_relationships_c8?).to eq(false) }
+    end
+
     # The following tests can be fragile, but on purpose. During the development phase
     # we have to update the tests each time we introduce a new row or remove another.
     # But once it is finished and stable, it will raise a red flag if it ever gets out
@@ -59,7 +63,9 @@ module Summary
       before do
         allow_any_instance_of(
           RelationshipsPresenter
-        ).to receive(:relationship_to_children).with(respondent, show_person_name: false).and_return('relationships')
+        ).to receive(:relationship_to_children).with(
+          respondent, show_person_name: false, bypass_c8: false
+        ).and_return('relationships')
       end
 
       it 'has the correct number of rows' do


### PR DESCRIPTION
We were hiding the relationships details for Other Parties in the C8 form. This solves the issue.

<img width="949" alt="screen shot 2018-03-09 at 15 21 42" src="https://user-images.githubusercontent.com/687910/37214679-9f6d8580-23ad-11e8-9066-be19fdb5d19c.png">
