### PR TITLE
Reset of `HasOneAssociationForm` fields

### DIFF
--- a/app/forms/steps/application/previous_proceedings_form.rb
+++ b/app/forms/steps/application/previous_proceedings_form.rb
@@ -3,7 +3,8 @@ module Steps
     class PreviousProceedingsForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :children_previous_proceedings
+      # The reset will delete the row from the `court_proceedings` table
+      yes_no_attribute :children_previous_proceedings, reset_when_no: [:court_proceeding]
     end
   end
 end

--- a/app/forms/steps/court_orders/has_orders_form.rb
+++ b/app/forms/steps/court_orders/has_orders_form.rb
@@ -3,7 +3,8 @@ module Steps
     class HasOrdersForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :has_court_orders
+      # The reset will delete the row from the `court_orders` table
+      yes_no_attribute :has_court_orders, reset_when_no: [:court_order]
     end
   end
 end

--- a/app/forms/steps/miam/exemption_claim_form.rb
+++ b/app/forms/steps/miam/exemption_claim_form.rb
@@ -3,7 +3,8 @@ module Steps
     class ExemptionClaimForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :miam_exemption_claim
+      # The reset will delete the row from the `miam_exemptions` table
+      yes_no_attribute :miam_exemption_claim, reset_when_no: [:miam_exemption]
     end
   end
 end

--- a/app/forms/steps/safety_questions/risk_of_abduction_form.rb
+++ b/app/forms/steps/safety_questions/risk_of_abduction_form.rb
@@ -3,7 +3,8 @@ module Steps
     class RiskOfAbductionForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :risk_of_abduction
+      # The reset will delete the row from the `abduction_details` table
+      yes_no_attribute :risk_of_abduction, reset_when_no: [:abduction_detail]
     end
   end
 end

--- a/spec/forms/steps/application/previous_proceedings_form_spec.rb
+++ b/spec/forms/steps/application/previous_proceedings_form_spec.rb
@@ -2,5 +2,6 @@ require 'spec_helper'
 
 RSpec.describe Steps::Application::PreviousProceedingsForm do
   it_behaves_like 'a yes-no question form',
-                  attribute_name: :children_previous_proceedings
+                  attribute_name: :children_previous_proceedings,
+                  reset_when_no: [:court_proceeding]
 end

--- a/spec/forms/steps/court_orders/has_orders_form_spec.rb
+++ b/spec/forms/steps/court_orders/has_orders_form_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Steps::CourtOrders::HasOrdersForm do
-  it_behaves_like 'a yes-no question form', attribute_name: :has_court_orders
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :has_court_orders,
+                  reset_when_no: [:court_order]
 end

--- a/spec/forms/steps/miam/exemption_claim_form_spec.rb
+++ b/spec/forms/steps/miam/exemption_claim_form_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Miam::ExemptionClaimForm do
-  it_behaves_like 'a yes-no question form', attribute_name: :miam_exemption_claim
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :miam_exemption_claim,
+                  reset_when_no: [:miam_exemption]
 end

--- a/spec/forms/steps/safety_questions/risk_of_abduction_form_spec.rb
+++ b/spec/forms/steps/safety_questions/risk_of_abduction_form_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Steps::SafetyQuestions::RiskOfAbductionForm do
-  it_behaves_like 'a yes-no question form', attribute_name: :risk_of_abduction
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :risk_of_abduction,
+                  reset_when_no: [:abduction_detail]
 end


### PR DESCRIPTION
Thanks to ActiveRecord this is pretty straight forward.
We just provide the name of the `has_one` attribute, and Rails will delete the whole row in the associated table, if it exists.