### PR TITLE
Wickedpdf config with buildpack

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,1 @@
+libxrender1

--- a/app.json
+++ b/app.json
@@ -80,6 +80,9 @@
   ],
   "buildpacks": [
     {
+      "url": "https://github.com/heroku/heroku-buildpack-apt"
+    },
+    {
       "url": "heroku/ruby"
     }
   ]

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -8,8 +8,7 @@
 #
 # https://github.com/mileszs/wicked_pdf/blob/master/README.md
 
-WickedPdf.config = {
+WickedPdf.config ||= {}
+WickedPdf.config.merge!({
   encoding: 'utf-8',
-  # Path to the wkhtmltopdf executable
-  exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
-}
+})


### PR DESCRIPTION
Sometime in the last few days Heroku has migrated our envs from Cedar16 to Heroku18, which doesn't have the libxrender1 at runtime (only buildtime) and that was breaking our PDF generation.

This makes sure libxrender1 is installed as part of the deployment process.