### PR TITLE
add what-next content to under_age exits

### DIFF
--- a/app/views/steps/applicant/under_age/edit.html.erb
+++ b/app/views/steps/applicant/under_age/edit.html.erb
@@ -8,10 +8,6 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <!-- TODO: prototype still needs to finish this view -->
-
-    <%= step_form @form_object do |f| %>
-      <%= f.continue_button %>
-    <% end %>
+    <%= render partial: '/steps/shared/screener_exit_actions' %>
   </div>
 </div>

--- a/app/views/steps/respondent/under_age/edit.html.erb
+++ b/app/views/steps/respondent/under_age/edit.html.erb
@@ -8,10 +8,6 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <!-- TODO: prototype still needs to finish this view -->
-
-    <%= step_form @form_object do |f| %>
-      <%= f.continue_button %>
-    <% end %>
+    <%= render partial: '/steps/shared/screener_exit_actions' %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,7 +159,7 @@ en:
         edit:
           page_title: Applicant under age
           heading: The applicant is (or may be) less than 18 years old
-          lead_text: CB1 text to go here
+          lead_text: Sorry, you’re not eligible to apply online. You can only use this online service if both you and the other person (the respondent) are over 18.
           continue: Continue
     respondent:
       names:
@@ -197,8 +197,7 @@ en:
         edit:
           page_title: Respondent under age
           heading: The respondent is (or may be) less than 18 years old
-          lead_text: CB1 text to go here
-          continue: Continue
+          lead_text: Sorry, you’re not eligible to apply online. You can only use this online service if both you and the other person (the respondent) are over 18.0
     children:
       names:
         edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,7 +197,7 @@ en:
         edit:
           page_title: Respondent under age
           heading: The respondent is (or may be) less than 18 years old
-          lead_text: Sorry, you’re not eligible to apply online. You can only use this online service if both you and the other person (the respondent) are over 18.0
+          lead_text: Sorry, you’re not eligible to apply online. You can only use this online service if both you and the other person (the respondent) are over 18
     children:
       names:
         edit:


### PR DESCRIPTION
as per [the Trello card](https://trello.com/c/rZPQYXVG/226-applicant-respondent-under-age)
<img width="612" alt="screen shot 2018-03-28 at 11 16 55" src="https://user-images.githubusercontent.com/134501/38023219-9378488e-3279-11e8-8f5b-34d23b160381.png">
