### PR TITLE
 Add `children abuse` section to CYA

### DIFF
--- a/app/presenters/summary/answers_group.rb
+++ b/app/presenters/summary/answers_group.rb
@@ -1,6 +1,6 @@
 module Summary
   class AnswersGroup
-    attr_reader :name, :answers, :change_path, :name_args
+    attr_reader :name, :change_path, :name_args
 
     def initialize(name, answers, params = {})
       @name = name
@@ -9,8 +9,12 @@ module Summary
       @name_args = params[:name_args]
     end
 
+    def answers
+      @answers.select(&:show?)
+    end
+
     def show?
-      answers.any?(&:show?)
+      answers.any?
     end
 
     def show_change_link?

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -13,6 +13,7 @@ module Summary
         HtmlSections::MiamExemptions.new(c100_application),
         HtmlSections::SafetyConcerns.new(c100_application),
         HtmlSections::Abduction.new(c100_application),
+        HtmlSections::ChildrenAbuseDetails.new(c100_application),
         HtmlSections::NatureOfApplication.new(c100_application),
         HtmlSections::Alternatives.new(c100_application),
         HtmlSections::ChildrenDetails.new(c100_application),

--- a/app/presenters/summary/html_sections/base_abuse_details.rb
+++ b/app/presenters/summary/html_sections/base_abuse_details.rb
@@ -1,0 +1,39 @@
+module Summary
+  module HtmlSections
+    class BaseAbuseDetails < Sections::BaseSectionPresenter
+      # rubocop:disable Metrics/AbcSize
+      def answers
+        abuses_suffered.map do |abuse|
+          [
+            Answer.new(:"abuse_#{abuse.kind}", abuse.answer,
+                       change_path: edit_steps_abuse_concerns_question_path(subject: abuse.subject, kind: abuse.kind)),
+
+            AnswersGroup.new(
+              :abuse_details,
+              [
+                FreeTextAnswer.new(:abuse_behaviour_description, abuse.behaviour_description),
+                FreeTextAnswer.new(:abuse_behaviour_start, abuse.behaviour_start),
+                Answer.new(:abuse_behaviour_ongoing, abuse.behaviour_ongoing),
+                FreeTextAnswer.new(:abuse_behaviour_stop, abuse.behaviour_stop),
+                Answer.new(:abuse_asked_for_help, abuse.asked_for_help),
+                FreeTextAnswer.new(:abuse_help_party, abuse.help_party),
+                Answer.new(:abuse_help_provided, abuse.help_provided),
+                FreeTextAnswer.new(:abuse_help_description, abuse.help_description),
+              ],
+              change_path: edit_steps_abuse_concerns_details_path(subject: abuse.subject, kind: abuse.kind)
+            ),
+          ].select(&:show?)
+        end.flatten
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def abuses_suffered
+        c100.abuse_concerns.where(
+          subject: subject,
+        ).reverse
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_sections/children_abuse_details.rb
+++ b/app/presenters/summary/html_sections/children_abuse_details.rb
@@ -1,0 +1,13 @@
+module Summary
+  module HtmlSections
+    class ChildrenAbuseDetails < BaseAbuseDetails
+      def name
+        :children_abuse_details
+      end
+
+      def subject
+        AbuseSubject::CHILDREN
+      end
+    end
+  end
+end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -584,6 +584,7 @@ en:
       miam_exemptions: Exemptions from attending a MIAM
       safety_concerns: Safety concerns
       abduction: 'Safety concerns: abduction'
+      children_abuse_details: Children safety
       nature_of_application: What you're asking the court to decide about the children
       alternatives: Alternative ways to reach an agreement
       children_details: About the children
@@ -592,6 +593,7 @@ en:
       abduction_passport_possession: Details of the children’s passports
       abduction_previous_attempt: Details of the previous abductions
       abduction_risk_details: Why do you think the children may be abducted or kept outside the UK without your consent?
+      abuse_details: Details
       child_details: Child %{index}
     child_protection_cases:
       question: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
@@ -806,6 +808,56 @@ en:
       question: Brief explanation
     abduction_current_location:
       question: Where are the children now?
+
+    ### Concerns of abuse ###
+    abuse_physical:
+      question: Physical abuse
+      answers:
+        <<: *YESNO
+    abuse_emotional:
+      question: Emotional abuse
+      answers:
+        <<: *YESNO
+    abuse_psychological:
+      question: Psychological abuse
+      answers:
+        <<: *YESNO
+    abuse_sexual:
+      question: Sexual abuse
+      answers:
+        <<: *YESNO
+    abuse_financial:
+      question: Financial abuse
+      answers:
+        <<: *YESNO
+    abuse_other:
+      question: Other abuse
+      answers:
+        <<: *YESNO
+
+    abuse_behaviour_description:
+      question: Nature of behaviour / what happened
+    abuse_behaviour_start:
+      question: When did behaviour start?
+    abuse_behaviour_ongoing:
+      question: Behaviour ongoing?
+      answers:
+        <<: *YESNO
+    abuse_behaviour_stop:
+      question: How long did it continue?
+    abuse_asked_for_help:
+      question: Did you seek help?
+      answers:
+        <<: *YESNO
+    abuse_help_party:
+      question: "Help from:"
+    abuse_help_provided:
+      question: Did they help you?
+      answers:
+        'yes': They helped me
+        'no': They did not help
+    abuse_help_description:
+      question: What did they do?
 
     child_arrangements_orders:
       question: 'You would like the court to:'

