### PR TITLE
Disable JS logging

### DIFF
--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -262,7 +262,7 @@ moj.Modules.gaEvents = {
         var self = this,
             opts = opts || {};
 
-        console.log(eventData);
+        //console.log(eventData);
 
         ga('send', 'event', eventData.eventCategory, eventData.eventAction, eventData.eventLabel, {
             hitCallback: self.createFunctionWithTimeout(function () {

--- a/app/views/steps/completion/what_next/show.en.html.erb
+++ b/app/views/steps/completion/what_next/show.en.html.erb
@@ -18,7 +18,7 @@
               This will be a PDF. If you can’t open the PDF after downloading, try using <a href="https://get.adobe.com/uk/reader/" target="external_link" rel="external">Adobe Acrobat Reader</a>.
             </p>
             <p>
-              <%= link_to 'Download your application', steps_completion_summary_path(format: :pdf), target: '_blank', class: 'button ga-pageLink', data: {ga_category: 'completion', ga_label: 'download application'} %>
+              <%= link_to 'Download your application', steps_completion_summary_path(format: :pdf), class: 'button ga-pageLink', data: {ga_category: 'completion', ga_label: 'download application'} %>
             </p>
           </li>
 


### PR DESCRIPTION
Also, removing target blank in the PDF download to minimise the risk of popup blockers intercepting the download.