### PR TITLE
Add `submission` step (feature-flagged)

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -75,6 +75,12 @@
   margin-top: 50px;
 }
 
+.prototype-step {
+  padding: 20px;
+  border: 1px solid #666666;
+  background-color: #dddddd;
+}
+
 // This will hide the Sentry user-feedback attribution. There is a setting
 // to hide it but currently it is not working, so this is an alternative.
 div.sentry-error-embed-wrapper p.powered-by {

--- a/app/controllers/steps/application/submission_controller.rb
+++ b/app/controllers/steps/application/submission_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Application
+    class SubmissionController < Steps::ApplicationStepController
+      def edit
+        @form_object = SubmissionForm.build(current_c100_application)
+      end
+
+      def update
+        update_and_advance(SubmissionForm, as: :submission)
+      end
+    end
+  end
+end

--- a/app/forms/steps/application/submission_form.rb
+++ b/app/forms/steps/application/submission_form.rb
@@ -1,0 +1,26 @@
+module Steps
+  module Application
+    class SubmissionForm < BaseForm
+      attribute :submission_type, String
+      attribute :receipt_email, NormalisedEmailType
+
+      validates_inclusion_of :submission_type, in: SubmissionType.string_values
+      validates :receipt_email, email: true, allow_blank: true
+
+      private
+
+      def online_submission?
+        submission_type.eql?(SubmissionType::ONLINE.to_s)
+      end
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        c100_application.update(
+          submission_type: submission_type,
+          receipt_email: (receipt_email if online_submission?),
+        )
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -20,7 +20,7 @@ module Summary
         HtmlSections::InternationalElement.new(c100_application),
         HtmlSections::ApplicationReasons.new(c100_application),
         HtmlSections::AttendingCourt.new(c100_application),
-        payment_section,
+        *payment_and_submission_sections,
       ].flatten.select(&:show?)
     end
 
@@ -62,11 +62,16 @@ module Summary
     end
 
     # TODO: temporary journey for user testing on staging
-    def payment_section
+    def payment_and_submission_sections
       if c100_application.payment_type.present?
-        HtmlSections::Payment.new(c100_application)
+        [
+          HtmlSections::Payment.new(c100_application),
+          HtmlSections::Submission.new(c100_application),
+        ]
       else
-        HtmlSections::HelpWithFees.new(c100_application)
+        [
+          HtmlSections::HelpWithFees.new(c100_application)
+        ]
       end
     end
   end

--- a/app/presenters/summary/html_sections/submission.rb
+++ b/app/presenters/summary/html_sections/submission.rb
@@ -1,0 +1,22 @@
+module Summary
+  module HtmlSections
+    class Submission < Sections::BaseSectionPresenter
+      def name
+        :submission
+      end
+
+      def answers
+        [
+          AnswersGroup.new(
+            :submission_type,
+            [
+              Answer.new(:submission_type, c100.submission_type),
+              FreeTextAnswer.new(:submission_receipt_email, c100.receipt_email),
+            ],
+            change_path: edit_steps_application_submission_path
+          )
+        ].select(&:show?)
+      end
+    end
+  end
+end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -27,7 +27,9 @@ module C100App
         edit(:special_arrangements)
       when :special_arrangements
         help_paying_or_payment
-      when :help_paying, :payment
+      when :payment
+        edit(:submission)
+      when :help_paying, :submission
         edit(:check_your_answers)
       when :declaration
         show('/steps/completion/what_next')

