### PR TITLE
Add children `further information` section to CYA

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -35,6 +35,7 @@ module Summary
     def children_sections
       [
         HtmlSections::ChildrenDetails.new(c100_application),
+        HtmlSections::ChildrenFurtherInformation.new(c100_application),
         HtmlSections::OtherChildrenDetails.new(c100_application),
       ]
     end

--- a/app/presenters/summary/html_sections/children_details.rb
+++ b/app/presenters/summary/html_sections/children_details.rb
@@ -8,15 +8,6 @@ module Summary
       def answers
         [
           children_details,
-          Answer.new(:children_known_to_authorities,
-                     c100.children_known_to_authorities,
-                     change_path: edit_steps_children_additional_details_path),
-          FreeTextAnswer.new(:children_known_to_authorities_details,
-                             c100.children_known_to_authorities_details,
-                             change_path: edit_steps_children_additional_details_path),
-          Answer.new(:children_protection_plan,
-                     c100.children_protection_plan,
-                     change_path: edit_steps_children_additional_details_path),
           Answer.new(:has_other_children,
                      c100.has_other_children,
                      change_path: edit_steps_children_has_other_children_path),

--- a/app/presenters/summary/html_sections/children_further_information.rb
+++ b/app/presenters/summary/html_sections/children_further_information.rb
@@ -1,0 +1,29 @@
+module Summary
+  module HtmlSections
+    class ChildrenFurtherInformation < Sections::BaseSectionPresenter
+      def name
+        :children_further_information
+      end
+
+      def answers
+        [
+          Answer.new(
+            :children_known_to_authorities,
+            c100.children_known_to_authorities,
+            change_path: edit_steps_children_additional_details_path
+          ),
+          FreeTextAnswer.new(
+            :children_known_to_authorities_details,
+            c100.children_known_to_authorities_details,
+            change_path: edit_steps_children_additional_details_path
+          ),
+          Answer.new(
+            :children_protection_plan,
+            c100.children_protection_plan,
+            change_path: edit_steps_children_additional_details_path
+          ),
+        ].select(&:show?)
+      end
+    end
+  end
+end

--- a/config/locales/summary/en.yml
+++ b/config/locales/summary/en.yml
@@ -592,6 +592,7 @@ en:
       safety_contact: 'Safety concerns: contact'
       nature_of_application: What you're asking the court to decide about the children
       alternatives: Alternative ways to reach an agreement
+      children_further_information: Further information about the child(ren)
       children_details: Child(ren)
       other_children_details: Other child(ren)
       applicants_details: Applicant(s)
@@ -681,11 +682,11 @@ en:
         <<: *PETITION_ORDER_TYPES
 
     children_known_to_authorities:
-      question: Are any of the children known to the local authority children’s services?
+      question: Are any of the children known to social services?
       answers:
         <<: *YESNO
     children_known_to_authorities_details:
-      question: Child name and local authority worker
+      question: Child and the name of the local authority and social worker (if known)
     children_protection_plan:
       question: Are any of the children the subject of a child protection plan?
       answers:

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -26,6 +26,7 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::NatureOfApplication,
         Summary::HtmlSections::Alternatives,
         Summary::HtmlSections::ChildrenDetails,
+        Summary::HtmlSections::ChildrenFurtherInformation,
         Summary::HtmlSections::OtherChildrenDetails,
         Summary::HtmlSections::ApplicantsDetails,
         Summary::HtmlSections::RespondentsDetails,

--- a/spec/presenters/summary/html_sections/children_details_spec.rb
+++ b/spec/presenters/summary/html_sections/children_details_spec.rb
@@ -8,9 +8,6 @@ module Summary
         other_children: [],
         applicants: [],
         respondents: [],
-        children_known_to_authorities: 'yes',
-        children_known_to_authorities_details: 'details',
-        children_protection_plan: 'no',
         has_other_children: 'yes',
       )
     }
@@ -58,7 +55,7 @@ module Summary
       end
 
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(11)
+        expect(answers.count).to eq(8)
       end
 
       it 'has the correct rows in the right order' do
@@ -99,26 +96,9 @@ module Summary
         expect(answers[6].change_path).to eq('/steps/children/orders/1234')
 
         expect(answers[7]).to be_an_instance_of(Answer)
-        expect(answers[7].question).to eq(:children_known_to_authorities)
-        expect(c100_application).to have_received(:children_known_to_authorities)
-        expect(answers[7].change_path).to eq('/steps/children/additional_details')
-
-
-        expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[8].question).to eq(:children_known_to_authorities_details)
-        expect(c100_application).to have_received(:children_known_to_authorities_details)
-        expect(answers[8].change_path).to eq('/steps/children/additional_details')
-
-        expect(answers[9]).to be_an_instance_of(Answer)
-        expect(answers[9].question).to eq(:children_protection_plan)
-        expect(c100_application).to have_received(:children_protection_plan)
-        expect(answers[9].change_path).to eq('/steps/children/additional_details')
-
-
-        expect(answers[10]).to be_an_instance_of(Answer)
-        expect(answers[10].question).to eq(:has_other_children)
+        expect(answers[7].question).to eq(:has_other_children)
         expect(c100_application).to have_received(:has_other_children)
-        expect(answers[10].change_path).to eq('/steps/children/has_other_children')
+        expect(answers[7].change_path).to eq('/steps/children/has_other_children')
 
       end
 

--- a/spec/presenters/summary/html_sections/children_further_information_spec.rb
+++ b/spec/presenters/summary/html_sections/children_further_information_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::ChildrenFurtherInformation do
+    let(:c100_application) {
+      instance_double(C100Application,
+        children_known_to_authorities: 'yes',
+        children_known_to_authorities_details: 'details',
+        children_protection_plan: 'no',
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:children_further_information)
+      end
+    end
+
+    describe '#answers' do
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(3)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:children_known_to_authorities)
+        expect(answers[0].change_path).to eq('/steps/children/additional_details')
+        expect(answers[0].value).to eq('yes')
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:children_known_to_authorities_details)
+        expect(answers[1].change_path).to eq('/steps/children/additional_details')
+        expect(answers[1].value).to eq('details')
+
+        expect(answers[2]).to be_an_instance_of(Answer)
+        expect(answers[2].question).to eq(:children_protection_plan)
+        expect(answers[2].change_path).to eq('/steps/children/additional_details')
+        expect(answers[2].value).to eq('no')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make it a separate section to stand out. This was previously inside the Children section.

<img width="1015" alt="screen shot 2018-05-04 at 11 50 49" src="https://user-images.githubusercontent.com/687910/39624574-c04a72da-4f91-11e8-879f-2b8e7d9df5f5.png">
