### PR TITLE
Add `applicant abuse` section to CYA

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -14,6 +14,7 @@ module Summary
         HtmlSections::SafetyConcerns.new(c100_application),
         HtmlSections::Abduction.new(c100_application),
         HtmlSections::ChildrenAbuseDetails.new(c100_application),
+        HtmlSections::ApplicantAbuseDetails.new(c100_application),
         HtmlSections::NatureOfApplication.new(c100_application),
         HtmlSections::Alternatives.new(c100_application),
         HtmlSections::ChildrenDetails.new(c100_application),

--- a/app/presenters/summary/html_sections/applicant_abuse_details.rb
+++ b/app/presenters/summary/html_sections/applicant_abuse_details.rb
@@ -1,0 +1,13 @@
+module Summary
+  module HtmlSections
+    class ApplicantAbuseDetails < BaseAbuseDetails
+      def name
+        :applicant_abuse_details
+      end
+
+      def subject
+        AbuseSubject::APPLICANT
+      end
+    end
+  end
+end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -585,6 +585,7 @@ en:
       safety_concerns: Safety concerns
       abduction: 'Safety concerns: abduction'
       children_abuse_details: Children safety
+      applicant_abuse_details: Applicant safety
       nature_of_application: What you're asking the court to decide about the children
       alternatives: Alternative ways to reach an agreement
       children_details: About the children
@@ -836,7 +837,7 @@ en:
         <<: *YESNO
 
     abuse_behaviour_description:
-      question: Nature of behaviour / what happened
+      question: What happened?
     abuse_behaviour_start:
       question: When did behaviour start?
     abuse_behaviour_ongoing:
@@ -850,12 +851,11 @@ en:
       answers:
         <<: *YESNO
     abuse_help_party:
-      question: "Help from:"
+      question: Who did you ask for help?
     abuse_help_provided:
       question: Did they help you?
       answers:
-        'yes': They helped me
-        'no': They did not help
+        <<: *YESNO
     abuse_help_description:
       question: What did they do?
 

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -20,6 +20,7 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::SafetyConcerns,
         Summary::HtmlSections::Abduction,
         Summary::HtmlSections::ChildrenAbuseDetails,
+        Summary::HtmlSections::ApplicantAbuseDetails,
         Summary::HtmlSections::NatureOfApplication,
         Summary::HtmlSections::Alternatives,
         Summary::HtmlSections::ChildrenDetails,

--- a/spec/presenters/summary/html_sections/applicant_abuse_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicant_abuse_details_spec.rb
@@ -58,6 +58,7 @@ module Summary
       it 'has the correct rows in the right order' do
         expect(answers[0]).to be_an_instance_of(Answer)
         expect(answers[0].question).to eq(:abuse_emotional)
+        expect(answers[0].change_path).to eq('/steps/abuse_concerns/question?kind=emotional&subject=applicant')
         expect(answers[0].value).to eq('yes')
 
         expect(answers[1]).to be_an_instance_of(AnswersGroup)

--- a/spec/presenters/summary/html_sections/applicant_abuse_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicant_abuse_details_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::ApplicantAbuseDetails do
+    let(:c100_application) { instance_double(C100Application, abuse_concerns: abuse_concerns_resultset) }
+    let(:abuse_concerns_resultset) { double('abuse_concerns_resultset') }
+
+    let(:abuse_concern) {
+      instance_double(
+        AbuseConcern,
+        subject: 'applicant',
+        kind: 'emotional',
+        answer: 'yes',
+        behaviour_description: 'behaviour_description',
+        behaviour_start: '2001',
+        behaviour_ongoing: 'no',
+        behaviour_stop: '2010',
+        asked_for_help: 'yes',
+        help_party: 'friend',
+        help_provided: 'yes',
+        help_description: 'help_description'
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:applicant_abuse_details)
+      end
+    end
+
+    # The following tests can be fragile, but on purpose. During the development phase
+    # we have to update the tests each time we introduce a new row or remove another.
+    # But once it is finished and stable, it will raise a red flag if it ever gets out
+    # of sync, which means a quite solid safety net for any maintainers in the future.
+    #
+    describe '#answers' do
+      let(:found_abuses_resultset) { double('found_abuses_resultset') }
+      let(:final_resultset) { [abuse_concern] }
+
+      before do
+        allow(
+          abuse_concerns_resultset
+        ).to receive(:where).with(
+          subject: AbuseSubject::APPLICANT
+        ).and_return(found_abuses_resultset)
+
+        allow(found_abuses_resultset).to receive(:reverse).and_return(final_resultset)
+      end
+
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(2)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:abuse_emotional)
+        expect(answers[0].value).to eq('yes')
+
+        expect(answers[1]).to be_an_instance_of(AnswersGroup)
+        expect(answers[1].name).to eq(:abuse_details)
+        expect(answers[1].change_path).to eq('/steps/abuse_concerns/details?kind=emotional&subject=applicant')
+        expect(answers[1].answers.count).to eq(8)
+
+          ## abuse_details group answers ###
+          details = answers[1].answers
+
+          expect(details[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[0].question).to eq(:abuse_behaviour_description)
+          expect(details[0].value).to eq('behaviour_description')
+
+          expect(details[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[1].question).to eq(:abuse_behaviour_start)
+          expect(details[1].value).to eq('2001')
+
+          expect(details[2]).to be_an_instance_of(Answer)
+          expect(details[2].question).to eq(:abuse_behaviour_ongoing)
+          expect(details[2].value).to eq('no')
+
+          expect(details[3]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[3].question).to eq(:abuse_behaviour_stop)
+          expect(details[3].value).to eq('2010')
+
+          expect(details[4]).to be_an_instance_of(Answer)
+          expect(details[4].question).to eq(:abuse_asked_for_help)
+          expect(details[4].value).to eq('yes')
+
+          expect(details[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[5].question).to eq(:abuse_help_party)
+          expect(details[5].value).to eq('friend')
+
+          expect(details[6]).to be_an_instance_of(Answer)
+          expect(details[6].question).to eq(:abuse_help_provided)
+          expect(details[6].value).to eq('yes')
+
+          expect(details[7]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[7].question).to eq(:abuse_help_description)
+          expect(details[7].value).to eq('help_description')
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/html_sections/children_abuse_details_spec.rb
+++ b/spec/presenters/summary/html_sections/children_abuse_details_spec.rb
@@ -58,6 +58,7 @@ module Summary
       it 'has the correct rows in the right order' do
         expect(answers[0]).to be_an_instance_of(Answer)
         expect(answers[0].question).to eq(:abuse_emotional)
+        expect(answers[0].change_path).to eq('/steps/abuse_concerns/question?kind=emotional&subject=children')
         expect(answers[0].value).to eq('yes')
 
         expect(answers[1]).to be_an_instance_of(AnswersGroup)


### PR DESCRIPTION
Same as children, but for applicant.

<img width="1003" alt="screen shot 2018-05-01 at 10 26 07" src="https://user-images.githubusercontent.com/687910/39468295-3259988e-4d2a-11e8-8cf7-5a9f96f487a3.png">
