### PR TITLE
Add sentry user-feedback to the unhandled error page

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -71,5 +71,11 @@
   margin: -1rem 0 2rem;
 }
 
+// This will hide the Sentry user-feedback attribution. There is a setting
+// to hide it but currently it is not working, so this is an alternative.
+div.sentry-error-embed-wrapper p.powered-by {
+  display: none;
+}
+
 @import 'app/flash_card';
 @import 'app/pros_cons';

--- a/app/views/errors/unhandled.html.erb
+++ b/app/views/errors/unhandled.html.erb
@@ -1,5 +1,7 @@
 <% title t('.page_title') %>
 
+<%= render partial: 'layouts/sentry_feedback' if Raven.last_event_id %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%= t '.heading' %></h1>

--- a/app/views/layouts/_sentry_feedback.html.erb
+++ b/app/views/layouts/_sentry_feedback.html.erb
@@ -1,0 +1,13 @@
+<% content_for(:head) do %>
+  <script src="https://cdn.ravenjs.com/3.24.0/raven.min.js"></script>
+<% end %>
+
+<% content_for(:body_end) do %>
+  <script>
+    Raven.showReportDialog({
+      eventId: '<%= Raven.last_event_id %>',
+      // Use only the public DSN here!
+      dsn: '<%= "https://#{Raven.configuration.public_key}@sentry.service.dsd.io/#{Raven.configuration.project_id}" %>'
+    });
+  </script>
+<% end %>


### PR DESCRIPTION
This nice feature from Sentry will show a modal window for users to provide optional feedback about what caused the error, including providing their email for a potential follow-up.

The modal can be closed without providing feedback, as it is optional, and also it will not show without JS (obviously) but will not stop our normal error page from showing.

<img width="999" alt="screen shot 2018-04-04 at 17 04 15" src="https://user-images.githubusercontent.com/687910/38358304-c4f7c9c2-38bc-11e8-8692-c9d31c479196.png">
