### PR TITLE
Update `nature of application` section in CYA

### DIFF
--- a/app/presenters/summary/html_sections/nature_of_application.rb
+++ b/app/presenters/summary/html_sections/nature_of_application.rb
@@ -5,7 +5,7 @@ module Summary
         :nature_of_application
       end
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def answers
         [
           MultiAnswer.new(:child_arrangements_orders,
@@ -28,9 +28,17 @@ module Summary
                              change_path: edit_steps_petition_orders_path(
                                anchor: 'steps_petition_orders_form_other_issue'
                              )),
+          AnswersGroup.new(
+            :protection_orders,
+            [
+              Answer.new(:protection_orders, c100.protection_orders),
+              FreeTextAnswer.new(:protection_orders_details, c100.protection_orders_details),
+            ],
+            change_path: edit_steps_petition_protection_path
+          ),
         ].select(&:show?)
       end
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
       private
 

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -601,6 +601,7 @@ en:
       abduction_risk_details: Why do you think the children may be abducted or kept outside the UK without your consent?
       abuse_details: Details
       court_orders_details: What orders have been made?
+      protection_orders: Is there anything else you are asking the court to decide, specifically to protect the safety of you or the children?
       child_details: Child %{index}
     child_protection_cases:
       question: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
@@ -915,5 +916,12 @@ en:
         <<: *PROHIBITED_STEPS_ORDERS
     other_issue_details:
       question: 'You told us that you need help with this dispute:'
+    protection_orders:
+      question: ''
+      answers:
+        <<: *YESNO
+    protection_orders_details:
+      question: ''
+
     alternatives:
       question: Alternative ways to reach an agreement

--- a/spec/presenters/summary/html_sections/nature_of_application_spec.rb
+++ b/spec/presenters/summary/html_sections/nature_of_application_spec.rb
@@ -5,7 +5,9 @@ module Summary
     let(:c100_application) {
       instance_double(C100Application,
         orders: orders,
-        orders_additional_details: orders_additional_details
+        orders_additional_details: orders_additional_details,
+        protection_orders: 'yes',
+        protection_orders_details: 'protection orders details',
       )
     }
 
@@ -37,7 +39,7 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(5)
 
         expect(answers[0]).to be_an_instance_of(MultiAnswer)
         expect(answers[0].question).to eq(:child_arrangements_orders)
@@ -70,6 +72,22 @@ module Summary
         expect(answers[3].question).to eq(:other_issue_details)
         expect(answers[3].value).to eq('orders detail')
         expect(answers[3].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_other_issue')
+
+        expect(answers[4]).to be_an_instance_of(AnswersGroup)
+        expect(answers[4].name).to eq(:protection_orders)
+        expect(answers[4].change_path).to eq('/steps/petition/protection')
+        expect(answers[4].answers.count).to eq(2)
+
+        ## protection_orders group answers ###
+        protection = answers[4].answers
+
+        expect(protection[0]).to be_an_instance_of(Answer)
+        expect(protection[0].question).to eq(:protection_orders)
+        expect(protection[0].value).to eq('yes')
+
+        expect(protection[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(protection[1].question).to eq(:protection_orders_details)
+        expect(protection[1].value).to eq('protection orders details')
       end
     end
   end


### PR DESCRIPTION
We need to include in this section the protection orders question and details, if C1A triggered.

<img width="1013" alt="screen shot 2018-05-02 at 16 28 52" src="https://user-images.githubusercontent.com/687910/39533329-ae59579c-4e26-11e8-9a62-6d3542635a8b.png">
