### PR TITLE
Completed applications audit

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -1,8 +1,12 @@
+# The step including this concern will mark the application as `completed`,
+# meaning it can't be drafted anymore, also can't be submitted again by mistake,
+# and we save an audit record of this submission and the court it was sent to.
+#
 module CompletionStep
   extend ActiveSupport::Concern
 
   included do
-    before_action :mark_completed
+    before_action :mark_completed, unless: :completed?
   end
 
   def show
@@ -11,9 +15,15 @@ module CompletionStep
 
   private
 
+  def completed?
+    current_c100_application.completed?
+  end
+
   def mark_completed
-    # The step including this concern will mark the current application as `completed`,
-    # meaning it can't be drafted (and don't appear anymore in drafts).
     current_c100_application.completed!
+
+    CompletedApplicationsAudit.log!(
+      current_c100_application
+    )
   end
 end

--- a/app/models/completed_applications_audit.rb
+++ b/app/models/completed_applications_audit.rb
@@ -1,0 +1,15 @@
+class CompletedApplicationsAudit < ApplicationRecord
+  self.table_name = 'completed_applications_audit'
+
+  default_scope { order(completed_at: :desc) }
+
+  def self.log!(c100_application)
+    create(
+      started_at: c100_application.created_at,
+      completed_at: c100_application.updated_at,
+      saved: c100_application.user_id.present?,
+      submission_type: c100_application.submission_type,
+      court: c100_application.screener_answers_court&.name,
+    )
+  end
+end

--- a/db/migrate/20180608081404_create_completed_applications_audit_table.rb
+++ b/db/migrate/20180608081404_create_completed_applications_audit_table.rb
@@ -1,0 +1,11 @@
+class CreateCompletedApplicationsAuditTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :completed_applications_audit, id: false do |t|
+      t.datetime :started_at, null: false
+      t.datetime :completed_at, null: false
+      t.boolean  :saved
+      t.string   :submission_type
+      t.string   :court
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180607151928) do
+ActiveRecord::Schema.define(version: 20180608081404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,14 @@ ActiveRecord::Schema.define(version: 20180607151928) do
     t.uuid "child_id"
     t.string "person_ids", default: [], array: true
     t.index ["child_id"], name: "index_child_residences_on_child_id"
+  end
+
+  create_table "completed_applications_audit", id: false, force: :cascade do |t|
+    t.datetime "started_at", null: false
+    t.datetime "completed_at", null: false
+    t.boolean "saved"
+    t.string "submission_type"
+    t.string "court"
   end
 
   create_table "court_orders", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/lib/tasks/misc.rake
+++ b/lib/tasks/misc.rake
@@ -1,0 +1,10 @@
+namespace :misc do
+  # This task can be removed once it has been run, as it serves
+  # no other purpose than pre-populate a fresh DB table.
+  #
+  task prepopulate_audit: :environment do
+    C100Application.completed.order(updated_at: :asc).each do |c100_application|
+      CompletedApplicationsAudit.log!(c100_application)
+    end
+  end
+end

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -40,7 +40,13 @@ end
 # Only include in this collection the models that matter and have specs.
 #
 def models
-  %w(C100Application User Court ShortUrl).freeze
+  %w(
+    C100Application
+    User
+    Court
+    CompletedApplicationsAudit
+    ShortUrl
+  ).freeze
 end
 
 # Everything inheriting from `BaseForm` and inside namespace `Steps`

--- a/spec/models/completed_applications_audit_spec.rb
+++ b/spec/models/completed_applications_audit_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe CompletedApplicationsAudit, type: :model do
+  let(:c100_application) {
+    instance_double(
+      C100Application,
+      created_at: Time.at(0),
+      updated_at: Time.at(100),
+      user_id: user_id,
+      submission_type: 'whatever',
+      screener_answers_court: screener_answers_court,
+    )
+  }
+
+  let(:user_id) { nil }
+  let(:screener_answers_court) { double(name: 'Test Court') }
+
+  describe 'db table name' do
+    it { expect(described_class.table_name).to eq('completed_applications_audit') }
+  end
+
+  describe '.log!' do
+    it 'creates a record with the expected information' do
+      expect(
+        described_class
+      ).to receive(:create).with(
+        started_at: Time.at(0),
+        completed_at: Time.at(100),
+        saved: false,
+        submission_type: 'whatever',
+        court: 'Test Court',
+      )
+
+      described_class.log!(c100_application)
+    end
+
+    context 'for a saved application' do
+      let(:user_id) { 123 }
+
+      it 'creates a record with the expected information' do
+        expect(
+          described_class
+        ).to receive(:create).with(
+          hash_including(saved: true)
+        )
+
+        described_class.log!(c100_application)
+      end
+    end
+
+    context 'for an application without screener_answers court data' do
+      # Note: this scenario should only be theoretical, but mutant wants to test it
+      let(:screener_answers_court) { nil }
+
+      it 'creates a record with the expected information' do
+        expect(
+          described_class
+        ).to receive(:create).with(
+          hash_including(court: nil)
+        )
+
+        described_class.log!(c100_application)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We will record an audit log with a few details about applications completed, intended for analytics past the 28 days retention time.

Simple rake task to prepopulate the table with whatever data we still hold.