### PR TITLE
Save for later will save any information already entered

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -491,11 +491,11 @@ AccessModifierIndentation:
 
 MethodLength:
   Enabled: true
-  Max: 20
+  Max: 21
 
 AbcSize:
   Enabled: true
-  Max: 22
+  Max: 23
 
 CyclomaticComplexity:
   Enabled: true

--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -6,12 +6,22 @@ moj.Modules.gaEvents = {
     linkClass: '.ga-pageLink',
     revealingLinkClass: 'summary span.summary',
     submitFormClass: '.ga-submitForm',
+    submitButtons: 'button[type="submit"], input[type="submit"]',
 
     init: function () {
         var self = this;
 
         // don't bind anything if the GA object isn't defined
         if (typeof window.ga !== 'undefined') {
+            // Some pesky side effect of unbinding/triggering the submit event in some of
+            // the following functions, is the submit button value is lost from the params.
+            // We use this value to know when the `Save and come back later` submit button
+            // was used, instead of the normal `Continue` button.
+            // Non-javascript browsers have no issues, will always send the submit value.
+            if ($(self.submitButtons).length) {
+                self.addSubmitValueParamOnClick();
+            }
+
             if ($(self.radioFormClass).length) {
                 self.trackRadioForms();
             }
@@ -32,6 +42,14 @@ moj.Modules.gaEvents = {
                 self.trackExternalLinks();
             }
         }
+    },
+
+    addSubmitValueParamOnClick: function() {
+        $(this.submitButtons).on('click', function() {
+            $('<input>',
+                { type: 'hidden', name: $(this).attr('name'), value: $(this).attr('value') }
+            ).appendTo($(this).closest('form'));
+        });
     },
 
     trackRadioForms: function () {

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -20,7 +20,12 @@ class StepController < ApplicationController
       hash.merge(c100_application: current_c100_application, record: record)
     )
 
-    if @form_object.save
+    if save_draft?
+      # Validations will not be run when saving a draft, and because there is
+      # only a possible destination, we can also bypass the decision tree code.
+      @form_object.save!
+      redirect_to new_user_registration_path
+    elsif @form_object.save
       destination = decision_tree_class.new(
         c100_application: current_c100_application,
         record:        record,
@@ -47,6 +52,10 @@ class StepController < ApplicationController
   # Override in subclasses to declare any additional parameters that should be permitted.
   def additional_permitted_params
     []
+  end
+
+  def save_draft?
+    params[:commit_draft].present?
   end
 
   def form_attribute_names(form_class)

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -39,6 +39,13 @@ class BaseForm
     end
   end
 
+  # This is a `save if you can, but it's fine if not` method, bypassing validations
+  def save!
+    persist!
+  rescue StandardError
+    false
+  end
+
   def to_key
     # Intentionally returns nil so the form builder picks up _only_
     # the class name to generate the HTML attributes.

--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -1,8 +1,7 @@
 module CustomFormHelpers
   delegate :t,
            :current_c100_application,
-           :user_signed_in?,
-           :new_user_registration_path, to: :@template
+           :user_signed_in?, to: :@template
 
   def continue_button
     content_tag(:div, class: 'form-submit') do
@@ -13,7 +12,7 @@ module CustomFormHelpers
       else
         safe_concat [
           submit_button(:continue),
-          content_tag(:a, t('helpers.submit.save_and_come_back_later'), href: new_user_registration_path, class: 'button button-secondary button-save-return')
+          submit_button(:save_and_come_back_later, name: :commit_draft, class: %w[button button-secondary commit-draft-link])
         ].join
       end
     end
@@ -35,7 +34,7 @@ module CustomFormHelpers
     current_c100_application.nil? || current_c100_application.screening?
   end
 
-  def submit_button(i18n_key)
-    submit t("helpers.submit.#{i18n_key}"), class: 'button'
+  def submit_button(i18n_key, opts = {})
+    submit t("helpers.submit.#{i18n_key}"), {class: 'button'}.merge(opts)
   end
 end

--- a/app/services/c100_app/miam_decision_tree.rb
+++ b/app/services/c100_app/miam_decision_tree.rb
@@ -1,6 +1,5 @@
 module C100App
   class MiamDecisionTree < BaseDecisionTree
-    # rubocop:disable Metrics/MethodLength
     def destination
       return next_step if next_step
 
@@ -25,7 +24,6 @@ module C100App
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/spec/controllers/steps/miam/child_protection_cases_controller_spec.rb
+++ b/spec/controllers/steps/miam/child_protection_cases_controller_spec.rb
@@ -3,4 +3,8 @@ require 'rails_helper'
 RSpec.describe Steps::Miam::ChildProtectionCasesController, type: :controller do
   it_behaves_like 'a savepoint step controller'
   it_behaves_like 'an intermediate step controller', Steps::Miam::ChildProtectionCasesForm, C100App::MiamDecisionTree
+
+  # The following shared specs can really be used in any other step controller.
+  # The important thing is to be tested in at least one, as any other will behave the same.
+  it_behaves_like 'a step that can be drafted', Steps::Miam::ChildProtectionCasesForm
 end

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe BaseForm do
     end
   end
 
+  describe '#save!' do
+    context 'when raising exceptions' do
+      it {
+        expect(subject).to receive(:persist!).and_raise(NoMethodError)
+        expect(subject.save!).to eq(false)
+      }
+    end
+
+    context 'when there are no exceptions' do
+      it {
+        expect(subject).to receive(:persist!).and_return(true)
+        expect(subject.save!).to eq(true)
+      }
+    end
+  end
+
   describe '[]' do
     let(:c100_application) { instance_double(C100Application) }
 

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -4,10 +4,6 @@ class TestHelper < ActionView::Base
   def user_signed_in?
     false
   end
-
-  def new_user_registration_path
-    '/test/sign_up'
-  end
 end
 
 # The module `CustomFormHelpers` gets mixed in and extends the helpers already
@@ -61,7 +57,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs the continue button with a link to sign-up' do
         expect(
           html_output
-        ).to eq('<div class="form-submit"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /><a href="/test/sign_up" class="button button-secondary button-save-return">Save and come back later</a></div>')
+        ).to eq('<div class="form-submit"><input type="submit" name="commit" value="Continue" class="button" data-disable-with="Continue" /><input type="submit" name="commit_draft" value="Save and come back later" class="button button-secondary commit-draft-link" data-disable-with="Save and come back later" /></div>')
       end
     end
   end


### PR DESCRIPTION
This will implement partial save of form objects, bypassing validation (and decision tree) so when the user selects the link 'Save and come back later', if they had entered any details in the form, these will be saved, and redirect the user to the sign up page.

On resume, the user will be taken back to the last step, and any saved details will be there, at which point if they decide to continue, the form will trigger the validations as expected, if there were blank fields, etc.

For more context:
https://trello.com/c/WlhMB1jc