### PR TITLE
More copy changes

### DIFF
--- a/app/views/entrypoint/v1.en.html.erb
+++ b/app/views/entrypoint/v1.en.html.erb
@@ -7,7 +7,8 @@
     </div>
 
     <div class=" govuk-govspeak gv-s-prose">
-      <p>You can use this service to apply for a court order about child arrangements. This can be for a child arrangements order, a prohibited steps order and a specific issue order.</p>
+      <p class="lede gv-u-text-lede">You can use this service to apply for a court order about child arrangements. This
+        can be for a child arrangements order, a prohibited steps order and a specific issue order.</p>
 
       <p>The process is different if you're applying in
         <a href="https://www.mygov.scot/crime-justice-and-the-law/courts-and-sentencing" target="external_link" rel="external">Scotland</a> and

--- a/app/views/entrypoint/what_is_needed.en.html.erb
+++ b/app/views/entrypoint/what_is_needed.en.html.erb
@@ -15,13 +15,13 @@
         <ul class="list list-bullet">
           <li>details of the other people (the respondents), including address and contact details</li>
           <li>details of any previous family court cases</li>
-          <li>signed document confirming <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> attendance (if applicable)</li>
+          <li>details confirming <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> attendance (if applicable)</li>
           <li>the child’s or children’s details, including date of birth</li>
-          <li>email account to send your application from</li>
+          <li>email account to send your application from, or a printer if you’d prefer to send by post</li>
         </ul>
 
         <div role="note" aria-label="Information" class=" panel panel-border-wide info-notice TODO">
-          <p>If you don’t know all of the details you can still complete your application but it may take longer to process.</p>
+          <p>If you do not know all of the details you can still complete your application but it may take longer to process.</p>
         </div>
       </div>
 

--- a/app/views/steps/completion/what_next/show.en.html.erb
+++ b/app/views/steps/completion/what_next/show.en.html.erb
@@ -22,9 +22,13 @@
             <p>
               This will be a PDF. If you cannot open the PDF after downloading, try using <a href="https://get.adobe.com/uk/reader/" target="external_link" rel="external">Adobe Acrobat Reader</a>.
             </p>
-            <div class="panel panel-border-narrow">
-              <p>To avoid losing your application, you must download it now. You cannot return to a completed application.</p>
-            </div>
+
+            <% unless user_signed_in? %>
+              <div class="panel panel-border-narrow">
+                <p>To avoid losing your application, you must download it now. You cannot return to a completed application.</p>
+              </div>
+            <% end %>
+
             <p>
               <%= link_to 'Download your PDF application', steps_completion_summary_path(format: :pdf), class: 'button ga-pageLink', data: {ga_category: 'completion', ga_label: 'download application'} %>
             </p>


### PR DESCRIPTION
- Copy amendments in the `What is needed` bullet list.
- Changed to lede the first paragraph in the entry page.
- If user is logged in, we can hide the download callout in the `what_next` page.