### PR TITLE
Add new `payment` step, behind feature flag

### DIFF
--- a/app/controllers/steps/application/payment_controller.rb
+++ b/app/controllers/steps/application/payment_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Application
+    class PaymentController < Steps::ApplicationStepController
+      def edit
+        @form_object = PaymentForm.build(current_c100_application)
+      end
+
+      def update
+        update_and_advance(PaymentForm, as: :payment)
+      end
+    end
+  end
+end

--- a/app/forms/steps/application/payment_form.rb
+++ b/app/forms/steps/application/payment_form.rb
@@ -1,0 +1,34 @@
+module Steps
+  module Application
+    class PaymentForm < BaseForm
+      attribute :payment_type, String
+      attribute :hwf_reference_number, StrippedString
+      attribute :solicitor_account_number, StrippedString
+
+      validates_inclusion_of :payment_type, in: PaymentType.string_values
+
+      validates_presence_of :hwf_reference_number, if: :help_with_fees_payment?
+      validates_presence_of :solicitor_account_number, if: :solicitor_payment?
+
+      private
+
+      def help_with_fees_payment?
+        payment_type.eql?(PaymentType::HELP_WITH_FEES.to_s)
+      end
+
+      def solicitor_payment?
+        payment_type.eql?(PaymentType::SOLICITOR.to_s)
+      end
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        c100_application.update(
+          payment_type: payment_type,
+          hwf_reference_number: (hwf_reference_number if help_with_fees_payment?),
+          solicitor_account_number: (solicitor_account_number if solicitor_payment?),
+        )
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -6,7 +6,6 @@ module Summary
       @c100_application = c100_application
     end
 
-    # rubocop:disable Metrics/AbcSize
     def sections
       [
         *miam_questions,
@@ -21,10 +20,9 @@ module Summary
         HtmlSections::InternationalElement.new(c100_application),
         HtmlSections::ApplicationReasons.new(c100_application),
         HtmlSections::AttendingCourt.new(c100_application),
-        HtmlSections::HelpWithFees.new(c100_application),
+        payment_section,
       ].flatten.select(&:show?)
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
@@ -61,6 +59,15 @@ module Summary
         HtmlSections::RespondentsDetails.new(c100_application),
         HtmlSections::OtherPartiesDetails.new(c100_application),
       ]
+    end
+
+    # TODO: temporary journey for user testing on staging
+    def payment_section
+      if c100_application.payment_type.present?
+        HtmlSections::Payment.new(c100_application)
+      else
+        HtmlSections::HelpWithFees.new(c100_application)
+      end
     end
   end
 end

--- a/app/presenters/summary/html_sections/payment.rb
+++ b/app/presenters/summary/html_sections/payment.rb
@@ -1,0 +1,23 @@
+module Summary
+  module HtmlSections
+    class Payment < Sections::BaseSectionPresenter
+      def name
+        :payment
+      end
+
+      def answers
+        [
+          AnswersGroup.new(
+            :payment_type,
+            [
+              Answer.new(:payment_type, c100.payment_type),
+              FreeTextAnswer.new(:hwf_reference_number, c100.hwf_reference_number),
+              FreeTextAnswer.new(:solicitor_account_number, c100.solicitor_account_number),
+            ],
+            change_path: edit_steps_application_payment_path
+          )
+        ].select(&:show?)
+      end
+    end
+  end
+end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -26,8 +26,8 @@ module C100App
       when :special_assistance
         edit(:special_arrangements)
       when :special_arrangements
-        edit(:help_paying)
-      when :help_paying
+        help_paying_or_payment
+      when :help_paying, :payment
         edit(:check_your_answers)
       when :declaration
         show('/steps/completion/what_next')
@@ -65,6 +65,15 @@ module C100App
 
     def start_international_journey
       edit('/steps/international/resident')
+    end
+
+    # TODO: temporary journey for user testing on staging
+    def help_paying_or_payment
+      if dev_tools_enabled?
+        edit(:payment)
+      else
+        edit(:help_paying)
+      end
     end
   end
 end

