### PR TITLE
Allow resuming a completed application

### DIFF
--- a/app/controllers/users/drafts_controller.rb
+++ b/app/controllers/users/drafts_controller.rb
@@ -3,13 +3,24 @@ module Users
     before_action :authenticate_user!
 
     def index
-      @drafts = drafts.order(created_at: :asc)
+      @drafts = current_user.drafts.order(created_at: :asc)
     end
 
     def resume
-      c100_application = draft_from_params
-      session[:c100_application_id] = c100_application.id
-      redirect_to c100_application.navigation_stack.last
+      # Note: there is no need for `else` because `draft_from_params`
+      # will raise an exception if no application was found
+      #
+      if completed_application_from_params
+        set_session_and_redirect(
+          completed_application_from_params,
+          steps_completion_what_next_path
+        )
+      elsif draft_from_params
+        set_session_and_redirect(
+          draft_from_params,
+          draft_from_params.navigation_stack.last
+        )
+      end
     end
 
     def destroy
@@ -19,12 +30,17 @@ module Users
 
     private
 
-    def drafts
-      current_user.drafts
+    def completed_application_from_params
+      @_c100_application ||= current_user.completed_applications.find_by(id: params[:id])
     end
 
     def draft_from_params
-      drafts.find_by(id: params[:id]) || (raise Errors::ApplicationNotFound)
+      @_c100_application ||= current_user.drafts.find_by(id: params[:id]) || (raise Errors::ApplicationNotFound)
+    end
+
+    def set_session_and_redirect(c100_application, path)
+      session[:c100_application_id] = c100_application.id
+      redirect_to path
     end
   end
 end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -26,8 +26,9 @@ class C100Application < ApplicationRecord
   has_many :other_children
   has_many :other_parties
 
-  scope :not_completed, -> { where.not(status: :completed) }
   scope :with_owner,    -> { where.not(user: nil) }
+  scope :completed,     -> { where(status: :completed) }
+  scope :not_completed, -> { where.not(status: :completed) }
 
   has_value_object :user_type
   has_value_object :concerns_contact_type

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
 
   has_many :c100_applications, dependent: :destroy
   has_many :drafts, -> { not_completed }, class_name: 'C100Application'
+  has_many :completed_applications, -> { completed }, class_name: 'C100Application'
 
   attribute :email, NormalisedEmailType.new
 

--- a/app/views/users/drafts/index.html.erb
+++ b/app/views/users/drafts/index.html.erb
@@ -5,7 +5,12 @@
     <h1 class="heading-large">
       <%=t '.heading' %>
     </h1>
+
     <p class="lede"><%=t '.drafts_intro' %></p>
+
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%=t '.completed_info' %></p>
+    </div>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -955,7 +955,7 @@ en:
       page_title: Application not found
       heading: Sorry, this application no longer exists
       lead_text: If you copied a web address, please check it’s correct.
-      more_text: "Please note: a draft application expires %{expire_in_days} days after it was created or when you complete it."
+      more_text: "Please note: a draft application expires %{expire_in_days} days after it was created, and is automatically removed from the service."
       <<: *START_FINISH
     application_screening:
       page_title: Application screening
@@ -966,7 +966,7 @@ en:
     application_completed:
       page_title: Application completed
       heading: You have already completed this application
-      lead_text: Your application won’t be processed until you complete a few more steps. If you want to make changes you can start a new application.
+      lead_text: Your application won’t be processed until you complete a few more steps. If you want to make changes you will need to start a new application.
       what_next: What you need to do next
       <<: *START_FINISH
     not_found:
@@ -1667,6 +1667,7 @@ en:
         page_title: Draft applications
         heading: Your saved drafts
         drafts_intro: Resume an application you haven't yet completed.
+        completed_info: Completed applications will not show here, but you can still use the link in the confirmation email to download the PDF.
         new_application: Start a new application
         table:
           caption: Table of saved drafts


### PR DESCRIPTION
If we know the application is completed, when the user clicks the link from the confirmation email, instead of giving them an 'application not found' error, we can take them directly to the `what next` page, where they can read the instructions again, and download the PDF if they wish to do so.

This should improve a the experience for at least one user we've detected having issues resuming their application (as it was completed and no longer shown in the drafts page).