### PR TITLE
Show complete applications in drafts page

### DIFF
--- a/app/controllers/users/drafts_controller.rb
+++ b/app/controllers/users/drafts_controller.rb
@@ -3,7 +3,7 @@ module Users
     before_action :authenticate_user!
 
     def index
-      @drafts = current_user.drafts.order(created_at: :asc)
+      @drafts = current_user.c100_applications.order(created_at: :asc)
     end
 
     def resume
@@ -13,7 +13,7 @@ module Users
       if completed_application_from_params
         set_session_and_redirect(
           completed_application_from_params,
-          steps_completion_what_next_path
+          steps_completion_how_to_submit_path
         )
       elsif draft_from_params
         set_session_and_redirect(

--- a/app/views/entrypoint/how_long.en.html.erb
+++ b/app/views/entrypoint/how_long.en.html.erb
@@ -16,7 +16,7 @@
         <h2 class="gv-u-heading-xlarge">Saving your progress</h2>
         <p>You can save your application and return at any time. You just need your email address and a
           password of your choice.</p>
-        <p>We’ll save your draft for <%= Rails.configuration.x.drafts.expire_in_days %> days or until you submit your application. For security reasons, we’ll delete
+        <p>We’ll save your draft for <%= Rails.configuration.x.drafts.expire_in_days %> days. For security reasons, we’ll delete
           any information after this time.</p>
         <div role="note" aria-label="Information" class=" panel panel-border-wide info-notice TODO">
           <p>You won’t be able to check your answers at the end of the service so we recommend doing so as you progress.</p>

--- a/app/views/errors/application_completed.html.erb
+++ b/app/views/errors/application_completed.html.erb
@@ -6,7 +6,7 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <p class="lede"><%= link_to t('.what_next'), steps_completion_what_next_path %></p>
+    <p class="lede"><%= link_to t('.how_to_submit'), steps_completion_how_to_submit_path %></p>
 
     <div class="form-group">
       <%= link_to t('.start_again'), root_path, class: 'button' %>

--- a/app/views/users/drafts/_draft_row.html.erb
+++ b/app/views/users/drafts/_draft_row.html.erb
@@ -11,8 +11,12 @@
 
   <td class="right">
     <span class="right actions actions-tight">
-      <%= button_to t('.delete'), users_draft_path(draft), method: :delete, data: {confirm: t('.delete_confirmation')}, class: 'button button-secondary' %>
-      <%= link_to t('.resume'), resume_users_draft_path(draft), class: 'button ga-pageLink', data: {ga_category: 'save and return', ga_label: 'resume application'} %>
+      <% if draft.completed? %>
+        <%= link_to t('.how_to_submit'), resume_users_draft_path(draft), class: 'ga-pageLink', data: {ga_category: 'save and return', ga_label: 'how to submit'} %>
+      <% else %>
+        <%= button_to t('.delete'), users_draft_path(draft), method: :delete, data: {confirm: t('.delete_confirmation')}, class: 'button button-secondary' %>
+        <%= link_to t('.resume'), resume_users_draft_path(draft), class: 'button ga-pageLink', data: {ga_category: 'save and return', ga_label: 'resume application'} %>
+      <% end %>
     </span>
   </td>
 </tr>

--- a/app/views/users/drafts/index.html.erb
+++ b/app/views/users/drafts/index.html.erb
@@ -6,10 +6,8 @@
       <%=t '.heading' %>
     </h1>
 
-    <p class="lede"><%=t '.drafts_intro' %></p>
-
-    <div class="govuk-govspeak gv-s-prose">
-      <p><%=t '.completed_info' %></p>
+    <div class="panel panel-border-narrow">
+      <p><%=t '.submit_info' %></p>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -966,8 +966,8 @@ en:
     application_completed:
       page_title: Application completed
       heading: You have already completed this application
-      lead_text: Your application won’t be processed until you complete a few more steps. If you want to make changes you will need to start a new application.
-      what_next: What you need to do next
+      lead_text: The court will not receive your application until you submit it. If you want to make changes you will need to start a new application.
+      how_to_submit: How to submit your application
       <<: *START_FINISH
     not_found:
       page_title: Page not found
@@ -1616,7 +1616,7 @@ en:
       logged_out:
         heading: You have signed out
         lead_text: You can return to a saved draft using the link sent in the email or by returning to the start of the service.
-        more_text_html: A draft expires %{expire_in_days} days after it was created or when you complete the application.
+        more_text_html: A draft expires %{expire_in_days} days after it was created.
         page_title: Signed out
       save_confirmation:
         heading: Your application has been saved
@@ -1666,8 +1666,7 @@ en:
       index:
         page_title: Draft applications
         heading: Your saved drafts
-        drafts_intro: Resume an application you haven't yet completed.
-        completed_info: Completed applications will not show here, but you can still use the link in the confirmation email to download the PDF.
+        submit_info: The court will not receive your application until you submit it.
         new_application: Start a new application
         table:
           caption: Table of saved drafts
@@ -1680,11 +1679,12 @@ en:
         resume: Resume
         delete: Delete
         delete_confirmation: Are you sure you want to delete this draft?
+        how_to_submit: How to submit
     shared:
       application_saved:
         lead_text_html: A confirmation email has been sent to:<br><strong>%{email_address}</strong>
-        expire_warning_html: We will keep a draft for <strong>%{expire_in_days} days</strong> or until
-          you complete your application. Any information will be automatically deleted for your security after this time.
+        expire_warning_html: We will keep a draft for <strong>%{expire_in_days} days</strong>.
+          Any information will be automatically deleted for your security after this time.
         return_info: You can return to continue entering details at any time.
 
   surveys:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -211,6 +211,8 @@ Rails.application.routes.draw do
     namespace :completion do
       show_step :what_next
       show_step :summary
+      # The following is an alias of the `what_next` route, for analytics tracking
+      get :how_to_submit, to: 'what_next#show'
     end
   end
 

--- a/spec/controllers/users/drafts_controller_spec.rb
+++ b/spec/controllers/users/drafts_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Users::DraftsController, type: :controller do
 
       before do
         sign_in(user)
-        expect(user).to receive(:drafts).and_return(finder_double)
+        expect(user).to receive(:c100_applications).and_return(finder_double)
       end
 
       it 'renders the drafts page' do
@@ -25,7 +25,7 @@ RSpec.describe Users::DraftsController, type: :controller do
         expect(response).to render_template(:index)
       end
 
-      it 'sorts the resulting drafts by ascending `created_at`' do
+      it 'sorts the result by ascending `created_at`' do
         expect(finder_double).to receive(:order).with(created_at: :asc)
         get :index
       end
@@ -70,7 +70,7 @@ RSpec.describe Users::DraftsController, type: :controller do
 
           it 'redirects to the completion step' do
             get :resume, params: {id: c100_application.id}
-            expect(response).to redirect_to('/steps/completion/what_next')
+            expect(response).to redirect_to('/steps/completion/how_to_submit')
           end
         end
 


### PR DESCRIPTION
As discussed, and based in google analytics findings, some changes to the drafts page:

- Completed applications are also visible and accessible using the link 'How to submit'

- Link 'how to submit' leads to a variation of '/what_next' page URL, called '/how_to_submit' - content is exactly the same, it's purely for analytics

For consistency, updated some copy in this and other pages.

<img width="756" alt="screen shot 2018-04-24 at 15 10 23" src="https://user-images.githubusercontent.com/687910/39192681-a8119238-47d1-11e8-885d-893d59986ae8.png">
