### PR TITLE
Add solicitor steps

### DIFF
--- a/app/controllers/steps/applicant/has_solicitor_controller.rb
+++ b/app/controllers/steps/applicant/has_solicitor_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Applicant
+    class HasSolicitorController < Steps::ApplicantStepController
+      def edit
+        @form_object = HasSolicitorForm.new(
+          c100_application: current_c100_application,
+          has_solicitor: current_c100_application.has_solicitor
+        )
+      end
+
+      def update
+        update_and_advance(HasSolicitorForm)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/solicitor/contact_details_controller.rb
+++ b/app/controllers/steps/solicitor/contact_details_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Solicitor
+    class ContactDetailsController < Steps::SolicitorStepController
+      def edit
+        @form_object = ContactDetailsForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(ContactDetailsForm, as: :contact_details)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/solicitor/personal_details_controller.rb
+++ b/app/controllers/steps/solicitor/personal_details_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Solicitor
+    class PersonalDetailsController < Steps::SolicitorStepController
+      def edit
+        @form_object = PersonalDetailsForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(PersonalDetailsForm, as: :personal_details)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/solicitor_step_controller.rb
+++ b/app/controllers/steps/solicitor_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class SolicitorStepController < StepController
+    private
+
+    def decision_tree_class
+      C100App::SolicitorDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/applicant/has_solicitor_form.rb
+++ b/app/forms/steps/applicant/has_solicitor_form.rb
@@ -3,7 +3,8 @@ module Steps
     class HasSolicitorForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :has_solicitor
+      # The reset will delete the row from the `solicitors` table
+      yes_no_attribute :has_solicitor, reset_when_no: [:solicitor]
     end
   end
 end

--- a/app/forms/steps/applicant/has_solicitor_form.rb
+++ b/app/forms/steps/applicant/has_solicitor_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Applicant
+    class HasSolicitorForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :has_solicitor
+    end
+  end
+end

--- a/app/forms/steps/solicitor/contact_details_form.rb
+++ b/app/forms/steps/solicitor/contact_details_form.rb
@@ -1,0 +1,31 @@
+module Steps
+  module Solicitor
+    class ContactDetailsForm < BaseForm
+      include HasOneAssociationForm
+
+      has_one_association :solicitor
+
+      attribute :address, StrippedString
+      attribute :dx_number, StrippedString
+      attribute :phone_number, StrippedString
+      attribute :fax_number, StrippedString
+      attribute :email, NormalisedEmail
+
+      validates_presence_of :address
+      validates :email, email: true, allow_blank: true
+
+      # Used to present the solicitor's name in the view
+      delegate :full_name, to: :record_to_persist
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record_to_persist.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/solicitor/personal_details_form.rb
+++ b/app/forms/steps/solicitor/personal_details_form.rb
@@ -1,0 +1,25 @@
+module Steps
+  module Solicitor
+    class PersonalDetailsForm < BaseForm
+      include HasOneAssociationForm
+
+      has_one_association :solicitor
+
+      attribute :full_name, StrippedString
+      attribute :firm_name, StrippedString
+      attribute :reference, StrippedString
+
+      validates_presence_of :full_name, :firm_name
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record_to_persist.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -11,6 +11,7 @@ class C100Application < ApplicationRecord
 
   belongs_to :user, optional: true
 
+  has_one  :solicitor,        dependent: :destroy
   has_one  :abduction_detail, dependent: :destroy
   has_one  :court_order,      dependent: :destroy
   has_one  :court_proceeding, dependent: :destroy

--- a/app/models/solicitor.rb
+++ b/app/models/solicitor.rb
@@ -1,0 +1,3 @@
+class Solicitor < ApplicationRecord
+  belongs_to :c100_application
+end

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -16,6 +16,8 @@ module C100App
         children_relationships
       when :contact_details
         after_contact_details
+      when :has_solicitor
+        after_has_solicitor
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
@@ -26,6 +28,14 @@ module C100App
     def after_contact_details
       if next_applicant_id
         edit(:personal_details, id: next_applicant_id)
+      else
+        edit(:has_solicitor)
+      end
+    end
+
+    def after_has_solicitor
+      if question(:has_solicitor).yes?
+        edit('/steps/solicitor/personal_details')
       else
         edit('/steps/respondent/names')
       end

--- a/app/services/c100_app/solicitor_decision_tree.rb
+++ b/app/services/c100_app/solicitor_decision_tree.rb
@@ -1,0 +1,16 @@
+module C100App
+  class SolicitorDecisionTree < BaseDecisionTree
+    def destination
+      return next_step if next_step
+
+      case step_name
+      when :solicitor_details
+        edit(:solicitor_contact_details)
+      when :solicitor_contact_details
+        edit('/steps/respondent/names')
+      else
+        raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+  end
+end

