### PR TITLE
Add MIAM exemptions to Check your answers

### DIFF
--- a/app/presenters/miam_exemptions_presenter.rb
+++ b/app/presenters/miam_exemptions_presenter.rb
@@ -1,4 +1,9 @@
 class MiamExemptionsPresenter < SimpleDelegator
+  FILTERS = {
+    default: /^group_|_none$/,
+    groups:  /^group_/,
+  }.freeze
+
   Exemption = Struct.new(:group_name, :collection) do
     def show?
       collection.any?
@@ -13,8 +18,13 @@ class MiamExemptionsPresenter < SimpleDelegator
     return [] unless __getobj__
 
     exemption_groups.map do |group|
-      Exemption.new(group, filtered(self[group]))
+      Exemption.new(group, selection_for(group))
     end.select(&:show?)
+  end
+
+  def selection_for(group, filter: nil)
+    return [] unless __getobj__
+    filtered(self[group], filter)
   end
 
   def exemption_groups
@@ -29,7 +39,7 @@ class MiamExemptionsPresenter < SimpleDelegator
   # Also we filter out the `xxx_none` because it means this exemptions group doesn't apply
   # to the user (none of the exemptions were selected, so nothing to playback).
   #
-  def filtered(collection)
-    collection.grep_v(/^group_|_none$/)
+  def filtered(collection, filter)
+    collection.grep_v(FILTERS.fetch(filter, FILTERS[:default]))
   end
 end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -10,6 +10,7 @@ module Summary
       [
         HtmlSections::ChildProtectionCases.new(c100_application),
         HtmlSections::MiamRequirement.new(c100_application),
+        HtmlSections::MiamExemptions.new(c100_application),
       ].flatten.select(&:show?)
     end
   end

--- a/app/presenters/summary/html_sections/miam_exemptions.rb
+++ b/app/presenters/summary/html_sections/miam_exemptions.rb
@@ -1,0 +1,51 @@
+module Summary
+  module HtmlSections
+    class MiamExemptions < Sections::BaseSectionPresenter
+      def name
+        :miam_exemptions
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def answers
+        [
+          MultiAnswer.new(
+            :miam_exemptions_domestic,
+            selection_for(:domestic),
+            change_path: edit_steps_miam_exemptions_domestic_path
+          ),
+          MultiAnswer.new(
+            :miam_exemptions_protection,
+            selection_for(:protection),
+            change_path: edit_steps_miam_exemptions_protection_path
+          ),
+          MultiAnswer.new(
+            :miam_exemptions_urgency,
+            selection_for(:urgency),
+            change_path: edit_steps_miam_exemptions_urgency_path
+          ),
+          MultiAnswer.new(
+            :miam_exemptions_adr,
+            selection_for(:adr),
+            change_path: edit_steps_miam_exemptions_adr_path
+          ),
+          MultiAnswer.new(
+            :miam_exemptions_misc,
+            selection_for(:misc),
+            change_path: edit_steps_miam_exemptions_misc_path
+          ),
+        ].select(&:show?)
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      private
+
+      def selection_for(group)
+        presenter.selection_for(group, filter: :groups)
+      end
+
+      def presenter
+        @_presenter ||= MiamExemptionsPresenter.new(c100.miam_exemption)
+      end
+    end
+  end
+end

--- a/app/views/steps/completion/shared/_multi_answer_row.html.erb
+++ b/app/views/steps/completion/shared/_multi_answer_row.html.erb
@@ -1,2 +1,19 @@
-<!-- HTML version to be implemented when needed for check your answers -->
-<p>Not implemented: <%= __FILE__ %></p>
+<div id="<%= multi_answer_row.question %>">
+  <dt class="question">
+    <%=t "check_answers_html.#{multi_answer_row.question}.question" %>
+  </dt>
+  <dd class="answer">
+    <ul class="list list-bullet">
+      <% multi_answer_row.value.each do |value| %>
+        <li>
+          <%= t("check_answers_html.#{multi_answer_row.question}.answers.#{value}") %>
+        </li>
+      <% end %>
+    </ul>
+  </dd>
+  <dd class="change">
+    <% if multi_answer_row.show_change_link? %>
+      <%= link_to t('check_answers_html.change_link'), multi_answer_row.change_path %>
+    <% end %>
+  </dd>
+</div>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -2,6 +2,7 @@ en:
   dictionary:
     to_be_completed: &to_be_completed "To be completed by the court"
     not_applicable: &not_applicable "Not applicable"
+    none_selected: &none_selected "None selected"
     unknown: &unknown "Don't know"
     details: &details "Details:"
 
@@ -579,7 +580,8 @@ en:
     change_link: Change
     sections:
       child_protection_cases: Emergency protection, care or supervision proceedings
-      miam_requirement: Attending a Mediation Information and Assessment Meeting (MIAM)
+      miam_requirement: Attending a MIAM
+      miam_exemptions: Exemptions from attending a MIAM
     groups:
       miam_certification_details: Certification details
 
