### PR TITLE
Do not rely on `HEROKU_APP_NAME` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ to complete the C100 form. It is based on software patterns developed for the
 
 ## Heroku demo.
 
-There is a demo app. running on Heroku at [this url][heroku-demo]
+There is a demo app. running on Heroku at [this url][heroku-staging]
 
 The demo. app. uses http basic auth. to restrict access. The username and
 password should be available from the MoJ Rattic server, in the Family Justice group.
@@ -47,4 +47,4 @@ However it is still possible to have full flexibility of what mutant runs in you
 `bundle exec rake mutant`
 
 [taxtribs]: https://github.com/ministryofjustice/tax-tribunals-datacapture
-[heroku-demo]: https://c100-demo.herokuapp.com
+[heroku-staging]: https://c100-staging.herokuapp.com

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  # Heroku demo app requires basic auth to restrict access
   # :nocov:
-  if ENV.fetch('HEROKU_APP_NAME', false)
+  if ENV.fetch('HTTP_AUTH_ENABLED', false)
     http_basic_authenticate_with name: ENV.fetch('HTTP_AUTH_USER'), password: ENV.fetch('HTTP_AUTH_PASSWORD')
   end
   # :nocov:

--- a/set_heroku_env_vars.sh
+++ b/set_heroku_env_vars.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 heroku config:set \
-  EXTERNAL_URL=https://c100-demo.herokuapp.com \
+  EXTERNAL_URL=https://c100-staging.herokuapp.com \
   RACK_ENV=production \
   RAILS_ENV=production \
   RAILS_LOG_TO_STDOUT=enabled \
@@ -11,6 +11,7 @@ heroku config:set \
   RAILS_SERVE_STATIC_FILES=enabled \
   SECRET_KEY_BASE=$(bundle exec rails secret) \
   GOVUK_NOTIFY_API_KEY=DUMMYVALUE \
+  HTTP_AUTH_ENABLED=1 \
   HTTP_AUTH_USER=${HTTP_AUTH_USER} \
   HTTP_AUTH_PASSWORD=${HTTP_AUTH_PASSWORD} \
   LANG=en_US.UTF-8


### PR DESCRIPTION
This env var is only set if a specific plugin is enabled on Heroku. If we ever move out of Heroku this will not make sense. Better to have a specific.