### PR TITLE
Insert a blank page before C8 form

### DIFF
--- a/app/presenters/summary/base_pdf_form.rb
+++ b/app/presenters/summary/base_pdf_form.rb
@@ -18,6 +18,11 @@ module Summary
     def sections
       raise 'implement in subclasses'
     end
+
+    # If needed, override in subclasses to change the format or to hide it completely.
+    def page_number
+      '[page]/[topage]'
+    end
     # :nocov:
 
     # If needed, specify in subclasses a PDF file to be used 'as it is', appended

--- a/app/presenters/summary/blank_page.rb
+++ b/app/presenters/summary/blank_page.rb
@@ -1,0 +1,17 @@
+module Summary
+  class BlankPage < BasePdfForm
+    def name
+      nil
+    end
+
+    def page_number
+      nil
+    end
+
+    def sections
+      [
+        Partial.new(:blank_page)
+      ]
+    end
+  end
+end

--- a/app/presenters/summary/partial.rb
+++ b/app/presenters/summary/partial.rb
@@ -12,6 +12,10 @@ module Summary
         new(:page_break)
       end
 
+      def blank_page
+        new(:blank_page)
+      end
+
       def row_blank_space
         new(:row_blank_space)
       end

--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -10,11 +10,10 @@ module Summary
       @pdf_generator = generator
     end
 
-    # The number of copies might change for the pilot
     def generate
-      pdf_generator.generate(c100_form, copies: 1)
-      pdf_generator.generate(c1a_form,  copies: 1) if c100_application.has_safety_concerns?
-      pdf_generator.generate(c8_form,   copies: 1) if c100_application.confidentiality_enabled?
+      generate_c100_form
+      generate_c1a_form
+      generate_c8_form
     end
 
     def filename
@@ -23,20 +22,29 @@ module Summary
 
     private
 
-    def c100_form
-      Summary::C100Form.new(c100_application)
+    def generate_c100_form
+      pdf_generator.generate(
+        Summary::C100Form.new(c100_application), copies: 1
+      )
     end
 
-    def c1a_form
-      Summary::C1aForm.new(c100_application)
+    def generate_c1a_form
+      return unless c100_application.has_safety_concerns?
+
+      pdf_generator.generate(
+        Summary::C1aForm.new(c100_application), copies: 1
+      )
     end
 
-    def c8_form
-      Summary::C8Form.new(c100_application)
-    end
+    def generate_c8_form
+      return unless c100_application.confidentiality_enabled?
 
-    def cover_letter
-      # TODO
+      pdf_generator.generate(
+        Summary::BlankPage.new(c100_application), copies: 1
+      )
+      pdf_generator.generate(
+        Summary::C8Form.new(c100_application), copies: 1
+      )
     end
   end
 end

--- a/app/presenters/summary/sections/risk_concerns.rb
+++ b/app/presenters/summary/sections/risk_concerns.rb
@@ -23,6 +23,10 @@ module Summary
         c100.has_safety_concerns?
       end
 
+      def confidentiality_enabled?
+        c100.confidentiality_enabled?
+      end
+
       private
 
       def default_value

--- a/app/services/c100_app/pdf_generator.rb
+++ b/app/services/c100_app/pdf_generator.rb
@@ -17,7 +17,7 @@ module C100App
     def pdf_from_presenter(presenter)
       WickedPdf.new.pdf_from_string(
         render(presenter),
-        footer: { right: "#{presenter.name}  [page]/[topage]" }
+        footer: { right: "#{presenter.name}  #{presenter.page_number}" }
       )
     end
 

--- a/app/views/steps/completion/shared/_blank_page.pdf.erb
+++ b/app/views/steps/completion/shared/_blank_page.pdf.erb
@@ -1,0 +1,4 @@
+<br/>
+<br/>
+
+<p><%=t 'shared.intentional_blank_page' %></p>

--- a/app/views/steps/completion/shared/_risk_concerns.pdf.erb
+++ b/app/views/steps/completion/shared/_risk_concerns.pdf.erb
@@ -17,6 +17,14 @@
             </td>
           </tr>
         <% end %>
+
+        <% if risk_concerns.confidentiality_enabled? %>
+          <tr>
+            <td class="question">
+              <%=t "check_answers.descriptions.c8_attached_html" %>
+            </td>
+          </tr>
+        <% end %>
       </table>
     </td>
   </tr>

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -138,6 +138,7 @@ en:
     descriptions:
       risk_concerns: Are you alleging that the child(ren) named in Section 1 of this form have experienced, or are at risk of experiencing, harm from any of the following by any person who has had contact with the child?
       c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
