### PR TITLE
Add a reference code to PDF and confirmation page

### DIFF
--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -1,4 +1,6 @@
 class C100Application < ApplicationRecord
+  include ApplicationReference
+
   enum status: {
     screening: 0,
     in_progress: 1,

--- a/app/models/concerns/application_reference.rb
+++ b/app/models/concerns/application_reference.rb
@@ -1,0 +1,34 @@
+module ApplicationReference
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def find_by_reference_code(ref)
+      year, month, uuid_part = ref.split('/')
+
+      where(
+        created_at: date_range(year, month)
+      ).where(
+        'id::text ILIKE :uuid_filter', uuid_filter: "#{uuid_part}%"
+      ).take
+    end
+
+    def date_range(year, month)
+      date = Date.new(year.to_i, month.to_i)
+      [date.beginning_of_month..date.end_of_month]
+    end
+  end
+
+  def reference_code
+    @_reference_code ||= [date_token, uuid_token].join('/').upcase
+  end
+
+  private
+
+  def date_token
+    created_at.strftime('%Y/%m')
+  end
+
+  def uuid_token
+    id.split('-').first
+  end
+end

--- a/app/services/c100_app/pdf_generator.rb
+++ b/app/services/c100_app/pdf_generator.rb
@@ -17,7 +17,7 @@ module C100App
     def pdf_from_presenter(presenter)
       WickedPdf.new.pdf_from_string(
         render(presenter),
-        footer: { right: "#{presenter.name}  #{presenter.page_number}" }
+        footer: { right: footer_line(presenter) }
       )
     end
 
@@ -26,6 +26,14 @@ module C100App
         template: presenter.template,
         locals: { presenter: presenter }
       )
+    end
+
+    def footer_line(presenter)
+      [
+        presenter.c100_application.reference_code,
+        presenter.name,
+        presenter.page_number,
+      ].join('   ')
     end
 
     def combiner

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -4,8 +4,10 @@
   <div class="column-two-thirds">
     <div class="grid_content_header govuk-box-highlight">
       <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge">Application submitted</h1>
-      <p class="app__lede lede gv-u-text-lede">Your reference number is: XXXX-XXXX</p>
+      <p class="app__lede lede gv-u-text-lede">Your reference is: <%= current_c100_application.reference_code %></p>
     </div>
+
+    <br/>
 
     <p class="lede gv-u-text-lede">
       Your application has been sent to the court.

--- a/spec/models/concerns/application_reference_spec.rb
+++ b/spec/models/concerns/application_reference_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationReference do
+  let(:test_class) { C100Application }
+
+  subject { test_class.new(id: 'db2ed4fd-b1d1-405b-ade6-4c1405512e9d', created_at: Date.new(2018, 5, 20)) }
+
+  context '#reference_code' do
+    it { expect(subject.reference_code).to eq('2018/05/DB2ED4FD') }
+  end
+
+  context '.find_by_reference_code' do
+    let(:date_finder_double) { double('date_finder_double').as_null_object }
+    let(:uuid_finder_double) { double('uuid_finder_double').as_null_object }
+
+    it 'has the correct date filter criteria' do
+      expect(test_class).to receive(:where).with(
+        created_at: [Date.new(2018, 5, 1)..Date.new(2018, 5, 31)]
+      ).and_return(date_finder_double)
+
+      test_class.find_by_reference_code('2018/05/DB2ED4FD')
+    end
+
+    it 'has the correct uuid filter criteria' do
+      expect(test_class).to receive(:where).and_return(date_finder_double)
+
+      expect(date_finder_double).to receive(:where).with(
+        "id::text ILIKE :uuid_filter", uuid_filter: 'DB2ED4FD%'
+      ).and_return(uuid_finder_double)
+
+      test_class.find_by_reference_code('2018/05/DB2ED4FD')
+    end
+  end
+end

--- a/spec/services/c100_app/pdf_generator_spec.rb
+++ b/spec/services/c100_app/pdf_generator_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe C100App::PdfGenerator do
   end
 
   describe '#generate' do
+    let(:c100_application) { double('c100_application') }
+
     let(:presenter) {
       double(
         'Presenter',
@@ -17,10 +19,15 @@ RSpec.describe C100App::PdfGenerator do
         page_number: '[xx]/[yy]',
         template: 'path/to/template',
         raw_file_path: raw_file_path,
+        c100_application: c100_application,
       )
     }
     let(:document)  { 'a form document' }
     let(:raw_file_path) { nil }
+
+    before do
+      allow(c100_application).to receive(:reference_code).and_return('12345/XYZ')
+    end
 
     it 'renders a form using a presenter' do
       expect(ApplicationController).to receive(:render).with(
@@ -28,7 +35,7 @@ RSpec.describe C100App::PdfGenerator do
       ).and_return(document)
 
       expect(wicked_pdf).to receive(:pdf_from_string).with(
-        document, { footer: { right: 'Test  [xx]/[yy]' } }
+        document, { footer: { right: '12345/XYZ   Test   [xx]/[yy]' } }
       ).and_return(document)
 
       # Using 0 copies just to make this test scenario simpler to mock,


### PR DESCRIPTION
This reference code is just a simple short version of the created_at, and the UUID of the application.

The purpose is mainly give the user peace of mind having a reference code to confirm their application has been sent and to be able to cross-reference in the future PDF with their codes in case the user wants to know about their application.

Will also be sent in the receipt email if the user chose to.

<img width="662" alt="screen shot 2018-05-29 at 16 37 32" src="https://user-images.githubusercontent.com/687910/40669334-9c8fd5c0-635e-11e8-8def-6638188e2978.png">
