### PR TITLE
Add `attending court` section to CYA

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -6,6 +6,7 @@ module Summary
       @c100_application = c100_application
     end
 
+    # rubocop:disable Metrics/AbcSize
     def sections
       [
         HtmlSections::ChildProtectionCases.new(c100_application),
@@ -20,8 +21,10 @@ module Summary
         HtmlSections::WithoutNoticeDetails.new(c100_application),
         HtmlSections::InternationalElement.new(c100_application),
         HtmlSections::ApplicationReasons.new(c100_application),
+        HtmlSections::AttendingCourt.new(c100_application),
       ].flatten.select(&:show?)
     end
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/app/presenters/summary/html_sections/attending_court.rb
+++ b/app/presenters/summary/html_sections/attending_court.rb
@@ -1,0 +1,84 @@
+module Summary
+  module HtmlSections
+    class AttendingCourt < Sections::BaseSectionPresenter
+      def name
+        :attending_court
+      end
+
+      def answers
+        [
+          language_assistance,
+          litigation_capacity,
+          intermediary,
+          special_assistance,
+          special_arrangements,
+        ].flatten.select(&:show?)
+      end
+
+      private
+
+      def language_assistance
+        AnswersGroup.new(
+          :language_help,
+          [
+            Answer.new(:language_help, c100.language_help),
+            FreeTextAnswer.new(:language_help_details, c100.language_help_details),
+          ],
+          change_path: edit_steps_application_language_path
+        )
+      end
+
+      def litigation_capacity
+        [
+          Answer.new(
+            :reduced_litigation_capacity,
+            c100.reduced_litigation_capacity,
+            change_path: edit_steps_application_litigation_capacity_path
+          ),
+          AnswersGroup.new(
+            :litigation_capacity,
+            [
+              FreeTextAnswer.new(:participation_capacity_details, c100.participation_capacity_details),
+              FreeTextAnswer.new(:participation_other_factors_details, c100.participation_other_factors_details),
+              FreeTextAnswer.new(:participation_referral_or_assessment_details, c100.participation_referral_or_assessment_details),
+            ],
+            change_path: edit_steps_application_litigation_capacity_details_path
+          )
+        ]
+      end
+
+      def intermediary
+        AnswersGroup.new(
+          :intermediary,
+          [
+            Answer.new(:intermediary_help, c100.intermediary_help),
+            FreeTextAnswer.new(:intermediary_help_details, c100.intermediary_help_details),
+          ],
+          change_path: edit_steps_application_intermediary_path
+        )
+      end
+
+      def special_assistance
+        AnswersGroup.new(
+          :special_assistance,
+          [
+            Answer.new(:special_assistance, c100.special_assistance),
+            FreeTextAnswer.new(:special_assistance_details, c100.special_assistance_details),
+          ],
+          change_path: edit_steps_application_special_assistance_path
+        )
+      end
+
+      def special_arrangements
+        AnswersGroup.new(
+          :special_arrangements,
+          [
+            Answer.new(:special_arrangements, c100.special_arrangements),
+            FreeTextAnswer.new(:special_arrangements_details, c100.special_arrangements_details),
+          ],
+          change_path: edit_steps_application_special_arrangements_path
+        )
+      end
+    end
+  end
+end

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -85,6 +85,7 @@ en:
       without_notice_hearing: Without notice hearing
       international_element: International elements
       application_reasons: About your application
+      attending_court: Attending court
     groups:
       miam_certification_details: Certification details
       abduction_passport_possession: Details of the children’s passports
@@ -99,6 +100,11 @@ en:
       without_notice_hearing_details: Without notice hearing details
       international_jurisdiction: Do you think another person in this application may be able to apply for a similar order in a country outside England or Wales?
       international_request: Has a request for information or other assistance involving the children been made to or by another country?
+      language_help: Does anyone in this application need help with language?
+      litigation_capacity: Factors affecting ability to participate
+      intermediary: Does anyone in this application need someone to help them communicate in court?
+      special_assistance: Does anyone in this application need assistance or special facilities when attending court?
+      special_arrangements: Do you or the children need specific arrangements when you attend court?
     separators:
       not_applicable: Not applicable
       children_details_index_title: Child %{index}
@@ -506,6 +512,39 @@ en:
         <<: *YESNO
     international_request_details:
       question: ''
-
     application_details:
       question: 'Why are you making this application?'
+    language_help:
+      question: ''
+      answers:
+        <<: *YESNO
+    language_help_details:
+      question: ''
+    reduced_litigation_capacity:
+      question: Are there any factors that may affect any adult in this application taking part in the court proceedings?
+      answers:
+        <<: *YESNO
+    participation_capacity_details:
+      question: Details of any adult in this application who lacks the mental capacity to conduct these court proceedings
+    participation_other_factors_details:
+      question: Details of anything else that could affect any adult in this application taking part in these court proceedings
+    participation_referral_or_assessment_details:
+      question: Details of anyone in this application who has been referred to or assessed by an Adult Learning Disability team or any adult health service and what the outcome was
+    intermediary_help:
+      question: ''
+      answers:
+        <<: *YESNO
+    intermediary_help_details:
+      question: ''
+    special_assistance:
+      question: ''
+      answers:
+        <<: *YESNO
+    special_assistance_details:
+      question: ''
+    special_arrangements:
+      question: ''
+      answers:
+        <<: *YESNO
+    special_arrangements_details:
+      question: ''

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -36,6 +36,7 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::WithoutNoticeDetails,
         Summary::HtmlSections::InternationalElement,
         Summary::HtmlSections::ApplicationReasons,
