### PR TITLE
 Add children relationships section to people

### DIFF
--- a/app/presenters/summary/base_answer.rb
+++ b/app/presenters/summary/base_answer.rb
@@ -1,12 +1,17 @@
 module Summary
   class BaseAnswer
-    attr_reader :question, :value, :show, :change_path
+    attr_reader :question, :value, :show, :change_path, :i18n_opts
 
-    def initialize(question, value, default: nil, show: nil, change_path: nil)
+    DEFAULT_OPTIONS = { default: nil, show: nil, change_path: nil, i18n_opts: {} }.freeze
+
+    def initialize(question, value, *args)
+      options = extract_supported_options!(args)
+
       @question = question
-      @value = value || default
-      @show = show
-      @change_path = change_path
+      @value = value || options[:default]
+      @show = options[:show]
+      @change_path = options[:change_path]
+      @i18n_opts = options[:i18n_opts]
     end
 
     def show?
@@ -27,5 +32,13 @@ module Summary
       raise 'implement in subclasses'
     end
     # :nocov:
+
+    private
+
+    def extract_supported_options!(args)
+      options = DEFAULT_OPTIONS.merge(args.extract_options!)
+      options.assert_valid_keys(DEFAULT_OPTIONS.keys)
+      options
+    end
   end
 end

--- a/app/presenters/summary/html_sections/applicants_details.rb
+++ b/app/presenters/summary/html_sections/applicants_details.rb
@@ -23,7 +23,7 @@ module Summary
         edit_steps_applicant_contact_details_path(person)
       end
 
-      def children_relationships_path(person, child)
+      def child_relationship_path(person, child)
         "/steps/applicant/relationship/#{person.to_param}/child/#{child.to_param}"
       end
     end

--- a/app/presenters/summary/html_sections/applicants_details.rb
+++ b/app/presenters/summary/html_sections/applicants_details.rb
@@ -22,6 +22,10 @@ module Summary
       def contact_details_path(person)
         edit_steps_applicant_contact_details_path(person)
       end
+
+      def children_relationships_path(person, child)
+        "/steps/applicant/relationship/#{person.to_param}/child/#{child.to_param}"
+      end
     end
   end
 end

--- a/app/presenters/summary/html_sections/other_parties_details.rb
+++ b/app/presenters/summary/html_sections/other_parties_details.rb
@@ -33,6 +33,10 @@ module Summary
       def contact_details_path(person)
         edit_steps_other_parties_contact_details_path(person)
       end
+
+      def child_relationship_path(person, child)
+        "/steps/other_parties/relationship/#{person.to_param}/child/#{child.to_param}"
+      end
     end
   end
 end

--- a/app/presenters/summary/html_sections/people_details.rb
+++ b/app/presenters/summary/html_sections/people_details.rb
@@ -18,8 +18,8 @@ module Summary
         raise 'must be implemented in subclasses'
       end
 
-      def children_relationships_path(*)
-        raise 'must be implemented in subclasses that support relationships'
+      def child_relationship_path(*)
+        raise 'must be implemented in subclasses'
       end
       # :nocov:
 
@@ -80,13 +80,13 @@ module Summary
             Answer.new(
               :relationship_to_child,
               (rel.relation unless rel.relation.eql?(Relation::OTHER.to_s)),
-              change_path: children_relationships_path(person, rel.minor),
+              change_path: child_relationship_path(person, rel.minor),
               i18n_opts: {child_name: rel.minor.full_name}
             ),
             FreeTextAnswer.new(
               :relationship_to_child,
               rel.relation_other_value,
-              change_path: children_relationships_path(person, rel.minor),
+              change_path: child_relationship_path(person, rel.minor),
               i18n_opts: {child_name: rel.minor.full_name}
             ), # The free text value only shows when the relation is `other`
           ]

--- a/app/presenters/summary/html_sections/respondents_details.rb
+++ b/app/presenters/summary/html_sections/respondents_details.rb
@@ -23,7 +23,7 @@ module Summary
         edit_steps_respondent_contact_details_path(person)
       end
 