--- a/spec/presenters/summary/answers_group_spec.rb
+++ b/spec/presenters/summary/answers_group_spec.rb
@@ -22,11 +22,23 @@ describe Summary::AnswersGroup do
     end
   end
 
-  describe '#show?' do
-    it 'calls `show?` on the questions and return true if any question should be shown' do
+  describe '#answers' do
+    it 'selects the answers that should be shown' do
       expect(question1).to receive(:show?).and_return(false)
       expect(question2).to receive(:show?).and_return(true)
+      expect(subject.answers).to eq([question2])
+    end
+  end
+
+  describe '#show?' do
+    it 'returns true if there are answers to show' do
+      expect(subject).to receive(:answers).and_return([question2])
       expect(subject.show?).to eq(true)
+    end
+
+    it 'returns true if there are no answers to show' do
+      expect(subject).to receive(:answers).and_return([])
+      expect(subject.show?).to eq(false)
     end
   end
 

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -19,6 +19,7 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::MiamExemptions,
         Summary::HtmlSections::SafetyConcerns,
         Summary::HtmlSections::Abduction,
+        Summary::HtmlSections::ChildrenAbuseDetails,
         Summary::HtmlSections::NatureOfApplication,
         Summary::HtmlSections::Alternatives,
         Summary::HtmlSections::ChildrenDetails,

--- a/spec/presenters/summary/html_sections/children_abuse_details_spec.rb
+++ b/spec/presenters/summary/html_sections/children_abuse_details_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::ChildrenAbuseDetails do
+    let(:c100_application) { instance_double(C100Application, abuse_concerns: abuse_concerns_resultset) }
+    let(:abuse_concerns_resultset) { double('abuse_concerns_resultset') }
+
+    let(:abuse_concern) {
+      instance_double(
+        AbuseConcern,
+        subject: 'children',
+        kind: 'emotional',
+        answer: 'yes',
+        behaviour_description: 'behaviour_description',
+        behaviour_start: '2001',
+        behaviour_ongoing: 'no',
+        behaviour_stop: '2010',
+        asked_for_help: 'yes',
+        help_party: 'friend',
+        help_provided: 'yes',
+        help_description: 'help_description'
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:children_abuse_details)
+      end
+    end
+
+    # The following tests can be fragile, but on purpose. During the development phase
+    # we have to update the tests each time we introduce a new row or remove another.
+    # But once it is finished and stable, it will raise a red flag if it ever gets out
+    # of sync, which means a quite solid safety net for any maintainers in the future.
+    #
+    describe '#answers' do
+      let(:found_abuses_resultset) { double('found_abuses_resultset') }
+      let(:final_resultset) { [abuse_concern] }
+
+      before do
+        allow(
+          abuse_concerns_resultset
+        ).to receive(:where).with(
+          subject: AbuseSubject::CHILDREN
+        ).and_return(found_abuses_resultset)
+
+        allow(found_abuses_resultset).to receive(:reverse).and_return(final_resultset)
+      end
+
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(2)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:abuse_emotional)
+        expect(answers[0].value).to eq('yes')
+
+        expect(answers[1]).to be_an_instance_of(AnswersGroup)
+        expect(answers[1].name).to eq(:abuse_details)
+        expect(answers[1].change_path).to eq('/steps/abuse_concerns/details?kind=emotional&subject=children')
+        expect(answers[1].answers.count).to eq(8)
+
+          ## abuse_details group answers ###
+          details = answers[1].answers
+
+          expect(details[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[0].question).to eq(:abuse_behaviour_description)
+          expect(details[0].value).to eq('behaviour_description')
+
+          expect(details[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[1].question).to eq(:abuse_behaviour_start)
+          expect(details[1].value).to eq('2001')
+
+          expect(details[2]).to be_an_instance_of(Answer)
+          expect(details[2].question).to eq(:abuse_behaviour_ongoing)
+          expect(details[2].value).to eq('no')
+
+          expect(details[3]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[3].question).to eq(:abuse_behaviour_stop)
+          expect(details[3].value).to eq('2010')
+
+          expect(details[4]).to be_an_instance_of(Answer)
+          expect(details[4].question).to eq(:abuse_asked_for_help)
+          expect(details[4].value).to eq('yes')
+
+          expect(details[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[5].question).to eq(:abuse_help_party)
+          expect(details[5].value).to eq('friend')
+
+          expect(details[6]).to be_an_instance_of(Answer)
+          expect(details[6].question).to eq(:abuse_help_provided)
+          expect(details[6].value).to eq('yes')
+
+          expect(details[7]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[7].question).to eq(:abuse_help_description)
+          expect(details[7].value).to eq('help_description')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The applicant section will follow the same structure, only the header will change.
I will do it as part of another PR.

<img width="851" alt="screen shot 2018-04-30 at 16 04 17" src="https://user-images.githubusercontent.com/687910/39434552-ce55b8de-4c90-11e8-843c-db7e9da84818.png">
