### PR TITLE
Do not check session validity on delete

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :ensure_session_validity, only: [:destroy]
+
   def ping
     head(:no_content)
   end


### PR DESCRIPTION
If we are destroying the session, there is little point on running the validity code, which can give us race conditions and raise false alarms in Sentry.

Bypassing this, for `destroy` session action.