### PR TITLE
Handle c100 status

### DIFF
--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -75,6 +75,10 @@ address {
     }
   }
 
+  a.button {
+    margin-left: 0;
+  }
+
   form {
     vertical-align: middle;
     display: inline-block;

--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -1,0 +1,15 @@
+module CompletionStep
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :mark_completed
+  end
+
+  private
+
+  def mark_completed
+    # The step including this concern will mark the current application as `completed`,
+    # meaning it can't be drafted (and don't appear anymore in drafts).
+    current_c100_application.completed!
+  end
+end

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -1,0 +1,39 @@
+module ErrorHandling
+  extend ActiveSupport::Concern
+
+  included do
+    protect_from_forgery with: :exception
+
+    rescue_from Exception do |exception|
+      case exception
+      when Errors::InvalidSession, ActionController::InvalidAuthenticityToken
+        redirect_to invalid_session_errors_path
+      when Errors::ApplicationNotFound
+        redirect_to application_not_found_errors_path
+      when Errors::ApplicationScreening
+        redirect_to application_screening_errors_path
+      when Errors::ApplicationCompleted
+        redirect_to application_completed_errors_path
+      else
+        raise if Rails.application.config.consider_all_requests_local
+
+        Raven.capture_exception(exception)
+        redirect_to unhandled_errors_path
+      end
+    end
+  end
+
+  private
+
+  def check_c100_application_presence
+    raise Errors::InvalidSession unless current_c100_application
+  end
+
+  def check_application_not_completed
+    raise Errors::ApplicationCompleted if current_c100_application.completed?
+  end
+
+  def check_application_not_screening
+    raise Errors::ApplicationScreening if current_c100_application.screening?
+  end
+end

--- a/app/controllers/concerns/savepoint_step.rb
+++ b/app/controllers/concerns/savepoint_step.rb
@@ -2,6 +2,7 @@ module SavepointStep
   extend ActiveSupport::Concern
 
   included do
+    skip_before_action :check_application_not_screening
     before_action :mark_in_progress, only: [:update]
     before_action :save_application_for_later, if: :user_signed_in?, only: [:update]
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -9,6 +9,14 @@ class ErrorsController < ApplicationController
     respond_with_status(:not_found)
   end
 
+  def application_screening
+    respond_with_status(:unprocessable_entity)
+  end
+
+  def application_completed
+    respond_with_status(:unprocessable_entity)
+  end
+
   def unhandled
     respond_with_status(:internal_server_error)
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,7 +28,7 @@ class SessionsController < ApplicationController
 
   # :nocov:
   def c100_application
-    @_c100_application ||= C100Application.create.tap do |c100_application|
+    current_c100_application || C100Application.create.tap do |c100_application|
       session[:c100_application_id] = c100_application.id
     end
   end

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -1,5 +1,6 @@
 class StepController < ApplicationController
   before_action :check_c100_application_presence
+  before_action :check_application_not_completed, :check_application_not_screening, except: [:show]
   before_action :update_navigation_stack, only: [:show, :edit]
 
   def previous_step_path

--- a/app/controllers/steps/completion/what_next_controller.rb
+++ b/app/controllers/steps/completion/what_next_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   module Completion
     class WhatNextController < Steps::CompletionStepController
+      include CompletionStep
+
       def show
         @court = court_from_screener_answers
       end

--- a/app/controllers/steps/screener_step_controller.rb
+++ b/app/controllers/steps/screener_step_controller.rb
@@ -1,5 +1,7 @@
 module Steps
   class ScreenerStepController < StepController
+    skip_before_action :check_application_not_screening
+
     private
 
     def decision_tree_class

--- a/app/errors/errors.rb
+++ b/app/errors/errors.rb
@@ -1,4 +1,6 @@
 module Errors
   class InvalidSession < StandardError; end
   class ApplicationNotFound < StandardError; end
+  class ApplicationCompleted < StandardError; end
+  class ApplicationScreening < StandardError; end
 end

--- a/app/views/errors/application_completed.html.erb
+++ b/app/views/errors/application_completed.html.erb
@@ -1,0 +1,13 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <div class="form-group">
+      <%= link_to t('.start_again'), root_path, class: 'button' %>
+    </div>
+  </div>
+</div>

--- a/app/views/errors/application_completed.html.erb
+++ b/app/views/errors/application_completed.html.erb
@@ -2,9 +2,11 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large"><%= t '.heading' %></h1>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%= t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>
+
+    <p class="lede"><%= link_to t('.what_next'), steps_completion_what_next_path %></p>
 
     <div class="form-group">
       <%= link_to t('.start_again'), root_path, class: 'button' %>

--- a/app/views/errors/application_not_found.html.erb
+++ b/app/views/errors/application_not_found.html.erb
@@ -2,9 +2,10 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large"><%= t '.heading' %></h1>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%= t '.heading' %></h1>
 
     <p class="lede"><%=t('.lead_text', session_timeout: Rails.configuration.x.session.expires_in_minutes) %></p>
+
     <p class="lede"><%=t('.more_text', expire_in_days: Rails.configuration.x.drafts.expire_in_days) %></p>
 
     <div class="form-group">

--- a/app/views/errors/application_screening.html.erb
+++ b/app/views/errors/application_screening.html.erb
@@ -1,0 +1,15 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <p class="lede"><%=t '.more_info_text' %></p>
+
+    <div class="form-group">
+      <%= link_to t('.start_again'), root_path, class: 'button' %>
+    </div>
+  </div>
+</div>

--- a/app/views/errors/application_screening.html.erb
+++ b/app/views/errors/application_screening.html.erb
@@ -2,7 +2,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large"><%= t '.heading' %></h1>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%= t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>
 

--- a/app/views/errors/unhandled.html.erb
+++ b/app/views/errors/unhandled.html.erb
@@ -8,6 +8,8 @@
 
     <p class="lede"><%=t '.more_text' %></p>
 
-    <%= render partial: 'steps/shared/finish_button', locals: {name: t('.start_again'), show_survey: false} %>
+    <div class="form-group">
+      <%= link_to t('.start_again'), root_path, class: 'button' %>
+    </div>
   </div>
 </div>

--- a/app/views/steps/completion/what_next/show.html.erb
+++ b/app/views/steps/completion/what_next/show.html.erb
@@ -2,8 +2,6 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= step_header %>
-
     <div class="grid_content_header govuk-box-highlight">
       <h1 class="app__heading  heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
       <p class="app__lede  lede gv-u-text-lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -19,8 +19,9 @@
       </ul>
     </div>
 
-    <div class="xform-group form-submit">
+    <p class="actions">
       <%= link_to 'Start now', edit_steps_screener_postcode_path, class: 'button', role: 'button' %>
-    </div>
+      <a href="/users/login">Or return to a saved application</a>
+    </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1005,12 +1005,13 @@ en:
       page_title: Application screening
       heading: You need to complete the criteria process
       lead_text: We’re trialling a new online service and you need to meet some criteria in order to continue.
-      more_info_text: It seems like you've not completed yet this process or is missing some information. You will need to start again.
+      more_info_text: It seems you've not completed yet this process or some information is missing. You will need to start again.
       <<: *START_FINISH
     application_completed:
       page_title: Application completed
       heading: You have already completed this application
-      lead_text: If you want to make changes or create a new application, you can start a new application.
+      lead_text: Your application won’t be processed until you complete a few more steps. If you want to make changes you can start a new application.
+      what_next: What you need to do next
       <<: *START_FINISH
 
   activemodel:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1001,6 +1001,17 @@ en:
       lead_text: If you copied a web address, please check it’s correct.
       more_text: "Please note: a draft application expires %{expire_in_days} days after it was created or when you complete it."
       <<: *START_FINISH
+    application_screening:
+      page_title: Application screening
+      heading: You need to complete the criteria process
+      lead_text: We’re trialling a new online service and you need to meet some criteria in order to continue.
+      more_info_text: It seems like you've not completed yet this process or is missing some information. You will need to start again.
+      <<: *START_FINISH
+    application_completed:
+      page_title: Application completed
+      heading: You have already completed this application
+      lead_text: If you want to make changes or create a new application, you can start a new application.
+      <<: *START_FINISH
 
   activemodel:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,6 +226,8 @@ Rails.application.routes.draw do
   resource :errors, only: [] do
     get :invalid_session
     get :application_not_found
+    get :application_screening
+    get :application_completed
     get :unhandled
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe ApplicationController do
   controller do
     def invalid_session; raise Errors::InvalidSession; end
     def application_not_found; raise Errors::ApplicationNotFound; end
+    def application_completed; raise Errors::ApplicationCompleted; end
+    def application_screening; raise Errors::ApplicationScreening; end
     def another_exception; raise Exception; end
   end
 
@@ -31,6 +33,28 @@ RSpec.describe ApplicationController do
 
         get :application_not_found
         expect(response).to redirect_to(application_not_found_errors_path)
+      end
+    end
+
+    context 'Errors::ApplicationScreening' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'application_screening' => 'anonymous#application_screening' }
+
+        expect(Raven).not_to receive(:capture_exception)
+
+        get :application_screening
+        expect(response).to redirect_to(application_screening_errors_path)
+      end
+    end
+
+    context 'Errors::ApplicationCompleted' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'application_completed' => 'anonymous#application_completed' }
+
+        expect(Raven).not_to receive(:capture_exception)
+
+        get :application_completed
+        expect(response).to redirect_to(application_completed_errors_path)
       end
     end
 

