### PR TITLE
Add C1A step `Protection Orders`

### DIFF
--- a/app/controllers/steps/petition/playback_controller.rb
+++ b/app/controllers/steps/petition/playback_controller.rb
@@ -5,6 +5,17 @@ module Steps
         @petition = PetitionPresenter.new(
           current_c100_application
         )
+        @next_step_path = next_step_path
+      end
+
+      private
+
+      def next_step_path
+        if current_c100_application.has_safety_concerns?
+          edit_steps_petition_protection_path
+        else
+          edit_steps_alternatives_court_path
+        end
       end
     end
   end

--- a/app/controllers/steps/petition/protection_controller.rb
+++ b/app/controllers/steps/petition/protection_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Petition
+    class ProtectionController < Steps::PetitionStepController
+      def edit
+        @form_object = ProtectionForm.build(current_c100_application)
+      end
+
+      def update
+        update_and_advance(ProtectionForm, as: :protection)
+      end
+    end
+  end
+end

--- a/app/forms/steps/petition/protection_form.rb
+++ b/app/forms/steps/petition/protection_form.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Petition
+    class ProtectionForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :protection_orders, reset_when_no: [:protection_orders_details]
+
+      attribute :protection_orders_details, String
+
+      validates_presence_of :protection_orders_details, if: -> { protection_orders&.yes? }
+    end
+  end
+end

--- a/app/services/c100_app/petition_decision_tree.rb
+++ b/app/services/c100_app/petition_decision_tree.rb
@@ -6,6 +6,8 @@ module C100App
       case step_name
       when :orders
         show(:playback)
+      when :protection
+        edit('/steps/alternatives/court')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/views/steps/petition/playback/show.html.erb
+++ b/app/views/steps/petition/playback/show.html.erb
@@ -64,7 +64,7 @@
     <% end %>
 
     <div class="xform-group form-submit">
-      <%= link_to t('.continue'), edit_steps_alternatives_court_path, class: 'button', role: 'button' %>
+      <%= link_to t('.continue'), @next_step_path, class: 'button', role: 'button' %>
     </div>
   </div>
 </div>

--- a/app/views/steps/petition/protection/edit.html.erb
+++ b/app/views/steps/petition/protection/edit.html.erb
@@ -1,0 +1,25 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%=t '.lead_text_html' %>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.radio_button_fieldset :protection_orders, inline: true do |fieldset|
+          fieldset.radio_input(GenericYesNo::YES, panel_id: :protection_orders_panel)
+          fieldset.radio_input(GenericYesNo::NO)
+          fieldset.revealing_panel(:protection_orders_panel) do |panel|
+            panel.text_area :protection_orders_details, size: '40x4', class: 'form-control-3-4'
+          end
+        end
+      %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -574,6 +574,19 @@ en:
             child_arrangements_order: This is known as a Child Arrangements Order.
             specific_issues_order: This is known as a Specific Issue Order.
             prohibited_steps_order: This is known as a Prohibited Steps Order.
+      protection:
+        edit:
+          page_title: Protection orders
+          heading: Is there anything else you are asking the court to decide, specifically to protect the safety of you or your children?
+          lead_text_html: |
+            <div class="govuk-govspeak gv-s-prose">
+              <p>This can include:</p>
+              <ul class="list list-bullet">
+                <li>that the person must not be violent or threaten or harass by any means (Non-Molestation Order)</li>
+                <li>preventing a person doing a particular action (Prohibited Steps Order)</li>
+                <li>making a decision about a specific issue on which you and the other person can’t decide (Specific Issue Order)</li>
+              </ul>
+            </div>
     abduction:
       children_have_passport:
         edit:
@@ -1045,6 +1058,8 @@ en:
         orders_html: ""
         orders_prohibited_steps_html: ""
         orders_specific_issues_html: ""
+      steps_petition_protection_form:
+        protection_orders_html: ""
       steps_safety_questions_address_confidentiality_form:
         address_confidentiality_html: "Do you want to keep your contact details private?"
       steps_safety_questions_risk_of_abduction_form:
