### PR TITLE
Remove worker from Heroku formation

### DIFF
--- a/app.json
+++ b/app.json
@@ -70,9 +70,6 @@
     }
   },
   "formation": {
-    "worker": {
-      "quantity": 1
-    },
     "web": {
       "quantity": 1
     }


### PR DESCRIPTION
This only affects the review apps. We don't have or need a worker.