### PR TITLE
Reintroduce and update `Payment` step

### DIFF
--- a/app/presenters/summary/c100_form.rb
+++ b/app/presenters/summary/c100_form.rb
@@ -15,7 +15,7 @@ module Summary
         international_element_sections,
         litigation_and_assistance_sections,
         people_sections,
-        statement_of_truth,
+        statement_of_truth_and_payment,
       ].flatten.select(&:show?)
     end
 
@@ -105,10 +105,11 @@ module Summary
       ]
     end
 
-    def statement_of_truth
+    def statement_of_truth_and_payment
       [
         Sections::SectionHeader.new(c100_application, name: :statement_of_truth),
         Sections::StatementOfTruth.new(c100_application),
+        Sections::CourtFee.new(c100_application),
       ]
     end
   end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -78,7 +78,7 @@ module Summary
 
     def payment_and_submission_sections
       [
-        HtmlSections::HelpWithFees.new(c100_application),
+        HtmlSections::Payment.new(c100_application),
         HtmlSections::Submission.new(c100_application),
       ]
     end

--- a/app/presenters/summary/sections/court_fee.rb
+++ b/app/presenters/summary/sections/court_fee.rb
@@ -1,0 +1,17 @@
+module Summary
+  module Sections
+    class CourtFee < BaseSectionPresenter
+      def name
+        :court_fee
+      end
+
+      def answers
+        [
+          Answer.new(:payment_type, c100.payment_type),
+          FreeTextAnswer.new(:hwf_reference_number, c100.hwf_reference_number),
+          FreeTextAnswer.new(:solicitor_account_number, c100.solicitor_account_number),
+        ].select(&:show?)
+      end
+    end
+  end
+end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -30,8 +30,8 @@ module C100App
       when :special_assistance
         edit(:special_arrangements)
       when :special_arrangements
-        edit(:help_paying)
-      when :help_paying
+        edit(:payment)
+      when :payment
         submission_type_or_cya
       when :submission
         edit(:check_your_answers)

--- a/app/value_objects/payment_type.rb
+++ b/app/value_objects/payment_type.rb
@@ -2,7 +2,8 @@ class PaymentType < ValueObject
   VALUES = [
     HELP_WITH_FEES = new(:help_with_fees),
     SOLICITOR = new(:solicitor),
-    SELF_PAYMENT = new(:self_payment),
+    SELF_PAYMENT_CARD = new(:self_payment_card),
+    SELF_PAYMENT_CHEQUE = new(:self_payment_cheque),
   ].freeze
 
   def self.values

--- a/app/views/steps/application/payment/edit.html.erb
+++ b/app/views/steps/application/payment/edit.html.erb
@@ -4,8 +4,6 @@
   <div class="column-two-thirds">
     <%= step_header %>
 
-    <div class="prototype-step">This page is a prototype and is not enabled in production.</div>
-
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
@@ -15,7 +13,8 @@
         f.radio_button_fieldset :payment_type do |fieldset|
           fieldset.radio_input(PaymentType::HELP_WITH_FEES) { f.text_field :hwf_reference_number, class: 'narrow' }
           fieldset.radio_input(PaymentType::SOLICITOR) { f.text_field :solicitor_account_number, class: 'narrow' }
-          fieldset.radio_input(PaymentType::SELF_PAYMENT)
+          fieldset.radio_input(PaymentType::SELF_PAYMENT_CARD)
+          fieldset.radio_input(PaymentType::SELF_PAYMENT_CHEQUE)
         end
       %>
 

--- a/app/views/steps/application/submission/edit.html.erb
+++ b/app/views/steps/application/submission/edit.html.erb
@@ -4,7 +4,7 @@
   <div class="column-two-thirds">
     <%= step_header %>
 
-    <div class="prototype-step">This page is a prototype and is not enabled in production.</div>
+    <div class="prototype-step">Online submission is a prototype and is not enabled in production.</div>
 
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -3,7 +3,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <br/>
-    <div class="prototype-step">This page is a prototype and is not enabled in production.</div>
+    <div class="prototype-step">Online submission is a prototype and is not enabled in production.</div>
 
     <div class="grid_content_header govuk-box-highlight">
       <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge">Your application has been submitted</h1>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -576,8 +576,9 @@ en:
       question: ''
       answers:
         help_with_fees: Help with fees
