### PR TITLE
Add check answers children details

### DIFF
--- a/app/assets/stylesheets/local/check_answers.scss
+++ b/app/assets/stylesheets/local/check_answers.scss
@@ -34,6 +34,13 @@
     right: 0;
   }
 
+  .subsection-header {
+    border-bottom-width: 1px;
+    display: table-row;
+    > * {
+      
+    }
+  }
 
   @include media(desktop) {
     display: table;

--- a/app/presenters/summary/answers_group.rb
+++ b/app/presenters/summary/answers_group.rb
@@ -2,7 +2,7 @@ module Summary
   class AnswersGroup
     attr_reader :name, :answers, :change_path, :name_args
 
-    def initialize(name, answers, params = {} )
+    def initialize(name, answers, params = {})
       @name = name
       @answers = answers
       @change_path = params[:change_path]

--- a/app/presenters/summary/answers_group.rb
+++ b/app/presenters/summary/answers_group.rb
@@ -1,11 +1,12 @@
 module Summary
   class AnswersGroup
-    attr_reader :name, :answers, :change_path
+    attr_reader :name, :answers, :change_path, :name_args
 
-    def initialize(name, answers, change_path: nil)
+    def initialize(name, answers, params = {} )
       @name = name
       @answers = answers
-      @change_path = change_path
+      @change_path = params[:change_path]
+      @name_args = params[:name_args]
     end
 
     def show?

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -13,6 +13,7 @@ module Summary
         HtmlSections::MiamExemptions.new(c100_application),
         HtmlSections::NatureOfApplication.new(c100_application),
         HtmlSections::Alternatives.new(c100_application),
+        HtmlSections::ChildrenDetails.new(c100_application),
       ].flatten.select(&:show?)
     end
   end

--- a/app/presenters/summary/html_sections/base_children_details.rb
+++ b/app/presenters/summary/html_sections/base_children_details.rb
@@ -3,26 +3,62 @@ module Summary
     class BaseChildrenDetails < Sections::BaseSectionPresenter
       protected
 
+      # rubocop:disable Metrics/MethodLength
       def personal_details(child)
         [
-          FreeTextAnswer.new(:child_full_name, child.full_name),
-          DateAnswer.new(:child_dob, child.dob),
-          FreeTextAnswer.new(:child_age_estimate, child.age_estimate), # This shows only if a value is present
-          Answer.new(:child_sex, child.gender),
+          FreeTextAnswer.new(
+            :child_full_name,
+            child.full_name,
+            change_path: edit_steps_children_names_path(child)
+          ),
+          DateAnswer.new(
+            :child_dob,
+            child.dob,
+            change_path: edit_child_details_path(child, 'dob_dd')
+          ),
+          FreeTextAnswer.new(
+            :child_age_estimate,
+            child.age_estimate,
+            change_path: edit_child_details_path(child, 'age_estimate')
+          ),
+          Answer.new(
+            :child_sex,
+            child.gender,
+            change_path: edit_child_details_path(child, 'gender_female')
+          ),
         ]
       end
+      # rubocop:enable Metrics/MethodLength
 
       def relationships(child)
         [
-          MultiAnswer.new(:child_applicants_relationship,  relation_to_child(child, c100.applicants)),
-          MultiAnswer.new(:child_respondents_relationship, relation_to_child(child, c100.respondents)),
+          MultiAnswer.new(:child_applicants_relationship,  relation_to_child(child, c100.applicants), change_path: edit_relation_path(child, c100.applicants)),
+          MultiAnswer.new(:child_respondents_relationship, relation_to_child(child, c100.respondents), change_path: edit_relation_path(child, c100.applicants)),
         ]
       end
 
       private
 
+      def edit_relation_path(child, people)
+        format("/steps/applicant/relationship/%<id>/child/%<child_id>",
+               id: relationship(child, people).pluck(:id),
+               child_id: child.id)
+      end
+
+      def edit_child_details_path(child, field_stub)
+        edit_steps_children_personal_details_path(
+          child,
+          anchor: format('steps_children_personal_details_form_%<field_stub>',
+                         field_stub)
+        )
+      end
+
       def relation_to_child(child, people)
