### PR TITLE
Implement `urgent hearing` steps

### DIFF
--- a/app/controllers/steps/application/urgent_hearing_controller.rb
+++ b/app/controllers/steps/application/urgent_hearing_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Application
+    class UrgentHearingController < Steps::ApplicationStepController
+      def edit
+        @form_object = UrgentHearingForm.new(
+          c100_application: current_c100_application,
+          urgent_hearing: current_c100_application.urgent_hearing
+        )
+      end
+
+      def update
+        update_and_advance(UrgentHearingForm)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/application/urgent_hearing_details_controller.rb
+++ b/app/controllers/steps/application/urgent_hearing_details_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Application
+    class UrgentHearingDetailsController < Steps::ApplicationStepController
+      def edit
+        @form_object = UrgentHearingDetailsForm.build(current_c100_application)
+      end
+
+      def update
+        update_and_advance(UrgentHearingDetailsForm, as: :urgent_hearing_details)
+      end
+    end
+  end
+end

--- a/app/forms/steps/application/urgent_hearing_details_form.rb
+++ b/app/forms/steps/application/urgent_hearing_details_form.rb
@@ -1,0 +1,27 @@
+module Steps
+  module Application
+    class UrgentHearingDetailsForm < BaseForm
+      attribute :urgent_hearing_details, String
+      attribute :urgent_hearing_when, String
+      attribute :urgent_hearing_short_notice, YesNo
+      attribute :urgent_hearing_short_notice_details, String
+
+      validates_presence_of :urgent_hearing_details,
+                            :urgent_hearing_when
+
+      validates_inclusion_of :urgent_hearing_short_notice, in: GenericYesNo.values
+
+      validates_presence_of :urgent_hearing_short_notice_details, if: -> { urgent_hearing_short_notice&.yes? }
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        c100_application.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/application/urgent_hearing_form.rb
+++ b/app/forms/steps/application/urgent_hearing_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Application
+    class UrgentHearingForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :urgent_hearing
+    end
+  end
+end

--- a/app/forms/steps/application/urgent_hearing_form.rb
+++ b/app/forms/steps/application/urgent_hearing_form.rb
@@ -3,7 +3,9 @@ module Steps
     class UrgentHearingForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :urgent_hearing
+      yes_no_attribute :urgent_hearing, reset_when_no: [
+        Steps::Application::UrgentHearingDetailsForm
+      ]
     end
   end
 end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -16,7 +16,7 @@ module Summary
         *people_sections,
         HtmlSections::ChildrenResidence.new(c100_application),
         HtmlSections::OtherCourtCases.new(c100_application),
-        HtmlSections::WithoutNoticeDetails.new(c100_application),
+        *urgent_and_without_notice_sections,
         HtmlSections::InternationalElement.new(c100_application),
         HtmlSections::ApplicationReasons.new(c100_application),
         HtmlSections::AttendingCourt.new(c100_application),
@@ -66,6 +66,13 @@ module Summary
         HtmlSections::ApplicantsDetails.new(c100_application),
         HtmlSections::RespondentsDetails.new(c100_application),
         HtmlSections::OtherPartiesDetails.new(c100_application),
+      ]
+    end
+
+    def urgent_and_without_notice_sections
+      [
+        HtmlSections::UrgentHearingDetails.new(c100_application),
+        HtmlSections::WithoutNoticeDetails.new(c100_application),
       ]
     end
 

--- a/app/presenters/summary/html_sections/urgent_hearing_details.rb
+++ b/app/presenters/summary/html_sections/urgent_hearing_details.rb
@@ -1,0 +1,27 @@
+module Summary
+  module HtmlSections
+    class UrgentHearingDetails < Sections::BaseSectionPresenter
+      def name
+        :urgent_hearing
+      end
+
+      def answers
+        [
+          Answer.new(:urgent_hearing, c100.urgent_hearing, change_path: edit_steps_application_urgent_hearing_path),
+          AnswersGroup.new(:urgent_hearing_details, urgent_hearing_details, change_path: edit_steps_application_urgent_hearing_details_path),
+        ].select(&:show?)
+      end
+
+      private
+
+      def urgent_hearing_details
+        [
+          FreeTextAnswer.new(:urgent_hearing_details, c100.urgent_hearing_details),
+          FreeTextAnswer.new(:urgent_hearing_when, c100.urgent_hearing_when),
+          Answer.new(:urgent_hearing_short_notice, c100.urgent_hearing_short_notice),
+          FreeTextAnswer.new(:urgent_hearing_short_notice_details, c100.urgent_hearing_short_notice_details),
+        ]
+      end
+    end
+  end
+end