-        solicitor: Solicitor payment
-        self_payment: I am paying myself
+        solicitor: Through a solicitor’s fee account
+        self_payment_card: I am paying myself by credit or debit card
+        self_payment_cheque: I am paying myself by cheque or cash
     submission_type:
       question: ''
       answers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1323,8 +1323,9 @@ en:
       steps_application_payment_form:
         payment_type:
           help_with_fees_html: '<strong>Help with fees</strong><br>You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" target="external_link" rel="external">get help paying</a> if you’re on a low income, receive certain benefits or have little or no savings. If you do qualify, you’ll need to provide your reference number.'
-          solicitor_html: '<strong>Solicitor payment</strong><br>If you have a solicitor representing you, they may pay the court by direct debit. You’ll need to provide their ‘fee account number’.'
-          self_payment_html: '<strong>I am paying myself</strong><br>You can pay over the phone using a credit or debit card, by post with a cheque, or in person at the court by cheque, cash or card.'
+          solicitor_html: '<strong>Through a solicitor’s fee account</strong><br>If you have a solicitor representing you, they may pay the court by direct debit. You’ll need to provide their ‘fee account number’.'
+          self_payment_card_html: '<strong>I am paying myself by credit or debit card</strong><br>Court staff will contact you within 3 working days to take payment over the phone.'
+          self_payment_cheque_html: '<strong>I am paying myself by cheque or cash</strong><br>You can send a cheque or pay in person at the court.'
         hwf_reference_number: Enter your reference number
         solicitor_account_number: Enter solicitor’s fee account number
       steps_application_submission_form:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -125,6 +125,7 @@ en:
       urgent_hearing: Urgent hearing
       without_notice_hearing: Without notice hearing
       other_children_details: Other children not part of the application
+      court_fee: Court fee
       ### C1A ###
       c1a_court_details: *to_be_completed
       c1a_children_details: Summary of children’s details
@@ -439,6 +440,15 @@ en:
       question: Type of proceedings - if known
     court_proceeding_previous_details:
       question: Details of any other previous family case
+    payment_type:
+      question: Payment option selected
+      answers:
+        help_with_fees: Help with fees
+        solicitor: Through solicitor
+        self_payment_card: Credit or debit card - contact the applicant within 3 working days of receiving application to take payment
+        self_payment_cheque: Cheque or cash
+    solicitor_account_number:
+      question: Fee account number
 
     ### C1A questions/answers ###
     #

--- a/spec/forms/steps/application/payment_form_spec.rb
+++ b/spec/forms/steps/application/payment_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Steps::Application::PaymentForm do
 
   let(:c100_application) { instance_double(C100Application) }
 
-  let(:payment_type) { PaymentType::SELF_PAYMENT.to_s }
+  let(:payment_type) { PaymentType::SELF_PAYMENT_CARD.to_s }
   let(:hwf_reference_number) { nil }
   let(:solicitor_account_number) { nil }
 
@@ -43,13 +43,13 @@ RSpec.describe Steps::Application::PaymentForm do
     end
 
     context 'when form is valid' do
-      let(:payment_type) { PaymentType::SELF_PAYMENT.to_s }
+      let(:payment_type) { PaymentType::SELF_PAYMENT_CARD.to_s }
       let(:hwf_reference_number) { 'HWF-12345' }
       let(:solicitor_account_number) { 'SOL-12345' }
 
       it 'saves the record' do
         expect(c100_application).to receive(:update).with(
-          payment_type: 'self_payment',
+          payment_type: 'self_payment_card',
           hwf_reference_number: nil,
           solicitor_account_number: nil,
         ).and_return(true)

--- a/spec/presenters/summary/c100_form_spec.rb
+++ b/spec/presenters/summary/c100_form_spec.rb
@@ -65,6 +65,7 @@ module Summary
           Sections::SolicitorDetails,
           Sections::SectionHeader,
           Sections::StatementOfTruth,
