### PR TITLE
Very basic application stats

### DIFF
--- a/app/models/cumulative_data.rb
+++ b/app/models/cumulative_data.rb
@@ -1,0 +1,68 @@
+class CumulativeData < ApplicationRecord
+  # Data points processed daily through `/lib/tasks/daily_tasks.rake`
+  #
+  # To create new data points, add the field to the table and to this
+  # collection, and then implement a class method of the same name.
+  #
+  DATA_POINTS ||= [
+    :applications_created,
+    :applications_eligible,
+    :applications_completed,
+    :applications_saved,
+    :applications_online_submission,
+    :applications_postal_submission,
+  ].freeze
+
+  def self.process!
+    data = {}
+
+    DATA_POINTS.each_with_object(data) do |column, hash|
+      hash[column] = public_send(column)
+    end
+
+    create(data)
+  end
+
+  # The assumption here is we will be running a daily task to gather data
+  # from the day before. If this assumption ever changes, adapt this method.
+  def self.finder
+    C100Application.where(
+      created_at: [Date.yesterday.beginning_of_day..Date.yesterday.end_of_day]
+    )
+  end
+
+  # Implement new data points below, as class methods
+  #
+  class << self
+    def applications_created
+      finder.count
+    end
+
+    # Any application that has completed the screener, no matter the status
+    def applications_eligible
+      finder.where(
+        'navigation_stack && ?', '{/steps/screener/done, /entrypoint/v1}'
+      ).count
+    end
+
+    def applications_completed
+      finder.completed.count
+    end
+
+    def applications_saved
+      finder.with_owner.count
+    end
+
+    def applications_online_submission
+      finder.where(
+        submission_type: SubmissionType::ONLINE.to_s
+      ).count
+    end
+
+    def applications_postal_submission
+      finder.where(
+        submission_type: SubmissionType::PRINT_AND_POST.to_s
+      ).count
+    end
+  end
+end

--- a/db/migrate/20180605110750_cumulative_data_table.rb
+++ b/db/migrate/20180605110750_cumulative_data_table.rb
@@ -1,7 +1,8 @@
 class CumulativeDataTable < ActiveRecord::Migration[5.1]
   def change
     create_table :cumulative_data, id: false do |t|
-      t.datetime :created_at, primary_key: true
+      t.datetime :created_at, null: false
+      t.date :reading_date, primary_key: true
 
       t.integer :applications_created
       t.integer :applications_eligible
@@ -9,6 +10,9 @@ class CumulativeDataTable < ActiveRecord::Migration[5.1]
       t.integer :applications_saved
       t.integer :applications_online_submission
       t.integer :applications_postal_submission
+
+      t.integer :miam_kickouts
+      t.integer :miam_expired
     end
   end
 end

--- a/db/migrate/20180605110750_cumulative_data_table.rb
+++ b/db/migrate/20180605110750_cumulative_data_table.rb
@@ -1,0 +1,14 @@
+class CumulativeDataTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :cumulative_data, id: false do |t|
+      t.datetime :created_at, primary_key: true
+
+      t.integer :applications_created
+      t.integer :applications_eligible
+      t.integer :applications_completed
+      t.integer :applications_saved
+      t.integer :applications_online_submission
+      t.integer :applications_postal_submission
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180530120103) do
+ActiveRecord::Schema.define(version: 20180605110750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,6 +186,15 @@ ActiveRecord::Schema.define(version: 20180530120103) do
     t.text "previous_details"
     t.uuid "c100_application_id"
     t.index ["c100_application_id"], name: "index_court_proceedings_on_c100_application_id"
+  end
+
+  create_table "cumulative_data", primary_key: "created_at", id: :datetime, force: :cascade do |t|
+    t.integer "applications_created"
+    t.integer "applications_eligible"
+    t.integer "applications_completed"
+    t.integer "applications_saved"
+    t.integer "applications_online_submission"
+    t.integer "applications_postal_submission"
   end
 
   create_table "email_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -188,13 +188,16 @@ ActiveRecord::Schema.define(version: 20180605110750) do
     t.index ["c100_application_id"], name: "index_court_proceedings_on_c100_application_id"
   end
 
-  create_table "cumulative_data", primary_key: "created_at", id: :datetime, force: :cascade do |t|
+  create_table "cumulative_data", primary_key: "reading_date", id: :date, force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.integer "applications_created"
     t.integer "applications_eligible"
     t.integer "applications_completed"
     t.integer "applications_saved"
     t.integer "applications_online_submission"
     t.integer "applications_postal_submission"
+    t.integer "miam_kickouts"
+    t.integer "miam_expired"
   end
 
   create_table "email_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -8,6 +8,8 @@ task :daily_tasks do
   Rake::Task['draft_reminders:first_email'].invoke
   Rake::Task['draft_reminders:last_email'].invoke
 
+  Rake::Task['stats:cumulative_data'].invoke
+
   log 'Finished daily tasks'
 end
 
@@ -40,6 +42,13 @@ namespace :draft_reminders do
 
     log "#{task_name}  - Count: #{rule_set.count}"
     C100App::DraftReminders.new(rule_set: rule_set).run
+  end
+end
+
+namespace :stats do
+  task cumulative_data: :environment do
+    log 'Processing cumulative data points...'
+    CumulativeData.process!
   end
 end
 


### PR DESCRIPTION
As our retention policy is quite restrictive (28 days for applications), and in order to quickly answer question like `how many applications were submitted last week`, etc. we need a way to persist totals for the most common metrics.

In GA we have almost all of this information too, so not really spending too much time here duplicating something GA do quite well.

Run daily through `daily_tasks.rake`