-      def children_relationships_path(person, child)
+      def child_relationship_path(person, child)
         "/steps/respondent/relationship/#{person.to_param}/child/#{child.to_param}"
       end
     end

--- a/app/presenters/summary/html_sections/respondents_details.rb
+++ b/app/presenters/summary/html_sections/respondents_details.rb
@@ -22,6 +22,10 @@ module Summary
       def contact_details_path(person)
         edit_steps_respondent_contact_details_path(person)
       end
+
+      def children_relationships_path(person, child)
+        "/steps/respondent/relationship/#{person.to_param}/child/#{child.to_param}"
+      end
     end
   end
 end

--- a/app/views/steps/completion/shared/_free_text_row.html.erb
+++ b/app/views/steps/completion/shared/_free_text_row.html.erb
@@ -1,6 +1,6 @@
 <dl id="<%= free_text_row.question %>">
   <dt class="question">
-    <%=t "check_answers_html.#{free_text_row.question}.question" %>
+    <%=t "check_answers_html.#{free_text_row.question}.question", free_text_row.i18n_opts %>
   </dt>
   <dd class="answer">
     <%= simple_format(

--- a/app/views/steps/completion/shared/_free_text_row.pdf.erb
+++ b/app/views/steps/completion/shared/_free_text_row.pdf.erb
@@ -1,6 +1,6 @@
 <tr id="<%= free_text_row.question %>">
   <td class="question">
-    <%=t "check_answers.#{free_text_row.question}.question" %>
+    <%=t "check_answers.#{free_text_row.question}.question", free_text_row.i18n_opts %>
   </td>
 
   <td class="answer answer-value">

--- a/app/views/steps/completion/shared/_row.html.erb
+++ b/app/views/steps/completion/shared/_row.html.erb
@@ -1,6 +1,6 @@
 <dl id="<%= row.question %>">
   <dt class="question">
-    <%=t "check_answers_html.#{row.question}.question" %>
+    <%=t "check_answers_html.#{row.question}.question", row.i18n_opts %>
   </dt>
   <dd class="answer">
     <%=t "check_answers_html.#{row.question}.answers.#{row.value}" %>

--- a/app/views/steps/completion/shared/_row.pdf.erb
+++ b/app/views/steps/completion/shared/_row.pdf.erb
@@ -1,6 +1,6 @@
 <tr id="<%= row.question %>">
   <td class="question">
-    <%=t "check_answers.#{row.question}.question" %>
+    <%=t "check_answers.#{row.question}.question", row.i18n_opts %>
   </td>
 
   <td class="answer answer-value">

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -142,13 +142,8 @@ en:
       question: Have you tried collaborative law?
       answers:
         <<: *YESNO
-
-    child_applicants_relationship:
-      question: Applicant(s) relationship to child
-      answers:
-        <<: *RELATIONS
-    child_respondents_relationship:
-      question: Respondent(s) relationship to child
+    relationship_to_child:
+      question: Relationship to %{child_name}
       answers:
         <<: *RELATIONS
     child_orders:

--- a/spec/presenters/summary/base_answer_spec.rb
+++ b/spec/presenters/summary/base_answer_spec.rb
@@ -8,6 +8,14 @@ describe Summary::BaseAnswer do
 
   subject { described_class.new(question, value, default: default, change_path: change_path) }
 
+  describe 'validates the options' do
+    subject { described_class.new(question, value, test: true) }
+
+    it 'raises an exception' do
+      expect { subject.show? }.to raise_error(ArgumentError)
+    end
+  end
+
   describe '#show?' do
     it 'returns true' do
       expect(subject.show?).to eq(true)
@@ -60,6 +68,16 @@ describe Summary::BaseAnswer do
 
       it 'returns the original value' do
         expect(subject.value).to eq('yes')
+      end
+    end
+  end
+
+  describe 'can be given i18n options' do
+    context 'when value is nil' do
+      subject { described_class.new(question, value, i18n_opts: {name: 'John'}) }
+
+      it 'returns the options' do
+        expect(subject.i18n_opts).to eq({name: 'John'})
       end
     end
   end

--- a/spec/presenters/summary/html_sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicants_details_spec.rb
@@ -25,6 +25,7 @@ module Summary
         home_phone: 'home_phone',
         mobile_phone: 'mobile_phone',
         email: 'email',
+        relationships: [relationships],
       )
     }
 
