### PR TITLE
Add `applicants` section to CYA

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -14,8 +14,8 @@ module Summary
         *safety_and_abuse_questions,
         HtmlSections::NatureOfApplication.new(c100_application),
         HtmlSections::Alternatives.new(c100_application),
-        HtmlSections::ChildrenDetails.new(c100_application),
-        HtmlSections::OtherChildrenDetails.new(c100_application),
+        *children_sections,
+        HtmlSections::ApplicantsDetails.new(c100_application),
       ].flatten.select(&:show?)
     end
 
@@ -29,6 +29,13 @@ module Summary
         HtmlSections::ApplicantAbuseDetails.new(c100_application),
         HtmlSections::CourtOrders.new(c100_application),
         HtmlSections::SafetyContact.new(c100_application),
+      ]
+    end
+
+    def children_sections
+      [
+        HtmlSections::ChildrenDetails.new(c100_application),
+        HtmlSections::OtherChildrenDetails.new(c100_application),
       ]
     end
   end

--- a/app/presenters/summary/html_sections/applicants_details.rb
+++ b/app/presenters/summary/html_sections/applicants_details.rb
@@ -1,0 +1,25 @@
+module Summary
+  module HtmlSections
+    class ApplicantsDetails < PeopleDetails
+      def name
+        :applicants_details
+      end
+
+      def record_collection
+        c100.applicants
+      end
+
+      def names_path
+        edit_steps_applicant_names_path(id: '')
+      end
+
+      def personal_details_path(person)
+        edit_steps_applicant_personal_details_path(person)
+      end
+
+      def contact_details_path(person)
+        edit_steps_applicant_contact_details_path(person)
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_sections/people_details.rb
+++ b/app/presenters/summary/html_sections/people_details.rb
@@ -1,0 +1,73 @@
+module Summary
+  module HtmlSections
+    class PeopleDetails < Sections::BaseSectionPresenter
+      # :nocov:
+      def record_collection
+        raise 'must be implemented in subclasses'
+      end
+
+      def names_path
+        raise 'must be implemented in subclasses'
+      end
+
+      def personal_details_path(*)
+        raise 'must be implemented in subclasses'
+      end
+
+      def contact_details_path(*)
+        raise 'must be implemented in subclasses'
+      end
+      # :nocov:
+
+      def answers
+        record_collection.map.with_index(1) do |person, index|
+          [
+            Separator.new("#{name}_index_title", index: index),
+            FreeTextAnswer.new(:person_full_name, person.full_name, change_path: names_path),
+            AnswersGroup.new(
+              :person_personal_details,
+              personal_details_questions(person),
+              change_path: personal_details_path(person)
+            ),
+            AnswersGroup.new(
+              :person_contact_details,
+              contact_details_questions(person),
+              change_path: contact_details_path(person)
+            ),
+          ]
+        end.flatten.select(&:show?)
+      end
+
+      private
+
+      def personal_details_questions(person)
+        [
+          previous_name_answer(person),
+          Answer.new(:person_sex, person.gender),
+          DateAnswer.new(:person_dob, person.dob),
+          FreeTextAnswer.new(:person_age_estimate, person.age_estimate), # This shows only if a value is present
+          FreeTextAnswer.new(:person_birthplace, person.birthplace),
+        ]
+      end
+
+      def contact_details_questions(person)
+        [
+          FreeTextAnswer.new(:person_address, person.address),
+          Answer.new(:person_residence_requirement_met, person.residence_requirement_met),
+          FreeTextAnswer.new(:person_residence_history, person.residence_history),
+          FreeTextAnswer.new(:person_home_phone, person.home_phone),
+          FreeTextAnswer.new(:person_mobile_phone, person.mobile_phone),
+          FreeTextAnswer.new(:person_email, person.email),
+        ]
+      end
+
+      def previous_name_answer(person)
+        if person.has_previous_name.eql?(GenericYesNo::YES.to_s)
+          FreeTextAnswer.new(:person_previous_name, person.previous_name)
+        else
+          Answer.new(:person_previous_name, person.has_previous_name)
+        end
+      end
+    end
+  end
+end

--- a/app/views/steps/completion/shared/_separator.html.erb
+++ b/app/views/steps/completion/shared/_separator.html.erb
@@ -1,4 +1,4 @@
 <br />
 <h3 class="heading-medium heading-bottom-border subsection-header">
-  <%=t "check_answers.separators.#{separator.title}", separator.i18n_opts %>
+  <%=t "check_answers_html.separators.#{separator.title}", separator.i18n_opts %>
 </h3>

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -592,8 +592,9 @@ en:
       safety_contact: 'Safety concerns: contact'
       nature_of_application: What you're asking the court to decide about the children
       alternatives: Alternative ways to reach an agreement
-      children_details: About the children
-      other_children_details: Other children
+      children_details: Child(ren)
+      other_children_details: Other child(ren)
+      applicants_details: Applicant(s)
     groups:
       miam_certification_details: Certification details
       abduction_passport_possession: Details of the children’s passports
@@ -603,6 +604,12 @@ en:
       court_orders_details: What orders have been made?
       protection_orders: Is there anything else you are asking the court to decide, specifically to protect the safety of you or the children?
       child_details: Child %{index}
+      person_personal_details: Personal details
+      person_contact_details: Contact details
+    separators:
+      child_index_title: Child %{index}
+      other_child_index_title: Other child %{index}
+      applicants_details_index_title: Applicant %{index}
     child_protection_cases:
       question: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
       answers:
@@ -925,3 +932,35 @@ en:
 
     alternatives:
       question: Alternative ways to reach an agreement
