### PR TITLE
remove _contact and _access options from petition order + form

### DIFF
--- a/app/value_objects/petition_order.rb
+++ b/app/value_objects/petition_order.rb
@@ -3,8 +3,6 @@ class PetitionOrder < ValueObject
     CHILD_ARRANGEMENTS = [
       new(:child_arrangements_home),
       new(:child_arrangements_time),
-      new(:child_arrangements_contact),
-      new(:child_arrangements_access),
     ].freeze,
 
     GROUP_PROHIBITED_STEPS = new(:group_prohibited_steps),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,8 +34,6 @@ en:
     PETITION_ORDERS: &PETITION_ORDERS
       child_arrangements_home_html: Decide who they live with and when
       child_arrangements_time_html: Decide how much time they spend with each person
-      child_arrangements_contact_html: Decide how and when the children are involved with each person
-      child_arrangements_access_html: Allow the children to spend time with you
       prohibited_steps_moving_html: Relocating the children to a different area in England and Wales
       prohibited_steps_moving_abroad_html: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
       prohibited_steps_names_html: Changing their names or surname

--- a/spec/presenters/petition_presenter_spec.rb
+++ b/spec/presenters/petition_presenter_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe PetitionPresenter do
       expect(subject.child_arrangements_orders).to eq(%w(
         child_arrangements_home
         child_arrangements_time
-        child_arrangements_contact
-        child_arrangements_access
       ))
     end
   end
@@ -53,8 +51,6 @@ RSpec.describe PetitionPresenter do
       expect(subject.all_selected_orders).to eq(%w(
         child_arrangements_home
         child_arrangements_time
-        child_arrangements_contact
-        child_arrangements_access
         prohibited_steps_names
         prohibited_steps_medical
         prohibited_steps_holiday

--- a/spec/value_objects/petition_order_spec.rb
+++ b/spec/value_objects/petition_order_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe PetitionOrder do
       expect(described_class.values.map(&:to_s)).to eq(%w(
         child_arrangements_home
         child_arrangements_time
-        child_arrangements_contact
-        child_arrangements_access
         group_prohibited_steps
         prohibited_steps_names
         prohibited_steps_medical
@@ -36,8 +34,6 @@ RSpec.describe PetitionOrder do
       expect(described_class::CHILD_ARRANGEMENTS.map(&:to_s)).to eq(%w(
         child_arrangements_home
         child_arrangements_time
-        child_arrangements_contact
-        child_arrangements_access
       ))
     end
   end


### PR DESCRIPTION
as per https://trello.com/c/gXzOD0fG/217-nature-of-application-remove-2-options
<img width="673" alt="screen shot 2018-03-26 at 10 43 19" src="https://user-images.githubusercontent.com/134501/37899133-8966c868-30e2-11e8-876c-d5eafacf5bc5.png">
