### PR TITLE
Introduce validations in MIAM exemptions

### DIFF
--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -19,8 +19,9 @@ module CustomFormHelpers
     end
   end
 
+  # Note: `#form_group_id` must receive a symbol (not a value-object)
   def single_check_box(attribute, options = {})
-    content_tag(:div, merge_attributes(options, default: {class: 'multiple-choice single-cb', id: form_group_id(attribute)})) do
+    content_tag(:div, merge_attributes(options, default: {class: 'multiple-choice single-cb', id: form_group_id(attribute.to_sym)})) do
       safe_concat [
         check_box(attribute),
         label(attribute) { localized_label(attribute) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
     order_court_name: &order_court_name "Which court issued the order?"
     provide_details: &provide_details "Provide details"
     select_all_that_apply_or_none: &select_all_that_apply_or_none "Select all that apply or ‘None of these’"
+    blank_exemptions_error: &blank_exemptions_error "Select at least one exemption or ‘None of these‘"
     sections:
       miam_exemptions: &miam_exemptions "MIAM exemptions"
       attending_court: &attending_court "Attending court"
@@ -1015,6 +1016,26 @@ en:
           attributes:
             court_acknowledgement:
               blank: Confirm you understand
+        steps/miam_exemptions/domestic_form:
+          attributes:
+            domestic_none:
+              blank: *blank_exemptions_error
+        steps/miam_exemptions/protection_form:
+          attributes:
+            protection_none:
+              blank: *blank_exemptions_error
+        steps/miam_exemptions/urgency_form:
+          attributes:
+            urgency_none:
+              blank: *blank_exemptions_error
+        steps/miam_exemptions/adr_form:
+          attributes:
+            adr_none:
+              blank: *blank_exemptions_error
+        steps/miam_exemptions/misc_form:
+          attributes:
+            misc_none:
+              blank: *blank_exemptions_error
         steps/application/declaration_form:
           attributes:
             declaration_made:

--- a/spec/forms/steps/miam_exemptions/adr_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/adr_form_spec.rb
@@ -40,5 +40,21 @@ RSpec.describe Steps::MiamExemptions::AdrForm do
         expect(subject.save).to be(true)
       end
     end
+
+    context 'when no checkboxes are selected' do
+      let(:arguments) { {
+        c100_application: c100_application,
+      } }
+
+      it 'does not save the record' do
+        expect(miam_exemption_record).not_to receive(:update)
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:adr_none]).to_not be_empty
+      end
+    end
   end
 end

--- a/spec/forms/steps/miam_exemptions/domestic_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/domestic_form_spec.rb
@@ -40,5 +40,21 @@ RSpec.describe Steps::MiamExemptions::DomesticForm do
         expect(subject.save).to be(true)
       end
     end
+
+    context 'when no checkboxes are selected' do
+      let(:arguments) { {
+        c100_application: c100_application,
+      } }
+
+      it 'does not save the record' do
+        expect(miam_exemption_record).not_to receive(:update)
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:domestic_none]).to_not be_empty
+      end
+    end
   end
 end

--- a/spec/forms/steps/miam_exemptions/misc_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/misc_form_spec.rb
@@ -40,5 +40,21 @@ RSpec.describe Steps::MiamExemptions::MiscForm do
         expect(subject.save).to be(true)
       end
     end
+
+    context 'when no checkboxes are selected' do
+      let(:arguments) { {
+        c100_application: c100_application,
+      } }
+
+      it 'does not save the record' do
+        expect(miam_exemption_record).not_to receive(:update)
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:misc_none]).to_not be_empty
+      end
+    end
   end
 end

--- a/spec/forms/steps/miam_exemptions/protection_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/protection_form_spec.rb
@@ -40,5 +40,21 @@ RSpec.describe Steps::MiamExemptions::ProtectionForm do
         expect(subject.save).to be(true)
       end
     end
+
+    context 'when no checkboxes are selected' do
+      let(:arguments) { {
+        c100_application: c100_application,
+      } }
+
+      it 'does not save the record' do
+        expect(miam_exemption_record).not_to receive(:update)
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:protection_none]).to_not be_empty
+      end
+    end
   end
 end

--- a/spec/forms/steps/miam_exemptions/urgency_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/urgency_form_spec.rb
@@ -40,5 +40,21 @@ RSpec.describe Steps::MiamExemptions::UrgencyForm do
         expect(subject.save).to be(true)
       end
     end
+
+    context 'when no checkboxes are selected' do
+      let(:arguments) { {
+        c100_application: c100_application,
+      } }
+
+      it 'does not save the record' do
+        expect(miam_exemption_record).not_to receive(:update)
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:urgency_none]).to_not be_empty
+      end
+    end
   end
 end

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -76,5 +76,17 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         html_output
       ).to eq('<div class="multiple-choice single-cb"><input name="c100_application[declaration_made]" type="hidden" value="0" /><input type="checkbox" value="1" name="c100_application[declaration_made]" id="c100_application_declaration_made" /><label for="c100_application_declaration_made">Declaration made</label></div>')
     end
+
+    context 'when there are errors' do
+      before do
+        c100_application.errors.add(:declaration_made, :blank)
+      end
+
+      it 'outputs the check box with the error markup' do
+        expect(
+          html_output
+        ).to eq('<div class="multiple-choice single-cb" id="error_c100_application_declaration_made"><input name="c100_application[declaration_made]" type="hidden" value="0" /><input aria-describedby="error_message_c100_application_declaration_made" type="checkbox" value="1" name="c100_application[declaration_made]" id="c100_application_declaration_made" /><label for="c100_application_declaration_made">Declaration made<span class="error-message" id="error_message_c100_application_declaration_made">Enter an answer</span></label></div>')
+      end
+    end
   end
 end


### PR DESCRIPTION
This will introduce a basic validation to ensure at least one valid exemption was selected by the user, otherwise they have to select 'none of these' checkbox.

Also it ensures the user can't get away with just selecting top-level group checkboxes without selecting anything inside the group.