### PR TITLE
Application submitted confirmation page

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -12,4 +12,17 @@ module CompletionStep
     # meaning it can't be drafted (and don't appear anymore in drafts).
     current_c100_application.completed!
   end
+
+  # TODO: I don't understand why these two different ways of retrieving the court
+  # data? Can we just get everything with the first (or the second) one?
+
+  def court_from_screener_answers
+    Court.new.from_courtfinder_data!(
+      current_c100_application.screener_answers.try(:local_court)
+    )
+  end
+
+  def local_court
+    Court.new(current_c100_application.screener_answers.try(:local_court))
+  end
 end

--- a/app/controllers/steps/application/check_your_answers_controller.rb
+++ b/app/controllers/steps/application/check_your_answers_controller.rb
@@ -8,7 +8,7 @@ module Steps
       end
 
       def update
-        update_and_advance(DeclarationForm, as: :declaration)
+        update_and_advance(DeclarationForm, as: step_name)
       end
 
       def resume; end
@@ -17,6 +17,14 @@ module Steps
 
       def set_presenter
         @presenter = Summary::HtmlPresenter.new(current_c100_application)
+      end
+
+      def step_name
+        if current_c100_application.online_submission?
+          :online_submission
+        else
+          :print_and_post_submission
+        end
       end
     end
   end

--- a/app/controllers/steps/completion/confirmation_controller.rb
+++ b/app/controllers/steps/completion/confirmation_controller.rb
@@ -1,6 +1,6 @@
 module Steps
   module Completion
-    class WhatNextController < Steps::CompletionStepController
+    class ConfirmationController < Steps::CompletionStepController
       include CompletionStep
 
       def show

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -33,6 +33,10 @@ class C100Application < ApplicationRecord
     where('created_at <= :date', date: date).destroy_all
   end
 
+  def online_submission?
+    submission_type.eql?(SubmissionType::ONLINE.to_s)
+  end
+
   def confidentiality_enabled?
     address_confidentiality.eql?(GenericYesNo::YES.to_s)
   end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -24,6 +24,14 @@ module Summary
       ].flatten.select(&:show?)
     end
 
+    def before_submit_warning
+      ['.submit_warning', submission_type].join('.')
+    end
+
+    def submit_button_label
+      ['submit_application', submission_type].join('.')
+    end
+
     private
 
     def miam_questions
@@ -73,6 +81,10 @@ module Summary
           HtmlSections::HelpWithFees.new(c100_application)
         ]
       end
+    end
+
+    def submission_type
+      c100_application.submission_type || SubmissionType::PRINT_AND_POST
     end
   end
 end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -31,8 +31,10 @@ module C100App
         edit(:submission)
       when :help_paying, :submission
         edit(:check_your_answers)
-      when :declaration
+      when :print_and_post_submission
         show('/steps/completion/what_next')
+      when :online_submission
+        show('/steps/completion/confirmation')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/views/steps/application/check_your_answers/edit.html.erb
+++ b/app/views/steps/application/check_your_answers/edit.html.erb
@@ -21,7 +21,7 @@
         <span class="visually-hidden gv-c-notice__icon-fallback-text"><%= t '.warning_title' %></span>
       </i>
       <strong class=" bold-small gv-c-notice__text">
-        <%= t '.warning_text' %>
+        <%= t '.false_information_warning' %>
       </strong>
     </div>
 
@@ -32,8 +32,11 @@
 
   <br/>
   <div class="panel panel-border-narrow">
-    <p><%=t '.no_more_changes_warning' %></p>
+    <p><%=t @presenter.before_submit_warning %></p>
   </div>
 
-  <%= f.continue_button %>
+  <%= f.continue_button(
+    continue: @presenter.submit_button_label,
+    save_and_continue: @presenter.submit_button_label
+  ) %>
 <% end %>

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -1,0 +1,29 @@
+<% title 'Application submitted' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <div class="grid_content_header govuk-box-highlight">
+      <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge">Application submitted</h1>
+      <p class="app__lede lede gv-u-text-lede">Your reference number is: XXXX-XXXX</p>
+    </div>
+
+    <p class="lede gv-u-text-lede">
+      Your application has been sent to the court.
+
+      <% if current_c100_application.receipt_email.present? %>
+        We’ve emailed a confirmation of this with a copy of your application to
+        <strong><%= current_c100_application.receipt_email %></strong>
+      <% end %>
+    </p>
+
+    <h3 class="heading-medium">Pay the application fee</h3>
+    <%= render partial: 'steps/shared/payment_instructions' %>
+
+    <h3 class="heading-medium">Download a copy of your application</h3>
+    <%= render partial: 'steps/shared/download_instructions' %>
+
+    <hr>
+
+    <%= render partial: 'steps/shared/court_help', locals: {court: @court} %>
+  </div>
+</div>

