### PR TITLE
Fix interceptor when there is no reply-to address

### DIFF
--- a/lib/court_email_interceptor.rb
+++ b/lib/court_email_interceptor.rb
@@ -23,14 +23,10 @@ class CourtEmailInterceptor
     def intercept_email!(message)
       # If the user chose to receive a confirmation receipt, we will use this
       # `reply-to` address as the new recipient of the intercepted email.
-      # Otherwise we will just stop the delivery completely.
+      # Otherwise we will default to the `from` address.
       #
-      if message.reply_to.present?
-        message.subject = "#{message.subject} | (Original recipient: #{message.to.join(',')})"
-        message.to = message.reply_to
-      else
-        message.perform_deliveries = false
-      end
+      message.subject = "#{message.subject} | (Original recipient: #{message.to.join(',')})"
+      message.to = message.reply_to.presence || message.from
     end
   end
 end

--- a/spec/lib/court_email_interceptor_spec.rb
+++ b/spec/lib/court_email_interceptor_spec.rb
@@ -4,6 +4,7 @@ describe CourtEmailInterceptor do
   let(:message) {
     Mail::Message.new(
       subject: 'Test email',
+      from: ['from@example.com'],
       to: ['recipient@example.com'],
       reply_to: reply_to,
     )
@@ -34,30 +35,30 @@ describe CourtEmailInterceptor do
       message.delivery_handler = 'whatever'
     end
 
+    it 'should be intercepted and the subject changed' do
+      deliver_email!
+      expect(message.subject).to eq('Test email | (Original recipient: recipient@example.com)')
+    end
+
+    it 'should perform deliveries' do
+      expect(message.perform_deliveries).to eq(true)
+    end
+
     context 'message with reply-to' do
       let(:reply_to) { ['replies@example.com'] }
 
-      it 'should be intercepted and the subject changed' do
-        deliver_email!
-        expect(message.subject).to eq('Test email | (Original recipient: recipient@example.com)')
-      end
-
-      it 'should be intercepted and the recipient changed' do
+      it 'changes the recipient to be the `REPLY-TO` address' do
         deliver_email!
         expect(message.to).to eq(reply_to)
-      end
-
-      it 'should perform deliveries' do
-        expect(message.perform_deliveries).to eq(true)
       end
     end
 
     context 'message without reply-to' do
       let(:reply_to) { nil }
 
-      it 'should not perform deliveries' do
+      it 'changes the recipient to be the `FROM` address' do
         deliver_email!
-        expect(message.perform_deliveries).to eq(false)
+        expect(message.to).to eq(['from@example.com'])
       end
     end
   end


### PR DESCRIPTION
Cancelling the delivery with `message.perform_deliveries = false` was not having an effect, so to not spam courts, we will send instead this emails to our google group.

If the reply-to is present, we continue using this.