### PR TITLE
Include C1A answers in risk concerns

### DIFF
--- a/app/presenters/summary/sections/risk_concerns.rb
+++ b/app/presenters/summary/sections/risk_concerns.rb
@@ -11,15 +11,15 @@ module Summary
 
       def answers
         [
-          Answer.new(:domestic_abuse,     c100.domestic_abuse,    default: default_value),
+          Answer.new(:domestic_abuse,     any_domestic_abuse,     default: default_value),
           Answer.new(:children_abduction, c100.risk_of_abduction, default: default_value),
-          Answer.new(:children_abuse,     c100.children_abuse,    default: default_value),
+          Answer.new(:children_abuse,     any_children_abuse,     default: default_value),
           Answer.new(:substance_abuse,    c100.substance_abuse,   default: default_value),
           Answer.new(:other_concerns,     c100.other_abuse,       default: default_value),
         ]
       end
 
-      def any?
+      def c1a_triggered?
         c100.has_safety_concerns?
       end
 
@@ -27,6 +27,24 @@ module Summary
 
       def default_value
         GenericYesNo::NO
+      end
+
+      def any_domestic_abuse
+        [
+          c100.domestic_abuse,
+          *abuse_answers_for(AbuseSubject::APPLICANT),
+        ].detect { |answer| answer.eql?(GenericYesNo::YES.to_s) }
+      end
+
+      def any_children_abuse
+        [
+          c100.children_abuse,
+          *abuse_answers_for(AbuseSubject::CHILDREN),
+        ].detect { |answer| answer.eql?(GenericYesNo::YES.to_s) }
+      end
+
+      def abuse_answers_for(subject)
+        c100.abuse_concerns.where(subject: subject).pluck(:answer)
       end
     end
   end

--- a/app/views/steps/completion/shared/_risk_concerns.pdf.erb
+++ b/app/views/steps/completion/shared/_risk_concerns.pdf.erb
@@ -10,7 +10,7 @@
       <table class="no-borders subtable">
         <%= render risk_concerns.answers %>
 
-        <% if risk_concerns.any? %>
+        <% if risk_concerns.c1a_triggered? %>
           <tr>
             <td class="question">
               <%=t "check_answers.descriptions.c1a_attached_html" %>

--- a/spec/presenters/summary/sections/risk_concerns_spec.rb
+++ b/spec/presenters/summary/sections/risk_concerns_spec.rb
@@ -45,10 +45,10 @@ module Summary
       end
     end
 
-    describe '#any?' do
-      it 'delegates the implementation to the c100 application' do
+    describe '#c1a_triggered?' do
+      it 'uses the implementation in the c100 application' do
         expect(c100_application).to receive(:has_safety_concerns?).and_return(true)
-        expect(subject.any?).to eq(true)
+        expect(subject.c1a_triggered?).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Apart from the "top level" question, and as it can be NO, we need to check if there are C1A abuse concerns for applicants and children too.

<img width="911" alt="screen shot 2018-03-12 at 16 03 20" src="https://user-images.githubusercontent.com/687910/37294955-ea63363a-260e-11e8-980a-fe40891166cd.png">