--- a/app/presenters/summary/sections/additional_information.rb
+++ b/app/presenters/summary/sections/additional_information.rb
@@ -19,8 +19,10 @@ module Summary
       private
 
       def urgent_or_without_notice_value
-        # TODO: to be decided when `urgent` apply
-        c100.without_notice
+        [
+          c100.urgent_hearing,
+          c100.without_notice,
+        ].detect { |answer| answer.eql?(GenericYesNo::YES.to_s) }
       end
 
       def international_or_capacity_value

--- a/app/presenters/summary/sections/urgent_hearing.rb
+++ b/app/presenters/summary/sections/urgent_hearing.rb
@@ -7,8 +7,11 @@ module Summary
 
       def answers
         [
-          # TODO: we don't have the urgent steps yet (but for MVP we might do screening)
-          Answer.new(:urgent_hearing_details, GenericYesNo::NO),
+          Answer.new(:urgent_hearing, c100.urgent_hearing, default: GenericYesNo::NO),
+          FreeTextAnswer.new(:urgent_hearing_details, c100.urgent_hearing_details),
+          FreeTextAnswer.new(:urgent_hearing_when, c100.urgent_hearing_when),
+          Answer.new(:urgent_hearing_short_notice, c100.urgent_hearing_short_notice),
+          FreeTextAnswer.new(:urgent_hearing_short_notice_details, c100.urgent_hearing_short_notice_details),
         ].select(&:show?)
       end
     end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -8,6 +8,10 @@ module C100App
       when :previous_proceedings
         after_previous_proceedings
       when :court_proceedings
+        edit(:urgent_hearing)
+      when :urgent_hearing
+        after_urgent_hearing
+      when :urgent_hearing_details
         edit(:without_notice)
       when :without_notice
         after_without_notice
@@ -44,6 +48,14 @@ module C100App
     def after_previous_proceedings
       if question(:children_previous_proceedings).yes?
         edit(:court_proceedings)
+      else
+        edit(:urgent_hearing)
+      end
+    end
+
+    def after_urgent_hearing
+      if question(:urgent_hearing).yes?
+        edit(:urgent_hearing_details)
       else
         edit(:without_notice)
       end

--- a/app/views/steps/application/urgent_hearing/edit.html.erb
+++ b/app/views/steps/application/urgent_hearing/edit.html.erb
@@ -1,0 +1,33 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%=t '.lead_text' %></p>
+      <%=t '.examples_html' %>
+    </div>
+
+    <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
+      <p><%= t '.warning' %></p>
+    </div>
+
+    <details>
+      <summary>
+        <span class="summary" data-ga-category="explanations" data-ga-label="urgent hearing"><%=t '.reasons_title' %></span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <%=t '.reasons_content_html' %>
+      </div>
+    </details>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :urgent_hearing, inline: true, choices: GenericYesNo.values %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/application/urgent_hearing_details/edit.html.erb
+++ b/app/views/steps/application/urgent_hearing_details/edit.html.erb
@@ -1,0 +1,30 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_area :urgent_hearing_details, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.text_field :urgent_hearing_when %>
+
+      <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
+        <p><%= t '.court_info_html' %></p>
+      </div>
+
+      <%=
+        f.radio_button_fieldset :urgent_hearing_short_notice, inline: true do |fieldset|
+          fieldset.radio_input(GenericYesNo::YES, panel_id: :urgent_hearing_short_notice_panel)
+          fieldset.radio_input(GenericYesNo::NO)
+          fieldset.revealing_panel(:urgent_hearing_short_notice_panel) do |panel|
+            panel.text_area :urgent_hearing_short_notice_details, size: '40x4', class: 'form-control-3-4'
+          end
+        end
+      %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -79,6 +79,7 @@ en:
       other_parties_details: Details of any other people
       children_residence: Where the children live
       other_court_cases: Involvement in other proceedings