@@ -32,6 +33,16 @@ module Summary
 
     let(:has_previous_name) { 'no' }
     let(:previous_name) { nil }
+
+    let(:relationships) {
+      instance_double(
+          Relationship,
+          relation: 'mother',
+          relation_other_value: nil,
+          minor: child,
+      )
+    }
+    let(:child) { instance_double(Child, to_param: 'uuid-555', full_name: 'Child Test') }
 
     let(:answers) { subject.answers }
 
@@ -53,7 +64,7 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(5)
       end
 
       it 'has the correct rows in the right order' do
@@ -121,6 +132,12 @@ module Summary
           expect(details[5]).to be_an_instance_of(FreeTextAnswer)
           expect(details[5].question).to eq(:person_email)
           expect(details[5].value).to eq('email')
+
+        expect(answers[4]).to be_an_instance_of(Answer)
+        expect(answers[4].question).to eq(:relationship_to_child)
+        expect(answers[4].change_path).to eq('/steps/applicant/relationship/uuid-123/child/uuid-555')
+        expect(answers[4].value).to eq('mother')
+        expect(answers[4].i18n_opts).to eq({child_name: 'Child Test'})
       end
 
       context 'for existing previous name' do
@@ -128,7 +145,7 @@ module Summary
         let(:previous_name) { 'previous_name' }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(4)
+          expect(answers.count).to eq(5)
         end
 
         it 'renders the previous name' do
@@ -138,6 +155,29 @@ module Summary
           expect(details[0]).to be_an_instance_of(FreeTextAnswer)
           expect(details[0].question).to eq(:person_previous_name)
           expect(details[0].value).to eq('previous_name')
+        end
+      end
+
+      context 'for `other` children relationship' do
+        let(:relationships) {
+          instance_double(
+            Relationship,
+            relation: 'other',
+            relation_other_value: 'Aunt',
+            minor: child,
+          )
+        }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(5)
+        end
+
+        it 'renders the correct relationship value' do
+          expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[4].question).to eq(:relationship_to_child)
+          expect(answers[4].change_path).to eq('/steps/applicant/relationship/uuid-123/child/uuid-555')
+          expect(answers[4].value).to eq('Aunt')
+          expect(answers[4].i18n_opts).to eq({child_name: 'Child Test'})
         end
       end
     end

--- a/spec/presenters/summary/html_sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/html_sections/other_parties_details_spec.rb
@@ -26,11 +26,21 @@ module Summary
         home_phone: nil,
         mobile_phone: nil,
         email: nil,
-        relationships: [],
+        relationships: [relationships],
       )
     }
 
     subject { described_class.new(c100_application) }
+
+    let(:relationships) {
+      instance_double(
+        Relationship,
+        relation: 'mother',
+        relation_other_value: nil,
+        minor: child,
+      )
+    }
+    let(:child) { instance_double(Child, to_param: 'uuid-555', full_name: 'Child Test') }
 
     let(:answers) { subject.answers }
 
@@ -52,7 +62,7 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(5)
+        expect(answers.count).to eq(6)
       end
 
       it 'has the correct rows in the right order' do
@@ -101,6 +111,12 @@ module Summary
           expect(details[0]).to be_an_instance_of(FreeTextAnswer)
           expect(details[0].question).to eq(:person_address)
           expect(details[0].value).to eq('address')
+
+        expect(answers[5]).to be_an_instance_of(Answer)
+        expect(answers[5].question).to eq(:relationship_to_child)
+        expect(answers[5].change_path).to eq('/steps/other_parties/relationship/uuid-123/child/uuid-555')
+        expect(answers[5].value).to eq('mother')
+        expect(answers[5].i18n_opts).to eq({child_name: 'Child Test'})
       end
 
       context 'when there are no other parties' do
@@ -119,6 +135,29 @@ module Summary
           expect(answers[0].question).to eq(:has_other_parties)
           expect(answers[0].change_path).to eq('/steps/respondent/has_other_parties')
           expect(answers[0].value).to eq('no')