--- a/spec/controllers/steps/completion/what_next_controller_spec.rb
+++ b/spec/controllers/steps/completion/what_next_controller_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Steps::Completion::WhatNextController, type: :controller do
     before do
       allow(subject).to receive(:court_from_screener_answers).and_return(court)
     end
+
     it_behaves_like 'a show step controller'
+    it_behaves_like 'a completion step controller'
   end
 
   describe '#court_from_screener_answers' do

--- a/spec/support/relationship_step_controller_shared_examples.rb
+++ b/spec/support/relationship_step_controller_shared_examples.rb
@@ -12,6 +12,8 @@ RSpec.shared_examples 'a relationship step controller' do |form_class, decision_
   # This is a side effect of everything being a double, we have to do a lot of 'setup', but all this
   # is not part of these tests and we don't need to test the functionality, just trust it.
   before do
+    allow(existing_case).to receive(:completed?).and_return(false)
+    allow(existing_case).to receive(:screening?).and_return(false)
     allow(controller).to receive(:current_c100_application).and_return(existing_case)
     allow(controller).to receive(:update_navigation_stack)
   end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -35,7 +35,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
     # end
 
     context 'when a case in progress is in the session' do
-      let(:existing_case) { C100Application.create }
+      let(:existing_case) { C100Application.create(status: :in_progress) }
 
       before do
         allow(form_class).to receive(:new).and_return(form_object)
