### PR TITLE
Make cucumber tests work on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,3 @@ before_script:
 
 script:
   - bundle exec rake travis
-  #- bundle exec danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
 
 script:
-  - bundle exec rake
+  - bundle exec rake travis
   #- bundle exec danger

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :test do
   gem 'brakeman'
   gem 'capybara'
   gem 'cucumber'
-  gem 'cucumber-rails'
+  gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'poltergeist'
   gem 'phantomjs'

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :test do
   gem 'brakeman'
   gem 'capybara'
   gem 'cucumber'
+  gem 'cucumber-rails'
   gem 'database_cleaner'
   gem 'poltergeist'
   gem 'phantomjs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,12 @@ GEM
       cucumber-tag_expressions (~> 1.1.0)
       gherkin (>= 5.0.0)
     cucumber-expressions (5.0.13)
+    cucumber-rails (1.5.0)
+      capybara (>= 1.1.2, < 3)
+      cucumber (>= 1.3.8, < 4)
+      mime-types (>= 1.17, < 4)
+      nokogiri (~> 1.5)
+      railties (>= 4, < 5.2)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     danger (5.5.10)
@@ -207,6 +213,9 @@ GEM
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.9.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     ministryofjustice-danger (0.1.2)
@@ -431,6 +440,7 @@ DEPENDENCIES
   capybara
   combine_pdf
   cucumber
+  cucumber-rails
   database_cleaner
   devise (~> 4.4.1)
   dotenv-rails

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ The features can be run manually (these are not part of the default rake task) i
 * `bundle exec cucumber features/screener.feature -t @happy_path`
 * `bundle exec cucumber features/screener.feature -t @unhappy_path`
 
-By default features will run against the URL defined in `EXTERNAL_URL` (check your local `.env` file) which should be the URL where your local rails server is accessible and running.
+By default cucumber will start a local server on a random port, run features against that server, and kill the server once the features have finished.
 
-If you want to point the features to another server (WARNING: NEVER PRODUCTION!) without editing your local `.env` file, then just pass the value when calling cucumber:
+If you want to point the features at another server (WARNING: NEVER PRODUCTION!), pass the environment variable CUCUMBER_URL (or set the value in your local `.env` file) when calling cucumber:
 
-* `EXTERNAL_URL=http://server.com bundle exec cucumber features`
+* `CUCUMBER_URL=http://server.com bundle exec cucumber features`
 
 ## Mutation testing
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,10 +3,11 @@ require 'capybara'
 require 'capybara/dsl'
 require 'capybara/cucumber'
 require 'capybara/poltergeist'
+require 'cucumber/rails'
 require 'dotenv/load'
 
-Capybara.app_host = ENV.fetch('EXTERNAL_URL')
-Capybara.run_server = false
+# Capybara.app_host = ENV.fetch('EXTERNAL_URL')
+# Capybara.run_server = false
 Capybara.default_driver = :poltergeist
 Capybara.javascript_driver = :poltergeist
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,8 +6,11 @@ require 'capybara/poltergeist'
 require 'cucumber/rails'
 require 'dotenv/load'
 
-# Capybara.app_host = ENV.fetch('EXTERNAL_URL')
-# Capybara.run_server = false
+if ENV['CUCUMBER_URL'].present?
+  Capybara.app_host = ENV.fetch('CUCUMBER_URL')
+  Capybara.run_server = false
+end
+
 Capybara.default_driver = :poltergeist
 Capybara.javascript_driver = :poltergeist
 

--- a/lib/tasks/all_tests.rake
+++ b/lib/tasks/all_tests.rake
@@ -1,0 +1,16 @@
+
+namespace :test do
+  # test:all is already defined by rails
+  task all_the_things: :environment do
+    Rake::Task['spec'].invoke
+    Rake::Task['rubocop'].invoke
+    Rake::Task['cucumber'].invoke
+    Rake::Task['brakeman'].invoke
+    Rake::Task['mutant'].invoke
+  end
+end
+
+
+if %w(development test).include? Rails.env
+  task(:default).prerequisites << task('test:all_the_things')
+end

