### PR TITLE
Improvements based on UR feedback

### DIFF
--- a/app/views/entrypoint/how_long.en.html.erb
+++ b/app/views/entrypoint/how_long.en.html.erb
@@ -18,9 +18,12 @@
           password of your choice.</p>
         <p>We’ll save your draft for <%= Rails.configuration.x.drafts.expire_in_days %> days. For security reasons, we’ll delete
           any information after this time.</p>
-        <div role="note" aria-label="Information" class=" panel panel-border-wide info-notice TODO">
-          <p>You won’t be able to check your answers at the end of the service so we recommend doing so as you progress.</p>
-        </div>
+
+        <% unless dev_tools_enabled? %>
+          <div role="note" aria-label="Information" class=" panel panel-border-wide info-notice TODO">
+            <p>You won’t be able to check your answers at the end of the service so we recommend doing so as you progress.</p>
+          </div>
+        <% end %>
       </div>
 
       <div class="xform-group form-submit">

--- a/app/views/steps/miam/certification_date/edit.html.erb
+++ b/app/views/steps/miam/certification_date/edit.html.erb
@@ -11,7 +11,10 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.gov_uk_date_field :miam_certification_date, placeholders: true, legend_text: nil, form_hint_text: '' %>
+      <%= f.gov_uk_date_field :miam_certification_date,
+                              placeholders: true,
+                              legend_text: nil,
+                              form_hint_text: t('shared.form_elements.certification_date_hint') %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1546,6 +1546,7 @@ en:
     form_elements:
       dob: Date of birth
       order_issue: What date was it made?
+      certification_date_hint: For example, 20 04 2018
     why_we_use_children_html: |
       <details style="margin-top: 0;">
         <summary>


### PR DESCRIPTION
* Remove the paragraph about not being able to check your answers at the end of the service, as we now have CYA in place (for now, only staging).

* Add certification date hint text.

<img width="648" alt="screen shot 2018-05-16 at 13 18 54" src="https://user-images.githubusercontent.com/687910/40116532-d4d59760-590b-11e8-8a86-debd8fe4f54e.png">
