### PR TITLE
Improve the exit page for an error checking postcode. 

### DIFF
--- a/app/controllers/steps/screener/error_but_continue_controller.rb
+++ b/app/controllers/steps/screener/error_but_continue_controller.rb
@@ -1,7 +1,9 @@
 module Steps
   module Screener
     class ErrorButContinueController < Steps::ScreenerStepController
-      def show; end
+      def show
+        @courtfinder_ok = C100App::CourtfinderAPI.new.is_ok?
+      end
     end
   end
 end

--- a/app/views/steps/screener/error_but_continue/show.html.erb
+++ b/app/views/steps/screener/error_but_continue/show.html.erb
@@ -6,12 +6,26 @@
 
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <p class="lede"><%=t '.lead_text' %></p>
+    <p class="lede">
+      <%- if @courtfinder_ok %>
+        <%= t '.lead_text.courtfinder_ok' %>
+      <%- else %>
+        <%= t '.lead_text.courtfinder_not_ok' %>
+      <%- end %>
+    </p>
+
+    <section id="what-to-do-now" class="moj-Section moj-Section--2" data-block-name="what-to-do-now">
+      <h2 class="gv-u-heading-xlarge"><%= t '.what_to_do_now.heading' %></h2>
+      <div class="Section__content govuk-govspeak gv-s-prose">
+        <p><%= t '.what_to_do_now.copy' %></p>
+      </div>
+    </section>
 
     <!-- TODO: Add the copy needed, and adapt the button linking to another step -->
 
     <div class="xform-group form-submit">
-      <%= link_to t('.continue'), '/steps/screener/urgency', class: 'button', role: 'button' %>
+      <%= link_to t('.go_back'), '/steps/screener/postcode', class: 'button', role: 'button' %>
+      <%= link_to t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'button', role: 'button' %>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -820,10 +820,14 @@ en:
         show:
           page_title: Where your children live
           heading: Something went wrong
-          lead_text: This might be a temporary problem with our court postcode checker, or there could be a problem with us recognising your postcode.
-          go_back_or_continue: You can go back and try again, or continue with your application anyway
+          lead_text:
+            courtfinder_ok: Although the postcode you entered looks like it's in the right format, our checker didn't recognize it. This can happen sometimes if it's a very new or old postcode.
+            courtfinder_not_ok: We're having some trouble connecting to our postcode checker at the moment - this could be a temporary problem, and it might work if you try again.
+          what_to_do_now:
+            heading: What to do now
+            copy: You can go back and try again, or download the paper form to print and fill in offline. You can then submit the completed form by post or in person at the court.
           go_back: Go back and try again
-          continue: Continue
+          download_c100_link: Download the paper form (PDF)
       no_court_found:
         show:
           page_title: Not eligible

--- a/spec/controllers/steps/screener/error_but_continue_controller_spec.rb
+++ b/spec/controllers/steps/screener/error_but_continue_controller_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Screener::ErrorButContinueController, type: :controller do
+  let(:courtfinder_ok){ true }
+
+  before do
+    allow_any_instance_of(C100App::CourtfinderAPI).to receive(:is_ok?).and_return(courtfinder_ok)
+  end
   it_behaves_like 'a show step controller'
+
+  describe '#show' do
+    let!(:existing_case) { C100Application.create }
+    let(:courtfinder_ok){ 'foo' }
+
+    it 'checks if the courtfinder api is ok' do
+      expect_any_instance_of(C100App::CourtfinderAPI).to receive(:is_ok?)
+      get :show, session: { c100_application_id: existing_case.id }
+    end
+
+    it 'sets @courtfinder_ok with the value of CourtfinderAPI.is_ok?' do
+      get :show, session: { c100_application_id: existing_case.id }
+      expect( assigns[:courtfinder_ok] ).to_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
Differentiate between an unrecognised postcode, and the courtfinder API being down, showing slightly different wording for each case

<img width="648" alt="screen shot 2018-03-21 at 16 02 03" src="https://user-images.githubusercontent.com/134501/37721397-3c78e14a-2d21-11e8-8648-8994abb8bf88.png">

OR

<img width="650" alt="screen shot 2018-03-21 at 16 01 22" src="https://user-images.githubusercontent.com/134501/37721346-268b963e-2d21-11e8-92f5-6dfbd261d9fe.png">