+        Summary::HtmlSections::AttendingCourt,
       ])
     end
   end

--- a/spec/presenters/summary/html_sections/attending_court_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::AttendingCourt do
+    let(:c100_application) {
+      instance_double(C100Application,
+        language_help: 'yes',
+        language_help_details: 'language_help_details',
+        reduced_litigation_capacity: 'yes',
+        participation_capacity_details: 'participation_capacity_details',
+        participation_other_factors_details: 'participation_other_factors_details',
+        participation_referral_or_assessment_details: 'participation_referral_or_assessment_details',
+        intermediary_help: 'yes',
+        intermediary_help_details: 'intermediary_help_details',
+        special_assistance: 'yes',
+        special_assistance_details: 'special_assistance_details',
+        special_arrangements: 'yes',
+        special_arrangements_details: 'special_arrangements_details',
+    ) }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:attending_court) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(6)
+
+        expect(answers[0]).to be_an_instance_of(AnswersGroup)
+        expect(answers[0].name).to eq(:language_help)
+        expect(answers[0].change_path).to eq('/steps/application/language')
+
+        expect(answers[1]).to be_an_instance_of(Answer)
+        expect(answers[1].question).to eq(:reduced_litigation_capacity)
+        expect(answers[1].value).to eq('yes')
+        expect(answers[1].change_path).to eq('/steps/application/litigation_capacity')
+
+        expect(answers[2]).to be_an_instance_of(AnswersGroup)
+        expect(answers[2].name).to eq(:litigation_capacity)
+        expect(answers[2].change_path).to eq('/steps/application/litigation_capacity_details')
+
+        expect(answers[3]).to be_an_instance_of(AnswersGroup)
+        expect(answers[3].name).to eq(:intermediary)
+        expect(answers[3].change_path).to eq('/steps/application/intermediary')
+
+        expect(answers[4]).to be_an_instance_of(AnswersGroup)
+        expect(answers[4].name).to eq(:special_assistance)
+        expect(answers[4].change_path).to eq('/steps/application/special_assistance')
+
+        expect(answers[5]).to be_an_instance_of(AnswersGroup)
+        expect(answers[5].name).to eq(:special_arrangements)
+        expect(answers[5].change_path).to eq('/steps/application/special_arrangements')
+      end
+
+      context 'language_assistance' do
+        let(:group_answers) { answers[0].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(2)
+
+          expect(group_answers[0]).to be_an_instance_of(Answer)
+          expect(group_answers[0].question).to eq(:language_help)
+          expect(group_answers[0].value).to eq('yes')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:language_help_details)
+          expect(group_answers[1].value).to eq('language_help_details')
+        end
+      end
+
+      context 'litigation_capacity' do
+        let(:group_answers) { answers[2].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(3)
+
+          expect(group_answers[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[0].question).to eq(:participation_capacity_details)
+          expect(group_answers[0].value).to eq('participation_capacity_details')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:participation_other_factors_details)
+          expect(group_answers[1].value).to eq('participation_other_factors_details')
+
+          expect(group_answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[2].question).to eq(:participation_referral_or_assessment_details)
+          expect(group_answers[2].value).to eq('participation_referral_or_assessment_details')
+        end
+      end
+
+      context 'intermediary' do
+        let(:group_answers) { answers[3].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(2)
+
+          expect(group_answers[0]).to be_an_instance_of(Answer)
+          expect(group_answers[0].question).to eq(:intermediary_help)
+          expect(group_answers[0].value).to eq('yes')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:intermediary_help_details)
+          expect(group_answers[1].value).to eq('intermediary_help_details')
+        end
+      end
+
+      context 'special_assistance' do
+        let(:group_answers) { answers[4].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(2)
+
+          expect(group_answers[0]).to be_an_instance_of(Answer)
+          expect(group_answers[0].question).to eq(:special_assistance)
+          expect(group_answers[0].value).to eq('yes')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:special_assistance_details)
+          expect(group_answers[1].value).to eq('special_assistance_details')
+        end
+      end
+
+      context 'special_arrangements' do
+        let(:group_answers) { answers[5].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(2)
+
+          expect(group_answers[0]).to be_an_instance_of(Answer)
+          expect(group_answers[0].question).to eq(:special_arrangements)
+          expect(group_answers[0].value).to eq('yes')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:special_arrangements_details)
+          expect(group_answers[1].value).to eq('special_arrangements_details')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This groups together most of the last questions of the service.

The only remaining one, that will go in a different section, is "Help with fees".

<img width="741" alt="screen shot 2018-05-10 at 13 14 38" src="https://user-images.githubusercontent.com/687910/39871938-4fc8387c-545e-11e8-8c2a-319f964b0adf.png">
