### PR TITLE
 Add timeout warning in application details

### DIFF
--- a/app/views/steps/application/details/edit.html.erb
+++ b/app/views/steps/application/details/edit.html.erb
@@ -10,6 +10,10 @@
       <%=t '.info_html' %>
     </div>
 
+    <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
+      <p><%=t '.timeout_warning', session_timeout: session_expire_in_minutes %></p>
+    </div>
+
     <%= step_form @form_object do |f| %>
       <%= f.text_area :application_details, size: '40x4', class: 'form-control-3-4' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -693,6 +693,7 @@ en:
               <li>why the other person disagrees</li>
               <li>any previous <a href="https://www.splittingup-putkidsfirst.org.uk/home" target="external_link" rel="external">parenting plans</a> or agreements (formal or informal), and why they broke down</li>
             </ul>
+          timeout_warning: For your security, your session ends after %{session_timeout} minutes if there’s no activity on your application. To avoid losing your application, make sure you save it. Any unsaved details will be deleted.
       language:
         edit:
           page_title: Language help


### PR DESCRIPTION
People seem to take longer in this step than others, so adding a warning about the session expiring.

<img width="668" alt="screen shot 2018-06-13 at 12 24 30" src="https://user-images.githubusercontent.com/687910/41349024-71ed896c-6f06-11e8-9785-75f7522b6d10.png">