@@ -118,7 +118,7 @@ end
 
 RSpec.shared_examples 'a savepoint step controller' do
   describe '#edit' do
-    let!(:existing_c100) { C100Application.create(navigation_stack: ['/not', '/empty']) }
+    let!(:existing_c100) { C100Application.create(status: :screening, navigation_stack: ['/not', '/empty']) }
 
     before do
       allow(controller).to receive(:current_c100_application).and_return(existing_c100)
@@ -152,7 +152,7 @@ RSpec.shared_examples 'a savepoint step controller' do
   end
 
   describe '#update' do
-    let!(:existing_c100) { C100Application.create(navigation_stack: ['/not', '/empty']) }
+    let!(:existing_c100) { C100Application.create(status: :screening, navigation_stack: ['/not', '/empty']) }
 
     before do
       allow(controller).to receive(:current_c100_application).and_return(existing_c100)
@@ -192,6 +192,24 @@ RSpec.shared_examples 'a savepoint step controller' do
   end
 end
 
+RSpec.shared_examples 'a completion step controller' do
+  describe '#show' do
+    context 'when a case exists in the session' do
+      let!(:existing_c100) { C100Application.create(status: :in_progress) }
+
+      before do
+        allow(controller).to receive(:current_c100_application).and_return(existing_c100)
+      end
+
+      it 'changes the status to `completed`' do
+        expect {
+          get :show, session: { c100_application_id: existing_c100.id }
+        }.to change { existing_c100.status }.to('completed')
+      end
+    end
+  end
+end
+
 RSpec.shared_examples 'an intermediate step controller' do |form_class, decision_tree_class|
   include_examples 'a generic step controller', form_class, decision_tree_class
 
@@ -210,7 +228,7 @@ RSpec.shared_examples 'an intermediate step controller' do |form_class, decision
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) { C100Application.create }
+      let!(:existing_case) { C100Application.create(status: :in_progress) }
 
       it 'responds with HTTP success' do
         get :edit, session: { c100_application_id: existing_case.id }
@@ -235,7 +253,7 @@ RSpec.shared_examples 'an intermediate step controller without update' do
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) { C100Application.create }
+      let!(:existing_case) { C100Application.create(status: :in_progress) }
 
       it 'responds with HTTP success' do
         get :edit, session: { c100_application_id: existing_case.id }
@@ -263,7 +281,7 @@ RSpec.shared_examples 'an names CRUD step controller' do |form_class, decision_t
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) {C100Application.create}
+      let!(:existing_case) { C100Application.create(status: :in_progress) }
       let!(:existing_resource) { resource_class.create(c100_application: existing_case) }
 
       before do


### PR DESCRIPTION
Introduce a `CompletionStep` concern to mark the final step when an application is considered completed, so, for example, it doesn't appear anymore in drafts, and we don't send email reminders anymore about it.

Also, check the application is not still screening in case the user had a bookmark, or enter a URL manually.

The copy for the errors is TBD.