-        child.relationships.where(person: people).pluck(:relation)
+        relationship(child, people).pluck(:relation)
+      end
+
+      def relationship(child, people)
+        child.relationships.where(person: people)
       end
     end
   end

--- a/app/presenters/summary/html_sections/base_children_details.rb
+++ b/app/presenters/summary/html_sections/base_children_details.rb
@@ -40,7 +40,7 @@ module Summary
       private
 
       def edit_relation_path(child, people)
-        format("/steps/applicant/relationship/%<id>/child/%<child_id>",
+        format("/steps/applicant/relationship/%<id>s/child/%<child_id>s",
                id: relationship(child, people).pluck(:id),
                child_id: child.id)
       end
@@ -48,8 +48,8 @@ module Summary
       def edit_child_details_path(child, field_stub)
         edit_steps_children_personal_details_path(
           child,
-          anchor: format('steps_children_personal_details_form_%<field_stub>',
-                         field_stub)
+          anchor: format('steps_children_personal_details_form_%<field_stub>s',
+                         field_stub: field_stub)
         )
       end
 

--- a/app/presenters/summary/html_sections/base_children_details.rb
+++ b/app/presenters/summary/html_sections/base_children_details.rb
@@ -1,0 +1,29 @@
+module Summary
+  module HtmlSections
+    class BaseChildrenDetails < Sections::BaseSectionPresenter
+      protected
+
+      def personal_details(child)
+        [
+          FreeTextAnswer.new(:child_full_name, child.full_name),
+          DateAnswer.new(:child_dob, child.dob),
+          FreeTextAnswer.new(:child_age_estimate, child.age_estimate), # This shows only if a value is present
+          Answer.new(:child_sex, child.gender),
+        ]
+      end
+
+      def relationships(child)
+        [
+          MultiAnswer.new(:child_applicants_relationship,  relation_to_child(child, c100.applicants)),
+          MultiAnswer.new(:child_respondents_relationship, relation_to_child(child, c100.respondents)),
+        ]
+      end
+
+      private
+
+      def relation_to_child(child, people)
+        child.relationships.where(person: people).pluck(:relation)
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_sections/children_details.rb
+++ b/app/presenters/summary/html_sections/children_details.rb
@@ -23,7 +23,6 @@ module Summary
             personal_details(child),
             relationships(child),
             MultiAnswer.new(:child_orders, order_types(child)),
-            #Partial.row_blank_space,
           ]
         end
       end

--- a/app/presenters/summary/html_sections/children_details.rb
+++ b/app/presenters/summary/html_sections/children_details.rb
@@ -1,6 +1,6 @@
 module Summary
   module HtmlSections
-    class ChildrenDetails < Sections::BaseChildrenDetails
+    class ChildrenDetails < Summary::HtmlSections::BaseChildrenDetails
       def name
         :children_details
       end
@@ -8,9 +8,15 @@ module Summary
       def answers
         [
           children_details,
-          Answer.new(:children_known_to_authorities, c100.children_known_to_authorities),
-          FreeTextAnswer.new(:children_known_to_authorities_details, c100.children_known_to_authorities_details),
-          Answer.new(:children_protection_plan, c100.children_protection_plan),
+          Answer.new(:children_known_to_authorities,
+                     c100.children_known_to_authorities,
+                     change_path: edit_steps_children_additional_details_path),
+          FreeTextAnswer.new(:children_known_to_authorities_details,
+                             c100.children_known_to_authorities_details,
+                             change_path: edit_steps_children_additional_details_path),
+          Answer.new(:children_protection_plan,
+                     c100.children_protection_plan,
+                     change_path: edit_steps_children_additional_details_path),
         ].flatten.select(&:show?)
       end
 