+      urgent_hearing: Urgent hearing
       without_notice_hearing: Without notice hearing
       international_element: International information
       application_reasons: Reasons for application
@@ -97,6 +98,7 @@ en:
       person_personal_details: Personal details
       person_contact_details: Contact details
       other_court_cases_details: Other proceedings details
+      urgent_hearing_details: Urgent hearing details
       without_notice_hearing_details: Without notice hearing details
       international_jurisdiction: Do you think another person in this application may be able to apply for a similar order in a country outside England or Wales?
       international_request: Has a request for information or other assistance involving the children been made to or by another country?
@@ -476,6 +478,21 @@ en:
     court_proceeding_previous_details:
       question: Details of any other previous family case
 
+    urgent_hearing:
+      question: Do you need an urgent hearing?
+      answers:
+        <<: *YESNO
+    urgent_hearing_details:
+      question: Why you’re asking for an urgent hearing
+    urgent_hearing_when:
+      question: How soon do you need an urgent hearing?
+    urgent_hearing_short_notice:
+      question: Do you need a hearing within the next 48 hours?
+      answers:
+        <<: *YESNO
+    urgent_hearing_short_notice_details:
+      question: What have you done to tell each respondent of this application?
+
     without_notice_hearing:
       question: Are you asking for a without notice hearing?
       answers:
@@ -494,6 +511,7 @@ en:
         <<: *YESNO
     without_notice_impossible_details:
       question: Details
+
     international_resident:
       question: Is the life of the child or children, a parent, or anyone significant to the children mainly based in a country outside England or Wales?
       answers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -765,6 +765,11 @@ en:
               <li>irretrievable problems in dealing with the dispute (including the irretrievable loss of significant evidence)</li>
             </ul>
           warning: Contact the police if you or the children are in immediate danger.
+      urgent_hearing_details:
+        edit:
+          page_title: Details of urgent hearing
+          heading: Details of urgent hearing
+          court_info_html: If you need to go to court now, <a href="https://courttribunalfinder.service.gov.uk/search/" target="external_link" rel="external">contact your nearest family court</a> for assistance.
     international:
       resident:
         edit:
@@ -1123,6 +1128,8 @@ en:
         children_previous_proceedings_html: ""
       steps_application_urgent_hearing_form:
         urgent_hearing_html: ""
+      steps_application_urgent_hearing_details_form:
+        urgent_hearing_short_notice_html: Do you need a hearing within the next 48 hours?
       steps_application_without_notice_form:
         without_notice_html: ""
       steps_application_without_notice_details_form:
@@ -1310,6 +1317,10 @@ en:
         cafcass_details: Name and office of Cafcass/Cafcass Cymru officer
         order_types: Type of proceedings
         previous_details: Add details of any other previous family case
+      steps_application_urgent_hearing_details_form:
+        urgent_hearing_details: Give details of why you’re asking for an urgent hearing
+        urgent_hearing_when: How soon do you need an urgent hearing?
+        urgent_hearing_short_notice_details: What have you done to tell each respondent of this application?
       steps_application_without_notice_details_form:
         without_notice_details: Give details of why you’re asking for a without notice hearing
         without_notice_frustrate_details: *provide_details
@@ -1499,6 +1510,9 @@ en:
         cafcass_details: Leave blank if you don’t know
         order_types: For example, an Emergency protection order, Supervision order, Care order or any orders related to child abduction
         previous_details: Try and include as many details as possible, for example case number, date and name of court