+      c8_attached_html: <strong>C8 is attached at the end of this form</strong>
     separators:
       c8_attached: See C8 attached
       not_applicable: Not applicable

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -66,6 +66,7 @@ en:
     admin_case_number: Case number
     admin_date_issued: Date issued
     admin_orders_applied_for: Order(s) applied for
+    intentional_blank_page: This page is intentionally left blank
     c8_confidential_answer: See C8 attached
     miam_exemptions_info: "The applicant has not attended a MIAM because the following exemption(s) applies:"
     statement_of_truth: "%{applicant_name} believes that the facts stated in this application are true."

--- a/spec/presenters/summary/blank_page_spec.rb
+++ b/spec/presenters/summary/blank_page_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+module Summary
+  describe BlankPage do
+    let(:c100_application) { instance_double(C100Application) }
+    subject { described_class.new(c100_application) }
+
+    describe '#template' do
+      it { expect(subject.template).to eq('steps/completion/summary/show.pdf') }
+    end
+
+    describe '#name' do
+      it { expect(subject.name).to be_nil }
+    end
+
+    describe '#page_number' do
+      it { expect(subject.page_number).to be_nil }
+    end
+
+    describe '#raw_file_path' do
+      it { expect(subject.raw_file_path).to be_nil }
+    end
+
+    describe '#sections' do
+      it 'has the right sections in the right order' do
+        expect(subject.sections).to match_instances_array([Partial])
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/partial_spec.rb
+++ b/spec/presenters/summary/partial_spec.rb
@@ -27,6 +27,13 @@ describe Summary::Partial do
     end
   end
 
+  describe '.blank_page' do
+    it 'instantiate a Partial object with a specific partial name' do
+      partial = described_class.blank_page
+      expect(partial.name).to eq(:blank_page)
+    end
+  end
+
   describe '.row_blank_space' do
     it 'instantiate a Partial object with a specific partial name' do
       partial = described_class.row_blank_space

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -43,6 +43,10 @@ describe Summary::PdfPresenter do
         )
 
         expect(generator).to receive(:generate).with(
+          an_instance_of(Summary::BlankPage), copies: 1
+        )
+
+        expect(generator).to receive(:generate).with(
           an_instance_of(Summary::C8Form), copies: 1
         )
 

--- a/spec/presenters/summary/sections/risk_concerns_spec.rb
+++ b/spec/presenters/summary/sections/risk_concerns_spec.rb
@@ -51,5 +51,12 @@ module Summary
         expect(subject.c1a_triggered?).to eq(true)
       end
     end
+
+    describe '#confidentiality_enabled?' do
+      it 'uses the implementation in the c100 application' do
+        expect(c100_application).to receive(:confidentiality_enabled?).and_return(true)
+        expect(subject.confidentiality_enabled?).to eq(true)
+      end
+    end
   end
 end

--- a/spec/services/c100_app/pdf_generator_spec.rb
+++ b/spec/services/c100_app/pdf_generator_spec.rb
@@ -10,7 +10,15 @@ RSpec.describe C100App::PdfGenerator do
   end
 
   describe '#generate' do
-    let(:presenter) { double('Presenter', name: 'Test', template: 'path/to/template', raw_file_path: raw_file_path) }
+    let(:presenter) {
+      double(
+        'Presenter',
+        name: 'Test',
+        page_number: '[xx]/[yy]',
+        template: 'path/to/template',
+        raw_file_path: raw_file_path,
+      )
+    }
     let(:document)  { 'a form document' }
     let(:raw_file_path) { nil }
 
@@ -20,7 +28,7 @@ RSpec.describe C100App::PdfGenerator do
       ).and_return(document)
 
       expect(wicked_pdf).to receive(:pdf_from_string).with(
-        document, { footer: { right: 'Test  [page]/[topage]' } }
+        document, { footer: { right: 'Test  [xx]/[yy]' } }
       ).and_return(document)
 
       # Using 0 copies just to make this test scenario simpler to mock,


### PR DESCRIPTION
* Add C8 instructions to risk concerns PDF section.

* Insert a blank page before C8 form (if triggered).

(individual commits for easier PR review)

<img width="829" alt="screen shot 2018-05-17 at 14 43 24" src="https://user-images.githubusercontent.com/687910/40181290-ad2e9538-59e0-11e8-8eaf-edab91656111.png">