--- a/app/views/steps/completion/what_next/show.en.html.erb
+++ b/app/views/steps/completion/what_next/show.en.html.erb
@@ -19,19 +19,7 @@
         <ol class="list list-number">
           <li class="util_mt-medium">
             <h3 class="heading-medium">Download your application</h3>
-            <p>
-              This will be a PDF. If you cannot open the PDF after downloading, try using <a href="https://get.adobe.com/uk/reader/" target="external_link" rel="external">Adobe Acrobat Reader</a>.
-            </p>
-
-            <% unless user_signed_in? %>
-              <div class="panel panel-border-narrow">
-                <p>To avoid losing your application, you must download it now. You cannot return to a completed application.</p>
-              </div>
-            <% end %>
-
-            <p>
-              <%= link_to 'Download your PDF application', steps_completion_summary_path(format: :pdf), class: 'button ga-pageLink', data: {ga_category: 'completion', ga_label: 'download application'} %>
-            </p>
+            <%= render partial: 'steps/shared/download_instructions' %>
           </li>
 
           <li>
@@ -60,13 +48,7 @@
 
           <li>
             <h3 class="heading-medium">Pay the application fee</h3>
-            <p>
-              It costs £215 to apply. Someone from the court will telephone you within 3 working days of receiving your application to take payment using a credit or debit card.
-            </p>
-            <p>You can also pay by post with a cheque made out to ‘HM Courts and Tribunals Service’, or in person at the court by cheque, cash or card.</p>
-            <p>
-              You don’t need to pay if you have a <a href="https://www.gov.uk/get-help-with-court-fees" target="external_link" rel="external">‘Help with fees’</a> reference.
-            </p>
+            <%= render partial: 'steps/shared/payment_instructions' %>
           </li>
         </ol>
       </div>
@@ -74,47 +56,6 @@
 
     <hr/>
 
-    <div class="govuk-govspeak gv-s-prose">
-      <h2 class="heading-large gv-u-heading-large">If you need help</h2>
-      <p>
-        You can contact the court if you need help with your application. Court staff can’t give legal advice so you’ll
-        need to
-        <a href="https://solicitors.lawsociety.org.uk/" target="external_link" rel="external">find a legal advisor</a> if
-        you have any issues.
-      </p>
-
-      <dl id="court-contact-details">
-        <%- unless @court.email.blank? %>
-          <dt><strong>Email</strong></dt>
-          <dd><%= mail_to @court.email, @court.email, class: 'ga-pageLink', data: {ga_category: 'completion', ga_label: 'email court'} %></dd>
-        <%- end %>
-
-        <%- unless @court.phone_number.blank? %>
-          <dt><strong>Phone number</strong></dt>
-          <dd><%= @court.phone_number %></dd>
-        <%- end %>
-
-        <%- if @court.opening_times? %>
-          <dt><strong>Opening times</strong></dt>
-          <%- @court.opening_times.each do |opening_time| %>
-            <dd><%= opening_time %></dd>
-          <%- end %>
-        <%- end %>
-      </dl>
-
-      <p>
-        <%= link_to "More information about #{@court.name}", C100App::CourtfinderAPI.new.court_url(@court.slug), target: 'external_link', rel: 'external' %>
-      </p>
-    </div>
-
-    <div class="govuk-govspeak gv-s-prose util_mt-large">
-      <h2 class="heading-large gv-u-heading-large">We’d like your feedback</h2>
-      <p>
-        Would you like to <%= link_to 'complete a 5-minute survey', Rails.configuration.surveys[:success], target: 'external_link', rel: 'external' %> to give us your feedback about the online service you have just used?
-      </p>
-      <p>
-        This will help us to improve it. Your feedback won’t affect your application in any way.
-      </p>
-    </div>
+    <%= render partial: 'steps/shared/court_help', locals: {court: @court} %>
   </div>
 </div>

