### PR TITLE
Reset of OtherChild and OtherParty records

### DIFF
--- a/app/forms/steps/children/has_other_children_form.rb
+++ b/app/forms/steps/children/has_other_children_form.rb
@@ -3,7 +3,9 @@ module Steps
     class HasOtherChildrenForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :has_other_children
+      # The reset will delete any associated OtherChild rows from the `people` table.
+      # Because this is a `has_many` association, we nil their IDs to delete the rows.
+      yes_no_attribute :has_other_children, reset_when_no: [:other_child_ids]
     end
   end
 end

--- a/app/forms/steps/respondent/has_other_parties_form.rb
+++ b/app/forms/steps/respondent/has_other_parties_form.rb
@@ -3,7 +3,9 @@ module Steps
     class HasOtherPartiesForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :has_other_parties
+      # The reset will delete any associated OtherParty rows from the `people` table.
+      # Because this is a `has_many` association, we nil their IDs to delete the rows.
+      yes_no_attribute :has_other_parties, reset_when_no: [:other_party_ids]
     end
   end
 end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -23,8 +23,8 @@ class C100Application < ApplicationRecord
   has_many :children
   has_many :applicants
   has_many :respondents
-  has_many :other_children
-  has_many :other_parties
+  has_many :other_children,   dependent: :destroy
+  has_many :other_parties,    dependent: :destroy
 
   scope :with_owner,    -> { where.not(user: nil) }
   scope :not_completed, -> { where.not(status: :completed) }

--- a/spec/forms/steps/children/has_other_children_form_spec.rb
+++ b/spec/forms/steps/children/has_other_children_form_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Children::HasOtherChildrenForm do
-  it_behaves_like 'a yes-no question form', attribute_name: :has_other_children
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :has_other_children,
+                  reset_when_no: [:other_child_ids]
 end

--- a/spec/forms/steps/respondent/has_other_parties_form_spec.rb
+++ b/spec/forms/steps/respondent/has_other_parties_form_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Respondent::HasOtherPartiesForm do
-  it_behaves_like 'a yes-no question form', attribute_name: :has_other_parties
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :has_other_parties,
+                  reset_when_no: [:other_party_ids]
 end


### PR DESCRIPTION
When selecting no to the corresponding questions, if there are any created records, we want to delete them.