+          Sections::CourtFee,
         ])
       end
     end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -76,7 +76,7 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::InternationalElement,
         Summary::HtmlSections::ApplicationReasons,
         Summary::HtmlSections::AttendingCourt,
-        Summary::HtmlSections::HelpWithFees,
+        Summary::HtmlSections::Payment,
         Summary::HtmlSections::Submission,
       ])
     end

--- a/spec/presenters/summary/html_sections/payment_spec.rb
+++ b/spec/presenters/summary/html_sections/payment_spec.rb
@@ -48,7 +48,7 @@ module Summary
         let(:c100_application) {
           instance_double(
             C100Application,
-            payment_type: 'self_payment',
+            payment_type: 'self_payment_card',
             hwf_reference_number: nil,
             solicitor_account_number: nil,
           )
@@ -61,7 +61,7 @@ module Summary
 
           expect(group.answers[0]).to be_an_instance_of(Answer)
           expect(group.answers[0].question).to eq(:payment_type)
-          expect(group.answers[0].value).to eq('self_payment')
+          expect(group.answers[0].value).to eq('self_payment_card')
         end
       end
     end

--- a/spec/presenters/summary/sections/court_fee_spec.rb
+++ b/spec/presenters/summary/sections/court_fee_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::CourtFee do
+    let(:c100_application) {
+      instance_double(
+        C100Application,
+        payment_type: payment_type,
+        hwf_reference_number: hwf_reference_number,
+        solicitor_account_number: solicitor_account_number,
+      )
+    }
+
+    let(:payment_type) { 'whatever' }
+    let(:hwf_reference_number) { nil }
+    let(:solicitor_account_number) { nil }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:court_fee)
+      end
+    end
+
+    describe '#answers' do
+      context 'self payment' do
+        it 'has the correct rows' do
+          expect(answers.count).to eq(1)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:payment_type)
+          expect(answers[0].value).to eq('whatever')
+        end
+      end
+
+      context 'help with fees payment' do
+        let(:hwf_reference_number) { '12345' }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(2)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:payment_type)
+          expect(answers[0].value).to eq('whatever')
+
+          expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[1].question).to eq(:hwf_reference_number)
+          expect(answers[1].value).to eq('12345')
+        end
+      end
+
+      context 'solicitor payment' do
+        let(:solicitor_account_number) { '12345' }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(2)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:payment_type)
+          expect(answers[0].value).to eq('whatever')
+
+          expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[1].question).to eq(:solicitor_account_number)
+          expect(answers[1].value).to eq('12345')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -112,11 +112,11 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
   context 'when the step is `special_arrangements`' do
     let(:step_params) { { special_arrangements: 'anything' } }
-    it { is_expected.to have_destination(:help_paying, :edit) }
+    it { is_expected.to have_destination(:payment, :edit) }
   end
 
-  context 'when the step is `help_paying`' do
-    let(:step_params) { { help_paying: 'anything' } }
+  context 'when the step is `payment`' do
+    let(:step_params) { { payment: 'anything' } }
 
     before do
       allow(subject).to receive(:dev_tools_enabled?).and_return(dev_tools_enabled)

--- a/spec/value_objects/payment_type_spec.rb
+++ b/spec/value_objects/payment_type_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe PaymentType do
       expect(described_class.values.map(&:to_s)).to eq(%w(
         help_with_fees
         solicitor
-        self_payment
+        self_payment_card
+        self_payment_cheque
       ))
     end
   end


### PR DESCRIPTION
This replaces the current Help with fees step. The old Help with fees code has not been removed yet, until we are sure we don't need it anymore.

<img width="644" alt="screen shot 2018-06-13 at 09 49 09" src="https://user-images.githubusercontent.com/687910/41340358-0a089aba-6eef-11e8-81b7-9cdcbabdf19a.png">

And in the PDF:

<img width="842" alt="screen shot 2018-06-12 at 16 19 38" src="https://user-images.githubusercontent.com/687910/41340365-10903258-6eef-11e8-95a7-a43ecbbe57ee.png">