--- a/app/services/c100_app/solicitor_decision_tree.rb
+++ b/app/services/c100_app/solicitor_decision_tree.rb
@@ -4,9 +4,9 @@ module C100App
       return next_step if next_step
 
       case step_name
-      when :solicitor_details
-        edit(:solicitor_contact_details)
-      when :solicitor_contact_details
+      when :personal_details
+        edit(:contact_details)
+      when :contact_details
         edit('/steps/respondent/names')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"

--- a/app/views/steps/applicant/has_solicitor/edit.html.erb
+++ b/app/views/steps/applicant/has_solicitor/edit.html.erb
@@ -1,0 +1,18 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">
+      <%=t '.heading', count: current_c100_application.applicants.count %>
+    </h1>
+
+    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :has_solicitor, inline: true, choices: GenericYesNo.values %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/solicitor/contact_details/edit.html.erb
+++ b/app/views/steps/solicitor/contact_details/edit.html.erb
@@ -1,0 +1,22 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">
+      <%=t '.heading', name: @form_object.full_name %>
+    </h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
+
+      <%= f.text_field :dx_number, class: 'narrow' %>
+      <%= f.text_field :phone_number, class: 'narrow' %>
+      <%= f.text_field :fax_number, class: 'narrow' %>
+      <%= f.text_field :email %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/solicitor/personal_details/edit.html.erb
+++ b/app/views/steps/solicitor/personal_details/edit.html.erb
@@ -1,0 +1,17 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_field :full_name %>
+      <%= f.text_field :firm_name %>
+      <%= f.text_field :reference %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,6 +274,11 @@ en:
       relationship:
         edit:
           page_title: Other person relationship
+    solicitor:
+      personal_details:
+        edit:
+          page_title: "Solicitor's details"
+          heading: "Solicitor's details"
     abuse_concerns:
       start:
         show:
@@ -1459,6 +1464,10 @@ en:
         new_name: Full name of respondent
       steps_respondent_names_form[names_attributes]:
         full_name: Full name of respondent
+      steps_solicitor_personal_details_form:
+        full_name: Full name of solicitor
+        firm_name: Name of firm
+        reference: Solicitor reference
       steps_screener_postcode_form:
         children_postcodes: Postcode
       steps_screener_email_consent_form:
@@ -1563,6 +1572,9 @@ en:
         adr_exemptions: *select_all_that_apply_or_none
       steps_miam_exemptions_misc_form:
         misc_exemptions: *select_all_that_apply_or_none
+      steps_solicitor_personal_details_form:
+        full_name: Enter the first name and last name.
+        reference: The solicitor should have given you a reference for your case.
 
     submit:
       continue: Continue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,14 @@ en:
           heading: The applicant is (or may be) less than 18 years old
           lead_text: Sorry, you’re not eligible to apply online. You can only use this online service if both you and the other person (the respondent) are over 18.
           continue: Continue
+      has_solicitor:
+        edit:
+          page_title: Do you have a solicitor?
+          heading:
+            zero: Do you have a solicitor?
+            one: Do you have a solicitor?
+            other: Do you or any of the other applicants have a solicitor?
+          lead_text: Tell us if a solicitor is representing you in these proceedings.
     respondent:
       names:
         edit:
@@ -1210,6 +1218,8 @@ en:
         gender: Sex
       steps_applicant_contact_details_form:
         residence_requirement_met: Have you lived at your current address for more than 5 years?
+      steps_applicant_has_solicitor_form:
+        has_solicitor_html: ""
       steps_respondent_personal_details_form:
         has_previous_name: Have they changed their name?
         gender: Sex

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,6 +279,10 @@ en:
         edit:
           page_title: "Solicitor's details"
           heading: "Solicitor's details"
+      contact_details:
+        edit:
+          page_title: "Solicitor's contact details"
+          heading: "Contact details of %{name}"
     abuse_concerns:
       start:
         show:
@@ -1043,6 +1047,9 @@ en:
         steps/other_parties/contact_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
+        steps/solicitor/contact_details_form:
+          attributes:
+            <<: *PERSONAL_DETAILS_ERRORS
         steps/children/residence_form:
           attributes:
             person_ids:
@@ -1468,6 +1475,12 @@ en:
         full_name: Full name of solicitor
         firm_name: Name of firm
         reference: Solicitor reference
+      steps_solicitor_contact_details_form:
+        address: Address
+        dx_number: DX number
+        phone_number: Phone number
+        fax_number: Fax number
+        email: Email address
       steps_screener_postcode_form:
         children_postcodes: Postcode
       steps_screener_email_consent_form:
@@ -1575,6 +1588,11 @@ en:
       steps_solicitor_personal_details_form:
         full_name: Enter the first name and last name.
         reference: The solicitor should have given you a reference for your case.