--- a/app/value_objects/payment_type.rb
+++ b/app/value_objects/payment_type.rb
@@ -1,0 +1,11 @@
+class PaymentType < ValueObject
+  VALUES = [
+    HELP_WITH_FEES = new(:help_with_fees),
+    SOLICITOR = new(:solicitor),
+    SELF_PAYMENT = new(:self_payment),
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/views/steps/application/payment/edit.html.erb
+++ b/app/views/steps/application/payment/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.radio_button_fieldset :payment_type do |fieldset|
+          fieldset.radio_input(PaymentType::HELP_WITH_FEES) { f.text_field :hwf_reference_number, class: 'narrow' }
+          fieldset.radio_input(PaymentType::SOLICITOR) { f.text_field :solicitor_account_number, class: 'narrow' }
+          fieldset.radio_input(PaymentType::SELF_PAYMENT)
+        end
+      %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -84,6 +84,7 @@ en:
       application_reasons: Reasons for application
       attending_court: Attending court
       help_with_fees: Help with fees
+      payment: How will you pay the application fee?
     groups:
       miam_certification_details: Certification details
       abduction_passport_possession: Details of the children’s passports
@@ -104,6 +105,7 @@ en:
       special_assistance: Does anyone in this application need assistance or special facilities when attending court?
       special_arrangements: Do you or the children need specific arrangements when you attend court?
       help_with_fees: Do you have a ‘Help with fees’ reference number?
+      payment_type: Payment type
     separators:
       children_details_index_title: Child %{index}
       other_children_details_index_title: Other child %{index}
@@ -548,3 +550,11 @@ en:
         <<: *YESNO
     hwf_reference_number:
       question: Reference number
+    solicitor_account_number:
+      question: Fee account number
+    payment_type:
+      question: ''
+      answers:
+        help_with_fees: Help with fees
+        solicitor: Solicitor payment
+        self_payment: I am paying myself

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -710,6 +710,11 @@ en:
           body_html: |
             <p>You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" target="external_link" rel="external">get help paying</a> the £215 fee if you’re on a low income, receive certain benefits or have little or no savings.</p>
             <p>If you do qualify, you’ll need to provide the reference number you were given.</p>
+      payment:
+        edit:
+          page_title: Payment type
+          heading: How will you pay the application fee?
+          lead_text: The court fee is £215. Only the person applying to court (the applicant) needs to pay.
       check_your_answers:
         edit:
           page_title: Check your answers
@@ -1227,6 +1232,8 @@ en:
         international_jurisdiction_html: ""
       steps_international_request_form:
         international_request_html: ""
+      steps_application_payment_form:
+        payment_type_html: ""
 
       ### SCREENER ###
       #
@@ -1278,8 +1285,17 @@ en:
         language_help_details: *provide_details
       steps_application_intermediary_form:
         intermediary_help_details: *provide_details
+      # TODO: the `help_paying` is to be removed once we introduce
+      # the `payment_form` substitute (only visible in staging for now)
       steps_application_help_paying_form:
         hwf_reference_number: Enter your reference number
+      steps_application_payment_form:
+        payment_type:
+          help_with_fees_html: '<strong>Help with fees</strong><br>You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" target="external_link" rel="external">get help paying</a> if you’re on a low income, receive certain benefits or have little or no savings. If you do qualify, you’ll need to provide your reference number.'
+          solicitor_html: '<strong>Solicitor payment</strong><br>If you have a solicitor representing you, they may pay the court by direct debit. You’ll need to provide their ‘fee account number’.'
+          self_payment_html: '<strong>I am paying myself</strong><br>You can pay over the phone using a credit or debit card, by post with a cheque, or in person at the court by cheque, cash or card.'
+        hwf_reference_number: Enter your reference number
+        solicitor_account_number: Enter solicitor’s fee account number
       steps_application_declaration_form:
         declaration_made: I confirm that I believe that the facts stated in this application are true
       steps_alternatives_court_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,7 @@ Rails.application.routes.draw do
       edit_step :language
       edit_step :intermediary
       edit_step :help_paying
-      edit_step :declaration
+      edit_step :payment
       edit_step :check_your_answers do
         get :resume, action: :resume
       end

--- a/db/migrate/20180521113047_add_payment_fields.rb
+++ b/db/migrate/20180521113047_add_payment_fields.rb
@@ -1,0 +1,7 @@
+class AddPaymentFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :c100_applications, :payment_type, :string
+    add_column :c100_applications, :solicitor_account_number, :string
+    # we already have from a previous migration the `hwf_reference_number` column
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180329160337) do
+ActiveRecord::Schema.define(version: 20180521113047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,6 +121,8 @@ ActiveRecord::Schema.define(version: 20180329160337) do
     t.string "protection_orders"
     t.text "protection_orders_details"
     t.boolean "declaration_made"
+    t.string "payment_type"
+    t.string "solicitor_account_number"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/controllers/steps/application/payment_controller_spec.rb
+++ b/spec/controllers/steps/application/payment_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Application::PaymentController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Application::PaymentForm, C100App::ApplicationDecisionTree
+end

--- a/spec/forms/steps/application/payment_form_spec.rb
+++ b/spec/forms/steps/application/payment_form_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Application::PaymentForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    payment_type: payment_type,
+    hwf_reference_number: hwf_reference_number,
+    solicitor_account_number: solicitor_account_number,
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:payment_type) { PaymentType::SELF_PAYMENT.to_s }
+  let(:hwf_reference_number) { nil }
+  let(:solicitor_account_number) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:payment_type, :inclusion) }
+
+      it { should_not validate_presence_of(:hwf_reference_number) }
+      it { should_not validate_presence_of(:solicitor_account_number) }
+
+      context 'when payment type is `help_with_fees`' do
+        let(:payment_type) { PaymentType::HELP_WITH_FEES.to_s }
+        it { should validate_presence_of(:hwf_reference_number) }
+      end
+
+      context 'when payment type is `solicitor`' do
+        let(:payment_type) { PaymentType::SOLICITOR.to_s }
+        it { should validate_presence_of(:solicitor_account_number) }
+      end
+    end
+
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'when form is valid' do
+      let(:payment_type) { PaymentType::SELF_PAYMENT.to_s }
+      let(:hwf_reference_number) { 'HWF-12345' }
+      let(:solicitor_account_number) { 'SOL-12345' }
+
+      it 'saves the record' do
+        expect(c100_application).to receive(:update).with(
+          payment_type: 'self_payment',
+          hwf_reference_number: nil,
+          solicitor_account_number: nil,
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+
+      context 'when payment type is `help_with_fees`' do
+        let(:payment_type) { PaymentType::HELP_WITH_FEES.to_s }
+
+        it 'saves the record' do
+          expect(c100_application).to receive(:update).with(
+            payment_type: 'help_with_fees',
+            hwf_reference_number: 'HWF-12345',
+            solicitor_account_number: nil,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when payment type is `solicitor`' do
+        let(:payment_type) { PaymentType::SOLICITOR.to_s }
+
+        it 'saves the record' do
+          expect(c100_application).to receive(:update).with(
+            payment_type: 'solicitor',
+            hwf_reference_number: nil,
+            solicitor_account_number: 'SOL-12345',
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -10,6 +10,9 @@ describe Summary::HtmlPresenter do
 
       # Abduction section
       allow(c100_application).to receive(:abduction_detail).and_return(AbductionDetail.new)
+
+      # Help with fees or Payment section (temporary feature-flagged code)
+      allow(c100_application).to receive(:payment_type).and_return(nil)
     end
 
     it 'has the right sections in the right order' do
@@ -39,6 +42,18 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::AttendingCourt,
         Summary::HtmlSections::HelpWithFees,
       ])
+    end
+
+    # TODO: temporary feature-flagged code
+    context 'when the payment type question has been answered' do
+      before do
+        allow(c100_application).to receive(:payment_type).and_return('whatever')
+      end
+
+      it 'presents the Payment section instead of the HelpWithFees section' do
+        expect(subject.sections).not_to include(Summary::HtmlSections::HelpWithFees)
+        expect(subject.sections).to include(Summary::HtmlSections::Payment)
+      end
     end
   end
 end

--- a/spec/presenters/summary/html_sections/payment_spec.rb
+++ b/spec/presenters/summary/html_sections/payment_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::Payment do
+    let(:c100_application) {
+      instance_double(
+        C100Application,
+        payment_type: 'help_with_fees',
+        hwf_reference_number: '123-XYZ',
+        solicitor_account_number: nil,
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:payment) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(AnswersGroup)
+        expect(answers[0].name).to eq(:payment_type)
+        expect(answers[0].change_path).to eq('/steps/application/payment')
+      end
+
+      context '`payment_type` answers group' do
+        let(:group) { answers[0] }
+
+        it 'has the right questions in the right order' do
+          expect(group.answers.count).to eq(2)
+
+          expect(group.answers[0]).to be_an_instance_of(Answer)
+          expect(group.answers[0].question).to eq(:payment_type)
+          expect(group.answers[0].value).to eq('help_with_fees')
+
+          expect(group.answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group.answers[1].question).to eq(:hwf_reference_number)
+          expect(group.answers[1].value).to eq('123-XYZ')
+        end
+      end
+
+      context 'when user is paying' do
+        let(:c100_application) {
+          instance_double(
+            C100Application,
+            payment_type: 'self_payment',
+            hwf_reference_number: nil,
+            solicitor_account_number: nil,
+          )
+        }
+
+        let(:group) { answers[0] }
+
+        it 'has the right questions in the right order' do
+          expect(group.answers.count).to eq(1)
+
+          expect(group.answers[0]).to be_an_instance_of(Answer)
+          expect(group.answers[0].question).to eq(:payment_type)
+          expect(group.answers[0].value).to eq('self_payment')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -92,11 +92,29 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
   context 'when the step is `special_arrangements`' do
     let(:step_params) { { special_arrangements: 'anything' } }
-    it { is_expected.to have_destination(:help_paying, :edit) }
+
+    before do
+      allow(subject).to receive(:dev_tools_enabled?).and_return(dev_tools_enabled)
+    end
+
+    context 'when dev_tools flag is enabled' do
+      let(:dev_tools_enabled) { true }
+      it { is_expected.to have_destination(:payment, :edit) }
+    end
+
+    context 'when dev_tools flag is disabled' do
+      let(:dev_tools_enabled) { false }
+      it { is_expected.to have_destination(:help_paying, :edit) }
+    end
   end
 
   context 'when the step is `help_paying`' do
     let(:step_params) { { help_paying: 'anything' } }
+    it { is_expected.to have_destination(:check_your_answers, :edit) }
+  end
+
+  context 'when the step is `payment`' do
+    let(:step_params) { { payment: 'anything' } }
     it { is_expected.to have_destination(:check_your_answers, :edit) }
   end
 

--- a/spec/value_objects/payment_type_spec.rb
+++ b/spec/value_objects/payment_type_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe PaymentType do
+  let(:value) { :foo }
+  subject     { described_class.new(value) }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(
+        help_with_fees
+        solicitor
+        self_payment
+      ))
+    end
+  end
+end


### PR DESCRIPTION
This, eventually, will replace the current `help paying` step, but for now it only shows in dev/staging environments, in order to do user testing.

Also updated the CYA to support this new step and set of questions (only on staging).

<img width="670" alt="screen shot 2018-05-21 at 15 07 55" src="https://user-images.githubusercontent.com/687910/40312752-a7d8436c-5d0b-11e8-9907-0a70f63dac22.png">