+      steps_application_urgent_hearing_details_form:
+        urgent_hearing_details: A court will only hear your case urgently if you can give good reason for the urgency.
+        urgent_hearing_short_notice_details: The court will expect you to tell the other people involved that you are making this application, unless you have a reason not to.
       steps_application_without_notice_details_form:
         without_notice_details: A judge will need to be sure that there is a good reason why the other people in the application should not be told about the application before the hearing takes place
         without_notice_impossible: This may be relevant in cases of exceptional urgency where the order is needed to prevent a threatened wrongful act. In some cases you may still be expected to have tried to give informal notice for example by telephone, text message, or email.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -739,6 +739,32 @@ en:
           heading: Resume application
           lead_text: Review your current progress and resume this application
           resume: Resume application
+      urgent_hearing:
+        edit:
+          page_title: Urgent hearing
+          heading: Do you need an urgent hearing?
+          lead_text: 'A hearing will usually take place within 5 or 6 weeks of the court processing your application. You can ask for a hearing to take place sooner and a court will consider if there’s good reason for the urgency, for example:'
+          examples_html: |
+            <ul class="list list-bullet">
+              <li>there’s a risk of harm to you or the children</li>
+              <li>the children are at risk of abduction</li>
+            </ul>
+          reasons_title: Examples of when a court may consider an urgent hearing
+          reasons_content_html: |
+            <p>There is:</p>
+            <ul class="list list-bullet">
+              <li>risk to the life, liberty or physical safety of you, your family or your home</li>
+              <li>significant risk that proceedings relating to the dispute will be brought in another country</li>
+            </ul>
+            <p>Any delay would cause:</p>
+            <ul class="list list-bullet">
+              <li>a risk of harm to the children</li>
+              <li>unreasonable hardship for you</li>
+              <li>a risk of unlawful removal of a child from the UK, or a risk of unlawful retention of a child who is currently outside England and Wales</li>
+              <li>a significant risk of a miscarriage of justice</li>
+              <li>irretrievable problems in dealing with the dispute (including the irretrievable loss of significant evidence)</li>
+            </ul>
+          warning: Contact the police if you or the children are in immediate danger.
     international:
       resident:
         edit:
@@ -1095,6 +1121,8 @@ en:
         relation_html: ""
       steps_application_previous_proceedings_form:
         children_previous_proceedings_html: ""
+      steps_application_urgent_hearing_form:
+        urgent_hearing_html: ""
       steps_application_without_notice_form:
         without_notice_html: ""
       steps_application_without_notice_details_form:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -315,11 +315,23 @@ en:
         'no': No - permission not required
     application_details:
       question: Why are you making this application?
-    urgent_hearing_details:
+
+    urgent_hearing:
       question: *details
       answers:
         'yes': ''
         'no': *not_applicable
+    urgent_hearing_details:
+      question: Give details of why you’re asking for an urgent hearing
+    urgent_hearing_when:
+      question: How soon do you need an urgent hearing?
+    urgent_hearing_short_notice:
+      question: Do you need a hearing within the next 48 hours?
+      answers:
+        <<: *YESNO
+    urgent_hearing_short_notice_details:
+      question: What have you done to tell each respondent of this application?
+
     without_notice_hearing_details:
       question: *details
       answers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
       edit_step :previous_proceedings
       edit_step :court_proceedings
       edit_step :urgent_hearing
+      edit_step :urgent_hearing_details
       edit_step :without_notice
       edit_step :without_notice_details
       edit_step :litigation_capacity

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
     namespace :application do
       edit_step :previous_proceedings
       edit_step :court_proceedings
+      edit_step :urgent_hearing
       edit_step :without_notice
       edit_step :without_notice_details
       edit_step :litigation_capacity