--- a/app/views/steps/shared/_court_help.en.html.erb
+++ b/app/views/steps/shared/_court_help.en.html.erb
@@ -1,0 +1,44 @@
+<div class="govuk-govspeak gv-s-prose">
+  <h2 class="heading-large gv-u-heading-large">If you need help</h2>
+  <p>
+    You can contact the court if you need help with your application. Court staff can’t give legal advice so you’ll
+    need to
+    <a href="https://solicitors.lawsociety.org.uk/" target="external_link" rel="external">find a legal advisor</a> if
+    you have any issues.
+  </p>
+
+  <dl id="court-contact-details">
+    <%- unless court.email.blank? %>
+      <dt><strong>Email</strong></dt>
+      <dd><%= mail_to court.email, court.email, class: 'ga-pageLink', data: {ga_category: 'completion', ga_label: 'email court'} %></dd>
+    <%- end %>
+
+    <%- unless court.phone_number.blank? %>
+      <dt><strong>Phone number</strong></dt>
+      <dd><%= court.phone_number %></dd>
+    <%- end %>
+
+    <%- if court.opening_times? %>
+      <dt><strong>Opening times</strong></dt>
+      <%- court.opening_times.each do |opening_time| %>
+        <dd><%= opening_time %></dd>
+      <%- end %>
+    <%- end %>
+  </dl>
+
+  <p>
+    <%= link_to "More information about #{court.name}", C100App::CourtfinderAPI.new.court_url(court.slug), target: 'external_link', rel: 'external' %>
+  </p>
+</div>
+
+<div class="govuk-govspeak gv-s-prose util_mt-large">
+  <h2 class="heading-large gv-u-heading-large">We’d like your feedback</h2>
+  <p>
+    Would you like
+    to <%= link_to 'complete a 5-minute survey', Rails.configuration.surveys[:success], target: 'external_link', rel: 'external' %>
+    to give us your feedback about the online service you have just used?
+  </p>
+  <p>
+    This will help us to improve it. Your feedback won’t affect your application in any way.
+  </p>
+</div>

--- a/app/views/steps/shared/_download_instructions.en.html.erb
+++ b/app/views/steps/shared/_download_instructions.en.html.erb
@@ -1,0 +1,17 @@
+<p>
+  This will be a PDF. If you cannot open the PDF after downloading, try using
+  <a href="https://get.adobe.com/uk/reader/" target="external_link" rel="external">Adobe Acrobat Reader</a>.
+</p>
+
+<% unless user_signed_in? %>
+  <div class="panel panel-border-narrow">
+    <p>To avoid losing your application, you must download it now. You cannot return to a completed application.</p>
+  </div>
+<% end %>
+
+<p>
+  <%= link_to 'Download your PDF application',
+              steps_completion_summary_path(format: :pdf),
+              class: 'button ga-pageLink',
+              data: {ga_category: 'completion', ga_label: 'download application'} %>
+</p>

--- a/app/views/steps/shared/_payment_instructions.en.html.erb
+++ b/app/views/steps/shared/_payment_instructions.en.html.erb
@@ -1,0 +1,12 @@
+<p>
+    It costs £215 to apply. Someone from the court will telephone you within 3 working days of receiving your
+    application to take payment using a credit or debit card.
+</p>
+<p>
+    You can also pay by post with a cheque made out to ‘HM Courts and Tribunals Service’, or in person at the court by
+    cheque, cash or card.
+</p>
+<p>
+    You don’t need to pay if you have a <a href="https://www.gov.uk/get-help-with-court-fees" target="external_link"
+                                           rel="external">‘Help with fees’</a> reference.
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -730,8 +730,10 @@ en:
           declaration_heading: Declaration
           declaration_lead_text: You must confirm that the information you’ve provided in your application is true.
           warning_title: Warning
