### PR TITLE
Tidy up styling

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -103,23 +103,49 @@ section.numbered-list ol > li:nth-child(4){
   padding-top:96px;
   padding-top:6rem;
 }
-#content [data-block-name="route:application-requirements"] {
-  background-color: #0053a5;
+#content .flash-card {
+  background-color: #005ea5;
   color: #fff;
   padding: 3rem;
+  @media (min-width: 641px) {
+    padding: 5rem;
+    margin-bottom: -6rem;
+  }
   margin-top: 1rem;
 }
-#content [data-block-name="route:application-requirements"] {
+#content .flash-card {
+  & .grid_content_header {
+    @media (min-width: 641px) {
+      width: 150%;
+    }
+  }
+  & p.app__section_heading {
+    margin-top: 0;
+  }
+  & h1.app__heading {
+    margin-bottom: 3rem;
+  }
+  & h2 {
+    font-size: 19px;
+    @media (min-width: 641px) {
+      font-size: 28px;
+    }
+  }
   & .button {
     background-color: #fff;
-    color: #0053a5;
+    color: #005ea5;
+    padding-left: 5rem;
+    padding-right: 5rem;
+    font-weight: bold;
+    &:hover {
+      background-color: #dee0e2;
+    }
   }
   & .panel-border-wide {
     border-color: #fff;
   }
   & .panel-border-wide p {
-    font-size: 1.6rem;
-    font-weight: 700;
+    font-weight: bold;
   }
 }
 

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -224,4 +224,16 @@ section.numbered-list ol > li:nth-child(4){
   }
 }
 
+.gv-c-notice .gv-c-notice__icon {
+  top: 0;
+  margin-top: 0;
+}
+
+.miam_exemptions > form > .form-group > fieldset > .multiple-choice > label > span.form-hint {
+  margin-top: 0.5rem;
+}
+.miam_exemptions > form p:empty {
+  display: none;
+}
+
 @import 'app/pros_cons';

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -179,8 +179,22 @@ section.numbered-list ol > li:nth-child(4){
   margin-left:0;
 }
 
-#new_steps_miam_acknowledgement_form {
+#new_steps_miam_acknowledgement_form,
+#new_steps_alternatives_court_form {
   margin-top: 6rem;
+}
+
+#new_steps_petition_orders_form > .form-group {
+  margin-bottom: 0;
+  & > fieldset {
+    & > .multiple-choice {
+      min-height: 6rem;
+    }
+    & > .panel {
+      margin-top: -2rem;
+      margin-bottom: 3rem;
+    }
+  }
 }
 
 #court-contact-details {

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -1,3 +1,11 @@
+#content {
+  margin-bottom: 3rem;
+  padding-bottom: 1rem;
+}
+.start-page a.button.button-start {
+  margin-bottom: 3rem;
+}
+
 .panel-border-wide {
   padding: 16px 32px;
   padding: 1rem 2rem;
@@ -20,6 +28,9 @@
   line-height: 1.25;
   margin-top: 0.625em;
   margin-bottom: 0.3125em;
+  a.link-back + & {
+    margin-top: 0;
+  }
 }
 
 @media (min-width: 641px) {
@@ -109,7 +120,7 @@ section.numbered-list ol > li:nth-child(4){
   padding: 3rem;
   @media (min-width: 641px) {
     padding: 5rem;
-    margin-bottom: -6rem;
+    margin-bottom: -1rem;
   }
   margin-top: 1rem;
 }
@@ -147,6 +158,29 @@ section.numbered-list ol > li:nth-child(4){
   & .panel-border-wide p {
     font-weight: bold;
   }
+}
+
+.button.button-secondary{
+  background:transparent;
+  color:#005ea5;
+  border-bottom-color:#fff;
+  box-shadow:none;
+  text-decoration:underline;
+  padding-left:0;
+  padding-right:0;
+  margin-left:96px;
+  margin-left:6rem
+}
+.button.button-secondary:hover{
+  background:transparent;
+  color:#2b8cc4;
+}
+.button.button-secondary:first-child{
+  margin-left:0;
+}
+
+#new_steps_miam_acknowledgement_form {
+  margin-top: 6rem;
 }
 
 #court-contact-details {

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -197,6 +197,23 @@ section.numbered-list ol > li:nth-child(4){
   }
 }
 