--- a/db/migrate/20180608112820_add_urgent_hearing_fields.rb
+++ b/db/migrate/20180608112820_add_urgent_hearing_fields.rb
@@ -1,0 +1,9 @@
+class AddUrgentHearingFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :c100_applications, :urgent_hearing, :string
+    add_column :c100_applications, :urgent_hearing_details, :text
+    add_column :c100_applications, :urgent_hearing_when, :string
+    add_column :c100_applications, :urgent_hearing_short_notice, :string
+    add_column :c100_applications, :urgent_hearing_short_notice_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180608081404) do
+ActiveRecord::Schema.define(version: 20180608112820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,6 +125,11 @@ ActiveRecord::Schema.define(version: 20180608081404) do
     t.string "solicitor_account_number"
     t.string "submission_type"
     t.string "receipt_email"
+    t.string "urgent_hearing"
+    t.text "urgent_hearing_details"
+    t.string "urgent_hearing_when"
+    t.string "urgent_hearing_short_notice"
+    t.text "urgent_hearing_short_notice_details"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/controllers/steps/application/urgent_hearing_controller_spec.rb
+++ b/spec/controllers/steps/application/urgent_hearing_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Application::UrgentHearingController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Application::UrgentHearingForm, C100App::ApplicationDecisionTree
+end

--- a/spec/controllers/steps/application/urgent_hearing_details_controller_spec.rb
+++ b/spec/controllers/steps/application/urgent_hearing_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Application::UrgentHearingDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Application::UrgentHearingDetailsForm, C100App::ApplicationDecisionTree
+end

--- a/spec/forms/steps/application/urgent_hearing_details_form_spec.rb
+++ b/spec/forms/steps/application/urgent_hearing_details_form_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Application::UrgentHearingDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    urgent_hearing_details: urgent_hearing_details,
+    urgent_hearing_when: urgent_hearing_when,
+    urgent_hearing_short_notice: urgent_hearing_short_notice,
+    urgent_hearing_short_notice_details: urgent_hearing_short_notice_details,
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:urgent_hearing_details) { 'details' }
+  let(:urgent_hearing_when) { 'next week' }
+  let(:urgent_hearing_short_notice) { 'no' }
+  let(:urgent_hearing_short_notice_details) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:urgent_hearing_details) }
+      it { should validate_presence_of(:urgent_hearing_when) }
+      it { should validate_presence_of(:urgent_hearing_short_notice, :inclusion) }
+
+      context 'when `urgent_hearing_short_notice` is yes' do
+        let(:urgent_hearing_short_notice) { 'yes' }
+        it { should validate_presence_of(:urgent_hearing_short_notice_details) }
+      end
+
+      context 'when `urgent_hearing_short_notice` is no' do
+        let(:urgent_hearing_short_notice) { 'no' }
+        it { should_not validate_presence_of(:urgent_hearing_short_notice_details) }
+      end
+    end
+
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(c100_application).to receive(:update).with(
+          urgent_hearing_details: 'details',
+          urgent_hearing_when: 'next week',
+          urgent_hearing_short_notice: GenericYesNo::NO,
+          urgent_hearing_short_notice_details: nil
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/forms/steps/application/urgent_hearing_form_spec.rb
+++ b/spec/forms/steps/application/urgent_hearing_form_spec.rb
@@ -2,5 +2,11 @@ require 'spec_helper'
 
 RSpec.describe Steps::Application::UrgentHearingForm do
   it_behaves_like 'a yes-no question form',
-                  attribute_name: :urgent_hearing
+                  attribute_name: :urgent_hearing,
+                  reset_when_no: [
+                    :urgent_hearing_details,
+                    :urgent_hearing_when,
+                    :urgent_hearing_short_notice,
+                    :urgent_hearing_short_notice_details,
+                  ]
 end

--- a/spec/forms/steps/application/urgent_hearing_form_spec.rb
+++ b/spec/forms/steps/application/urgent_hearing_form_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Application::UrgentHearingForm do
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :urgent_hearing
+end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -71,6 +71,7 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::OtherPartiesDetails,
         Summary::HtmlSections::ChildrenResidence,
         Summary::HtmlSections::OtherCourtCases,
+        Summary::HtmlSections::UrgentHearingDetails,
         Summary::HtmlSections::WithoutNoticeDetails,
         Summary::HtmlSections::InternationalElement,
         Summary::HtmlSections::ApplicationReasons,

--- a/spec/presenters/summary/html_sections/urgent_hearing_details_spec.rb
+++ b/spec/presenters/summary/html_sections/urgent_hearing_details_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::UrgentHearingDetails do
+    let(:c100_application) {
+      instance_double(C100Application,
+        given_answers
+    ) }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    let(:urgent_hearing_requested) {
+      {
+        urgent_hearing: 'yes',
+        urgent_hearing_details: 'details',
+        urgent_hearing_when: 'when',
+        urgent_hearing_short_notice: 'yes',
+        urgent_hearing_short_notice_details: 'short notice details',
+      }
+    }
+    let(:urgent_hearing_not_requested) {
+      {
+        urgent_hearing: 'no',
+        urgent_hearing_details: nil,
+        urgent_hearing_when: nil,
+        urgent_hearing_short_notice: nil,
+        urgent_hearing_short_notice_details: nil,
+      }
+    }
+    let(:given_answers) { urgent_hearing_requested }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:urgent_hearing) }
+    end
+
+    describe '#answers' do
+      describe 'the first row' do
+        let(:row){ answers[0] }
+
+        it 'is an Answer' do
+          expect(row).to be_an_instance_of(Answer)
+        end
+
+        it 'has the correct question' do
+          expect(row.question).to eq(:urgent_hearing)
+        end
+
+        it 'has the correct change_path' do
+          expect(row.change_path).to eq('/steps/application/urgent_hearing')
+        end
+      end
+
+      context 'when the user has not asked for a without notice hearing' do
+        let(:given_answers) { urgent_hearing_not_requested }
+
+        it 'has only one row' do
+          expect(answers.count).to eq(1)
+        end
+      end
+
+      context 'when the user has asked for a without notice hearing' do
+        let(:given_answers) { urgent_hearing_requested }
+
+        it 'has two rows' do
+          expect(answers.count).to eq(2)
+        end
+
+        describe 'the second row' do
+          let(:row){ answers[1] }
+
+          it 'is an AnswersGroup' do
+            expect(row).to be_an_instance_of(AnswersGroup)
+          end
+
+          it 'has the correct name' do
+            expect(row.name).to eq(:urgent_hearing_details)
+          end
+
+          it 'has the correct change_path' do
+            expect(row.change_path).to eq('/steps/application/urgent_hearing_details')
+          end
+
+          describe 'the grouped answers' do
+            let(:grouped_answers){ row.answers }
+
+            it 'has the right number of answers' do
+              expect(grouped_answers.count).to eq(4)
+            end
+
+            it 'has the right rows' do
+              expect(grouped_answers[0]).to be_an_instance_of(FreeTextAnswer)
+              expect(grouped_answers[0].question).to eq(:urgent_hearing_details)
+              expect(grouped_answers[0].value).to eq('details')
+
+              expect(grouped_answers[1]).to be_an_instance_of(FreeTextAnswer)
+              expect(grouped_answers[1].question).to eq(:urgent_hearing_when)
+              expect(grouped_answers[1].value).to eq('when')
+
+              expect(grouped_answers[2]).to be_an_instance_of(Answer)
+              expect(grouped_answers[2].question).to eq(:urgent_hearing_short_notice)
+              expect(grouped_answers[2].value).to eq('yes')
+
+              expect(grouped_answers[3]).to be_an_instance_of(FreeTextAnswer)
+              expect(grouped_answers[3].question).to eq(:urgent_hearing_short_notice_details)
+              expect(grouped_answers[3].value).to eq('short notice details')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/sections/additional_information_spec.rb
+++ b/spec/presenters/summary/sections/additional_information_spec.rb
@@ -25,7 +25,7 @@ module Summary
 
         expect(answers[1]).to be_an_instance_of(Answer)
         expect(answers[1].question).to eq(:urgent_or_without_notice)