-          warning_text: You could be fined or imprisoned for contempt of court if you deliberately submit false information.
-          no_more_changes_warning: Once you continue, you cannot make any further changes to your application.
+          false_information_warning: You could be fined or imprisoned for contempt of court if you deliberately submit false information.
+          submit_warning:
+            online: Once you submit your application, you cannot make any further changes. You can download a copy of your submitted application on the next page.
+            print_and_post: Once you continue, you cannot make any further changes to your application. You can download a copy of your application on the next page.
         resume:
           page_title: Resume application
           heading: Resume application
@@ -1555,6 +1557,9 @@ en:
       change_password: Change my password
       save_and_continue: Save and continue
       confirm_and_finish: Confirm and finish
+      submit_application:
+        online: Submit application
+        print_and_post: Continue
 
   number:
     currency:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,7 @@ Rails.application.routes.draw do
       edit_step :request
     end
     namespace :completion do
+      show_step :confirmation
       show_step :what_next
       show_step :summary
       # The following is an alias of the `what_next` route, for analytics tracking

--- a/spec/controllers/steps/application/check_your_answers_controller_spec.rb
+++ b/spec/controllers/steps/application/check_your_answers_controller_spec.rb
@@ -28,4 +28,35 @@ RSpec.describe Steps::Application::CheckYourAnswersController, type: :controller
       end
     end
   end
+
+  context 'step name based on submission type' do
+    let(:existing_case) { C100Application.create(status: :in_progress, submission_type: submission_type) }
+
+    context 'when the submission type is online' do
+      let(:submission_type) { SubmissionType::ONLINE }
+
+      it 'asks the decision tree for the next destination and redirects there' do
+        expect(subject).to receive(:update_and_advance).with(Steps::Application::DeclarationForm, as: :online_submission)
+        put :update, params: {}, session: { c100_application_id: existing_case.id }
+      end
+    end
+
+    context 'when the submission type is print and post' do
+      let(:submission_type) { SubmissionType::PRINT_AND_POST }
+
+      it 'asks the decision tree for the next destination and redirects there' do
+        expect(subject).to receive(:update_and_advance).with(Steps::Application::DeclarationForm, as: :print_and_post_submission)
+        put :update, params: {}, session: { c100_application_id: existing_case.id }
+      end
+    end
+
+    context 'when the submission type is not present' do
+      let(:submission_type) { nil }
+
+      it 'asks the decision tree for the next destination and redirects there' do
+        expect(subject).to receive(:update_and_advance).with(Steps::Application::DeclarationForm, as: :print_and_post_submission)
+        put :update, params: {}, session: { c100_application_id: existing_case.id }
+      end
+    end
+  end
 end

--- a/spec/controllers/steps/completion/confirmation_controller_spec.rb
+++ b/spec/controllers/steps/completion/confirmation_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Completion::ConfirmationController, type: :controller do
+  it_behaves_like 'a completion step controller'
+end

--- a/spec/controllers/steps/completion/what_next_controller_spec.rb
+++ b/spec/controllers/steps/completion/what_next_controller_spec.rb
@@ -1,55 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Completion::WhatNextController, type: :controller do
-  context 'in standard interactions' do
-    let(:court){ instance_double(Court) }
-    before do
-      allow(subject).to receive(:court_from_screener_answers).and_return(court)
-    end
-
-    it_behaves_like 'a show step controller'
-    it_behaves_like 'a completion step controller'
-  end
-
-  describe '#court_from_screener_answers' do
-    let(:screener_answers){ instance_double(ScreenerAnswers, local_court: local_court) }
-    let(:c100_application){ instance_double(C100Application, screener_answers: screener_answers)}
-    before do
-      allow(subject).to receive(:current_c100_application).and_return(c100_application)
-    end
-
-    context 'when there is a local_court in screener_answers' do
-      let(:local_court){ {} }
-      let(:new_court){ instance_double(Court) }
-
-      before do
-        allow(c100_application).to receive(:screener_answers).and_return(screener_answers)
-        allow_any_instance_of(Court).to receive(:from_courtfinder_data!).with(local_court).and_return(new_court)
-
-      end
-
-      it 'creates a new Court from_court_finder_data passing the local_court' do
-        expect_any_instance_of(Court).to receive(:from_courtfinder_data!).with(local_court)
-        subject.send(:court_from_screener_answers)
-      end
-
-      it 'returns the new Court' do
-        expect(subject.send(:court_from_screener_answers)).to eq(new_court)
-      end
-    end
-
-    context 'when there is no local_court in screener_answers' do
-      let(:local_court){ nil }
-      it 'returns a new Court' do
-        expect(subject.send(:court_from_screener_answers)).to be_a(Court)
-      end
-
-      describe 'the returned Court' do
-        let(:returned_court){ subject.send(:court_from_screener_answers) }
-        it 'has nil instance_variables' do
-          expect(returned_court.instance_variables).to be_empty
-        end
-      end
-    end
-  end
+  it_behaves_like 'a completion step controller'
 end

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe C100Application, type: :model do
     end
   end
 