@@ -1217,6 +1232,8 @@ en:
           <span class="gv-u-heading-small">Resolve a specific issue</span><br>
           <span class="form-hint">For example, what school they’ll go to</span>
         orders_additional_details: Briefly provide more details
+      steps_petition_protection_form:
+        protection_orders_details: Please give details
       steps_abduction_passport_details_form:
         passport_possession_mother: Mother
         passport_possession_father: Father

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
     namespace :petition do
       edit_step :orders
       show_step :playback
+      edit_step :protection
     end
     namespace :miam do
       edit_step :consent_order

--- a/db/migrate/20180309155937_add_children_protection_fields.rb
+++ b/db/migrate/20180309155937_add_children_protection_fields.rb
@@ -1,0 +1,6 @@
+class AddChildrenProtectionFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :c100_applications, :protection_orders, :string
+    add_column :c100_applications, :protection_orders_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180305101934) do
+ActiveRecord::Schema.define(version: 20180309155937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,6 +120,8 @@ ActiveRecord::Schema.define(version: 20180305101934) do
     t.string "orders", default: [], array: true
     t.text "orders_additional_details"
     t.integer "status", default: 0
+    t.string "protection_orders"
+    t.text "protection_orders_details"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/controllers/steps/petition/playback_controller_spec.rb
+++ b/spec/controllers/steps/petition/playback_controller_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe Steps::Petition::PlaybackController, type: :controller do
 
   describe '#show' do
     let(:c100_application) { instance_double(C100Application) }
+    let(:safety_concerns)  { false }
 
     before do
+      allow(c100_application).to receive(:has_safety_concerns?).and_return(safety_concerns)
       allow(controller).to receive(:current_c100_application).and_return(c100_application)
       allow(controller).to receive(:update_navigation_stack)
     end
@@ -18,6 +20,28 @@ RSpec.describe Steps::Petition::PlaybackController, type: :controller do
 
       expect(response).to render_template(:show)
       expect(assigns[:petition]).to be_a(PetitionPresenter)
+    end
+
+    context 'assigns the next step path' do
+      context 'when there are safety concerns' do
+        let(:safety_concerns) { true }
+
+        it 'assigns the correct next step path' do
+          get :show
+
+          expect(response).to render_template(:show)
+          expect(assigns[:next_step_path]).to eq('/steps/petition/protection')
+        end
+      end
+
+      context 'when there are no safety concerns' do
+        it 'assigns the correct next step path' do
+          get :show
+
+          expect(response).to render_template(:show)
+          expect(assigns[:next_step_path]).to eq('/steps/alternatives/court')
+        end
+      end
     end
   end
 end

--- a/spec/controllers/steps/petition/protection_controller_spec.rb
+++ b/spec/controllers/steps/petition/protection_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Petition::ProtectionController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Petition::ProtectionForm, C100App::PetitionDecisionTree
+end

--- a/spec/forms/steps/petition/protection_form_spec.rb
+++ b/spec/forms/steps/petition/protection_form_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Petition::ProtectionForm do
+  it_behaves_like 'a yes-no question form',
+                  attribute_name:   :protection_orders,
+                  linked_attribute: :protection_orders_details,
+                  reset_when_no:   [:protection_orders_details]
+end

--- a/spec/services/c100_app/petition_decision_tree_spec.rb
+++ b/spec/services/c100_app/petition_decision_tree_spec.rb
@@ -14,4 +14,9 @@ RSpec.describe C100App::PetitionDecisionTree do
     let(:step_params) { {orders: 'anything'} }
     it {is_expected.to have_destination(:playback, :show)}
   end
+
+  context 'when the step is `protection`' do
+    let(:step_params) { {protection: 'anything'} }
+    it {is_expected.to have_destination('/steps/alternatives/court', :edit)}
+  end
 end


### PR DESCRIPTION
This was a missing step.

Simple Yes/No question, with revealing text area when choosing Yes.

<img width="700" alt="screen shot 2018-03-12 at 09 40 27" src="https://user-images.githubusercontent.com/687910/37276382-6f46d0ae-25d9-11e8-8c6e-c0f5f07c80ed.png">