--- a/app/value_objects/submission_type.rb
+++ b/app/value_objects/submission_type.rb
@@ -1,0 +1,10 @@
+class SubmissionType < ValueObject
+  VALUES = [
+    ONLINE = new(:online),
+    PRINT_AND_POST = new(:print_and_post),
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/views/steps/application/submission/edit.html.erb
+++ b/app/views/steps/application/submission/edit.html.erb
@@ -12,10 +12,12 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :payment_type do |fieldset|
-          fieldset.radio_input(PaymentType::HELP_WITH_FEES) { f.text_field :hwf_reference_number, class: 'narrow' }
-          fieldset.radio_input(PaymentType::SOLICITOR) { f.text_field :solicitor_account_number, class: 'narrow' }
-          fieldset.radio_input(PaymentType::SELF_PAYMENT)
+        f.radio_button_fieldset :submission_type, inline: true do |fieldset|
+          fieldset.radio_input(SubmissionType::ONLINE, panel_id: :receipt_email_panel)
+          fieldset.radio_input(SubmissionType::PRINT_AND_POST)
+          fieldset.revealing_panel(:receipt_email_panel) do |panel|
+            panel.text_field :receipt_email
+          end
         end
       %>
 

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -85,6 +85,7 @@ en:
       attending_court: Attending court
       help_with_fees: Help with fees
       payment: How will you pay the application fee?
+      submission: How will you submit your application to court?
     groups:
       miam_certification_details: Certification details
       abduction_passport_possession: Details of the children’s passports
@@ -106,6 +107,7 @@ en:
       special_arrangements: Do you or the children need specific arrangements when you attend court?
       help_with_fees: Do you have a ‘Help with fees’ reference number?
       payment_type: Payment type
+      submission_type: Submission type
     separators:
       children_details_index_title: Child %{index}
       other_children_details_index_title: Other child %{index}
@@ -558,3 +560,10 @@ en:
         help_with_fees: Help with fees
         solicitor: Solicitor payment
         self_payment: I am paying myself
+    submission_type:
+      question: ''
+      answers:
+        online: Online
+        print_and_post: Print and post
+    submission_receipt_email:
+      question: 'A copy of your application will be sent to:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
     select_all_that_apply_or_none: &select_all_that_apply_or_none "Select all that apply or ‘None of these’"
     blank_exemptions_error: &blank_exemptions_error "Select at least one exemption or ‘None of these‘"
     account_purge_info: &account_purge_info "If you have not signed in for %{expire_in_days} days we delete your account for security reasons."
+    invalid_email_error: &invalid_email_error "Enter a valid email address"
+    blank_email_error: &blank_email_error "Enter an email address"
     sections:
       miam_exemptions: &miam_exemptions "MIAM exemptions"
       attending_court: &attending_court "Attending court"
@@ -715,6 +717,11 @@ en:
           page_title: Payment type
           heading: How will you pay the application fee?
           lead_text: The court fee is £215. Only the person applying to court (the applicant) needs to pay.
+      submission:
+        edit:
+          page_title: How would you submit your application?
+          heading: How would you like to submit your application to court?
+          lead_text: Your completed application can be sent straight to the court online, or you can print it and send it by post if you prefer.
       check_your_answers:
         edit:
           page_title: Check your answers
@@ -935,11 +942,14 @@ en:
       base:
         blank_orders: You must select at least one option
       email:
-        invalid: Enter a valid email address
-        blank: Enter an email address
+        invalid: *invalid_email_error
+        blank: *blank_email_error
       email_address:
-        invalid: Enter a valid email address
-        blank: Enter an email address
+        invalid: *invalid_email_error
+        blank: *blank_email_error
+      receipt_email:
+        invalid: *invalid_email_error
+        blank: *blank_email_error
       children_postcodes:
         invalid: Please enter a valid full postcode, with or without a space (e.g. 'SW1h 9AJ' or 'sw1h9aj')
         blank: Please enter a full postcode, with or without a space (e.g. 'SW1h 9AJ' or 'SW1h9AJ')
@@ -1235,6 +1245,8 @@ en:
         international_request_html: ""
       steps_application_payment_form:
         payment_type_html: ""
+      steps_application_submission_form:
+        submission_type_html: ""
 
       ### SCREENER ###
       #
@@ -1297,6 +1309,11 @@ en:
           self_payment_html: '<strong>I am paying myself</strong><br>You can pay over the phone using a credit or debit card, by post with a cheque, or in person at the court by cheque, cash or card.'
         hwf_reference_number: Enter your reference number
         solicitor_account_number: Enter solicitor’s fee account number
+      steps_application_submission_form:
+        submission_type:
+          online: Submit online
+          print_and_post: Print and send by post
+        receipt_email: Enter an email address if you would like to get a confirmation
       steps_application_declaration_form:
         declaration_made: I confirm that I believe that the facts stated in this application are true
       steps_alternatives_court_form:
@@ -1462,6 +1479,8 @@ en:
         participation_other_factors_details: For example, a learning disability or other mental or physical health problem
       steps_application_details_form:
         application_details: You do not have to give a full statement although you may be asked to provide one later.
+      steps_application_submission_form:
+        receipt_email: We will send an copy of your application to this address
       steps_abduction_passport_details_form:
         passport_possesion: Select all that apply
       steps_abduction_risk_details_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
       edit_step :intermediary
       edit_step :help_paying
       edit_step :payment
+      edit_step :submission
       edit_step :check_your_answers do
         get :resume, action: :resume
       end

--- a/db/migrate/20180525105634_add_submission_fields.rb
+++ b/db/migrate/20180525105634_add_submission_fields.rb
@@ -1,0 +1,6 @@
+class AddSubmissionFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :c100_applications, :submission_type, :string
+    add_column :c100_applications, :receipt_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180521113047) do
+ActiveRecord::Schema.define(version: 20180525105634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -123,6 +123,8 @@ ActiveRecord::Schema.define(version: 20180521113047) do
     t.boolean "declaration_made"
     t.string "payment_type"
     t.string "solicitor_account_number"
+    t.string "submission_type"
+    t.string "receipt_email"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/controllers/steps/application/submission_controller_spec.rb
+++ b/spec/controllers/steps/application/submission_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Application::SubmissionController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Application::SubmissionForm, C100App::ApplicationDecisionTree
+end

--- a/spec/forms/steps/application/submission_form_spec.rb
+++ b/spec/forms/steps/application/submission_form_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Application::SubmissionForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    submission_type: submission_type,
+    receipt_email: receipt_email,
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:submission_type) { SubmissionType::ONLINE.to_s }
+  let(:receipt_email) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:submission_type, :inclusion) }
+      it { should_not validate_presence_of(:receipt_email) }
+
+      context 'receipt_email' do
+        context 'email is not validated if not present' do
+          let(:receipt_email) { nil }
+          it { expect(subject).to be_valid }
+        end
+
+        context 'email is validated if present' do
+          let(:receipt_email) { 'xxx' }
+          it {
+            expect(subject).not_to be_valid
+            expect(subject.errors[:receipt_email]).to_not be_empty
+          }
+        end
+      end
+    end
+
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'when form is valid' do
+      context 'when submission type is `online`' do
+        let(:submission_type) { SubmissionType::ONLINE.to_s }
+        let(:receipt_email) { 'test@example.com' }
+
+        it 'saves the record' do
+          expect(c100_application).to receive(:update).with(
+            submission_type: 'online',
+            receipt_email: 'test@example.com',
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when submission type is `print_and_post`' do
+        let(:submission_type) { SubmissionType::PRINT_AND_POST.to_s }
+        let(:receipt_email) { 'test@example.com' }
+
+        it 'saves the record' do
+          expect(c100_application).to receive(:update).with(
+            submission_type: 'print_and_post',
+            receipt_email: nil,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -50,9 +50,10 @@ describe Summary::HtmlPresenter do
         allow(c100_application).to receive(:payment_type).and_return('whatever')
       end
 
-      it 'presents the Payment section instead of the HelpWithFees section' do
+      it 'presents the Payment and Submission sections instead of the HelpWithFees section' do
         expect(subject.sections).not_to include(Summary::HtmlSections::HelpWithFees)
         expect(subject.sections).to include(Summary::HtmlSections::Payment)
+        expect(subject.sections).to include(Summary::HtmlSections::Submission)
       end
     end
   end

--- a/spec/presenters/summary/html_sections/submission_spec.rb
+++ b/spec/presenters/summary/html_sections/submission_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::Submission do
+    let(:c100_application) {
+      instance_double(
+        C100Application,
+        submission_type: 'online',
+        receipt_email: 'test@example.com',
+      )
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:submission) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(AnswersGroup)
+        expect(answers[0].name).to eq(:submission_type)
+        expect(answers[0].change_path).to eq('/steps/application/submission')
+      end
+
+      context '`submission_type` answers group' do
+        let(:group) { answers[0] }
+
+        it 'has the right questions in the right order' do
+          expect(group.answers.count).to eq(2)
+
+          expect(group.answers[0]).to be_an_instance_of(Answer)
+          expect(group.answers[0].question).to eq(:submission_type)
+          expect(group.answers[0].value).to eq('online')
+
+          expect(group.answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group.answers[1].question).to eq(:submission_receipt_email)
+          expect(group.answers[1].value).to eq('test@example.com')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -115,6 +115,11 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
   context 'when the step is `payment`' do
     let(:step_params) { { payment: 'anything' } }
+    it { is_expected.to have_destination(:submission, :edit) }
+  end
+
+  context 'when the step is `submission`' do
+    let(:step_params) { { submission: 'anything' } }
     it { is_expected.to have_destination(:check_your_answers, :edit) }
   end
 

--- a/spec/value_objects/submission_type_spec.rb
+++ b/spec/value_objects/submission_type_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionType do
+  let(:value) { :foo }
+  subject     { described_class.new(value) }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(
+        online
+        print_and_post
+      ))
+    end
+  end
+end


### PR DESCRIPTION
This will capture the user decision to send the application online (and if so, optionally the email for a receipt) or print and post.

Also updated the CYA to show these details.

Only visible on local/staging environments. Still kind of a prototype, WIP, things may change.

<img width="666" alt="screen shot 2018-05-25 at 15 35 16" src="https://user-images.githubusercontent.com/687910/40550543-47787bde-6032-11e8-9ed8-7f745a31f3a4.png">
