### PR TITLE
Add `declaration` step

### DIFF
--- a/app/controllers/steps/application/declaration_controller.rb
+++ b/app/controllers/steps/application/declaration_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Application
+    class DeclarationController < Steps::ApplicationStepController
+      def edit
+        @form_object = DeclarationForm.new(
+          c100_application: current_c100_application,
+          declaration_made: current_c100_application.declaration_made
+        )
+      end
+
+      def update
+        update_and_advance(DeclarationForm, as: :declaration)
+      end
+    end
+  end
+end

--- a/app/forms/steps/application/declaration_form.rb
+++ b/app/forms/steps/application/declaration_form.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Application
+    class DeclarationForm < BaseForm
+      attribute :declaration_made, Boolean
+
+      validates_presence_of :declaration_made
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        c100_application.update(
+          declaration_made: declaration_made
+        )
+      end
+    end
+  end
+end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -1,6 +1,6 @@
 module C100App
   class ApplicationDecisionTree < BaseDecisionTree
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
     def destination
       return next_step if next_step
 
@@ -28,12 +28,14 @@ module C100App
       when :special_arrangements
         edit(:help_paying)
       when :help_paying
-        show('/steps/completion/summary') # TODO: change when we have 'statement of truth'
+        edit(:declaration)
+      when :declaration
+        show('/steps/completion/summary')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
 
     private
 

--- a/app/views/steps/application/declaration/edit.html.erb
+++ b/app/views/steps/application/declaration/edit.html.erb
@@ -1,0 +1,27 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <p class="lede gv-u-text-lede"><%= t '.lead_text' %></p>
+
+    <div role="note" aria-label="Warning" class="notice gv-c-notice">
+      <i class=" icon icon-important gv-c-notice__icon gv-c-notice__icon--important">
+        <span class=" visually-hidden gv-c-notice__icon-fallback-text"><%= t '.warning_title' %></span>
+      </i>
+      <strong class=" bold-small gv-c-notice__text">
+        <%= t '.warning_text' %>
+      </strong>
+    </div>
+
+    <p>&nbsp;</p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.check_box_fieldset :declaration_made, [:declaration_made] %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -724,6 +724,13 @@ en:
           body_html: |
             <p>You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" target="_blank">get help paying</a> the £215 fee if you’re on a low income, receive certain benefits or have little or no savings.</p>
             <p>If you do qualify, you’ll need to provide the reference number you were given.</p>
+      declaration:
+        edit:
+          page_title: Declaration
+          heading: Declaration
+          lead_text: By submitting your application you confirm the information you’ve provided is true.
+          warning_title: Warning
+          warning_text: You could be fined or imprisoned for contempt of court if you deliberately submit false information.
     international:
       resident:
         edit:
@@ -1037,6 +1044,8 @@ en:
         intermediary_help_html: ""
       steps_application_help_paying_form:
         help_paying_html: "Do you have a ‘Help with fees’ reference number?"
+      steps_application_declaration_form:
+        declaration_made_html: ""
       steps_applicant_user_type_form:
         user_type_html: ""
       steps_miam_consent_order_form:
@@ -1212,6 +1221,8 @@ en:
         intermediary_help_details: *provide_details
       steps_application_help_paying_form:
         hwf_reference_number: Enter your reference number
+      steps_application_declaration_form:
+        declaration_made: I confirm that I believe that the facts stated in this application are true
       steps_applicant_user_type_form:
         user_type:
           themself: Yes, I am the person making the application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
       edit_step :language
       edit_step :intermediary
       edit_step :help_paying
+      edit_step :declaration
     end
     namespace :petition do
       edit_step :orders

--- a/db/migrate/20180313105729_add_declaration_made_field.rb
+++ b/db/migrate/20180313105729_add_declaration_made_field.rb
@@ -1,0 +1,5 @@
+class AddDeclarationMadeField < ActiveRecord::Migration[5.1]
+  def change
+    add_column :c100_applications, :declaration_made, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180312115018) do
+ActiveRecord::Schema.define(version: 20180313105729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 20180312115018) do
     t.integer "status", default: 0
     t.string "protection_orders"
     t.text "protection_orders_details"
+    t.boolean "declaration_made"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/controllers/steps/application/declaration_controller_spec.rb
+++ b/spec/controllers/steps/application/declaration_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Application::DeclarationController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Application::DeclarationForm, C100App::ApplicationDecisionTree
+end

--- a/spec/forms/steps/application/declaration_form_spec.rb
+++ b/spec/forms/steps/application/declaration_form_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Application::DeclarationForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    declaration_made: declaration_made,
+  } }
+  let(:c100_application) { instance_double(C100Application, declaration_made: nil) }
+  let(:declaration_made) { '1' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'validations' do
+      it { should validate_presence_of(:declaration_made) }
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(c100_application).to receive(:update).with(
+          declaration_made: true
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -97,6 +97,11 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
   context 'when the step is `help_paying`' do
     let(:step_params) { { help_paying: 'anything' } }
+    it { is_expected.to have_destination(:declaration, :edit) }
+  end
+
+  context 'when the step is `declaration`' do
+    let(:step_params) { { declaration: 'anything' } }
     it { is_expected.to have_destination('/steps/completion/summary', :show) }
   end
 end


### PR DESCRIPTION
Declaration step to go before the `What's next`.

The checkbox is functional but the error message doesn't link properly. This is due to the way form_builder works. I will try to figure out why.
We have this same problem in at least a couple of other steps.

<img width="669" alt="screen shot 2018-03-13 at 11 44 56" src="https://user-images.githubusercontent.com/687910/37339856-fa524f0e-26b3-11e8-93a1-e632e28f6f5d.png">
