### PR TITLE
Add missing 404 page

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -5,6 +5,10 @@ class ErrorsController < ApplicationController
     respond_with_status(:not_found)
   end
 
+  def not_found
+    respond_with_status(:not_found)
+  end
+
   def application_not_found
     respond_with_status(:not_found)
   end

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -6,7 +6,7 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <p class="lede"><%=t('.more_text', expire_in_days: Rails.configuration.x.drafts.expire_in_days) %></p>
+    <%=t '.paper_form_html' %>
 
     <div class="form-group">
       <%= link_to t('.start_again'), root_path, class: 'button' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -964,6 +964,15 @@ en:
       lead_text: Your application won’t be processed until you complete a few more steps. If you want to make changes you can start a new application.
       what_next: What you need to do next
       <<: *START_FINISH
+    not_found:
+      page_title: Page not found
+      heading: Page not found
+      lead_text: If you copied a web address, please check it’s correct.
+      paper_form_html: |
+        <p>You can also try starting again from the homepage.</p>
+        <p>If the problem continues, you can <a href="https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf" target="external_link" rel="external">download and
+        complete a C100 paper application form</a>, print it and send it by post.</p>
+      <<: *START_FINISH
 
   activemodel:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -230,6 +230,7 @@ Rails.application.routes.draw do
     get :application_screening
     get :application_completed
     get :unhandled
+    get :not_found
   end
 
   root 'steps/screener/start#show'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema.define(version: 20180329160337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pgcrypto"
   enable_extension "uuid-ossp"
+  enable_extension "pgcrypto"
 
   create_table "abduction_details", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "children_have_passport"


### PR DESCRIPTION
This will show a "nice" 404 page when hitting an unrecognized URL.

On localhost however it will continue to show the error trace to help debugging.

<img width="635" alt="screen shot 2018-04-03 at 11 45 04" src="https://user-images.githubusercontent.com/687910/38245034-7a719bfa-3734-11e8-8f1b-4c501deb137a.png">