+      steps_solicitor_contact_details_form:
+        address: Enter the full address including postcode.
+        dx_number_html: |
+          You can ask your solicitor for this (if they have one).<br/>
+          This is a secure document exchange system used by the legal profession.
 
     submit:
       continue: Continue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,6 +197,7 @@ Rails.application.routes.draw do
     end
     namespace :solicitor do
       edit_step :personal_details
+      edit_step :contact_details
     end
     namespace :respondent do
       crud_step :names

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,7 @@ Rails.application.routes.draw do
       crud_step :personal_details, only: [:edit, :update]
       crud_step :under_age,        only: [:edit, :update]
       crud_step :contact_details,  only: [:edit, :update]
+      edit_step :has_solicitor
       edit_step :relationship, only: [] do
         edit_routes ':id/child/:child_id'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,6 +195,9 @@ Rails.application.routes.draw do
         edit_routes ':id/child/:child_id'
       end
     end
+    namespace :solicitor do
+      edit_step :personal_details
+    end
     namespace :respondent do
       crud_step :names
       crud_step :personal_details, only: [:edit, :update]

--- a/db/migrate/20180611114319_add_solicitor_fields.rb
+++ b/db/migrate/20180611114319_add_solicitor_fields.rb
@@ -1,0 +1,5 @@
+class AddSolicitorFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :c100_applications, :has_solicitor, :string
+  end
+end

--- a/db/migrate/20180611122325_create_solicitors_table.rb
+++ b/db/migrate/20180611122325_create_solicitors_table.rb
@@ -1,0 +1,18 @@
+class CreateSolicitorsTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :solicitors, id: :uuid do |t|
+      t.timestamps null: false
+
+      t.string  :full_name
+      t.string  :firm_name
+      t.string  :reference
+      t.text    :address
+      t.string  :dx_number
+      t.string  :phone_number
+      t.string  :fax_number
+      t.string  :email
+    end
+
+    add_reference :solicitors, :c100_application, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180611102906) do
+ActiveRecord::Schema.define(version: 20180611122325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 20180611102906) do
     t.string "urgent_hearing_when"
     t.string "urgent_hearing_short_notice"
     t.text "urgent_hearing_short_notice_details"
+    t.string "has_solicitor"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end
@@ -286,6 +287,21 @@ ActiveRecord::Schema.define(version: 20180611102906) do
     t.string "utm_campaign"
   end
 
+  create_table "solicitors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "full_name"
+    t.string "firm_name"
+    t.string "reference"
+    t.text "address"
+    t.string "dx_number"
+    t.string "phone_number"
+    t.string "fax_number"
+    t.string "email"
+    t.uuid "c100_application_id"
+    t.index ["c100_application_id"], name: "index_solicitors_on_c100_application_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -314,4 +330,5 @@ ActiveRecord::Schema.define(version: 20180611102906) do
   add_foreign_key "relationships", "people"
   add_foreign_key "relationships", "people", column: "minor_id"
   add_foreign_key "screener_answers", "c100_applications"
+  add_foreign_key "solicitors", "c100_applications"
 end

--- a/spec/controllers/steps/applicant/has_solicitor_controller_spec.rb
+++ b/spec/controllers/steps/applicant/has_solicitor_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Applicant::HasSolicitorController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Applicant::HasSolicitorForm, C100App::ApplicantDecisionTree
+end

--- a/spec/controllers/steps/solicitor/contact_details_controller_spec.rb
+++ b/spec/controllers/steps/solicitor/contact_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Solicitor::ContactDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Solicitor::ContactDetailsForm, C100App::SolicitorDecisionTree
+end

--- a/spec/controllers/steps/solicitor/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/solicitor/personal_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Solicitor::PersonalDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Solicitor::PersonalDetailsForm, C100App::SolicitorDecisionTree
+end

--- a/spec/forms/steps/applicant/has_solicitor_form_spec.rb
+++ b/spec/forms/steps/applicant/has_solicitor_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Applicant::HasSolicitorForm do
+  it_behaves_like 'a yes-no question form', attribute_name: :has_solicitor
+end

--- a/spec/forms/steps/applicant/has_solicitor_form_spec.rb
+++ b/spec/forms/steps/applicant/has_solicitor_form_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Applicant::HasSolicitorForm do
-  it_behaves_like 'a yes-no question form', attribute_name: :has_solicitor
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :has_solicitor,
+                  reset_when_no: [:solicitor]
 end