+
+    person_full_name:
+      question: Full name
+    person_previous_name:
+      question: Previous name
+      answers:
+        <<: *YESNO
+    person_sex:
+      question: Sex
+      answers:
+        <<: *SEX_OPTIONS
+    person_dob:
+      question: Date of birth
+    person_age_estimate:
+      question: Approximate age or year born
+    person_birthplace:
+      question: Place of birth
+    person_address:
+      question: Address
+      absence_answer: *unknown
+    person_residence_requirement_met:
+      question: Lived at this address for more than 5 years?
+      answers:
+        <<: *YESNO
+    person_residence_history:
+      question: Previous addresses
+    person_home_phone:
+      question: Home telephone number
+    person_mobile_phone:
+      question: Mobile telephone number
+    person_email:
+      question: Email address

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -27,6 +27,7 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::Alternatives,
         Summary::HtmlSections::ChildrenDetails,
         Summary::HtmlSections::OtherChildrenDetails,
+        Summary::HtmlSections::ApplicantsDetails,
       ])
     end
   end

--- a/spec/presenters/summary/html_sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicants_details_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::ApplicantsDetails do
+    let(:c100_application) {
+      instance_double(
+        C100Application,
+        applicants: [applicant]
+      )
+    }
+
+    let(:applicant) {
+      instance_double(Applicant,
+        to_param: 'uuid-123',
+        full_name: 'fullname',
+        has_previous_name: has_previous_name,
+        previous_name: previous_name,
+        dob: Date.new(2018, 1, 20),
+        age_estimate: nil,
+        gender: 'female',
+        birthplace: 'birthplace',
+        address: 'address',
+        residence_requirement_met: 'yes',
+        residence_history: 'history',
+        home_phone: 'home_phone',
+        mobile_phone: 'mobile_phone',
+        email: 'email',
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:has_previous_name) { 'no' }
+    let(:previous_name) { nil }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:applicants_details) }
+    end
+
+    describe '#record_collection' do
+      it {
+        expect(c100_application).to receive(:applicants)
+        subject.record_collection
+      }
+    end
+
+    # The following tests can be fragile, but on purpose. During the development phase
+    # we have to update the tests each time we introduce a new row or remove another.
+    # But once it is finished and stable, it will raise a red flag if it ever gets out
+    # of sync, which means a quite solid safety net for any maintainers in the future.
+    #
+    describe '#answers' do
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(4)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Separator)
+        expect(answers[0].title).to eq('applicants_details_index_title')
+        expect(answers[0].i18n_opts).to eq({index: 1})
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:person_full_name)
+        expect(answers[1].change_path).to eq('/steps/applicant/names/')
+        expect(answers[1].value).to eq('fullname')
+
+        expect(answers[2]).to be_an_instance_of(AnswersGroup)
+        expect(answers[2].name).to eq(:person_personal_details)
+        expect(answers[2].change_path).to eq('/steps/applicant/personal_details/uuid-123')
+        expect(answers[2].answers.count).to eq(4)
+
+          # personal_details group answers ###
+          details = answers[2].answers
+
+          expect(details[0]).to be_an_instance_of(Answer)
+          expect(details[0].question).to eq(:person_previous_name)
+          expect(details[0].value).to eq('no')
+
+          expect(details[1]).to be_an_instance_of(Answer)
+          expect(details[1].question).to eq(:person_sex)
+          expect(details[1].value).to eq('female')
+
+          expect(details[2]).to be_an_instance_of(DateAnswer)
+          expect(details[2].question).to eq(:person_dob)
+          expect(details[2].value).to eq(Date.new(2018, 1, 20))
+
+          expect(details[3]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[3].question).to eq(:person_birthplace)
+          expect(details[3].value).to eq('birthplace')
+
+        expect(answers[3]).to be_an_instance_of(AnswersGroup)
+        expect(answers[3].name).to eq(:person_contact_details)
+        expect(answers[3].change_path).to eq('/steps/applicant/contact_details/uuid-123')
+        expect(answers[3].answers.count).to eq(6)
+
+          # personal_details group answers ###
+          details = answers[3].answers
+
+          expect(details[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[0].question).to eq(:person_address)
+          expect(details[0].value).to eq('address')
+
+          expect(details[1]).to be_an_instance_of(Answer)
+          expect(details[1].question).to eq(:person_residence_requirement_met)
+          expect(details[1].value).to eq('yes')
+
+          expect(details[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[2].question).to eq(:person_residence_history)
+          expect(details[2].value).to eq('history')
+
+          expect(details[3]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[3].question).to eq(:person_home_phone)
+          expect(details[3].value).to eq('home_phone')
+
+          expect(details[4]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[4].question).to eq(:person_mobile_phone)
+          expect(details[4].value).to eq('mobile_phone')
+
+          expect(details[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[5].question).to eq(:person_email)
+          expect(details[5].value).to eq('email')
+      end
+
+      context 'for existing previous name' do
+        let(:has_previous_name) { 'yes' }
+        let(:previous_name) { 'previous_name' }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(4)
+        end
+
+        it 'renders the previous name' do
+          expect(answers[2]).to be_an_instance_of(AnswersGroup)
+
+          details = answers[2].answers
+          expect(details[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[0].question).to eq(:person_previous_name)
+          expect(details[0].value).to eq('previous_name')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Still we need to figure out where to place the relationships and how to present these.

The respondents and other parties will follow the same structure and will inherit from the superclass.

<img width="859" alt="screen shot 2018-05-03 at 16 05 46" src="https://user-images.githubusercontent.com/687910/39585352-8157db6c-4eec-11e8-98c4-56691e119639.png">
