### PR TITLE
Implement single checkbox form helper

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -208,7 +208,6 @@ label[for="steps_abduction_risk_details_form_risk_details"]
 
 .form-block.or-block {
   float: none;
-  margin: -3rem 0 -1rem;
 
   .or-block__shift & {
     margin-top: -5rem;

--- a/app/assets/stylesheets/local/inputs.scss
+++ b/app/assets/stylesheets/local/inputs.scss
@@ -11,6 +11,11 @@ textarea.form-control-large {
   margin-bottom: 10px;
 }
 
+// Individual checkboxes
+.single-cb {
+  width: $full-width;
+}
+
 // Maintain the width when toggling between input password and input text.
 // Otherwise the input text override the width, making it bigger.
 .js-toggleable-password {

--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -61,14 +61,18 @@ address {
 }
 
 .actions {
-
   a, input {
     vertical-align: middle;
     display: inline-block;
   }
 
   a {
-    margin-left: 3em;
+    margin-top: 1em;
+
+    @media (min-width: 641px) {
+      margin-left: 3em;
+      margin-top: 1.6em;
+    }
   }
 
   form {

--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -19,6 +19,15 @@ module CustomFormHelpers
     end
   end
 
+  def single_check_box(attribute, options = {})
+    content_tag(:div, merge_attributes(options, default: {class: 'multiple-choice single-cb', id: form_group_id(attribute)})) do
+      safe_concat [
+        check_box(attribute),
+        label(attribute) { localized_label(attribute) }
+      ].join
+    end
+  end
+
   private
 
   def save_and_return_disabled?
@@ -26,6 +35,6 @@ module CustomFormHelpers
   end
 
   def submit_button(i18n_key)
-    submit t("helpers.submit.#{i18n_key}"), class: 'button'
+    submit t("helpers.submit.#{i18n_key}"), class: 'button form-submit'
   end
 end

--- a/app/views/steps/alternatives/court/edit.en.html.erb
+++ b/app/views/steps/alternatives/court/edit.en.html.erb
@@ -62,7 +62,7 @@
         </div>
 
         <%= step_form @form_object do |f| %>
-          <%= f.check_box_fieldset :court_acknowledgement, [:court_acknowledgement] %>
+          <%= f.single_check_box :court_acknowledgement, class: 'util_mt-large' %>
           <%= f.continue_button %>
         <% end %>
       </div>

--- a/app/views/steps/application/declaration/edit.html.erb
+++ b/app/views/steps/application/declaration/edit.html.erb
@@ -20,7 +20,7 @@
     <p>&nbsp;</p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.check_box_fieldset :declaration_made, [:declaration_made] %>
+      <%= f.single_check_box :declaration_made %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/miam/acknowledgement/edit.en.html.erb
+++ b/app/views/steps/miam/acknowledgement/edit.en.html.erb
@@ -10,8 +10,8 @@
     </div>
 
     <div class="govuk-govspeak gv-s-prose">
-      <p>A <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> is an initial meeting where you'll be given information about <a href="https://helpwithchildarrangements.service.justice.gov.uk/professional-mediation target="_blank"">mediation</a> and alternative ways of reaching an agreement without going to court. A mediator will consider with you whether these other ways are suitable in your case.</p>
-      <p><a href="https://www.gov.uk/check-legal-aid target="_blank"">Check if you’re eligible for legal aid during mediation</a></p>
+      <p>A <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> is an initial meeting where you'll be given information about <a href="https://helpwithchildarrangements.service.justice.gov.uk/professional-mediation" target="_blank">mediation</a> and alternative ways of reaching an agreement without going to court. A mediator will consider with you whether these other ways are suitable in your case.</p>
+      <p><a href="https://www.gov.uk/check-legal-aid" target="_blank">Check if you’re eligible for legal aid during mediation</a></p>
 
       <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
         <p>A <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> is a one-off meeting and not the same as mediation.</p>
@@ -27,7 +27,7 @@
         <li>if you may qualify for help with the costs of mediation and legal advice</li>
         <li>other options available to you</li>
       </ul>
-      <p><a href="https://www.familymediationcouncil.org.uk/find-local-mediator/ target="_blank"">Find a mediator to book a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr></a></p>
+      <p><a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" target="_blank">Find a mediator to book a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr></a></p>
 
       <h2 class="gv-u-heading-xlarge">If you’ve already attended a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr></h2>
       <p>If you have attended a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> it must have taken place within the past 4 months. It must also have been about the same or a very similar child arrangements issue. You should have a certificate signed by the mediator confirming this (which you should bring to your first hearing).</p>
@@ -38,7 +38,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.check_box_fieldset :miam_acknowledgement, [:miam_acknowledgement] %>
+      <%= f.single_check_box :miam_acknowledgement %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/miam_exemptions/adr/edit.html.erb
+++ b/app/views/steps/miam_exemptions/adr/edit.html.erb
@@ -25,7 +25,7 @@
 
       <p class="form-block or-block"><%=t '.or' %></p>
 
-      <%= f.check_box_fieldset :exemptions_group, [AdrExemptions::ADR_NONE] %>
+      <%= f.single_check_box AdrExemptions::ADR_NONE %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam_exemptions/domestic/edit.html.erb
+++ b/app/views/steps/miam_exemptions/domestic/edit.html.erb
@@ -45,7 +45,7 @@
 
       <p class="form-block or-block"><%=t '.or' %></p>
 
-      <%= f.check_box_fieldset :exemptions_group, [DomesticExemptions::DOMESTIC_NONE] %>
+      <%= f.single_check_box DomesticExemptions::DOMESTIC_NONE %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam_exemptions/misc/edit.html.erb
+++ b/app/views/steps/miam_exemptions/misc/edit.html.erb
@@ -31,7 +31,7 @@
 
       <p class="form-block or-block"><%=t '.or' %></p>
 
-      <%= f.check_box_fieldset :exemptions_group, [MiscExemptions::MISC_NONE] %>
+      <%= f.single_check_box MiscExemptions::MISC_NONE %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam_exemptions/protection/edit.html.erb
+++ b/app/views/steps/miam_exemptions/protection/edit.html.erb
@@ -13,7 +13,7 @@
 
       <p class="form-block or-block"><%=t '.or' %></p>
 
-      <%= f.check_box_fieldset :exemptions_group, [ProtectionExemptions::PROTECTION_NONE] %>
+      <%= f.single_check_box ProtectionExemptions::PROTECTION_NONE %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam_exemptions/urgency/edit.html.erb
+++ b/app/views/steps/miam_exemptions/urgency/edit.html.erb
@@ -31,10 +31,10 @@
 
       <p class="form-block or-block"><%=t '.or' %></p>
 
-      <%= f.check_box_fieldset :exemptions_group, [UrgencyExemptions::URGENCY_NONE] %>
+      <%= f.single_check_box UrgencyExemptions::URGENCY_NONE %>
 
       <%= f.continue_button %>
     <% end %>
-    </div
+    </div>
   </div>
 </div>

--- a/app/views/steps/other_parties/contact_details/edit.html.erb
+++ b/app/views/steps/other_parties/contact_details/edit.html.erb
@@ -8,7 +8,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
-      <%= f.check_box_fieldset :address_unknown, [:address_unknown] %>
+      <%= f.single_check_box :address_unknown %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/respondent/contact_details/edit.html.erb
+++ b/app/views/steps/respondent/contact_details/edit.html.erb
@@ -12,7 +12,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
-      <%= f.check_box_fieldset :address_unknown, [:address_unknown] %>
+      <%= f.single_check_box :address_unknown, class: 'util_mb-large' %>
 
       <%=
         f.radio_button_fieldset :residence_requirement_met, inline: true do |fieldset|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -998,6 +998,18 @@ en:
         steps/other_parties/contact_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
+        steps/miam/acknowledgement_form:
+          attributes:
+            miam_acknowledgement:
+              blank: Confirm you understand
+        steps/alternatives/court_form:
+          attributes:
+            court_acknowledgement:
+              blank: Confirm you understand
+        steps/application/declaration_form:
+          attributes:
+            declaration_made:
+              blank: You must accept the declaration
 
   activerecord:
     errors:

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -15,11 +15,10 @@ end
 #
 RSpec.describe GovukElementsFormBuilder::FormBuilder do
   let(:helper) { TestHelper.new }
-  let(:resource) { Applicant.new }
-  let(:builder) { described_class.new :applicant, resource, helper, {} }
 
   describe '#continue_button' do
     let(:c100_application) { C100Application.new(status: :in_progress) }
+    let(:builder) { described_class.new :applicant, Applicant.new, helper, {} }
     let(:html_output) { builder.continue_button }
 
     before do
@@ -32,7 +31,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs the continue button' do
         expect(
           html_output
-        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /></p>')
+        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button form-submit" data-disable-with="Continue" /></p>')
       end
     end
 
@@ -42,7 +41,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs the continue button' do
         expect(
           html_output
-        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /></p>')
+        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button form-submit" data-disable-with="Continue" /></p>')
       end
     end
 
@@ -54,7 +53,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs the save and continue button' do
         expect(
           html_output
-        ).to eq('<p class="actions"><input type="submit" name="commit" value="Save and continue" class="button" data-disable-with="Save and continue" /></p>')
+        ).to eq('<p class="actions"><input type="submit" name="commit" value="Save and continue" class="button form-submit" data-disable-with="Save and continue" /></p>')
       end
     end
 
@@ -62,8 +61,20 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs the continue button with a link to sign-up' do
         expect(
           html_output
-        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /><a href="/test/sign_up">Save and come back later</a></p>')
+        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button form-submit" data-disable-with="Continue" /><a href="/test/sign_up">Save and come back later</a></p>')
       end
+    end
+  end
+
+  describe '#single_check_box' do
+    let(:c100_application) { C100Application.new }
+    let(:builder) { described_class.new :c100_application, c100_application, helper, {} }
+    let(:html_output) { builder.single_check_box(:declaration_made) }
+
+    it 'outputs the check box' do
+      expect(
+        html_output
+      ).to eq('<div class="multiple-choice single-cb"><input name="c100_application[declaration_made]" type="hidden" value="0" /><input type="checkbox" value="1" name="c100_application[declaration_made]" id="c100_application_declaration_made" /><label for="c100_application_declaration_made">Declaration made</label></div>')
     end
   end
 end


### PR DESCRIPTION
The `govuk_elements_form_builder` gem doesn't provide with an easy way to render single, individual checkboxes, instead of groups of checkboxes.

We had several places in the app where individual checkboxes were neccessary and this solve the issue with the error messages not being rendered properly and not linking from the error summary.

It follows GOV.UK elements pattern.

<img width="1008" alt="screen shot 2018-03-13 at 15 46 47" src="https://user-images.githubusercontent.com/687910/37352721-cd77550c-26d5-11e8-872c-8fede9632130.png">
