### PR TITLE
Only log exception for valid sessions

### DIFF
--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -60,7 +60,7 @@ module SecurityHandling
 
   # :nocov:
   def sentry_debug_session_expire(epoch)
-    return if Rails.application.config.consider_all_requests_local
+    return if Rails.application.config.consider_all_requests_local || session[:c100_application_id].nil?
 
     exception = StandardError.new('ensure_session_validity')
 


### PR DESCRIPTION
For the purposes of this debug logging, we only care about the sessions with a current application ID.
Otherwise we get too much noise.