### PR TITLE
Add a simple URL shortener feature

### DIFF
--- a/app/lib/short_url_expander.rb
+++ b/app/lib/short_url_expander.rb
@@ -1,0 +1,11 @@
+class ShortUrlExpander
+  attr_reader :target_url
+
+  def initialize(target_url)
+    @target_url = target_url
+  end
+
+  def call(params, _request)
+    ShortUrl.resolve(path: params[:path], target_url: target_url)
+  end
+end

--- a/app/models/short_url.rb
+++ b/app/models/short_url.rb
@@ -1,0 +1,23 @@
+class ShortUrl < ApplicationRecord
+  class << self
+    def resolve(path:, target_url:)
+      url = find_or_initialize_by(path: path)
+      url.target_url ||= target_url
+      url
+    end
+  end
+
+  def to_str
+    [target_url, target_path, analytics_query].join
+  end
+
+  private
+
+  def analytics_query
+    {
+      utm_source: utm_source,
+      utm_medium: utm_medium,
+      utm_campaign: utm_campaign,
+    }.compact.to_query.presence&.prepend('?')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,12 @@ end
 # :nocov:
 
 Rails.application.routes.draw do
+  constraints host: 'c100.dsd.io' do
+    get '/(*path)' => redirect(
+      ShortUrlExpander.new('https://apply-to-court-about-child-arrangements.dsd.io'), status: 302
+    )
+  end
+
   devise_for :users,
              controllers: {
                registrations: 'users/registrations',

--- a/db/migrate/20180606145430_short_urls_table.rb
+++ b/db/migrate/20180606145430_short_urls_table.rb
@@ -1,0 +1,16 @@
+class ShortUrlsTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :short_urls, id: false do |t|
+      t.timestamps
+
+      t.string :path, primary_key: true
+
+      t.string :target_url
+      t.string :target_path
+
+      t.string :utm_source
+      t.string :utm_medium
+      t.string :utm_campaign
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180605110750) do
+ActiveRecord::Schema.define(version: 20180606145430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -274,6 +274,16 @@ ActiveRecord::Schema.define(version: 20180605110750) do
     t.index ["c100_application_id"], name: "index_screener_answers_on_c100_application_id"
     t.index ["email_address"], name: "index_screener_answers_on_email_address"
     t.index ["email_consent"], name: "index_screener_answers_on_email_consent"
+  end
+
+  create_table "short_urls", primary_key: "path", id: :string, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "target_url"
+    t.string "target_path"
+    t.string "utm_source"
+    t.string "utm_medium"
+    t.string "utm_campaign"
   end
 
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -40,7 +40,7 @@ end
 # Only include in this collection the models that matter and have specs.
 #
 def models
-  %w(C100Application User Court).freeze
+  %w(C100Application User Court ShortUrl).freeze
 end
 
 # Everything inheriting from `BaseForm` and inside namespace `Steps`

--- a/lib/tasks/short_urls.rake
+++ b/lib/tasks/short_urls.rake
@@ -1,0 +1,45 @@
+require 'optparse'
+
+namespace :short_urls do
+  task list: :environment do
+    ShortUrl.order(created_at: :asc).each do |url|
+      url.target_url ||= default_target_url
+      puts "[created: #{url.created_at}] #{default_host_domain}/#{url.path} => #{url.to_str}"
+    end
+  end
+
+  task create: :environment do
+    ARGV.shift(2)
+
+    options = {}
+
+    OptionParser.new do |opts|
+      opts.on("--path ARG", String) { |str| options[:path] = str }
+      opts.on("--target_url [ARG]", String) { |str| options[:target_url] = str }
+      opts.on("--target_path [ARG]", String) { |str| options[:target_path] = str }
+      opts.on("--utm_source [ARG]", String) { |str| options[:utm_source] = str }
+      opts.on("--utm_medium [ARG]", String) { |str| options[:utm_medium] = str }
+      opts.on("--utm_campaign [ARG]", String) { |str| options[:utm_campaign] = str }
+    end.parse!
+
+    unless options[:path]
+      raise ArgumentError, '`--path ARG` is a mandatory parameter'
+    end
+
+    ShortUrl.create(options)
+
+    Rake::Task['short_urls:list'].invoke
+
+    exit(0)
+  end
+end
+
+private
+
+def default_host_domain
+  'https://c100.dsd.io'.freeze
+end
+
+def default_target_url
+  'https://apply-to-court-about-child-arrangements.dsd.io'.freeze
+end

--- a/spec/lib/short_url_expander_spec.rb
+++ b/spec/lib/short_url_expander_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe ShortUrlExpander do
+  let(:request) { spy('request') }
+
+  subject { described_class.new('http://test.com') }
+
+  describe '#call' do
+    context '`params` contains the `path`' do
+      let(:params) { {path: 'xyz'} }
+
+      it 'calls the resolver with the value of `path`' do
+        expect(ShortUrl).to receive(:resolve).with(path: 'xyz', target_url: 'http://test.com')
+        subject.call(params, request)
+      end
+    end
+
+    context '`params` does not contain the `path`' do
+      let(:params) { {} }
+
+      it 'calls the resolver with `path` nil' do
+        expect(ShortUrl).to receive(:resolve).with(path: nil, target_url: 'http://test.com')
+        subject.call(params, request)
+      end
+    end
+  end
+end

--- a/spec/models/short_url_spec.rb
+++ b/spec/models/short_url_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe ShortUrl, type: :model do
+  subject { described_class.new({path: 'test'}.merge(config)) }
+
+  let(:config) { {} }
+
+  describe '#to_str' do
+    context 'with custom `target_url`' do
+      let(:config) { {target_url: 'http://example.com'} }
+      it { expect(subject.to_str).to eq('http://example.com') }
+    end
+
+    context 'with custom `target_path`' do
+      let(:config) { {target_path: '/xyz'} }
+      it { expect(subject.to_str).to eq('/xyz') }
+    end
+
+    context 'with custom `target_url` and `target_path`' do
+      let(:config) { {target_url: 'http://example.com', target_path: '/xyz'} }
+      it { expect(subject.to_str).to eq('http://example.com/xyz') }
+    end
+
+    describe 'utm tracking params' do
+      context '`utm_source`' do
+        let(:config) { {utm_source: 'source'} }
+        it { expect(subject.to_str).to eq('?utm_source=source') }
+      end
+
+      context '`utm_medium`' do
+        let(:config) { {utm_medium: 'medium'} }
+        it { expect(subject.to_str).to eq('?utm_medium=medium') }
+      end
+
+      context '`utm_campaign`' do
+        let(:config) { {utm_campaign: 'campaign'} }
+        it { expect(subject.to_str).to eq('?utm_campaign=campaign') }
+      end
+
+      context 'multiple utm params' do
+        let(:config) { {utm_source: 'source', utm_medium: 'medium'} }
+        it { expect(subject.to_str).to eq('?utm_medium=medium&utm_source=source') }
+      end
+    end
+
+    context 'complete URL with tracking' do
+      let(:config) { {target_url: 'http://example.com', target_path: '/xyz', utm_source: 'source'} }
+      it { expect(subject.to_str).to eq('http://example.com/xyz?utm_source=source') }
+    end
+  end
+
+  describe '.resolve' do
+    let(:resolved_url) { described_class.resolve(path: 'xyz', target_url: 'http://example.com') }
+
+    context 'for an existing path' do
+      let!(:short_url) { ShortUrl.create(path: 'xyz', target_url: target_url) }
+      let(:target_url) { nil }
+
+      it 'returns the found URL' do
+        expect(described_class).not_to receive(:new)
+        expect(resolved_url).to eq(short_url)
+      end
+
+      context 'blank target_url' do
+        it 'defaults to the provided target_url' do
+          expect(resolved_url.target_url).to eq('http://example.com')
+        end
+      end
+
+      context 'existing target_url' do
+        let(:target_url) { 'http://test.com' }
+
+        it 'uses the existing `target_url` if present' do
+          expect(resolved_url.target_url).to eq('http://test.com')
+        end
+      end
+    end
+
+    context 'for a non existent path' do
+      it 'initialises a new short URL' do
+        expect(described_class).to receive(:new).with(path: 'xyz').and_call_original
+        resolved_url
+      end
+    end
+  end
+end


### PR DESCRIPTION
This works together with our new 'shorter' domain CNAME `c100.dsd.io`

Short urls can be added and/or listed via a rake task as a first step. In the future, and if needed, we can expose a simple CRUD admin page, but at the moment this is the MVP to be able to produce short URLs with tracking.