### PR TITLE
Attempt to make `wkhtmltopdf` play nice on Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,11 +23,11 @@ gem 'virtus'
 # PDF generation
 gem 'combine_pdf'
 gem 'wicked_pdf', '~> 1.1.0'
-gem 'wkhtmltopdf-binary'
 
 group :production do
   gem 'lograge'
   gem 'logstash-event'
+  gem 'wkhtmltopdf-heroku' # in Heroku, we need this version of `wkhtmltopdf`
 end
 
 group :development do
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec-rails'
+  gem 'wkhtmltopdf-binary' # in local, we need this version of `wkhtmltopdf`
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,6 +426,7 @@ GEM
     websocket-extensions (0.1.3)
     wicked_pdf (1.1.0)
     wkhtmltopdf-binary (0.12.3.1)
+    wkhtmltopdf-heroku (2.12.4.0)
     xpath (3.0.0)
       nokogiri (~> 1.8)
 
@@ -482,6 +483,7 @@ DEPENDENCIES
   webmock
   wicked_pdf (~> 1.1.0)
   wkhtmltopdf-binary
+  wkhtmltopdf-heroku
 
 RUBY VERSION
    ruby 2.4.2p198

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -8,8 +8,7 @@
 #
 # https://github.com/mileszs/wicked_pdf/blob/master/README.md
 
-WickedPdf.config = {
+WickedPdf.config ||= {}
+WickedPdf.config.merge!({
   encoding: 'utf-8',
-  # Path to the wkhtmltopdf executable
-  exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
-}
+})


### PR DESCRIPTION
Something has changed in the Heroku stacks and we can't rely anymore on the `wkhtmltopdf` gem we were using.

As a first attempt, let's try a heroku-specific version.