+.dont-know {
+  margin-top: -5px;
+    @media (min-width: 641px) {
+      margin-top: -20px;
+    }
+}
+
+[data-target="dob_unknown_panel"] {
+  margin-top: -15px;
+    @media (min-width: 641px) {
+      margin-top: -30px;
+    }
+}
+.form-date .form-hint {
+  margin-bottom: 0;
+}
+
 #court-contact-details {
   dt {
     margin-top: 15px;

--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -99,6 +99,7 @@ label[for="steps_abduction_risk_details_form_risk_details"]
 }
 
 fieldset + .form-group {
+  margin-top: 30px;
   margin-bottom: 15px;
 }
 @media (min-width: 641px) {

--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -88,9 +88,9 @@ label[for="steps_abduction_risk_details_form_risk_details"]
 
 .form-block.or-block {
   float: none;
-
+  margin-top: -4rem;
   .or-block__shift & {
-    margin-top: -5rem;
+    margin-top: -4rem;
   }
 }
 

--- a/app/assets/stylesheets/local/inputs.scss
+++ b/app/assets/stylesheets/local/inputs.scss
@@ -28,6 +28,10 @@ textarea.form-control-large {
 .single-cb {
   width: 90%;
 }
+.multiple-choice.single-cb {
+  float: none;
+  display: table;
+}
 
 // Maintain the width when toggling between input password and input text.
 // Otherwise the input text override the width, making it bigger.

--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -126,12 +126,13 @@ h1.gv-u-heading-xxlarge {
     font-size: 36px;
   }
 
-  a.link-back + & {
+  a.link-back + &,
+  a.link-back + .app__section_heading + & {
     margin: 0.25rem 0 3rem;
   }
 }
 
-.gv-s-prose h2 {
+.start-page h2 {
   margin-top: 1.25em;
   margin-bottom: 0.55556em;
   @media (min-width: 641px) {

--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -11,11 +11,6 @@ form {
   padding-bottom: $gutter;
 }
 
-fieldset + .form-group {
-  margin-bottom: 0;
-  margin-top: $gutter;
-}
-
 .step-info {
   @include core-19;
   color: $grey-1;

--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -127,6 +127,7 @@ h1.gv-u-heading-xxlarge {
   }
 
   a.link-back + &,
+  a.link-back + .grid_content_header > &,
   a.link-back + .app__section_heading + & {
     margin: 0.25rem 0 3rem;
   }

--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -121,5 +121,28 @@ h2.notice {
 }
 
 h1.gv-u-heading-xxlarge {
-  font-size: 36px;
+  font-size: 24px;
+  @media (min-width: 641px) {
+    font-size: 36px;
+  }
+
+  a.link-back + & {
+    margin: 0.25rem 0 3rem;
+  }
+}
+
+.gv-s-prose h2 {
+  margin-top: 1.25em;
+  margin-bottom: 0.55556em;
+  @media (min-width: 641px) {
+    font-size: 36px;
+    line-height: 1.11111;
+  }
+}
+
+h1.heading-start {
+  font-size: 32px;
+  @media (min-width: 641px) {
+    font-size: 48px;
+  }
 }

--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -5,7 +5,7 @@ module CustomFormHelpers
            :new_user_registration_path, to: :@template
 
   def continue_button
-    content_tag(:p, class: 'actions') do
+    content_tag(:div, class: 'form-submit') do
       if save_and_return_disabled?
         submit_button(:continue)
       elsif user_signed_in?
@@ -13,7 +13,7 @@ module CustomFormHelpers
       else
         safe_concat [
           submit_button(:continue),
-          content_tag(:a, t('helpers.submit.save_and_come_back_later'), href: new_user_registration_path)
+          content_tag(:a, t('helpers.submit.save_and_come_back_later'), href: new_user_registration_path, class: 'button button-secondary button-save-return')
         ].join
       end
     end
@@ -35,6 +35,6 @@ module CustomFormHelpers
   end
 
   def submit_button(i18n_key)
-    submit t("helpers.submit.#{i18n_key}"), class: 'button form-submit'
+    submit t("helpers.submit.#{i18n_key}"), class: 'button'
   end
 end

--- a/app/views/entrypoint/how_long.en.html.erb
+++ b/app/views/entrypoint/how_long.en.html.erb
@@ -2,7 +2,7 @@
 
 <a class="link-back" href="/entrypoint/what_is_needed">Back</a>
 
-<main data-block-name="route:application-requirements">
+<div data-block-name="route:application-requirements" class="flash-card">
   <div class=" grid-row gv-o-grid-row">
     <div class=" column-two-thirds gv-o-grid-item gv-u-two-thirds">
       <div class="grid_content_header">
@@ -28,4 +28,4 @@
       </div>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/entrypoint/v1.en.html.erb
+++ b/app/views/entrypoint/v1.en.html.erb
@@ -3,7 +3,7 @@
 <div class=" grid-row gv-o-grid-row">
   <div class=" column-two-thirds gv-o-grid-item gv-u-two-thirds">
     <div class="grid_content_header">
-      <h1 class="heading-xlarge gv-u-heading-xxlarge">Apply to court about child arrangements</h1>
+      <h1 class="heading-xlarge gv-u-heading-xxlarge heading-start">Apply to court about child arrangements</h1>
     </div>
 
     <div class=" govuk-govspeak gv-s-prose">
@@ -15,7 +15,6 @@
         <div role="note" aria-label="Information" class=" panel panel-border-wide info-notice TODO">
           <p>This service is the digital version of the C100 paper application form.</p>
         </div>
-    </div>
 
     <section id="fees-explanation" class="moj-Section moj-Section--2" data-block-name="fees-explanation">
       <h2 class="gv-u-heading-xlarge">Fees</h2>
@@ -55,6 +54,7 @@
         <p>Once you’ve saved your application you’ll need to email the PDF to your nearest family court.</p>
       </div>
     </section>
+    </div>
 
     <%= render partial: 'entrypoint/shared/start_application' %>
   </div>

--- a/app/views/entrypoint/v1.en.html.erb
+++ b/app/views/entrypoint/v1.en.html.erb
@@ -1,6 +1,6 @@
 <% title 'Entrypoint version 1' %>
 
-<div class=" grid-row gv-o-grid-row">
+<div class=" grid-row gv-o-grid-row start-page">
   <div class=" column-two-thirds gv-o-grid-item gv-u-two-thirds">
     <div class="grid_content_header">
       <h1 class="heading-xlarge gv-u-heading-xxlarge heading-start">Apply to court about child arrangements</h1>

--- a/app/views/entrypoint/what_is_needed.en.html.erb
+++ b/app/views/entrypoint/what_is_needed.en.html.erb
@@ -2,7 +2,7 @@
 
 <a class="link-back" href="/entrypoint/v1">Back</a>
 
-<main data-block-name="route:application-requirements">
+<div data-block-name="route:application-requirements" class="flash-card">
   <div class=" grid-row gv-o-grid-row">
     <div class=" column-two-thirds gv-o-grid-item gv-u-two-thirds">
       <div class="grid_content_header">
@@ -32,4 +32,4 @@
       </div>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/steps/abuse_concerns/contact/edit.html.erb
+++ b/app/views/steps/abuse_concerns/contact/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= step_header %>
-
+    <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <div class="govuk-govspeak gv-s-prose">

--- a/app/views/steps/alternatives/collaborative_law/edit.en.html.erb
+++ b/app/views/steps/alternatives/collaborative_law/edit.en.html.erb
@@ -3,10 +3,8 @@
 <div class="grid-row gv-o-grid-row">
   <div class="column-two-thirds gv-o-grid-item gv-u-two-thirds">
     <%= step_header %>
-
-    <div class="grid_content_header">
-      <h1 class="heading-xlarge gv-u-heading-xxlarge">Collaborative law</h1>
-    </div>
+    <p class="app__section_heading">Alternative ways to reach an agreement</p>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Collaborative law</h1>
 
     <div class="govuk-govspeak gv-s-prose">
       <p>Collaborative lawyers work with you and the other parent to resolve your issues out of court. You each hire a lawyer then all meet to negotiate face-to-face.</p>

--- a/app/views/steps/alternatives/lawyer_negotiation/edit.en.html.erb
+++ b/app/views/steps/alternatives/lawyer_negotiation/edit.en.html.erb
@@ -3,10 +3,8 @@
 <div class="grid-row gv-o-grid-row">
   <div class="column-two-thirds gv-o-grid-item gv-u-two-thirds">
     <%= step_header %>
-
-    <div class="grid_content_header">
-      <h1 class="heading-xlarge gv-u-heading-xxlarge">Lawyer negotiation</h1>
-    </div>
+    <p class="app__section_heading">Alternative ways to reach an agreement</p>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Lawyer negotiation</h1>
 
     <div class="govuk-govspeak gv-s-prose">
       <p>With lawyer negotiation you don’t deal directly with the person. You hire a lawyer to negotiate arrangements for you.</p>

--- a/app/views/steps/alternatives/mediation/edit.en.html.erb
+++ b/app/views/steps/alternatives/mediation/edit.en.html.erb
@@ -3,10 +3,8 @@
 <div class="grid-row gv-o-grid-row">
   <div class="column-two-thirds gv-o-grid-item gv-u-two-thirds">
     <%= step_header %>
-
-    <div class="grid_content_header">
+      <p class="app__section_heading">Alternative ways to reach an agreement</p>
       <h1 class="heading-xlarge gv-u-heading-xxlarge">Professional mediation</h1>
-    </div>
 
     <div class="govuk-govspeak gv-s-prose">
       <p>Mediation sessions are run by professionals who help you try to reach an agreement without going to court.</p>

--- a/app/views/steps/alternatives/negotiation_tools/edit.en.html.erb
+++ b/app/views/steps/alternatives/negotiation_tools/edit.en.html.erb
@@ -3,10 +3,8 @@
 <div class="grid-row gv-o-grid-row">
   <div class="column-two-thirds gv-o-grid-item gv-u-two-thirds">
     <%= step_header %>
-
-    <div class="grid_content_header">
-      <h1 class="heading-xlarge gv-u-heading-xxlarge">Negotiation tools and services</h1>
-    </div>
+    <p class="app__section_heading">Alternative ways to reach an agreement</p>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Negotiation tools and services</h1>
 
     <div class="govuk-govspeak gv-s-prose">
       <p>If you still communicate with the other person, and there are no concerns about domestic or child abuse, the

--- a/app/views/steps/application/intermediary/edit.html.erb
+++ b/app/views/steps/application/intermediary/edit.html.erb
@@ -7,7 +7,9 @@
     <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%= t '.lead_text' %></p>
+    </div>
 
     <%= step_form @form_object do |f| %>
       <%=

--- a/app/views/steps/application/litigation_capacity/edit.html.erb
+++ b/app/views/steps/application/litigation_capacity/edit.html.erb
@@ -7,7 +7,9 @@
     <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%= t '.lead_text' %></p>
+    </div>
 
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :reduced_litigation_capacity, inline: true, choices: GenericYesNo.values %>

--- a/app/views/steps/application/special_arrangements/edit.html.erb
+++ b/app/views/steps/application/special_arrangements/edit.html.erb
@@ -7,7 +7,9 @@
     <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%= t '.lead_text' %></p>
+    </div>
 
     <%= step_form @form_object do |f| %>
       <%=

--- a/app/views/steps/application/special_assistance/edit.html.erb
+++ b/app/views/steps/application/special_assistance/edit.html.erb
@@ -7,7 +7,9 @@
     <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%= t '.lead_text' %></p>
+    </div>
 
     <%= step_form @form_object do |f| %>
       <%=

--- a/app/views/steps/court_orders/details/edit.html.erb
+++ b/app/views/steps/court_orders/details/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= step_header %>
-
+    <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/court_orders/has_orders/edit.html.erb
+++ b/app/views/steps/court_orders/has_orders/edit.html.erb
@@ -3,10 +3,12 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= step_header %>
-
+    <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%=t '.lead_text' %></p>
+    </div>
 
     <%= step_form @form_object, inline: true do |f| %>
       <%= f.radio_button_fieldset :has_court_orders, inline: true, choices: GenericYesNo.values %>

--- a/app/views/steps/miam_exemptions/protection/edit.html.erb
+++ b/app/views/steps/miam_exemptions/protection/edit.html.erb
@@ -7,7 +7,7 @@
 
     <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <div class="miam_exemptions">
+    <div class="miam_exemptions or-block__shift">
     <%= step_form @form_object do |f| %>
       <%= f.check_box_fieldset :protection_exemptions, ProtectionExemptions::AUTHORITY_INVOLVEMENT %>
 

--- a/app/views/steps/other_parties/contact_details/edit.html.erb
+++ b/app/views/steps/other_parties/contact_details/edit.html.erb
@@ -8,7 +8,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
-      <%= f.single_check_box :address_unknown %>
+      <%= f.single_check_box :address_unknown, class: 'dont-know' %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/respondent/contact_details/edit.html.erb
+++ b/app/views/steps/respondent/contact_details/edit.html.erb
@@ -12,7 +12,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
-      <%= f.single_check_box :address_unknown, class: 'util_mb-large' %>
+      <%= f.single_check_box :address_unknown, class: 'util_mb-large dont-know' %>
 
       <%=
         f.radio_button_fieldset :residence_requirement_met, inline: true do |fieldset|

--- a/app/views/steps/safety_questions/other_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/other_abuse/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= step_header %>
-
+    <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>

--- a/app/views/steps/safety_questions/substance_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/substance_abuse/edit.html.erb
@@ -6,7 +6,9 @@
     <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%=t '.lead_text' %></p>
+    </div>
 
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :substance_abuse, inline: true, choices: GenericYesNo.values %>

--- a/app/views/steps/screener/error_but_continue/show.html.erb
+++ b/app/views/steps/screener/error_but_continue/show.html.erb
@@ -21,11 +21,9 @@
       </div>
     </section>
 
-    <!-- TODO: Add the copy needed, and adapt the button linking to another step -->
-
     <div class="xform-group form-submit">
-      <%= link_to t('.go_back'), '/steps/screener/postcode', class: 'button', role: 'button' %>
       <%= link_to t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'button', role: 'button' %>
+      <%= link_to t('.go_back'), '/steps/screener/postcode', class: 'button button-secondary', role: 'button' %>
     </div>
   </div>
 </div>

--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -19,9 +19,9 @@
       </ul>
     </div>
 
-    <p class="actions">
+    <div class="form-submit">
       <%= link_to 'Check now', edit_steps_screener_postcode_path, class: 'button button-start', role: 'button' %>
-      <a href="/users/login" class="return-application">Or return to a saved application</a>
-    </p>
+      <a href="/users/login" class="button button-secondary return-application">Or return to a saved application</a>
+    </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,6 +401,7 @@ en:
       contact:
         edit:
           page_title: Concerns contact
+          section: Safety concerns
           heading: Contact between the children and the other people in this application
           lead_text: The court needs to know if you will allow your children to have contact with the other people in this application while you wait for a court date.
           info_notice: The court will presume it's better for the children to have regular contact with both parents, unless there are valid reasons not to.
@@ -408,11 +409,13 @@ en:
       has_orders:
         edit:
           page_title: Have you had court orders made?
+          section: Safety concerns
           heading: Have you had or do you currently have any court orders made for your protection?
           lead_text: For example, a restraining order, non-molestation order, occupation order or forced marriage protection order.
       details:
         edit:
           page_title: Orders details
+          section: Safety concerns
           heading: What orders have been made?
           lead_text: Select all that apply
     safety_questions:

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs the continue button' do
         expect(
           html_output
-        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button form-submit" data-disable-with="Continue" /></p>')
+        ).to eq('<div class="form-submit"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /></div>')
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs the continue button' do
         expect(
           html_output
-        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button form-submit" data-disable-with="Continue" /></p>')
+        ).to eq('<div class="form-submit"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /></div>')
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs the save and continue button' do
         expect(
           html_output
-        ).to eq('<p class="actions"><input type="submit" name="commit" value="Save and continue" class="button form-submit" data-disable-with="Save and continue" /></p>')
+        ).to eq('<div class="form-submit"><input type="submit" name="commit" value="Save and continue" class="button" data-disable-with="Save and continue" /></div>')
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs the continue button with a link to sign-up' do
         expect(
           html_output
-        ).to eq('<p class="actions"><input type="submit" name="commit" value="Continue" class="button form-submit" data-disable-with="Continue" /><a href="/test/sign_up">Save and come back later</a></p>')
+        ).to eq('<div class="form-submit"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /><a href="/test/sign_up" class="button button-secondary button-save-return">Save and come back later</a></div>')
       end
     end
   end


### PR DESCRIPTION
- Tidy up start page
- Tidy up flash card pages
- Add section heading to safety questions
- Add start-page class to start page
- Add section values for pages that require it
- Change markup for form action
- Adjust question heading and action block spacing
- Kludge nature of application styling to handle non-semantic structure
- Add section heading to alternatives to court pages
- Tighten spacing for don't know checkboxes
- Switch from lede to body for attending court pages
- Improve spacing of exemptions checkboxes and hints
- Handle form-groups following fieldsets better
- Switch button order and add secondary class of postcode lookup fail
- Update check page to match action block on other pages