+        end
+      end
+
+      context 'for `other` children relationship' do
+        let(:relationships) {
+          instance_double(
+            Relationship,
+            relation: 'other',
+            relation_other_value: 'Aunt',
+            minor: child,
+          )
+        }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(6)
+        end
+
+        it 'renders the correct relationship value' do
+          expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[5].question).to eq(:relationship_to_child)
+          expect(answers[5].change_path).to eq('/steps/other_parties/relationship/uuid-123/child/uuid-555')
+          expect(answers[5].value).to eq('Aunt')
+          expect(answers[5].i18n_opts).to eq({child_name: 'Child Test'})
         end
       end
     end

--- a/spec/presenters/summary/html_sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/html_sections/other_parties_details_spec.rb
@@ -26,6 +26,7 @@ module Summary
         home_phone: nil,
         mobile_phone: nil,
         email: nil,
+        relationships: [],
       )
     }
 

--- a/spec/presenters/summary/html_sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/html_sections/respondents_details_spec.rb
@@ -25,6 +25,7 @@ module Summary
         home_phone: 'home_phone',
         mobile_phone: 'mobile_phone',
         email: 'email',
+        relationships: [relationships],
       )
     }
 
@@ -32,6 +33,16 @@ module Summary
 
     let(:has_previous_name) { 'no' }
     let(:previous_name) { nil }
+
+    let(:relationships) {
+      instance_double(
+        Relationship,
+        relation: 'mother',
+        relation_other_value: nil,
+        minor: child,
+      )
+    }
+    let(:child) { instance_double(Child, to_param: 'uuid-555', full_name: 'Child Test') }
 
     let(:answers) { subject.answers }
 
@@ -53,7 +64,7 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(5)
       end
 
       it 'has the correct rows in the right order' do
@@ -121,6 +132,12 @@ module Summary
           expect(details[5]).to be_an_instance_of(FreeTextAnswer)
           expect(details[5].question).to eq(:person_email)
           expect(details[5].value).to eq('email')
+
+        expect(answers[4]).to be_an_instance_of(Answer)
+        expect(answers[4].question).to eq(:relationship_to_child)
+        expect(answers[4].change_path).to eq('/steps/respondent/relationship/uuid-123/child/uuid-555')
+        expect(answers[4].value).to eq('mother')
+        expect(answers[4].i18n_opts).to eq({child_name: 'Child Test'})
       end
 
       context 'for existing previous name' do
@@ -128,7 +145,7 @@ module Summary
         let(:previous_name) { 'previous_name' }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(4)
+          expect(answers.count).to eq(5)
         end
 
         it 'renders the previous name' do
@@ -138,6 +155,29 @@ module Summary
           expect(details[0]).to be_an_instance_of(FreeTextAnswer)
           expect(details[0].question).to eq(:person_previous_name)
           expect(details[0].value).to eq('previous_name')
+        end
+      end
+
+      context 'for `other` children relationship' do
+        let(:relationships) {
+          instance_double(
+            Relationship,
+            relation: 'other',
+            relation_other_value: 'Aunt',
+            minor: child,
+          )
+        }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(5)
+        end
+
+        it 'renders the correct relationship value' do
+          expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[4].question).to eq(:relationship_to_child)
+          expect(answers[4].change_path).to eq('/steps/respondent/relationship/uuid-123/child/uuid-555')
+          expect(answers[4].value).to eq('Aunt')
+          expect(answers[4].i18n_opts).to eq({child_name: 'Child Test'})
         end
       end
     end


### PR DESCRIPTION
Unfortunately it is just too much work to try to fit this into an AnswerGroup, as technically, it is not a single group. Each of the relations, require their own links, and that's just not possible with an AnswerGroup (the change links would not even appear in the right column, to start with).

So this is the second best approach.

<img width="1008" alt="screen shot 2018-05-09 at 11 51 32" src="https://user-images.githubusercontent.com/687910/39811163-bc73f0c2-537f-11e8-9a38-0d02e912482c.png">
