### PR TITLE
Add an email interceptor intended for dev/test envs

### DIFF
--- a/config/initializers/court_email_interceptor.rb
+++ b/config/initializers/court_email_interceptor.rb
@@ -1,0 +1,7 @@
+# Intercept any email potentially sent to court in local or test environments.
+# This will avoid courts inadvertently receiving test, not real, applications.
+#
+if %w(development test).include?(Rails.env) || ENV['DEV_TOOLS_ENABLED'].present?
+  require_relative '../../lib/court_email_interceptor'
+  ActionMailer::Base.register_interceptor(CourtEmailInterceptor)
+end

--- a/lib/court_email_interceptor.rb
+++ b/lib/court_email_interceptor.rb
@@ -1,0 +1,35 @@
+# This interceptor is only used in dev or test environments.
+# Refer to `/initializers/court_email_interceptor.rb` for more information.
+#
+class CourtEmailInterceptor
+  # Add here the delivery handlers allowed to bypass the interception.
+  DELIVERY_WHITELIST = [
+    NotifyMailer,
+  ].freeze
+
+  class << self
+    def delivering_email(message)
+      return if whitelisted?(message)
+      intercept_email!(message)
+    end
+
+    private
+
+    def whitelisted?(message)
+      DELIVERY_WHITELIST.include?(message.delivery_handler)
+    end
+
+    def intercept_email!(message)
+      # If the user chose to receive a confirmation receipt, we will use this
+      # `reply-to` address as the new recipient of the intercepted email.
+      # Otherwise we will just stop the delivery completely.
+      #
+      if message.reply_to.present?
+        message.subject = "#{message.subject} | (Original recipient: #{message.to.join(',')})"
+        message.to = message.reply_to
+      else
+        message.perform_deliveries = false
+      end
+    end
+  end
+end

--- a/spec/lib/court_email_interceptor_spec.rb
+++ b/spec/lib/court_email_interceptor_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe CourtEmailInterceptor do
+  let(:message) {
+    Mail::Message.new(
+      subject: 'Test email',
+      to: ['recipient@example.com'],
+      reply_to: reply_to,
+    )
+  }
+  let(:reply_to) { nil }
+
+  def deliver_email!
+    described_class.delivering_email(message)
+  end
+
+  context 'for a whitelisted delivery handler' do
+    before do
+      message.delivery_handler = NotifyMailer
+    end
+
+    it 'let the email be sent untouched' do
+      expect(described_class).not_to receive(:intercept_email!)
+      deliver_email!
+    end
+  end
+
+  context 'for a non-whitelisted delivery handler' do
+    before do
+      message.delivery_handler = 'whatever'
+    end
+
+    context 'message with reply-to' do
+      let(:reply_to) { ['replies@example.com'] }
+
+      it 'should be intercepted and the subject changed' do
+        deliver_email!
+        expect(message.subject).to eq('Test email | (Original recipient: recipient@example.com)')
+      end
+
+      it 'should be intercepted and the recipient changed' do
+        deliver_email!
+        expect(message.to).to eq(reply_to)
+      end
+
+      it 'should perform deliveries' do
+        expect(message.perform_deliveries).to eq(true)
+      end
+    end
+
+    context 'message without reply-to' do
+      let(:reply_to) { nil }
+
+      it 'should not perform deliveries' do
+        deliver_email!
+        expect(message.perform_deliveries).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to avoid inadvertently sending to court test, not real, applications, once we integrate the online submission.

This interceptor works on a whitelist basis, letting through emails that are 'safe' to send, and intercepting others, based on their `delivery_handler`.