@@ -22,7 +28,9 @@ module Summary
             Separator.new(:child_index_title, index: index),
             personal_details(child),
             relationships(child),
-            MultiAnswer.new(:child_orders, order_types(child)),
+            MultiAnswer.new(:child_orders,
+                            order_types(child),
+                            change_path: edit_steps_children_orders_path(child)),
           ]
         end
       end

--- a/app/presenters/summary/html_sections/children_details.rb
+++ b/app/presenters/summary/html_sections/children_details.rb
@@ -1,0 +1,42 @@
+module Summary
+  module HtmlSections
+    class ChildrenDetails < Sections::BaseChildrenDetails
+      def name
+        :children_details
+      end
+
+      def answers
+        [
+          children_details,
+          Answer.new(:children_known_to_authorities, c100.children_known_to_authorities),
+          FreeTextAnswer.new(:children_known_to_authorities_details, c100.children_known_to_authorities_details),
+          Answer.new(:children_protection_plan, c100.children_protection_plan),
+        ].flatten.select(&:show?)
+      end
+
+      private
+
+      def children_details
+        children.map.with_index(1) do |child, index|
+          [
+            Separator.new(:child_index_title, index: index),
+            personal_details(child),
+            relationships(child),
+            MultiAnswer.new(:child_orders, order_types(child)),
+            #Partial.row_blank_space,
+          ]
+        end
+      end
+
+      def order_types(child)
+        child.child_order&.orders.to_a.map do |o|
+          PetitionOrder.type_for(o)
+        end.uniq
+      end
+
+      def children
+        @_children ||= c100.children
+      end
+    end
+  end
+end

--- a/app/views/steps/completion/shared/_answers_group.html.erb
+++ b/app/views/steps/completion/shared/_answers_group.html.erb
@@ -1,4 +1,4 @@
-<div class="answers-group" id="<%= answers_group.name %>">
+<dl class="answers-group" id="<%= answers_group.name %>">
   <dt class="question">
     <%=t "check_answers_html.groups.#{answers_group.name}", answers_group.name_args || {} %>
   </dt>
@@ -12,4 +12,4 @@
       <%= link_to t('check_answers_html.change_link'), answers_group.change_path %>
     <% end %>
   </dd>
-</div>
+</dl>

--- a/app/views/steps/completion/shared/_answers_group.html.erb
+++ b/app/views/steps/completion/shared/_answers_group.html.erb
@@ -1,6 +1,6 @@
 <div class="answers-group" id="<%= answers_group.name %>">
   <dt class="question">
-    <%=t "check_answers_html.groups.#{answers_group.name}" %>
+    <%=t "check_answers_html.groups.#{answers_group.name}", answers_group.name_args || {} %>
   </dt>
   <dd class="answer">
     <dl class="answers-group-inner">

--- a/app/views/steps/completion/shared/_date_row.html.erb
+++ b/app/views/steps/completion/shared/_date_row.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= date_row.question %>">
+<dl id="<%= date_row.question %>">
   <dt class="question">
     <%=t "check_answers_html.#{date_row.question}.question" %>
   </dt>
@@ -10,4 +10,4 @@
       <%= link_to t('check_answers_html.change_link'), date_row.change_path %>
     <% end %>
   </dd>
-</div>
+</dl>

--- a/app/views/steps/completion/shared/_free_text_row.html.erb
+++ b/app/views/steps/completion/shared/_free_text_row.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= free_text_row.question %>">
+<dl id="<%= free_text_row.question %>">
   <dt class="question">
     <%=t "check_answers_html.#{free_text_row.question}.question" %>
   </dt>
@@ -12,4 +12,4 @@
       <%= link_to t('check_answers_html.change_link'), free_text_row.change_path %>
     <% end %>
   </dd>
-</div>
+</dl>

--- a/app/views/steps/completion/shared/_multi_answer_row.html.erb
+++ b/app/views/steps/completion/shared/_multi_answer_row.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= multi_answer_row.question %>">
+<dl id="<%= multi_answer_row.question %>">
   <dt class="question">
     <%=t "check_answers_html.#{multi_answer_row.question}.question" %>
   </dt>