--- a/lib/tasks/all_tests.rake
+++ b/lib/tasks/all_tests.rake
@@ -2,10 +2,10 @@
 namespace :test do
   # test:all is already defined by rails
   task all_the_things: :environment do
-    Rake::Task['spec'].invoke
     Rake::Task['rubocop'].invoke
-    Rake::Task['cucumber'].invoke
+    Rake::Task['spec'].invoke
     Rake::Task['brakeman'].invoke
+    Rake::Task['cucumber'].invoke
     Rake::Task['mutant'].invoke
   end
 end

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -3,7 +3,3 @@ task :brakeman do
 mkdir -p tmp && (brakeman --no-progress --quiet --output tmp/brakeman.out --exit-on-warn && echo "no warnings or errors") || (cat tmp/brakeman.out; exit 1)
 end
 end
-
-if %w(development test).include? Rails.env
-  task(:default).prerequisites << task(:brakeman)
-end

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -1,0 +1,11 @@
+task :cucumber => :environment do
+  vars = 'RAILS_ENV=test NOCOVERAGE=true'
+
+  unless system("bundle exec cucumber")
+    raise 'Mutation testing failed'
+  end
+
+  exit
+end
+
+task(:default).prerequisites << task(:cucumber)

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -2,10 +2,7 @@ task :cucumber => :environment do
   vars = 'RAILS_ENV=test NOCOVERAGE=true'
 
   unless system("bundle exec cucumber")
-    raise 'Mutation testing failed'
+    raise 'Cucumber testing failed'
   end
 
-  exit
 end
-
-task(:default).prerequisites << task(:cucumber)

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -12,8 +12,6 @@ task :mutant => :environment do
   exit
 end
 
-task(:default).prerequisites << task(:mutant)
-
 private
 
 def classes_to_mutate

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,5 +1,4 @@
 if %w(development test).include?(Rails.env) && Gem.loaded_specs.key?('rubocop')
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
-  task(:default).prerequisites.unshift(task(:rubocop))
 end

--- a/lib/tasks/travis.rake
+++ b/lib/tasks/travis.rake
@@ -1,0 +1,14 @@
+
+
+task :travis => :environment do
+
+  # start a webserver
+  # system("export DISPLAY=:99.0 && bundle exec cucumber")
+  # raise "#{cucumber} failed!" unless $?.exitstatus == 0
+
+  Rake::Task['cucumber'].invoke
+  Rake::Task['spec'].invoke
+  Rake::Task['rubocop'].invoke
+  Rake::Task['brakeman'].invoke
+  Rake::Task['mutant'].invoke
+end

--- a/lib/tasks/travis.rake
+++ b/lib/tasks/travis.rake
@@ -1,14 +1,3 @@
-
-
 task :travis => :environment do
-
-  # start a webserver
-  # system("export DISPLAY=:99.0 && bundle exec cucumber")
-  # raise "#{cucumber} failed!" unless $?.exitstatus == 0
-
-  Rake::Task['cucumber'].invoke
-  Rake::Task['spec'].invoke
-  Rake::Task['rubocop'].invoke
-  Rake::Task['brakeman'].invoke
-  Rake::Task['mutant'].invoke
+  Rake::Task['test:all_the_things'].invoke
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,10 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  config.before(:each, js: true) do
+    page.driver.browser.url_whitelist = ["127.0.0.1", "localhost"]
+  end
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ unless ENV['NOCOVERAGE']
   SimpleCov.start do
     add_filter '.bundle'
     add_filter 'spec/support'
+    add_filter 'spec/rails_helper.rb'
+    add_filter 'config/initializers'
   end
 end
 


### PR DESCRIPTION
Cucumber was not able to run on travis-ci, so we had to run it locally only.

This PR:
* fixes the issue
* still allows cucumber to be run locally and pointed at arbitrary servers via the CUCUMBER_URL env var
* refactors the rake tasks to only hook into the default task prerequisites in one place rather than everywhere in unclear order
* updates the README to reflect the change from using EXTERNAL_URL to CUCUMBER_URL

<img width="528" alt="screen shot 2018-05-16 at 15 06 59" src="https://user-images.githubusercontent.com/134501/40122037-d2f3c444-591a-11e8-860f-b39528c6d1d0.png">