-        expect(c100_application).to have_received(:without_notice)
+        expect(answers[1].value).to eq(GenericYesNo::NO) # The values of this are tested separated
 
         expect(answers[2]).to be_an_instance_of(Answer)
         expect(answers[2].question).to eq(:children_previous_proceedings)
@@ -42,6 +42,29 @@ module Summary
         expect(answers[5]).to be_an_instance_of(Answer)
         expect(answers[5].question).to eq(:language_assistance)
         expect(c100_application).to have_received(:language_help)
+      end
+    end
+
+    describe '`urgent_or_without_notice_value` answer values' do
+      before do
+        expect(c100_application).to receive(:urgent_hearing).and_return(urgent_hearing)
+        expect(c100_application).to receive(:without_notice)
+      end
+
+      context 'at least one question was answered as `YES`' do
+        let(:urgent_hearing) { 'yes' }
+
+        it 'returns the question value' do
+          expect(answers[1].value).to eq('yes')
+        end
+      end
+
+      context 'there are no questions answered with `YES`' do
+        let(:urgent_hearing) { 'no' }
+
+        it 'returns the default value for the answer' do
+          expect(answers[1].value).to eq(GenericYesNo::NO)
+        end
       end
     end
 

--- a/spec/presenters/summary/sections/urgent_hearing_spec.rb
+++ b/spec/presenters/summary/sections/urgent_hearing_spec.rb
@@ -2,7 +2,16 @@ require 'spec_helper'
 
 module Summary
   describe Sections::UrgentHearing do
