### PR TITLE
Update `nature of application` section in CYA

### DIFF
--- a/app/presenters/summary/html_sections/nature_of_application.rb
+++ b/app/presenters/summary/html_sections/nature_of_application.rb
@@ -5,32 +5,26 @@ module Summary
         :nature_of_application
       end
 
-      # rubocop:disable Metrics/MethodLength
       def answers
         [
-          MultiAnswer.new(:child_arrangements_orders,
-                          petition.child_arrangements_orders,
-                          change_path: edit_steps_petition_orders_path(
-                            anchor: 'steps_petition_orders_form_group_child_arrangements_home'
-                          )),
-          MultiAnswer.new(:prohibited_steps_orders,
-                          petition.prohibited_steps_orders,
-                          change_path: edit_steps_petition_orders_path(
-                            anchor: 'steps_petition_orders_form_group_prohibited_steps'
-                          )),
-          MultiAnswer.new(:specific_issues_orders,
-                          petition.specific_issues_orders,
-                          change_path: edit_steps_petition_orders_path(
-                            anchor: 'steps_petition_orders_form_group_specific_issues'
-                          )),
-          FreeTextAnswer.new(:other_issue_details,
-                             petition.other_issue_details,
+          MultiAnswer.new(:petition_orders, petition.all_selected_orders,
+                          change_path: edit_steps_petition_orders_path),
+
+          FreeTextAnswer.new(:other_issue_details, petition.other_issue_details,
                              change_path: edit_steps_petition_orders_path(
                                anchor: 'steps_petition_orders_form_other_issue'
                              )),
+
+          AnswersGroup.new(
+            :protection_orders,
+            [
+              Answer.new(:protection_orders, c100.protection_orders),
+              FreeTextAnswer.new(:protection_orders_details, c100.protection_orders_details),
+            ],
+            change_path: edit_steps_petition_protection_path
+          ),
         ].select(&:show?)
       end
-      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -599,6 +599,7 @@ en:
       abduction_risk_details: Why do you think the children may be abducted or kept outside the UK without your consent?
       abuse_details: Details
       court_orders_details: What orders have been made?
+      protection_orders: Is there anything else you are asking the court to decide, specifically to protect the safety of you or the children?
       child_details: Child %{index}
     child_protection_cases:
       question: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
@@ -896,19 +897,21 @@ en:
       answers:
         <<: *YESNO
 
-    child_arrangements_orders:
+    petition_orders:
       question: 'You would like the court to:'
       answers:
         <<: *ARRANGEMENT_ORDERS
-    specific_issues_orders:
-      question: 'You would like the court to resolve an issue about:'
-      answers:
         <<: *SPECIFIC_ISSUE_ORDERS
-    prohibited_steps_orders:
-      question: 'You would like the court to stop the other person:'
-      answers:
         <<: *PROHIBITED_STEPS_ORDERS
+        other_issue: Other issue or dispute
     other_issue_details:
-      question: 'You told us that you need help with this dispute:'
+      question: 'Deal with another issue:'
+    protection_orders:
+      question: ''
+      answers:
+        <<: *YESNO
+    protection_orders_details:
+      question: ''
+
     alternatives:
       question: Alternative ways to reach an agreement

--- a/spec/presenters/summary/html_sections/nature_of_application_spec.rb
+++ b/spec/presenters/summary/html_sections/nature_of_application_spec.rb
@@ -5,30 +5,30 @@ module Summary
     let(:c100_application) {
       instance_double(C100Application,
         orders: orders,
-        orders_additional_details: orders_additional_details
+        orders_additional_details: orders_additional_details,
+        protection_orders: protection_orders,
+        protection_orders_details: protection_orders_details,
       )
     }
 
     subject { described_class.new(c100_application) }
 
     let(:orders){
-      [
-        "child_arrangements_home",
-        "child_arrangements_time",
-        "group_prohibited_steps",
-        "prohibited_steps_medical",
-        "prohibited_steps_holiday",
-        "prohibited_steps_moving",
-        "group_specific_issues",
-        "specific_issues_school",
-        "specific_issues_religion",
-        "specific_issues_names",
-        "other_issue"
-      ]
+      %w(
+        child_arrangements_home
+        group_prohibited_steps
+        prohibited_steps_medical
+        prohibited_steps_moving
+        group_specific_issues
+        specific_issues_religion
+        other_issue
+      )
     }
-    let(:orders_additional_details){
-      'orders detail'
-    }
+
+    let(:orders_additional_details) { 'orders detail' }
+    let(:protection_orders) { 'yes' }
+    let(:protection_orders_details) { 'protection orders details' }
+
     let(:answers) { subject.answers }
 
     describe '#name' do
@@ -37,39 +37,53 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(3)
 
         expect(answers[0]).to be_an_instance_of(MultiAnswer)
-        expect(answers[0].question).to eq(:child_arrangements_orders)
-        expect(answers[0].value).to eq(
-          ['child_arrangements_home', 'child_arrangements_time']
-        )
-        expect(answers[0].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_group_child_arrangements_home')
+        expect(answers[0].question).to eq(:petition_orders)
+        expect(answers[0].value).to eq(%w(
+          child_arrangements_home
+          prohibited_steps_medical
+          prohibited_steps_moving
+          specific_issues_religion
+          other_issue
+        ))
+        expect(answers[0].change_path).to eq('/steps/petition/orders')
 
-        expect(answers[1]).to be_an_instance_of(MultiAnswer)
-        expect(answers[1].question).to eq(:prohibited_steps_orders)
-        expect(answers[1].value).to eq(
-          [
-            'prohibited_steps_medical',
-            'prohibited_steps_holiday',
-            'prohibited_steps_moving'
-          ]
-        )
-        expect(answers[1].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_group_prohibited_steps')
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:other_issue_details)
+        expect(answers[1].value).to eq('orders detail')
+        expect(answers[1].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_other_issue')
 
-        expect(answers[2]).to be_an_instance_of(MultiAnswer)
-        expect(answers[2].question).to eq(:specific_issues_orders)
-        expect(answers[2].value).to eq([
-          'specific_issues_school',
-          'specific_issues_religion',
-          'specific_issues_names'
-        ])
-        expect(answers[2].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_group_specific_issues')
+        expect(answers[2]).to be_an_instance_of(AnswersGroup)
+        expect(answers[2].name).to eq(:protection_orders)
+        expect(answers[2].change_path).to eq('/steps/petition/protection')
+        expect(answers[2].answers.count).to eq(2)
 
-        expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[3].question).to eq(:other_issue_details)
-        expect(answers[3].value).to eq('orders detail')
-        expect(answers[3].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_other_issue')
+        ## protection_orders group answers ###
+        protection = answers[2].answers
+
+        expect(protection[0]).to be_an_instance_of(Answer)
+        expect(protection[0].question).to eq(:protection_orders)
+        expect(protection[0].value).to eq('yes')
+
+        expect(protection[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(protection[1].question).to eq(:protection_orders_details)
+        expect(protection[1].value).to eq('protection orders details')
+      end
+
+      context 'when there is no other issue' do
+        let(:orders_additional_details) { nil }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(2)
+
+          expect(answers[0]).to be_an_instance_of(MultiAnswer)
+          expect(answers[0].question).to eq(:petition_orders)
+
+          expect(answers[1]).to be_an_instance_of(AnswersGroup)
+          expect(answers[1].name).to eq(:protection_orders)
+        end
       end
     end
   end


### PR DESCRIPTION
We need to include in this section the protection orders question and details, if C1A triggered.

A bit of refactor to compact a bit this section so it doesn't take too much space and is simpler to read.

<img width="1016" alt="screen shot 2018-05-02 at 15 56 51" src="https://user-images.githubusercontent.com/687910/39530767-8cc94fd8-4e21-11e8-9e4d-3719458f6ff5.png">
