### PR TITLE
Force SSL-only in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,4 +44,7 @@ Rails.application.configure do
   # missing translations of model attribute names. The form will
   # get the constantized attribute name itself, in form labels.
   config.action_view.raise_on_missing_translations = false
+
+  # Enforce SSl-only
+  config.force_ssl = true
 end


### PR DESCRIPTION
as per [section 4.5 in the pentest report](https://docs.google.com/document/d/1xG5GNKTnBHToawfH00kVOEf_LY2jEZKNlVeORgaMr4A/edit?ts=5ab8e04d#heading=h.hbjovvwcsyy8) & the corresponding [Trello card](https://trello.com/c/Nc55Lv5X/222-enforce-ssl-only-and-add-hypertext-sts-header)