### PR TITLE
Remove `nta` from PDF font-family

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -6,7 +6,7 @@
   $sub-heading-font-size: 14px;
   $questions-font-size: 12px;
 
-  font-family: "nta", Arial, sans-serif;
+  font-family: Arial, Helvetica, sans-serif;
   width: 95%;
   margin: 0 auto;
 


### PR DESCRIPTION
After the change in Heroku stacks, the PDF fonts are not consistent between local/dev and production envs.

This makes sure we use Arial as a first attempt, which should be available in Heroku stacks.
It is actually the font we've been using up until now (`nta` seemed not to be available regardless).