### PR TITLE
show petition order type in PDF children details -> orders applied for section

### DIFF
--- a/app/controllers/steps/screener/error_but_continue_controller.rb
+++ b/app/controllers/steps/screener/error_but_continue_controller.rb
@@ -2,7 +2,11 @@ module Steps
   module Screener
     class ErrorButContinueController < Steps::ScreenerStepController
       def show
-        @courtfinder_ok = C100App::CourtfinderAPI.new.is_ok?
+        @courtfinder_ok = begin
+          C100App::CourtfinderAPI.new.is_ok?
+        rescue SocketError
+          false
+        end
       end
     end
   end

--- a/app/presenters/summary/sections/children_details.rb
+++ b/app/presenters/summary/sections/children_details.rb
@@ -22,10 +22,16 @@ module Summary
             Separator.new(:child_index_title, index: index),
             personal_details(child),
             relationships(child),
-            MultiAnswer.new(:child_orders, child.child_order&.orders),
+            MultiAnswer.new(:child_orders, order_types(child)),
             Partial.row_blank_space,
           ]
         end
+      end
+
+      def order_types(child)
+        child.child_order&.orders.to_a.map do |o|
+          PetitionOrder.type_for(o)
+        end.uniq
       end
 
       def children

--- a/app/value_objects/petition_order.rb
+++ b/app/value_objects/petition_order.rb
@@ -32,4 +32,13 @@ class PetitionOrder < ValueObject
   def self.values
     VALUES
   end
+
+  def self.type_for(sub_type)
+    case sub_type.to_s
+    when /^child_arrangements_.*/ then 'child_arrangements'
+    when /^prohibited_steps_.*/ then 'prohibited_steps'
+    when /^specific_issues_.*/ then 'specific_issues'
+    else 'other_issue'
+    end
+  end
 end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -43,6 +43,12 @@ en:
     OTHER_ORDER: &OTHER_ORDER
       other_issue: Deal with another issue not listed
 
+    PETITION_ORDER_TYPES: &PETITION_ORDER_TYPES
+      child_arrangements: Child Arrangements Order
+      prohibited_steps: Prohibited Steps Order
+      specific_issues: Specific Issue Order
+      other_issue: Other issue
+
     # Note: this is duplicated in `locales/en.yml`, due to the way locales work
     # (they don't see each other when they are in different files). If you change copy here,
     # remember to also update it in `locales/en.yml`
@@ -250,10 +256,7 @@ en:
     child_orders:
       question: Order(s) applied for
       answers:
-        <<: *ARRANGEMENT_ORDERS
-        <<: *SPECIFIC_ISSUE_ORDERS
-        <<: *PROHIBITED_STEPS_ORDERS
-        <<: *OTHER_ORDER
+        <<: *PETITION_ORDER_TYPES
     children_known_to_authorities:
       question: Are any of the children known to the local authority children’s services?
       answers:

--- a/spec/presenters/summary/sections/children_details_spec.rb
+++ b/spec/presenters/summary/sections/children_details_spec.rb
@@ -82,7 +82,7 @@ module Summary
 
         expect(answers[6]).to be_an_instance_of(MultiAnswer)
         expect(answers[6].question).to eq(:child_orders)
-        expect(answers[6].value).to eq(['an_order'])
+        expect(answers[6].value).to eq(['other_issue'])
 
         expect(answers[7]).to be_an_instance_of(Partial)
         expect(answers[7].name).to eq(:row_blank_space)

--- a/spec/value_objects/petition_order_spec.rb
+++ b/spec/value_objects/petition_order_spec.rb
@@ -70,4 +70,32 @@ RSpec.describe PetitionOrder do
       expect(described_class::OTHER_ISSUE.to_s).to eq('other_issue')
     end
   end
+
+  describe '.type_for' do
+    context 'given a sub_type' do
+      context 'starting with child_arrangements_' do
+        it 'returns "child_arrangements"' do
+          expect(described_class.type_for('child_arrangements_foo')).to eq("child_arrangements")
+        end
+      end
+
+      context 'starting with prohibited_steps_' do
+        it 'returns "prohibited_steps"' do
+          expect(described_class.type_for('prohibited_steps_foo')).to eq("prohibited_steps")
+        end
+      end
+
+      context 'starting with specific_issues_' do
+        it 'returns "specific_issues"' do
+          expect(described_class.type_for('specific_issues_foo')).to eq("specific_issues")
+        end
+      end
+
+      context 'starting with anything else' do
+        it 'returns "other_issue"' do
+          expect(described_class.type_for('foo')).to eq("other_issue")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
rather than the more verbose description of the sub-type, as per [Trello card](https://trello.com/c/uG9mTt8T/230-pdf-issue-change-information-displayed-in-orders-applied-for-to-the-actual-order-type)

<img width="638" alt="screen shot 2018-03-28 at 23 02 05" src="https://user-images.githubusercontent.com/134501/38059027-d0e22100-32dc-11e8-94f9-c71114b0a9ac.png">