--- a/spec/forms/steps/solicitor/contact_details_form_spec.rb
+++ b/spec/forms/steps/solicitor/contact_details_form_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Solicitor::ContactDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    address: 'address',
+    dx_number: 'dx_number',
+    phone_number: 'phone_number',
+    fax_number: 'fax_number',
+    email: email,
+  } }
+
+  let(:email) { 'test@example.com' }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:address) }
+
+      context 'email validation' do
+        context 'email is not validated if not present' do
+          let(:email) { nil }
+          it { expect(subject).to be_valid }
+        end
+
+        context 'email is validated if present' do
+          let(:email) { 'xxx' }
+          it {
+            expect(subject).not_to be_valid
+            expect(subject.errors[:email]).to_not be_empty
+          }
+        end
+      end
+    end
+
+    it_behaves_like 'a has-one-association form',
+                    association_name: :solicitor,
+                    expected_attributes: {
+                      address: 'address',
+                      dx_number: 'dx_number',
+                      phone_number: 'phone_number',
+                      fax_number: 'fax_number',
+                      email: 'test@example.com',
+                    }
+  end
+end

--- a/spec/forms/steps/solicitor/personal_details_form_spec.rb
+++ b/spec/forms/steps/solicitor/personal_details_form_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Solicitor::PersonalDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    full_name: 'full_name',
+    firm_name: 'firm_name',
+    reference: 'reference',
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:full_name) }
+      it { should validate_presence_of(:firm_name) }
+    end
+
+    it_behaves_like 'a has-one-association form',
+                    association_name: :solicitor,
+                    expected_attributes: {
+                      full_name: 'full_name',
+                      firm_name: 'firm_name',
+                      reference: 'reference',
+                    }
+  end
+end

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -105,7 +105,25 @@ RSpec.describe C100App::ApplicantDecisionTree do
 
     context 'when all applicants have been edited' do
       let(:record) { double('Applicant', id: 3) }
-      it {is_expected.to have_destination('/steps/respondent/names', :edit)}
+      it {is_expected.to have_destination(:has_solicitor, :edit)}
+    end
+  end
+
+  context 'when the step is `has_solicitor`' do
+    let(:step_params) { { has_solicitor: 'anything' } }
+
+    before do
+      allow(c100_application).to receive(:has_solicitor).and_return(value)
+    end
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+      it { is_expected.to have_destination('/steps/solicitor/personal_details', :edit) }
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+      it { is_expected.to have_destination('/steps/respondent/names', :edit) }
     end
   end
 end

--- a/spec/services/c100_app/solicitor_decision_tree_spec.rb
+++ b/spec/services/c100_app/solicitor_decision_tree_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe C100App::SolicitorDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-  context 'when the step is `solicitor_details`' do
-    let(:step_params) { { solicitor_details: 'anything' } }
-    it { is_expected.to have_destination(:solicitor_contact_details, :edit) }
+  context 'when the step is `personal_details`' do
+    let(:step_params) { { personal_details: 'anything' } }
+    it { is_expected.to have_destination(:contact_details, :edit) }
   end
 
-  context 'when the step is `solicitor_contact_details`' do
-    let(:step_params) { { solicitor_contact_details: 'anything' } }
+  context 'when the step is `contact_details`' do
+    let(:step_params) { { contact_details: 'anything' } }
     it { is_expected.to have_destination('/steps/respondent/names', :edit) }
   end
 end

--- a/spec/services/c100_app/solicitor_decision_tree_spec.rb
+++ b/spec/services/c100_app/solicitor_decision_tree_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe C100App::SolicitorDecisionTree do
+  let(:c100_application) { double('Object') }
+  let(:step_params)      { double('Step') }
+  let(:next_step)        { nil }
+  let(:as)               { nil }
+
+  subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
+
+  it_behaves_like 'a decision tree'
+
+  context 'when the step is `solicitor_details`' do
+    let(:step_params) { { solicitor_details: 'anything' } }
+    it { is_expected.to have_destination(:solicitor_contact_details, :edit) }
+  end
+
+  context 'when the step is `solicitor_contact_details`' do
+    let(:step_params) { { solicitor_contact_details: 'anything' } }
+    it { is_expected.to have_destination('/steps/respondent/names', :edit) }
+  end
+end


### PR DESCRIPTION
Note: the screener question is still present, will be removed as part of a future PR. Also, CYA and PDF not yet updated to show the solicitor details. 

<img width="671" alt="screen shot 2018-06-12 at 11 45 29" src="https://user-images.githubusercontent.com/687910/41286093-371e44d2-6e36-11e8-9e17-289d9ce4649f.png">

If yes:

* solicitor personal details

<img width="688" alt="screen shot 2018-06-12 at 11 45 46" src="https://user-images.githubusercontent.com/687910/41286100-3c1d11c0-6e36-11e8-90a4-8fc2f28b80a0.png">

* solicitor contact details

<img width="585" alt="screen shot 2018-06-12 at 11 45 58" src="https://user-images.githubusercontent.com/687910/41286112-403c3f9c-6e36-11e8-9159-ac7d525fe7c3.png">
