### PR TITLE
re-apply "make eligibility check & dest'n address only consider closest court" (#365)

### DIFF
--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -7,7 +7,8 @@ module C100App
       "reading-county-court-and-family-court",
       "guildford-county-court-and-family-court",
       "milton-keynes-county-court-and-family-court",
-      "watford-county-court-and-family-court"
+      "watford-county-court-and-family-court",
+      "slough-county-court-and-family-court",
     ].freeze
 
     # Separate multiple postcodes/postcode areas by "\n"
@@ -29,9 +30,11 @@ module C100App
     private
 
     def choose_from(possible_courts)
-      possible_courts.find do |court|
-        COURT_SLUGS_USING_THIS_APP.include?(court['slug'] || court[:slug])
+      slug = nil
+      first_with_slug = possible_courts.find do |court|
+        slug = court[:slug] || court['slug']
       end
+      first_with_slug if COURT_SLUGS_USING_THIS_APP.include?(slug)
     end
   end
 end

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -97,28 +97,92 @@ describe C100App::CourtPostcodeChecker do
   end
 
   describe '#choose_from' do
-    context 'given an array of hashes' do
-      let(:arg){
-        [
-          {key: 'value'},
-          {slug: 'slug-1'},
-          {slug: C100App::CourtPostcodeChecker::COURT_SLUGS_USING_THIS_APP.first}
-        ]
-      }
+    let(:result){ subject.send(:choose_from,arg) }
+    let(:valid_slug){ C100App::CourtPostcodeChecker::COURT_SLUGS_USING_THIS_APP.first }
 
-      it 'returns the first hash whose :slug is in the COURT_SLUGS_USING_THIS_APP' do
-        expect(subject.send(:choose_from,arg)).to eq({slug: C100App::CourtPostcodeChecker::COURT_SLUGS_USING_THIS_APP.first})
+    context 'given an array of hashes' do
+      context 'with at least one hash that has a :slug key' do
+        context 'when the first slug is in the COURT_SLUGS_USING_THIS_APP' do
+          let(:arg){
+            [
+              {key: 'value'},
+              {slug: valid_slug},
+              {slug: 'slug-1'},
+            ]
+          }
+
+          it 'returns the hash' do
+            expect(result).to eq({slug: valid_slug})
+          end
+        end
+
+        context 'when the first slug is not in the COURT_SLUGS_USING_THIS_APP' do
+          let(:arg){
+            [
+              {key: 'value'},
+              {slug: 'slug-1'},
+              {slug: valid_slug},
+            ]
+          }
+          it 'returns nil' do
+            expect(result).to eq(nil)
+          end
+        end
       end
 
-      context 'with a string key' do
-        let(:arg){
-          [
-            {'slug' => 'my slug'},
-            {'slug' => C100App::CourtPostcodeChecker::COURT_SLUGS_USING_THIS_APP.first}
-          ]
-        }
-        it 'returns the first hash whose :slug is in the COURT_SLUGS_USING_THIS_APP' do
-          expect(subject.send(:choose_from,arg)).to eq({'slug'=> C100App::CourtPostcodeChecker::COURT_SLUGS_USING_THIS_APP.first})
+
+      context 'with no hash that has a :slug key, but at least one that has a "slug" key' do
+        context 'when the first slug is in the COURT_SLUGS_USING_THIS_APP' do
+          let(:arg){
+            [
+              {key: 'value'},
+              {'slug' => valid_slug},
+              {'slug' => 'slug-1'},
+            ]
+          }
+
+          it 'returns the hash' do
+            expect(result).to eq({'slug' => valid_slug})
+          end
+        end
+
+        context 'when the first slug is not in the COURT_SLUGS_USING_THIS_APP' do
+          let(:arg){
+            [
+              {key: 'value'},
+              {'slug' => 'slug-1'},
+              {'slug' => valid_slug},
+            ]
+          }
+
+          it 'returns nil' do
+            expect(result).to eq(nil)
+          end
+        end
+      end
+
+      context 'with a hash that has a :slug key, and one that has a "slug" key' do
+        context 'when the string key is first' do
+          let(:arg){
+            [
+              {'slug' => valid_slug},
+              {slug: 'slug-1'},
+            ]
+          }
+          it 'only considers the first value' do
+            expect(result).to eq({'slug' => valid_slug})
+          end
+        end
+        context 'when the string key is first' do
+          let(:arg){
+            [
+              {slug: valid_slug},
+              {'slug' => 'slug-1'},
+            ]
+          }
+          it 'only considers the first value' do
+            expect(result).to eq({slug: valid_slug})
+          end
         end
       end
     end


### PR DESCRIPTION
After much discussion, the team (including Alejandra) have decided that PR #365 should stand - even though that means a couple of Reading postcodes will not be considered eligible as their closest court in courtfinder is Oxford.

If this highlights something not right in the setup of the Courtfinder data, then we should fix that _in Courtfinder_, rather than trying to special-case it in a downstream service. That way lies more legacy lock-in headaches for the future.

This reverts commit f2c466955016ff8d5f8f7dd2a79d2597b4fbbc00.