### PR TITLE
Basic `check your answers`

### DIFF
--- a/app/assets/stylesheets/local/check_answers.scss
+++ b/app/assets/stylesheets/local/check_answers.scss
@@ -58,6 +58,22 @@
       .question {
         width: 50%;
       }
+
+      dl.answers-group-inner {
+        .question {
+          width: 100%;
+          padding-bottom: 0;
+          margin-bottom: 0;
+          margin-top: 0;
+        }
+        .answer {
+          padding-bottom: 0;
+          margin-bottom: 0;
+        }
+        .change {
+          display: none;
+        }
+      }
     }
 
     .change {

--- a/app/forms/steps/miam/attended_form.rb
+++ b/app/forms/steps/miam/attended_form.rb
@@ -4,6 +4,7 @@ module Steps
       include SingleQuestionForm
 
       yes_no_attribute :miam_attended, reset_when_no: [
+        :miam_exemption_claim,
         :miam_certification,
         Steps::Miam::CertificationDateForm,
         Steps::Miam::CertificationDetailsForm,

--- a/app/forms/steps/miam/certification_form.rb
+++ b/app/forms/steps/miam/certification_form.rb
@@ -4,6 +4,7 @@ module Steps
       include SingleQuestionForm
 
       yes_no_attribute :miam_certification, reset_when_no: [
+        :miam_exemption_claim,
         Steps::Miam::CertificationDateForm,
         Steps::Miam::CertificationDetailsForm,
       ]

--- a/app/presenters/summary/answers_group.rb
+++ b/app/presenters/summary/answers_group.rb
@@ -1,0 +1,23 @@
+module Summary
+  class AnswersGroup
+    attr_reader :name, :answers, :change_path
+
+    def initialize(name, answers, change_path: nil)
+      @name = name
+      @answers = answers
+      @change_path = change_path
+    end
+
+    def show?
+      answers.any?(&:show?)
+    end
+
+    def show_change_link?
+      change_path.present?
+    end
+
+    def to_partial_path
+      'steps/completion/shared/answers_group'
+    end
+  end
+end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -7,7 +7,10 @@ module Summary
     end
 
     def sections
-      [] # If we were to have a check your answers page, add here the sections
+      [
+        HtmlSections::ChildProtectionCases.new(c100_application),
+        HtmlSections::MiamRequirement.new(c100_application),
+      ].flatten.select(&:show?)
     end
   end
 end

--- a/app/presenters/summary/html_sections/child_protection_cases.rb
+++ b/app/presenters/summary/html_sections/child_protection_cases.rb
@@ -1,0 +1,19 @@
+module Summary
+  module HtmlSections
+    class ChildProtectionCases < Sections::BaseSectionPresenter
+      def name
+        :child_protection_cases
+      end
+
+      def answers
+        [
+          Answer.new(
+            :child_protection_cases,
+            c100.child_protection_cases,
+            change_path: edit_steps_miam_child_protection_cases_path
+          ),
+        ].select(&:show?)
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_sections/miam_requirement.rb
+++ b/app/presenters/summary/html_sections/miam_requirement.rb
@@ -1,0 +1,29 @@
+module Summary
+  module HtmlSections
+    class MiamRequirement < Sections::BaseSectionPresenter
+      def name
+        :miam_requirement
+      end
+
+      def answers
+        [
+          Answer.new(:miam_attended, c100.miam_attended, change_path: edit_steps_miam_attended_path),
+          Answer.new(:miam_certification, c100.miam_certification, change_path: edit_steps_miam_certification_path),
+          Answer.new(:miam_exemption_claim, c100.miam_exemption_claim, change_path: edit_steps_miam_exemption_claim_path),
+          DateAnswer.new(:miam_certification_date, c100.miam_certification_date, change_path: edit_steps_miam_certification_date_path),
+          AnswersGroup.new(:miam_certification_details, miam_certification_details, change_path: edit_steps_miam_certification_details_path),
+        ].select(&:show?)
+      end
+
+      private
+
+      def miam_certification_details
+        [
+          FreeTextAnswer.new(:miam_certification_number, c100.miam_certification_number),
+          FreeTextAnswer.new(:miam_certification_service_name, c100.miam_certification_service_name),
+          FreeTextAnswer.new(:miam_certification_sole_trader_name, c100.miam_certification_sole_trader_name),
+        ]
+      end
+    end
+  end
+end

--- a/app/views/steps/completion/shared/_answers_group.html.erb
+++ b/app/views/steps/completion/shared/_answers_group.html.erb
@@ -1,0 +1,15 @@
+<div class="answers-group" id="<%= answers_group.name %>">
+  <dt class="question">
+    <%=t "check_answers_html.groups.#{answers_group.name}" %>
+  </dt>
+  <dd class="answer">
+    <dl class="answers-group-inner">
+      <%= render answers_group.answers %>
+    </dl>
+  </dd>
+  <dd class="change">
+    <% if answers_group.show_change_link? %>
+      <%= link_to t('check_answers_html.change_link'), answers_group.change_path %>
+    <% end %>
+  </dd>
+</div>

--- a/app/views/steps/completion/shared/_date_row.html.erb
+++ b/app/views/steps/completion/shared/_date_row.html.erb
@@ -1,2 +1,13 @@
-<!-- HTML version to be implemented when needed for check your answers -->
-<p>Not implemented: <%= __FILE__ %></p>
+<div id="<%= date_row.question %>">
+  <dt class="question">
+    <%=t "check_answers_html.#{date_row.question}.question" %>
+  </dt>
+  <dd class="answer">
+    <%= l(date_row.value) %>
+  </dd>
+  <dd class="change">
+    <% if date_row.show_change_link? %>
+      <%= link_to t('check_answers_html.change_link'), date_row.change_path %>
+    <% end %>
+  </dd>
+</div>

--- a/app/views/steps/completion/shared/_free_text_row.html.erb
+++ b/app/views/steps/completion/shared/_free_text_row.html.erb
@@ -1,2 +1,15 @@
-<!-- HTML version to be implemented when needed for check your answers -->
-<p>Not implemented: <%= __FILE__ %></p>
+<div id="<%= free_text_row.question %>">
+  <dt class="question">
+    <%=t "check_answers_html.#{free_text_row.question}.question" %>
+  </dt>
+  <dd class="answer">
+    <%= simple_format(
+      free_text_row.value.presence || t("check_answers.#{free_text_row.question}.absence_answer"), {}, wrapper_tag: 'div'
+    ) %>
+  </dd>
+  <dd class="change">
+    <% if free_text_row.show_change_link? %>
+      <%= link_to t('check_answers_html.change_link'), free_text_row.change_path %>
+    <% end %>
+  </dd>
+</div>

--- a/app/views/steps/completion/shared/_free_text_row.pdf.erb
+++ b/app/views/steps/completion/shared/_free_text_row.pdf.erb
@@ -5,7 +5,7 @@
 
   <td class="answer answer-value">
     <%= simple_format(
-      free_text_row.value.presence || t("check_answers.#{free_text_row.question}.absence_answer")
+      free_text_row.value.presence || t("check_answers.#{free_text_row.question}.absence_answer"), {}, wrapper_tag: 'div'
     ) %>
   </td>
 </tr>

--- a/app/views/steps/completion/shared/_row.html.erb
+++ b/app/views/steps/completion/shared/_row.html.erb
@@ -1,15 +1,13 @@
-<div>
+<div id="<%= row.question %>">
   <dt class="question">
-    <%=t "check_answers.#{row.question}.question" %>
+    <%=t "check_answers_html.#{row.question}.question" %>
   </dt>
   <dd class="answer">
-    <%=t "check_answers.#{row.question}.answers.#{row.value}" %>
+    <%=t "check_answers_html.#{row.question}.answers.#{row.value}" %>
   </dd>
   <dd class="change">
     <% if row.show_change_link? %>
-      <%= link_to row.change_path do %>
-        Change <span class="visuallyhidden"><%=t "check_answers.#{row.question}.accessible_change_text" %></span>
-      <% end %>
+      <%= link_to t('check_answers_html.change_link'), row.change_path %>
     <% end %>
   </dd>
 </div>

--- a/app/views/steps/completion/shared/_section.html.erb
+++ b/app/views/steps/completion/shared/_section.html.erb
@@ -1,5 +1,7 @@
-<h2 class="heading-medium heading-bottom-border"><%=t "check_answers.sections.#{section.name}" %></h2>
+<% if section.show_header? %>
+  <h2 class="heading-medium heading-bottom-border section-header"><%=t "check_answers_html.sections.#{section.name}" %></h2>
+<% end %>
 
-<dl class="check-your-answers multiple-sections">
+<dl class="check-your-answers multiple-sections" id="<%= section.name %>">
   <%= render section.answers %>
 </dl>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -898,7 +898,7 @@ en:
         show:
           page_title: Check your answers
           heading: Check your answers
-          lead_text: Please review your answers before submitting your application
+          lead_text: Please review your answers before you continue
           confirm: Confirm and continue
   home:
     index:

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -574,3 +574,36 @@ en:
       question: Child(ren)’s names
       answers:
         c8_children_numbers: Child(ren)’s numbers
+
+  check_answers_html:
+    change_link: Change
+    sections:
+      child_protection_cases: Emergency protection, care or supervision proceedings
+      miam_requirement: Attending a Mediation Information and Assessment Meeting (MIAM)
+    groups:
+      miam_certification_details: Certification details
+
+    child_protection_cases:
+      question: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
+      answers:
+        <<: *YESNO
+    miam_attended:
+      question: Have you attended a MIAM?
+      answers:
+        <<: *YESNO
+    miam_exemption_claim:
+      question: Do you have a valid reason for not attending a MIAM?
+      answers:
+        <<: *YESNO
+    miam_certification:
+      question: Have you got a document signed by the mediator?
+      answers:
+        <<: *YESNO
+    miam_certification_date:
+      question: When did you attend the MIAM?
+    miam_certification_number:
+      question: FMC registration number
+    miam_certification_service_name:
+      question: Family mediation service name
+    miam_certification_sole_trader_name:
+      question: Sole trader name

--- a/spec/forms/steps/miam/attended_form_spec.rb
+++ b/spec/forms/steps/miam/attended_form_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe Steps::Miam::AttendedForm do
   it_behaves_like 'a yes-no question form', attribute_name: :miam_attended,
     reset_when_no: [
+      :miam_exemption_claim,
       :miam_certification,
       :miam_certification_date,
       :miam_certification_number,

--- a/spec/forms/steps/miam/certification_form_spec.rb
+++ b/spec/forms/steps/miam/certification_form_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Steps::Miam::CertificationForm do
   it_behaves_like 'a yes-no question form',
                   attribute_name: :miam_certification,
                   reset_when_no: [
+                    :miam_exemption_claim,
                     :miam_certification_date,
                     :miam_certification_number,
                     :miam_certification_service_name,

--- a/spec/presenters/summary/answers_group_spec.rb
+++ b/spec/presenters/summary/answers_group_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Summary::AnswersGroup do
+  let(:questions) { [
+    question1,
+    question2,
+  ] }
+  let(:change_path) { nil }
+
+  let(:question1) { double('question1') }
+  let(:question2) { double('question2') }
+
+  subject { described_class.new(:group_name, questions, change_path: change_path) }
+
+  describe '#name' do
+    it { expect(subject.name).to eq(:group_name) }
+  end
+
+  describe '#to_partial_path' do
+    it 'returns the correct partial path' do
+      expect(subject.to_partial_path).to eq('steps/completion/shared/answers_group')
+    end
+  end
+
+  describe '#show?' do
+    it 'calls `show?` on the questions and return true if any question should be shown' do
+      expect(question1).to receive(:show?).and_return(false)
+      expect(question2).to receive(:show?).and_return(true)
+      expect(subject.show?).to eq(true)
+    end
+  end
+
+  describe '#show_change_link?' do
+    it 'returns false' do
+      expect(subject.show_change_link?).to eq(false)
+    end
+
+    context 'when change_path is given' do
+      let(:change_path) {'/change'}
+
+      it 'returns true' do
+        expect(subject.show_change_link?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -5,8 +5,15 @@ describe Summary::HtmlPresenter do
   subject { described_class.new(c100_application) }
 
   describe '#sections' do
+    before do
+      allow_any_instance_of(Summary::Sections::BaseSectionPresenter).to receive(:show?).and_return(true)
+    end
+
     it 'has the right sections in the right order' do
-      expect(subject.sections.count).to eq(0)
+      expect(subject.sections).to match_instances_array([
+        Summary::HtmlSections::ChildProtectionCases,
+        Summary::HtmlSections::MiamRequirement,
+      ])
     end
   end
 end

--- a/spec/presenters/summary/html_sections/child_protection_cases_spec.rb
+++ b/spec/presenters/summary/html_sections/child_protection_cases_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::ChildProtectionCases do
+    let(:c100_application) { instance_double(C100Application, child_protection_cases: 'yes') }
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:child_protection_cases) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:child_protection_cases)
+        expect(answers[0].value).to eq('yes')
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/html_sections/miam_requirement_spec.rb
+++ b/spec/presenters/summary/html_sections/miam_requirement_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::MiamRequirement do
+    let(:c100_application) {
+      instance_double(C100Application,
+        miam_attended: 'yes',
+        miam_certification: 'yes',
+        miam_exemption_claim: 'no',
+        miam_certification_date: Date.new(2018, 1, 20),
+        miam_certification_number: '12345',
+        miam_certification_service_name: 'service name',
+        miam_certification_sole_trader_name: 'sole trader name',
+    ) }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:miam_requirement) }
+    end
+
+    # The following tests can be fragile, but on purpose. During the development phase
+    # we have to update the tests each time we introduce a new row or remove another.
+    # But once it is finished and stable, it will raise a red flag if it ever gets out
+    # of sync, which means a quite solid safety net for any maintainers in the future.
+    #
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(5)
+
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:miam_attended)
+        expect(answers[0].change_path).to eq('/steps/miam/attended')
+        expect(answers[0].value).to eq('yes')
+
+        expect(answers[1]).to be_an_instance_of(Answer)
+        expect(answers[1].question).to eq(:miam_certification)
+        expect(answers[1].change_path).to eq('/steps/miam/certification')
+        expect(answers[1].value).to eq('yes')
+
+        expect(answers[2]).to be_an_instance_of(Answer)
+        expect(answers[2].question).to eq(:miam_exemption_claim)
+        expect(answers[2].change_path).to eq('/steps/miam/exemption_claim')
+        expect(answers[2].value).to eq('no')
+
+        expect(answers[3]).to be_an_instance_of(DateAnswer)
+        expect(answers[3].question).to eq(:miam_certification_date)
+        expect(answers[3].change_path).to eq('/steps/miam/certification_date')
+        expect(answers[3].value).to eq(Date.new(2018, 1, 20))
+
+        expect(answers[4]).to be_an_instance_of(AnswersGroup)
+        expect(answers[4].name).to eq(:miam_certification_details)
+        expect(answers[4].change_path).to eq('/steps/miam/certification_details')
+        expect(answers[4].answers.count).to eq(3)
+
+        ### group answers ###
+        certification = answers[4].answers
+
+        expect(certification[0]).to be_an_instance_of(FreeTextAnswer)
+        expect(certification[0].question).to eq(:miam_certification_number)
+        expect(certification[0].value).to eq('12345')
+
+        expect(certification[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(certification[1].question).to eq(:miam_certification_service_name)
+        expect(certification[1].value).to eq('service name')
+
+        expect(certification[2]).to be_an_instance_of(FreeTextAnswer)
+        expect(certification[2].question).to eq(:miam_certification_sole_trader_name)
+        expect(certification[2].value).to eq('sole trader name')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a first version of the check your answers page.

Only the first few questions (MIAM attendance) are shown, and in any case this is not yet integrated into the user journey so will only be visible if the URL is known.

We can iterate on this and if we are happy, start adding more and more question/answers.

<img width="859" alt="screen shot 2018-04-19 at 09 44 05" src="https://user-images.githubusercontent.com/687910/38981044-4d4bb71c-43b6-11e8-8027-2a7355e36ead.png">