@@ -607,3 +609,75 @@ en:
       question: Family mediation service name
     miam_certification_sole_trader_name:
       question: Sole trader name
+
+    # TODO: Review the copy for each of the MIAM exemptions and make it concise
+    # enough for Check your answers, as it does not need to be as verbose as in
+    # the steps or in the PDF. It is intended to be a quick check for the user.
+    #
+    miam_exemptions_domestic:
+      question: Domestic reasons
+      answers:
+        police_arrested: Evidence that a prospective party has been arrested for a relevant domestic violence offence
+        police_caution: Evidence of a relevant police caution for a domestic violence offence
+        police_ongoing_proceedings: Evidence of relevant criminal proceedings for a domestic violence offence which have not concluded
+        police_conviction: Evidence of a relevant conviction for a domestic violence offence
+        police_dvpn: A domestic violence protection notice issued under section 24 of the Crime and Security Act 2010 against a prospective party
+        court_bound_over: A court order binding a prospective party over in connection with a domestic violence offence
+        court_protective_injunction: A relevant protective injunction
+        court_undertaking: An undertaking given in England and Wales under section 46 or 63E of the Family Law Act 1996 (or given in Scotland or Northern Ireland in place of a protective injunction) by a prospective party, provided that a cross-undertaking relating to domestic violence was not given by another prospective party
+        court_finding_of_fact: A copy of a finding of fact, made in proceedings in the United Kingdom, that there has been domestic violence by a prospective party
+        court_expert_report: An expert report produced as evidence in proceedings in the United Kingdom for the benefit of a court or tribunal confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party
+        specialist_examination: A letter or report from an appropriate health professional
+        specialist_referral: specialist_referral ???
+        local_authority_marac: A letter from any person who is a member of a multi-agency risk assessment conference (or other suitable local safeguarding forum) confirming that a prospective party, or a person with whom that prospective party is in a family relationship, is or has been at risk of harm from domestic violence by another prospective party
+        local_authority_la_ha: A letter from an officer employed by a local authority or housing association
+        local_authority_public_authority: A letter from a public authority confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party (or a copy of that assessment)
+        da_service_idva: A letter from an independent domestic violence advisor confirming that they are providing support to a prospective party
+        da_service_isva: A letter from an independent sexual violence advisor confirming that they are providing support to a prospective party relating to sexual violence by another prospective party
+        da_service_organisation: da_service_organisation ???
+        da_service_refuge_refusal: da_service_refuge_refusal ???
+        right_to_remain: You or any of the other people in this application (the respondents) have been granted indefinite leave to remain in the UK as a victim of domestic violence or abuse
+        financial_abuse: You have evidence that you or the other people in this application (the respondents) have been, or are at risk of being, financially abused by the other
+        domestic_none: *none_selected
+
+    miam_exemptions_protection:
+      question: Protection reasons
+      answers:
+        authority_enquiring: A local authority is carrying out enquiries or assessment about any of the children in this application, or other child in the household
+        authority_protection_order: Any of the children in this application, or other child in the household, is the subject of a child protection plan
+        protection_none: *none_selected
+
+    miam_exemptions_urgency:
+      question: Urgency reasons
+      answers:
+        risk_applicant: There is risk to the life, liberty or physical safety of you, your family or your home
+        unreasonable_hardship: Any delay caused by attending a MIAM would cause unreasonable hardship for you
+        risk_children: Any delay caused by attending a MIAM would cause a risk of harm to the children
+        risk_unlawful_removal_retention: Any delay caused by attending a MIAM would cause a risk of unlawful removal of a child from the UK, or a risk of unlawful retention of a child who is currently outside England and Wales
+        miscarriage_justice: Any delay caused by attending a MIAM would cause a significant risk of a miscarriage of justice
+        irretrievable_problems: Any delay caused by attending a MIAM would cause irretrievable problems in dealing with the dispute (including the irretrievable loss of significant evidence)
+        international_proceedings: There is a significant risk that in the period necessary to schedule and attend a MIAM, proceedings relating to the dispute will be brought in another state in which a valid claim to jurisdiction may exist, such that a court in that other State would be seized of the dispute before a court in England and Wales
+        urgency_none: *none_selected
+
+    miam_exemptions_adr:
+      question: ADR reasons ???
+      answers:
+        previous_attendance: In the 4 months prior to making the application, the person attended a MIAM or participated in another form of non-court dispute resolution relating to the same or a very similar dispute
+        ongoing_attendance: At the time of making the application, the person is participating in another form of non-court dispute resolution relating to the same or substantially the same dispute
+        existing_proceedings_attendance: The application would be made in existing proceedings which are continuing and the prospective applicant attended a MIAM before initiating those proceedings
+        previous_exemption: In the 4 months prior to making the application, the person filed a relevant family application confirming that a MIAM exemption applied and that application related to the same or substantially the same dispute
+        existing_proceedings_exemption: The application would be made in existing proceedings which are continuing and a MIAM exemption applied to the application for those proceedings
+        adr_none: *none_selected
+
+    miam_exemptions_misc:
+      question: Other reasons
+      answers:
+        no_respondent_address: You don’t have sufficient contact details for the other people in this application (the respondents)
+        without_notice: You’re applying for a without notice hearing
+        no_disabled_facilities: You or the other person has a disability and the mediator doesn’t have disabled facilities
+        no_appointment: You or the other person has contacted 3 mediators within 15 miles and can’t get an appointment within 15 working days
+        no_mediator_nearby: There is no authorised family mediator with an office within 15 miles of your home
+        access_prohibited: You or the other people in this application (the respondents) can’t attend a MIAM
+        non_resident: You or the other people in this application (the respondents) don’t live in England and Wales
+        applicant_under_age: The applicant or any of the other people in this application (the respondents) are under 18 years old
+        misc_none: *none_selected

