### PR TITLE
Modify resume draft to use CYA

### DIFF
--- a/app/controllers/steps/application/check_your_answers_controller.rb
+++ b/app/controllers/steps/application/check_your_answers_controller.rb
@@ -1,7 +1,7 @@
 module Steps
   module Application
     class CheckYourAnswersController < Steps::ApplicationStepController
-      before_action :set_presenter, only: [:edit, :update]
+      before_action :set_presenter
 
       def edit
         @form_object = DeclarationForm.build(current_c100_application)
@@ -10,6 +10,8 @@ module Steps
       def update
         update_and_advance(DeclarationForm, as: :declaration)
       end
+
+      def resume; end
 
       private
 

--- a/app/controllers/users/drafts_controller.rb
+++ b/app/controllers/users/drafts_controller.rb
@@ -18,7 +18,7 @@ module Users
       elsif draft_from_params
         set_session_and_redirect(
           draft_from_params,
-          draft_from_params.navigation_stack.last
+          check_your_answers_or_last_step # temporary feature-flagged journey
         )
       end
     end
@@ -41,6 +41,14 @@ module Users
     def set_session_and_redirect(c100_application, path)
       session[:c100_application_id] = c100_application.id
       redirect_to path
+    end
+
+    def check_your_answers_or_last_step
+      if helpers.dev_tools_enabled?
+        resume_steps_application_check_your_answers_path
+      else
+        draft_from_params.navigation_stack.last
+      end
     end
   end
 end

--- a/app/views/steps/application/check_your_answers/resume.html.erb
+++ b/app/views/steps/application/check_your_answers/resume.html.erb
@@ -1,0 +1,13 @@
+<% title t('.page_title') %>
+
+<h1 class="app__heading heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+<p class="lede"><%=t '.lead_text' %></p>
+
+<%= render @presenter.sections %>
+
+<br/>
+
+<div class="xform-group form-submit">
+  <%= link_to t('.resume'), previous_step_path, class: 'button', role: 'button' %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -724,6 +724,11 @@ en:
           declaration_lead_text: You must confirm that the information you’ve provided in your application is true.
           warning_title: Warning
           warning_text: You could be fined or imprisoned for contempt of court if you deliberately submit false information.
+        resume:
+          page_title: Resume application
+          heading: Resume application
+          lead_text: Review your current progress and resume this application
+          resume: Resume application
     international:
       resident:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,9 @@ Rails.application.routes.draw do
       edit_step :intermediary
       edit_step :help_paying
       edit_step :declaration
-      edit_step :check_your_answers
+      edit_step :check_your_answers do
+        get :resume, action: :resume
+      end
     end
     namespace :petition do
       edit_step :orders

--- a/spec/controllers/steps/application/check_your_answers_controller_spec.rb
+++ b/spec/controllers/steps/application/check_your_answers_controller_spec.rb
@@ -15,4 +15,17 @@ RSpec.describe Steps::Application::CheckYourAnswersController, type: :controller
       end
     end
   end
+
+  describe '#resume' do
+    context 'when a case exists in the session' do
+      let!(:existing_case) { C100Application.create(status: :in_progress) }
+
+      it 'assigns the HTML presenter' do
+        get :resume, session: { c100_application_id: existing_case.id }
+
+        expect(response).to render_template(:resume)
+        expect(assigns[:presenter]).to be_an_instance_of(Summary::HtmlPresenter)
+      end
+    end
+  end
 end

--- a/spec/controllers/users/drafts_controller_spec.rb
+++ b/spec/controllers/users/drafts_controller_spec.rb
@@ -86,9 +86,26 @@ RSpec.describe Users::DraftsController, type: :controller do
             expect(session[:c100_application_id]).to eq(c100_application.id)
           end
 
-          it 'redirects to the last recorded step' do
-            get :resume, params: {id: c100_application.id}
-            expect(response).to redirect_to('/step/2')
+          context 'when dev_tools flag is enabled' do
+            before do
+              allow(controller.helpers).to receive(:dev_tools_enabled?).and_return(true)
+            end
+
+            it 'redirects to the CYA resume application step' do
+              get :resume, params: {id: c100_application.id}
+              expect(response).to redirect_to('/steps/application/check_your_answers/resume')
+            end
+          end
+
+          context 'when dev_tools flag is disabled' do
+            before do
+              allow(controller.helpers).to receive(:dev_tools_enabled?).and_return(false)
+            end
+
+            it 'redirects to the last recorded step' do
+              get :resume, params: {id: c100_application.id}
+              expect(response).to redirect_to('/step/2')
+            end
           end
         end
       end


### PR DESCRIPTION
Again, this is behind a feature flag so for now, no real users will be able to access it.

When resuming a draft, now instead of taking you directly to the last step, there will be a middle page which is the `Check your answers`, to check the current progress and from there to be able to resume (will take you to the last completed step).

<img width="999" alt="screen shot 2018-05-11 at 15 06 23" src="https://user-images.githubusercontent.com/687910/39928395-23809488-552d-11e8-9c8d-c2711a52416a.png">