@@ -16,4 +16,4 @@
       <%= link_to t('check_answers_html.change_link'), multi_answer_row.change_path %>
     <% end %>
   </dd>
-</div>
+</dl>

--- a/app/views/steps/completion/shared/_row.html.erb
+++ b/app/views/steps/completion/shared/_row.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= row.question %>">
+<dl id="<%= row.question %>">
   <dt class="question">
     <%=t "check_answers_html.#{row.question}.question" %>
   </dt>
@@ -10,4 +10,4 @@
       <%= link_to t('check_answers_html.change_link'), row.change_path %>
     <% end %>
   </dd>
-</div>
+</dl>

--- a/app/views/steps/completion/shared/_section.html.erb
+++ b/app/views/steps/completion/shared/_section.html.erb
@@ -2,6 +2,6 @@
   <h2 class="heading-medium heading-bottom-border section-header"><%=t "check_answers_html.sections.#{section.name}" %></h2>
 <% end %>
 
-<dl class="check-your-answers multiple-sections" id="<%= section.name %>">
+<div class="check-your-answers multiple-sections" id="<%= section.name %>">
   <%= render section.answers %>
-</dl>
+</div>

--- a/app/views/steps/completion/shared/_separator.html.erb
+++ b/app/views/steps/completion/shared/_separator.html.erb
@@ -1,2 +1,1 @@
-<!-- HTML version to be implemented when needed for check your answers -->
-<p>Not implemented: <%= __FILE__ %></p>
+<h3 class="heading-medium heading-bottom-border section-header"><%=t "check_answers.separators.#{separator.title}", separator.i18n_opts %></h3>

--- a/app/views/steps/completion/shared/_separator.html.erb
+++ b/app/views/steps/completion/shared/_separator.html.erb
@@ -1,1 +1,4 @@
-<h3 class="heading-medium heading-bottom-border section-header"><%=t "check_answers.separators.#{separator.title}", separator.i18n_opts %></h3>
+<br />
+<h3 class="heading-medium heading-bottom-border subsection-header">
+  <%=t "check_answers.separators.#{separator.title}", separator.i18n_opts %>
+</h3>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -584,9 +584,10 @@ en:
       miam_exemptions: Exemptions from attending a MIAM
       nature_of_application: What you're asking the court to decide about the children
       alternatives: Alternative ways to reach an agreement
+      children_details: About the children
     groups:
       miam_certification_details: Certification details
-
+      child_details: Child %{index}
     child_protection_cases:
       question: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
       answers:
@@ -626,6 +627,40 @@ en:
         <<: *YESNO
     alternative_collaborative_law:
       question: Have you tried collaborative law?
+      answers:
+        <<: *YESNO
+
+    child_full_name:
+      question: Full name
+    child_dob:
+      question: Date of birth
+    child_age_estimate:
+      question: Approximate age or year born
+    child_sex:
+      question: Sex
+      answers:
+        <<: *SEX_OPTIONS
+    child_applicants_relationship:
+      question: Applicant(s) relationship to child
+      answers:
+        <<: *RELATIONS
+    child_respondents_relationship:
+      question: Respondent(s) relationship to child
+      answers:
+        <<: *RELATIONS
+    child_orders:
+      question: Order(s) applied for
+      answers:
+        <<: *PETITION_ORDER_TYPES
+
+    children_known_to_authorities:
+      question: Are any of the children known to the local authority children’s services?
+      answers:
+        <<: *YESNO
+    children_known_to_authorities_details:
+      question: Child name and local authority worker
+    children_protection_plan:
+      question: Are any of the children the subject of a child protection plan?
       answers:
         <<: *YESNO
 

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -16,6 +16,7 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::MiamExemptions,
         Summary::HtmlSections::NatureOfApplication,
         Summary::HtmlSections::Alternatives,
+        Summary::HtmlSections::ChildrenDetails,
       ])
     end
   end