-    let(:c100_application) { instance_double(C100Application) }
+    let(:c100_application) {
+      instance_double(
+        C100Application,
+        urgent_hearing: 'yes',
+        urgent_hearing_details: 'details',
+        urgent_hearing_when: 'when',
+        urgent_hearing_short_notice: 'yes',
+        urgent_hearing_short_notice_details: 'short notice details',
+      )
+    }
 
     subject { described_class.new(c100_application) }
 
@@ -14,11 +23,27 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(1)
+        expect(answers.count).to eq(5)
 
         expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:urgent_hearing_details)
-        expect(answers[0].value).to eq(GenericYesNo::NO)
+        expect(answers[0].question).to eq(:urgent_hearing)
+        expect(answers[0].value).to eq('yes')
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:urgent_hearing_details)
+        expect(answers[1].value).to eq('details')
+
+        expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[2].question).to eq(:urgent_hearing_when)
+        expect(answers[2].value).to eq('when')
+
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:urgent_hearing_short_notice)
+        expect(answers[3].value).to eq('yes')
+
+        expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[4].question).to eq(:urgent_hearing_short_notice_details)
+        expect(answers[4].value).to eq('short notice details')
       end
     end
   end

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -21,12 +21,32 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
     context 'when answer is `no`' do
       let(:answer) { 'no' }
-      it { is_expected.to have_destination(:without_notice, :edit) }
+      it { is_expected.to have_destination(:urgent_hearing, :edit) }
     end
   end
 
   context 'when the step is `court_proceedings`' do
     let(:step_params) { { court_proceedings: 'anything' } }
+    it { is_expected.to have_destination(:urgent_hearing, :edit) }
+  end
+
+  context 'when the step is `urgent_hearing`' do
+    let(:c100_application) { instance_double(C100Application, urgent_hearing: answer) }
+    let(:step_params) { { urgent_hearing: 'whatever' } }
+
+    context 'and the answer is `yes`' do
+      let(:answer) { 'yes' }
+      it { is_expected.to have_destination(:urgent_hearing_details, :edit) }
+    end
+
+    context 'and the answer is `no`' do
+      let(:answer) { 'no' }
+      it { is_expected.to have_destination(:without_notice, :edit) }
+    end
+  end
+
+  context 'when the step is `urgent_hearing_details`' do
+    let(:step_params) { { urgent_hearing_details: 'anything' } }
     it { is_expected.to have_destination(:without_notice, :edit) }
   end
 


### PR DESCRIPTION
The screener question is still there, as we don't know yet if we are going to release this to production or not. 

* If we release this, I will create a follow-up PR to remove the screener question.

* If we are not releasing just yet, then I will need to create a follow-up PR to bypass these new steps in production, so these don't show, and everything continues to behave as it is now (with the screening question present).

<img width="675" alt="screen shot 2018-06-11 at 09 42 30" src="https://user-images.githubusercontent.com/687910/41222951-541698fe-6d60-11e8-8636-9bc0f699309a.png">

PDF:

<img width="823" alt="screen shot 2018-06-11 at 09 46 57" src="https://user-images.githubusercontent.com/687910/41222953-544e97a4-6d60-11e8-9124-750d0e5426a7.png">