--- a/spec/presenters/miam_exemptions_presenter_spec.rb
+++ b/spec/presenters/miam_exemptions_presenter_spec.rb
@@ -49,4 +49,25 @@ RSpec.describe MiamExemptionsPresenter do
       it { expect(exemptions).to eq([]) }
     end
   end
+
+  describe '#selection_for' do
+    let(:domestic_exemptions) { %w(group_police police_conviction domestic_none) }
+
+    context 'when there are no exemptions' do
+      let(:miam_exemption) { nil }
+      it { expect(subject.selection_for(:domestic)).to eq([]) }
+    end
+
+    context 'when a filter is not provided' do
+      it 'retrieves the exemptions from the given group, using the default filter' do
+        expect(subject.selection_for(:domestic)).to eq(['police_conviction'])
+      end
+    end
+
+    context 'when a filter is provided' do
+      it 'retrieves the exemptions from the given group, using the default filter' do
+        expect(subject.selection_for(:domestic, filter: :groups)).to eq(%w(police_conviction domestic_none))
+      end
+    end
+  end
 end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -13,6 +13,7 @@ describe Summary::HtmlPresenter do
       expect(subject.sections).to match_instances_array([
         Summary::HtmlSections::ChildProtectionCases,
         Summary::HtmlSections::MiamRequirement,
+        Summary::HtmlSections::MiamExemptions,
       ])
     end
   end

--- a/spec/presenters/summary/html_sections/miam_exemptions_spec.rb
+++ b/spec/presenters/summary/html_sections/miam_exemptions_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::MiamExemptions do
+    let(:c100_application) {
+      instance_double(C100Application,
+        miam_exemption: miam_exemption,
+    ) }
+
+    let(:miam_exemption) {
+      MiamExemption.new(
+        domestic: [:test_domestic],
+        protection: [:test_protection],
+        urgency: [:test_urgency],
+        adr: [:test_adr],
+        misc: [:test_misc],
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:miam_exemptions) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(5)
+
+        expect(answers[0]).to be_an_instance_of(MultiAnswer)
+        expect(answers[0].question).to eq(:miam_exemptions_domestic)
+        expect(answers[0].value).to eq(['test_domestic'])
+        expect(answers[0].change_path).to eq('/steps/miam_exemptions/domestic')
+
+        expect(answers[1]).to be_an_instance_of(MultiAnswer)
+        expect(answers[1].question).to eq(:miam_exemptions_protection)
+        expect(answers[1].value).to eq(['test_protection'])
+        expect(answers[1].change_path).to eq('/steps/miam_exemptions/protection')
+
+        expect(answers[2]).to be_an_instance_of(MultiAnswer)
+        expect(answers[2].question).to eq(:miam_exemptions_urgency)
+        expect(answers[2].value).to eq(['test_urgency'])
+        expect(answers[2].change_path).to eq('/steps/miam_exemptions/urgency')
+
+        expect(answers[3]).to be_an_instance_of(MultiAnswer)
+        expect(answers[3].question).to eq(:miam_exemptions_adr)
+        expect(answers[3].value).to eq(['test_adr'])
+        expect(answers[3].change_path).to eq('/steps/miam_exemptions/adr')
+
+        expect(answers[4]).to be_an_instance_of(MultiAnswer)
+        expect(answers[4].question).to eq(:miam_exemptions_misc)
+        expect(answers[4].value).to eq(['test_misc'])
+        expect(answers[4].change_path).to eq('/steps/miam_exemptions/misc')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Show, in groups, the MIAM exemptions selected by the user, if any, and link to each of the exemption pages directly.

The copy is still WIP and we should review it to simplify and shorten as much as possible so is easy to check by the user without having lots of copy to read.

Also the layout might change but this follows the current CYA layout and is 100% responsive (for mobile devices), so leaving it for now.

<img width="867" alt="screen shot 2018-04-23 at 14 28 31" src="https://user-images.githubusercontent.com/687910/39129542-a9896b2e-4702-11e8-9876-c8a0a5a73947.png">
