### PR TITLE
Improvements to the session expire mechanism

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,6 @@
 class ApplicationController < ActionController::Base
+  include SecurityHandling
   include ErrorHandling
-
-  # :nocov:
-  if ENV.fetch('HTTP_AUTH_ENABLED', false)
-    http_basic_authenticate_with name: ENV.fetch('HTTP_AUTH_USER'), password: ENV.fetch('HTTP_AUTH_PASSWORD')
-  end
-
-  before_action :drop_dangerous_headers!
-  after_action :set_security_headers
-  # :nocov:
 
   # This is required to get request attributes in to the production logs.
   # See the various lograge configurations in `production.rb`.
@@ -19,11 +11,10 @@ class ApplicationController < ActionController::Base
     payload[:user_agent] = request&.user_agent
   end
 
-  helper_method :current_c100_application
-
   def current_c100_application
     @_current_c100_application ||= C100Application.find_by_id(session[:c100_application_id])
   end
+  helper_method :current_c100_application
 
   private
 
@@ -35,24 +26,5 @@ class ApplicationController < ActionController::Base
     C100Application.create(attributes).tap do |c100_application|
       session[:c100_application_id] = c100_application.id
     end
-  end
-
-  def drop_dangerous_headers!
-    request.env.except!('HTTP_X_FORWARDED_HOST') # just drop the variable
-  end
-
-  def set_security_headers
-    additional_headers_for_all_requests.each do |name, value|
-      response.set_header(name, value)
-    end
-  end
-
-  def additional_headers_for_all_requests
-    {
-      'X-Frame-Options'           => 'SAMEORIGIN',
-      'X-XSS-Protection'          => '1; mode=block',
-      'X-Content-Type-Options'    => 'nosniff',
-      'Strict-Transport-Security' => 'max-age=15768000; includeSubDomains',
-    }
   end
 end

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -2,8 +2,6 @@ module ErrorHandling
   extend ActiveSupport::Concern
 
   included do
-    protect_from_forgery with: :exception, prepend: true
-
     rescue_from Exception do |exception|
       case exception
       when Errors::InvalidSession, ActionController::InvalidAuthenticityToken

--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -1,0 +1,59 @@
+module SecurityHandling
+  extend ActiveSupport::Concern
+
+  included do
+    # :nocov:
+    if ENV.fetch('HTTP_AUTH_ENABLED', false)
+      http_basic_authenticate_with name: ENV.fetch('HTTP_AUTH_USER'), password: ENV.fetch('HTTP_AUTH_PASSWORD')
+    end
+    # :nocov:
+
+    protect_from_forgery with: :exception, prepend: true
+
+    before_action :drop_dangerous_headers!,
+                  :ensure_session_validity
+
+    after_action :set_security_headers
+
+    helper_method :session_expire_in_minutes
+  end
+
+  def session_expire_in_minutes
+    Rails.configuration.x.session.expires_in_minutes
+  end
+
+  def session_expire_in_seconds
+    session_expire_in_minutes * 60
+  end
+
+  private
+
+  def ensure_session_validity
+    epoch = Time.now.to_i
+
+    if epoch - session.fetch(:last_seen, epoch) > session_expire_in_seconds
+      reset_session
+    end
+
+    session[:last_seen] = epoch
+  end
+
+  def drop_dangerous_headers!
+    request.env.except!('HTTP_X_FORWARDED_HOST') # just drop the variable
+  end
+
+  def set_security_headers
+    additional_headers_for_all_requests.each do |name, value|
+      response.set_header(name, value)
+    end
+  end
+
+  def additional_headers_for_all_requests
+    {
+      'X-Frame-Options'           => 'SAMEORIGIN',
+      'X-XSS-Protection'          => '1; mode=block',
+      'X-Content-Type-Options'    => 'nosniff',
+      'Strict-Transport-Security' => 'max-age=15768000; includeSubDomains',
+    }
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -37,9 +37,7 @@ class SessionsController < ApplicationController
 
   # :nocov:
   def c100_application
-    current_c100_application || C100Application.create.tap do |c100_application|
-      session[:c100_application_id] = c100_application.id
-    end
+    current_c100_application || initialize_c100_application
   end
 
   def local_court_fixture

--- a/app/views/errors/invalid_session.html.erb
+++ b/app/views/errors/invalid_session.html.erb
@@ -4,7 +4,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%= t '.heading' %></h1>
 
-    <p class="lede"><%=t '.lead_text', session_timeout: Rails.configuration.x.session.expires_in_minutes %></p>
+    <p class="lede"><%=t '.lead_text', session_timeout: session_expire_in_minutes %></p>
 
     <p class="lede"><%=t '.more_text' %></p>
 

--- a/app/views/home/cookies.en.html.erb
+++ b/app/views/home/cookies.en.html.erb
@@ -48,7 +48,7 @@
     <p><strong>Remembering your progress</strong></p>
 
     <p>We will store a cookie to remember your application progress in this computer and to expire your session
-      after <%= Rails.configuration.x.session.expires_in_minutes %> minutes of inactivity or when you close your browser.</p>
+      after <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser.</p>
 
     <table>
       <thead>
@@ -62,7 +62,7 @@
       <tr>
         <td>_c100_application_session</td>
         <td>Saves your current progress in this computer and tracks inactivity periods</td>
-        <td>After <%= Rails.configuration.x.session.expires_in_minutes %> minutes of inactivity or when you close your browser</td>
+        <td>After <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser</td>
       </tr>
       </tbody>
     </table>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,13 @@
-Rails.application.config.session_store :cookie_store,
-  key: '_c100_application_session',
-  expire_after: Rails.application.config.x.session.expires_in_minutes.minutes
+# Note: this will setup a session-only cookie, which will expire as soon as
+# the browser is closed.
+#
+# While the browser is open, there is a JS mechanism to alert the user if
+# there is no activity (i.e. server-side requests) for a prolonged period
+# of time (see `config.x.session.expires_in_minutes` and
+# `config.x.session.warning_when_remaining` for the time values, and
+# `/assets/javascripts/modules/session-timeout.js` for the details).
+#
+# As we can't rely only on JS, there is also a request-based check to expire
+# the session if the cookie is too old (see `/concerns/security_handling.rb`).
+#
+Rails.application.config.session_store :cookie_store, key: '_c100_application_session'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -937,7 +937,7 @@ en:
     invalid_session:
       heading: Sorry, you'll have to start again
       <<: *START_FINISH
-      lead_text: Your session automatically ends if you don't use the service for %{session_timeout} minutes or after you complete your application.
+      lead_text: Your session automatically ends if you don't use the service for %{session_timeout} minutes.
       more_text: We do this for your security. Any unsaved details will be deleted.
       page_title: Invalid session
     unhandled:


### PR DESCRIPTION
* Revert to session-only cookie, so once the browser is closed, the session is revoked.

* In addition to the already existing JS expire mechanism, add a request-based check to ensure the cookie is no older than X, and if so, reset the session. This should add an extra layer of protection in case JS fails or there is no JS available.