### PR TITLE
fix session timeout env var being ignored by app

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -2,7 +2,7 @@ module ErrorHandling
   extend ActiveSupport::Concern
 
   included do
-    protect_from_forgery with: :exception
+    protect_from_forgery with: :exception, prepend: true
 
     rescue_from Exception do |exception|
       case exception

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,8 +27,8 @@ Rails.application.configure do
   config.active_record.migration_error = :page_load
 
   config.assets.debug = true
-
   config.assets.quiet = true
+  
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # NB: Because of the way the form builder works, and hence the

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,3 @@
-Rails.application.config.session_store :cookie_store, key: '_c100_application_session'
+Rails.application.config.session_store :cookie_store,
+  key: '_c100_application_session',
+  expire_after: Rails.application.config.x.session.expires_in_minutes.minutes


### PR DESCRIPTION
Looked like the session timeout environment variable wasn't being obeyed in the app session timeout (see [Trello card](https://trello.com/c/IZbQV29E/229-check-session-timeout-on-production-rebecca-brawn-getting-several-session-timeouts-at-much-less-than-1hr-intervals)).

This seems to fix the issue (although it's difficult to provide a test case to prove it)