### PR TITLE
Copy amendments to `what next` page

### DIFF
--- a/app/assets/stylesheets/local/lists.scss
+++ b/app/assets/stylesheets/local/lists.scss
@@ -42,6 +42,11 @@ li li li {
   list-style: square;
 }
 
+// Allow overriding the bullets style
+ul.force-disc-style li {
+  list-style-type: disc !important;
+}
+
 section.numbered-list h3 {
   margin-top: 0;
 }

--- a/app/assets/stylesheets/local/utilities.scss
+++ b/app/assets/stylesheets/local/utilities.scss
@@ -6,6 +6,10 @@
   margin-top: 45px;
 }
 
+.util_mt-medium {
+  margin-top: 25px;
+}
+
 .util_mb-large {
   margin-bottom: 45px;
 }

--- a/app/views/steps/completion/what_next/show.en.html.erb
+++ b/app/views/steps/completion/what_next/show.en.html.erb
@@ -2,33 +2,46 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">Send your application</h1>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">How to submit your application</h1>
 
-    <p class="lede gv-u-text-lede">
-      Your application won’t be processed until you complete these steps.
-    </p>
+    <div role="note" aria-label="Warning" class="notice gv-c-notice">
+      <i class="icon icon-important gv-c-notice__icon gv-c-notice__icon--important">
+        <span class="visually-hidden gv-c-notice__icon-fallback-text">Warning</span>
+      </i>
+      <strong class="bold-small gv-c-notice__text">
+        The court will not receive your application until you complete the steps below.
+      </strong>
+    </div>
 
     <section class="numbered-list">
       <h2 class="visuallyhidden">Steps</h2>
       <div class="govuk-govspeak gv-s-prose">
         <ol class="list list-number">
-          <li>
+          <li class="util_mt-medium">
             <h3 class="heading-medium">Download your application</h3>
             <p>
-              This will be a PDF. If you can’t open the PDF after downloading, try using <a href="https://get.adobe.com/uk/reader/" target="external_link" rel="external">Adobe Acrobat Reader</a>.
+              This will be a PDF. If you cannot open the PDF after downloading, try using <a href="https://get.adobe.com/uk/reader/" target="external_link" rel="external">Adobe Acrobat Reader</a>.
             </p>
+            <div class="panel panel-border-narrow">
+              <p>To avoid losing your application, you must download it now. You cannot return to a completed application.</p>
+            </div>
             <p>
-              <%= link_to 'Download your application', steps_completion_summary_path(format: :pdf), class: 'button ga-pageLink', data: {ga_category: 'completion', ga_label: 'download application'} %>
+              <%= link_to 'Download your PDF application', steps_completion_summary_path(format: :pdf), class: 'button ga-pageLink', data: {ga_category: 'completion', ga_label: 'download application'} %>
             </p>
           </li>
 
           <li>
             <span class="heading-medium">Send your application</span>
-            <p>
-              Attach your PDF to an email. Put ‘C100 New application - Child arrangements’ in the subject line and send it to:
-              <%= mail_to @court.email, @court.email, subject: 'C100 New application - Child arrangements', class: 'ga-pageLink', data: {ga_category: 'completion', ga_label: 'email application'} %>
-            </p>
+            <p>To send by email:</p>
+
+            <ul class="list list-bullet force-disc-style">
+              <li>attach your downloaded PDF application to an email</li>
+              <li>put ‘C100 New application - Child arrangements’ in the subject line</li>
+              <li>send it to: <%= mail_to @court.email, @court.email, subject: 'C100 New application - Child arrangements', class: 'ga-pageLink', data: {ga_category: 'completion', ga_label: 'email application'} %></li>
+            </ul>
+
             <p>The court will email you to confirm they have received your application.</p>
+
             <details>
               <summary>
                 <span class="summary" data-ga-category="completion" data-ga-label="print instructions">You can also print it and send by post</span>


### PR DESCRIPTION
A few copy amendments and adding some callouts to the `what next` page, as detailed here:

https://trello.com/c/CBVF9OKR

<img width="572" alt="screen shot 2018-04-20 at 15 16 41" src="https://user-images.githubusercontent.com/687910/39056175-dc3cedcc-44ad-11e8-95ec-6686ab99f6cd.png">
