### PR TITLE
Improve debug of expiring sessions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
 
   def reset_c100_application_session
     session.delete(:c100_application_id)
+    session.delete(:last_seen)
   end
 
   def initialize_c100_application(attributes = {})

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -4,7 +4,7 @@ module ErrorHandling
   included do
     rescue_from Exception do |exception|
       case exception
-      when Errors::InvalidSession, ActionController::InvalidAuthenticityToken
+      when Errors::InvalidSession # , ActionController::InvalidAuthenticityToken
         redirect_to invalid_session_errors_path
       when Errors::ApplicationNotFound
         redirect_to application_not_found_errors_path

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe ApplicationController do
       context 'when cookie is present but expired' do
         before do
           session[:last_seen] = Time.now.to_i - 155
+          expect(controller).to receive(:sentry_debug_session_expire).with(555555) # Temporary for debug purposes
         end
 
         it 'sets the `last_seen` value' do

--- a/spec/controllers/steps/screener/start_controller_spec.rb
+++ b/spec/controllers/steps/screener/start_controller_spec.rb
@@ -1,14 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Screener::StartController, type: :controller do
-  before do
-    expect(subject).to receive(:reset_c100_application_session)
-  end
-
   describe '#show' do
     it 'responds with HTTP success' do
       get :show
       expect(response).to be_successful
+    end
+
+    it 'resets the c100_application session data' do
+      expect(session).to receive(:delete).with(:c100_application_id).ordered
+      expect(session).to receive(:delete).with(:last_seen).ordered
+      expect(session).to receive(:delete) # any other deletes
+      get :show
     end
   end
 end


### PR DESCRIPTION
* We are going to send to Sentry `ActionController::InvalidAuthenticityToken` exceptions, to have visibility in case this is an issue we are hiding.

* When the server-side code that checks the validity of a session "considers" the session has expired, we are going to silently send to Sentry an exception with some debug data (the user will notice nothing, just the same error page as before).

* Make sure we also reset the `last_seen` when resetting the c100 application session data.