+  describe '#online_submission?' do
+    context 'for `online` values' do
+      let(:attributes) { {submission_type: 'online'} }
+      it { expect(subject.online_submission?).to eq(true) }
+    end
+
+    context 'for other values' do
+      let(:attributes) { {submission_type: 'whatever'} }
+      it { expect(subject.online_submission?).to eq(false) }
+    end
+  end
+
   describe '#confidentiality_enabled?' do
     context 'for `yes` values' do
       let(:attributes) { {address_confidentiality: 'yes'} }

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -4,6 +4,44 @@ describe Summary::HtmlPresenter do
   let(:c100_application) { instance_double(C100Application) }
   subject { described_class.new(c100_application) }
 
+  describe '#before_submit_warning' do
+    let(:c100_application) { instance_double(C100Application, submission_type: submission_type) }
+
+    context 'for online submissions' do
+      let(:submission_type) { 'online' }
+      it { expect(subject.before_submit_warning).to eq('.submit_warning.online') }
+    end
+
+    context 'for print and post submissions' do
+      let(:submission_type) { 'print_and_post' }
+      it { expect(subject.before_submit_warning).to eq('.submit_warning.print_and_post') }
+    end
+
+    context 'defaults to print and post if `submission_type` is not present' do
+      let(:submission_type) { nil }
+      it { expect(subject.before_submit_warning).to eq('.submit_warning.print_and_post') }
+    end
+  end
+
+  describe '#submit_button_label' do
+    let(:c100_application) { instance_double(C100Application, submission_type: submission_type) }
+
+    context 'for online submissions' do
+      let(:submission_type) { 'online' }
+      it { expect(subject.submit_button_label).to eq('submit_application.online') }
+    end
+
+    context 'for print and post submissions' do
+      let(:submission_type) { 'print_and_post' }
+      it { expect(subject.submit_button_label).to eq('submit_application.print_and_post') }
+    end
+
+    context 'defaults to print and post if `submission_type` is not present' do
+      let(:submission_type) { nil }
+      it { expect(subject.submit_button_label).to eq('submit_application.print_and_post') }
+    end
+  end
+
   describe '#sections' do
     before do
       allow_any_instance_of(Summary::Sections::BaseSectionPresenter).to receive(:show?).and_return(true)

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -123,8 +123,13 @@ RSpec.describe C100App::ApplicationDecisionTree do
     it { is_expected.to have_destination(:check_your_answers, :edit) }
   end
 
-  context 'when the step is `declaration`' do
-    let(:step_params) { { declaration: 'anything' } }
+  context 'when the step is `print_and_post_submission`' do
+    let(:step_params) { { print_and_post_submission: 'anything' } }
     it { is_expected.to have_destination('/steps/completion/what_next', :show) }
+  end
+
+  context 'when the step is `online_submission`' do
+    let(:step_params) { { online_submission: 'anything' } }
+    it { is_expected.to have_destination('/steps/completion/confirmation', :show) }
   end
 end


### PR DESCRIPTION
Depending on whether it is an online submission or a print and post, we customise a bit the CYA copy and continue button label.

And DRY a bit the current what next and new confirmation pages to use common partials.

<img width="1030" alt="screen shot 2018-05-29 at 09 30 01" src="https://user-images.githubusercontent.com/687910/40653905-838e4220-6334-11e8-8099-9d2a3c8859ee.png">

<img width="502" alt="screen shot 2018-05-29 at 11 37 31" src="https://user-images.githubusercontent.com/687910/40653963-b740b99a-6334-11e8-8ade-083ea5e930e0.png">
