### PR TITLE
Add solicitor details to C100 and C1A pdf

### DIFF
--- a/app/presenters/summary/sections/c1a_solicitor_details.rb
+++ b/app/presenters/summary/sections/c1a_solicitor_details.rb
@@ -5,10 +5,33 @@ module Summary
         :c1a_solicitor_details
       end
 
+      # This is almost identical to the C100 version, except a couple
+      # of answers (`solicitor_applicant_name` and `solicitor_fee_account`)
+      # we have omitted for the C1A version.
+      # rubocop:disable Metrics/AbcSize
       def answers
+        return [
+          Answer.new(:has_solicitor, GenericYesNo::NO)
+        ] if solicitor.nil?
+
         [
-          Answer.new(:c1a_has_solicitor, GenericYesNo::NO), # Always `NO` for pilot (we are screening)
-        ]
+          Answer.new(:has_solicitor, GenericYesNo::YES),
+          FreeTextAnswer.new(:solicitor_full_name, solicitor.full_name),
+          FreeTextAnswer.new(:solicitor_firm_name, solicitor.firm_name),
+          FreeTextAnswer.new(:solicitor_address, solicitor.address),
+          FreeTextAnswer.new(:solicitor_phone_number, solicitor.phone_number),
+          FreeTextAnswer.new(:solicitor_fax_number, solicitor.fax_number),
+          FreeTextAnswer.new(:solicitor_dx_number, solicitor.dx_number),
+          FreeTextAnswer.new(:solicitor_reference, solicitor.reference),
+          FreeTextAnswer.new(:solicitor_email, solicitor.email),
+        ].select(&:show?)
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def solicitor
+        @_solicitor ||= c100.solicitor
       end
     end
   end

--- a/app/presenters/summary/sections/solicitor_details.rb
+++ b/app/presenters/summary/sections/solicitor_details.rb
@@ -9,10 +9,36 @@ module Summary
         false
       end
 
+      # rubocop:disable Metrics/AbcSize
       def answers
+        return [
+          Answer.new(:has_solicitor, GenericYesNo::NO)
+        ] if solicitor.nil?
+
         [
-          Answer.new(:has_solicitor, GenericYesNo::NO), # Always `NO` for pilot (we are screening)
+          Answer.new(:has_solicitor, GenericYesNo::YES),
+          FreeTextAnswer.new(:solicitor_applicant_name, applicant_name),
+          FreeTextAnswer.new(:solicitor_full_name, solicitor.full_name),
+          FreeTextAnswer.new(:solicitor_firm_name, solicitor.firm_name),
+          FreeTextAnswer.new(:solicitor_address, solicitor.address),
+          FreeTextAnswer.new(:solicitor_phone_number, solicitor.phone_number),
+          FreeTextAnswer.new(:solicitor_fax_number, solicitor.fax_number),
+          FreeTextAnswer.new(:solicitor_dx_number, solicitor.dx_number),
+          FreeTextAnswer.new(:solicitor_reference, solicitor.reference),
+          FreeTextAnswer.new(:solicitor_fee_account, c100.solicitor_account_number, show: true),
+          FreeTextAnswer.new(:solicitor_email, solicitor.email),
         ].select(&:show?)
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def solicitor
+        @_solicitor ||= c100.solicitor
+      end
+
+      def applicant_name
+        c100.applicants.first&.full_name
       end
     end
   end

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -422,10 +422,34 @@ en:
       question: Email address
     person_relationship_to_children:
       question: Relationship to children listed in this application
+
+    # Note: the solicitor i18n is shared among the C100 and C1A forms.
     has_solicitor:
       question: Is a solicitor acting for you?
       answers:
         <<: *YESNO
+    solicitor_applicant_name:
+      question: Solicitor acting for
+    solicitor_full_name:
+      question: Solicitor’s name
+    solicitor_firm_name:
+      question: Name of firm
+    solicitor_address:
+      question: Address
+    solicitor_phone_number:
+      question: Telephone number
+    solicitor_fax_number:
+      question: Fax number
+    solicitor_dx_number:
+      question: DX number
+    solicitor_reference:
+      question: Solicitor’s reference
+    solicitor_fee_account:
+      question: Fee account number
+      absence_answer: *not_applicable
+    solicitor_email:
+      question: Email address
+
     court_proceeding_children_names:
       question: Name of child(ren)
     court_proceeding_court_name:

--- a/spec/presenters/summary/sections/c1a_solicitor_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_solicitor_details_spec.rb
@@ -3,10 +3,26 @@ require 'spec_helper'
 module Summary
   describe Sections::C1aSolicitorDetails do
     let(:c100_application) {
-      instance_double(C100Application,
+      instance_double(
+        C100Application,
+        has_solicitor: 'yes',
+        solicitor: solicitor,
     ) }
 
     subject { described_class.new(c100_application) }
+
+    let(:solicitor) {
+      instance_double(
+        Solicitor,
+        full_name: 'full_name',
+        firm_name: 'firm_name',
+        reference: 'reference',
+        address: 'address',
+        dx_number: 'dx_number',
+        phone_number: 'phone_number',
+        fax_number: 'fax_number',
+        email: 'email',
+    ) }
 
     let(:answers) { subject.answers }
 
@@ -15,12 +31,58 @@ module Summary
     end
 
     describe '#answers' do
-      it 'has the correct rows' do
-        expect(answers.count).to eq(1)
+      context 'no solicitor details' do
+        let(:solicitor) { nil }
 
-        expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:c1a_has_solicitor)
-        expect(answers[0].value).to eq(GenericYesNo::NO) # Always `NO` for pilot (we are screening)
+        it 'has the correct rows' do
+          expect(answers.count).to eq(1)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:has_solicitor)
+          expect(answers[0].value).to eq(GenericYesNo::NO)
+        end
+      end
+
+      context 'solicitor details are present' do
+        it 'has the correct rows' do
+          expect(answers.count).to eq(9)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:has_solicitor)
+          expect(answers[0].value).to eq(GenericYesNo::YES)
+
+          expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[1].question).to eq(:solicitor_full_name)
+          expect(answers[1].value).to eq('full_name')
+
+          expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[2].question).to eq(:solicitor_firm_name)
+          expect(answers[2].value).to eq('firm_name')
+
+          expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[3].question).to eq(:solicitor_address)
+          expect(answers[3].value).to eq('address')
+
+          expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[4].question).to eq(:solicitor_phone_number)
+          expect(answers[4].value).to eq('phone_number')
+
+          expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[5].question).to eq(:solicitor_fax_number)
+          expect(answers[5].value).to eq('fax_number')
+
+          expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[6].question).to eq(:solicitor_dx_number)
+          expect(answers[6].value).to eq('dx_number')
+
+          expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[7].question).to eq(:solicitor_reference)
+          expect(answers[7].value).to eq('reference')
+
+          expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[8].question).to eq(:solicitor_email)
+          expect(answers[8].value).to eq('email')
+        end
       end
     end
   end

--- a/spec/presenters/summary/sections/solicitor_details_spec.rb
+++ b/spec/presenters/summary/sections/solicitor_details_spec.rb
@@ -3,10 +3,30 @@ require 'spec_helper'
 module Summary
   describe Sections::SolicitorDetails do
     let(:c100_application) {
-      instance_double(C100Application,
+      instance_double(
+        C100Application,
+        applicants: [applicant],
+        solicitor_account_number: solicitor_account_number,
+        has_solicitor: 'yes',
+        solicitor: solicitor,
     ) }
 
     subject { described_class.new(c100_application) }
+
+    let(:applicant) { instance_double(Applicant, full_name: 'John Doe') }
+    let(:solicitor) {
+      instance_double(
+        Solicitor,
+        full_name: 'full_name',
+        firm_name: 'firm_name',
+        reference: 'reference',
+        address: 'address',
+        dx_number: 'dx_number',
+        phone_number: 'phone_number',
+        fax_number: 'fax_number',
+        email: 'email',
+    ) }
+    let(:solicitor_account_number) { '12345' }
 
     let(:answers) { subject.answers }
 
@@ -19,12 +39,79 @@ module Summary
     end
 
     describe '#answers' do
-      it 'has the correct rows' do
-        expect(answers.count).to eq(1)
+      context 'no solicitor details' do
+        let(:solicitor) { nil }
 
-        expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:has_solicitor)
-        expect(answers[0].value).to eq(GenericYesNo::NO) # Always `NO` for pilot (we are screening)
+        it 'has the correct rows' do
+          expect(answers.count).to eq(1)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:has_solicitor)
+          expect(answers[0].value).to eq(GenericYesNo::NO)
+        end
+      end
+
+      context 'no solicitor solicitor_fee_account' do
+        let(:solicitor_account_number) { nil }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(11)
+
+          expect(answers[9]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[9].question).to eq(:solicitor_fee_account)
+          expect(answers[9].show?).to eq(true)
+          expect(answers[9].value).to be_nil
+        end
+      end
+
+      context 'solicitor details are present' do
+        it 'has the correct rows' do
+          expect(answers.count).to eq(11)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:has_solicitor)
+          expect(answers[0].value).to eq(GenericYesNo::YES)
+
+          expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[1].question).to eq(:solicitor_applicant_name)
+          expect(answers[1].value).to eq('John Doe')
+
+          expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[2].question).to eq(:solicitor_full_name)
+          expect(answers[2].value).to eq('full_name')
+
+          expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[3].question).to eq(:solicitor_firm_name)
+          expect(answers[3].value).to eq('firm_name')
+
+          expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[4].question).to eq(:solicitor_address)
+          expect(answers[4].value).to eq('address')
+
+          expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[5].question).to eq(:solicitor_phone_number)
+          expect(answers[5].value).to eq('phone_number')
+
+          expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[6].question).to eq(:solicitor_fax_number)
+          expect(answers[6].value).to eq('fax_number')
+
+          expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[7].question).to eq(:solicitor_dx_number)
+          expect(answers[7].value).to eq('dx_number')
+
+          expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[8].question).to eq(:solicitor_reference)
+          expect(answers[8].value).to eq('reference')
+
+          expect(answers[9]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[9].question).to eq(:solicitor_fee_account)
+          expect(answers[9].value).to eq('12345')
+
+          expect(answers[10]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[10].question).to eq(:solicitor_email)
+          expect(answers[10].value).to eq('email')
+        end
       end
     end
   end


### PR DESCRIPTION
We already had this sections but hardcoded to `no`. Now it will show the details if present.

<img width="807" alt="screen shot 2018-06-13 at 14 48 23" src="https://user-images.githubusercontent.com/687910/41358350-1e10cef2-6f20-11e8-87dd-9d0ecd0ba0f6.png">
