### PR TITLE
add app.json to enable Heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,90 @@
+{
+  "name": "c100-application",
+  "scripts": {},
+  "env": {
+    "APP_DEBUG": {
+      "required": true
+    },
+    "DEV_TOOLS_ENABLED": {
+      "required": true
+    },
+    "EXTERNAL_URL": {
+      "required": true
+    },
+    "GA_TRACKING_ID": {
+      "required": true
+    },
+    "GOVUK_NOTIFY_API_KEY": {
+      "required": true
+    },
+    "HEROKU_APP_ID": {
+      "required": true
+    },
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
+    "HEROKU_RELEASE_CREATED_AT": {
+      "required": true
+    },
+    "HEROKU_RELEASE_VERSION": {
+      "required": true
+    },
+    "HEROKU_SLUG_COMMIT": {
+      "required": true
+    },
+    "HEROKU_SLUG_DESCRIPTION": {
+      "required": true
+    },
+    "HTTP_AUTH_ENABLED": {
+      "required": true
+    },
+    "HTTP_AUTH_PASSWORD": {
+      "required": true
+    },
+    "HTTP_AUTH_USER": {
+      "required": true
+    },
+    "LANG": {
+      "required": true
+    },
+    "RACK_ENV": {
+      "required": true
+    },
+    "RAILS_ENV": {
+      "required": true
+    },
+    "RAILS_LOG_TO_STDOUT": {
+      "required": true
+    },
+    "RAILS_MAX_THREADS": {
+      "required": true
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "required": true
+    },
+    "SECRET_KEY_BASE": {
+      "required": true
+    },
+    "SENTRY_DSN": {
+      "required": true
+    }
+  },
+  "formation": {
+    "worker": {
+      "quantity": 1
+    },
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [
+    "heroku-postgresql",
+    "scheduler"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}
+


### PR DESCRIPTION
This config file tells Heroku which environment variables to copy from staging when cloning the app. It will lets Heroku automatically generate disposable 'review' apps from submitted PRs