--- a/spec/presenters/summary/html_sections/children_details_spec.rb
+++ b/spec/presenters/summary/html_sections/children_details_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::ChildrenDetails do
+    let(:c100_application) {
+      instance_double(C100Application,
+        children: [child],
+        applicants: [],
+        respondents: [],
+        children_known_to_authorities: 'yes',
+        children_known_to_authorities_details: 'details',
+        children_protection_plan: 'no',
+      )
+    }
+
+    let(:child) {
+      instance_double(Child,
+        id: '1234',
+        full_name: 'name',
+        dob: dob,
+        age_estimate: age_estimate,
+        gender: 'female',
+        child_order: child_order,
+        relationships: relationships,
+      )
+    }
+
+    let(:dob) { Date.new(2018, 1, 20) }
+    let(:age_estimate) { nil }
+    let(:child_order) { instance_double(ChildOrder, orders: ['an_order']) }
+    let(:relationships) { double('relationships') }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:children_details)
+      end
+    end
+
+    # The following tests can be fragile, but on purpose. During the development phase
+    # we have to update the tests each time we introduce a new row or remove another.
+    # But once it is finished and stable, it will raise a red flag if it ever gets out
+    # of sync, which means a quite solid safety net for any maintainers in the future.
+    #
+    describe '#answers' do
+      before do
+        allow(relationships).to receive_message_chain(:where, :pluck).and_return(['mother'])
+      end
+
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(10)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Separator)
+        expect(answers[0].title).to eq(:child_index_title)
+        expect(answers[0].i18n_opts).to eq({index: 1})
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:child_full_name)
+        expect(answers[1].value).to eq('name')
+
+        expect(answers[2]).to be_an_instance_of(DateAnswer)
+        expect(answers[2].question).to eq(:child_dob)
+        expect(answers[2].value).to eq(Date.new(2018, 1, 20))
+
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:child_sex)
+        expect(answers[3].value).to eq('female')
+
+        expect(answers[4]).to be_an_instance_of(MultiAnswer)
+        expect(answers[4].question).to eq(:child_applicants_relationship)
+        expect(answers[4].value).to eq(['mother'])
+        expect(c100_application).to have_received(:applicants).at_least(:once)
+
+        expect(answers[5]).to be_an_instance_of(MultiAnswer)
+        expect(answers[5].question).to eq(:child_respondents_relationship)
+        expect(answers[5].value).to eq(['mother'])
+        expect(c100_application).to have_received(:respondents)
+
+        expect(answers[6]).to be_an_instance_of(MultiAnswer)
+        expect(answers[6].question).to eq(:child_orders)
+        expect(answers[6].value).to eq(['other_issue'])
+
+        expect(answers[7]).to be_an_instance_of(Answer)
+        expect(answers[7].question).to eq(:children_known_to_authorities)
+        expect(c100_application).to have_received(:children_known_to_authorities)
+
+        expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[8].question).to eq(:children_known_to_authorities_details)
+        expect(c100_application).to have_received(:children_known_to_authorities_details)
+
+        expect(answers[9]).to be_an_instance_of(Answer)
+        expect(answers[9].question).to eq(:children_protection_plan)
+        expect(c100_application).to have_received(:children_protection_plan)
+      end
+
+      context 'when `dob` is nil' do
+        let(:dob) { nil }
+        let(:age_estimate) { 18 }
+
+        it 'uses the age estimate' do
+          expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[2].question).to eq(:child_age_estimate)
+          expect(answers[2].value).to eq(18)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also fix broken HTML structure in the summary, replacing wrapper DL's with wrapper divs, and pushing the DL elements to the individual answers.

_NOTE_ this does not include the "do you have any other children?" sections, that will be a separate PR

<img width="665" alt="screen shot 2018-04-25 at 16 29 30" src="https://user-images.githubusercontent.com/134501/39256070-e5478bba-48a5-11e8-8b5c-b53eced10b33.png">
