### PR TITLE
Add applicant name to email sent to court

### DIFF
--- a/app/mailer_previews/submission_mailer_preview.rb
+++ b/app/mailer_previews/submission_mailer_preview.rb
@@ -18,9 +18,10 @@ class SubmissionMailerPreview < ActionMailer::Preview
   # We don't have a factory, so just building (not need to persist)
   # a bare minimum C100 application struct for the purpose of the preview
   def c100_application
-    Struct.new(:reference_code, :screener_answers_court).new(
+    Struct.new(:reference_code, :screener_answers_court, :applicants).new(
       '12345',
       local_court_fixture,
+      applicants_fixture,
     )
   end
 
@@ -36,6 +37,10 @@ class SubmissionMailerPreview < ActionMailer::Preview
       to: 'to-address@example.com',
       reply_to: 'reply-to@example.com',
     }
+  end
+
+  def applicants_fixture
+    [Applicant.new(full_name: 'John Doe')]
   end
 
   def local_court_fixture

--- a/app/mailers/court_mailer.rb
+++ b/app/mailers/court_mailer.rb
@@ -2,6 +2,11 @@ class CourtMailer < SubmissionMailer
   def submission_to_court(to:, reply_to:)
     attach_c100_pdf!
 
+    # A 'real' application would never reach this point without having at
+    # least 1 applicant, but on staging and local, we may jump steps and
+    # don't want this to explode, thus, protecting from `nil`.
+    @applicant_full_name = @c100_application.applicants.first&.full_name
+
     mail(
       to: to,
       reply_to: reply_to

--- a/app/mailers/receipt_mailer.rb
+++ b/app/mailers/receipt_mailer.rb
@@ -2,6 +2,8 @@ class ReceiptMailer < SubmissionMailer
   def copy_to_user(to:, reply_to:)
     attach_c100_pdf!
 
+    @court = @c100_application.screener_answers_court
+
     mail(
       to: to,
       reply_to: reply_to

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -10,9 +10,8 @@ class SubmissionMailer < ActionMailer::Base
   before_action do
     @service_name = I18n.translate!('service.name')
     @c100_application = params[:c100_application]
-    @reference_code = @c100_application.reference_code
-    @court = @c100_application.screener_answers_court
     @c100_pdf = params[:c100_pdf]
+    @reference_code = @c100_application.reference_code
   end
 
   protected

--- a/app/views/mailers/court_mailer/submission_to_court.en.html.erb
+++ b/app/views/mailers/court_mailer/submission_to_court.en.html.erb
@@ -1,4 +1,4 @@
-<p>Someone has submitted the attached C100 application through the ‘<%= link_to @service_name, root_url %>’ online
+<p><%= @applicant_full_name -%> has submitted the attached C100 application through the ‘<%= link_to @service_name, root_url %>’ online
   service.</p>
 
 <p>Their reference code is: <strong><%= @reference_code %></strong></p>

--- a/app/views/mailers/court_mailer/submission_to_court.en.text.erb
+++ b/app/views/mailers/court_mailer/submission_to_court.en.text.erb
@@ -1,4 +1,4 @@
-Someone has submitted the attached C100 application through the ‘<%= @service_name %>’ online service at <%= url_for root_url %>
+<%= @applicant_full_name -%> has submitted the attached C100 application through the ‘<%= @service_name %>’ online service at <%= url_for root_url %>
 
 Their reference code is: <%= @reference_code %>
 

--- a/app/views/mailers/shared/_technical_help.en.html.erb
+++ b/app/views/mailers/shared/_technical_help.en.html.erb
@@ -1,4 +1,4 @@
 <!-- TODO: decide if we want this, and which email address -->
 
 <p>For any technical questions about this email, please
-  email: <%= mail_to 'c100helpdesk@digital.justice.gov.uk', 'c100helpdesk@digital.justice.gov.uk' %></p>
+  contact: <%= mail_to 'c100helpdesk@digital.justice.gov.uk', 'c100helpdesk@digital.justice.gov.uk' %></p>

--- a/app/views/mailers/shared/_technical_help.en.text.erb
+++ b/app/views/mailers/shared/_technical_help.en.text.erb
@@ -1,1 +1,1 @@
-For any technical questions about this email, please email: c100helpdesk@digital.justice.gov.uk
+For any technical questions about this email, please contact: c100helpdesk@digital.justice.gov.uk

--- a/spec/mailers/court_mailer_spec.rb
+++ b/spec/mailers/court_mailer_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe CourtMailer, type: :mailer do
             mail.subject
           ).to eq('C100 new application - child arrangements')
         end
+
+        context 'assigns the first applicant full name' do
+          before do
+            allow(
+              c100_application
+            ).to receive(:applicants).and_return(
+              [double('Applicant', full_name: 'John Doe')]
+            )
+          end
+
+          it { expect(mail.body.encoded).to match('John Doe') }
+        end
       end
     end
   end

--- a/spec/mailers/receipt_mailer_spec.rb
+++ b/spec/mailers/receipt_mailer_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe ReceiptMailer, type: :mailer do
         it 'has the right subject' do
           expect(mail.subject).to eq('C100 new application - child arrangements')
         end
+
+        context 'assigns the court data' do
+          before do
+            allow(
+              c100_application
+            ).to receive(:screener_answers_court).and_return(
+              double('Court', name: 'Court XYZ', slug: 'court-xyz', present?: true).as_null_object
+            )
+          end
+
+          it { expect(mail.body.encoded).to match('Court XYZ') }
+          it { expect(mail.body.encoded).to match('https://courttribunalfinder.service.gov.uk/courts/court-xyz') }
+        end
       end
     end
   end

--- a/spec/support/submission_mailer_shared_examples.rb
+++ b/spec/support/submission_mailer_shared_examples.rb
@@ -31,6 +31,10 @@ RSpec.shared_examples 'a Submission mailer' do
     expect(mail.attachments.size).to eq(1)
   end
 
+  context 'assigns the application reference code' do
+    it { expect(mail.body.encoded).to match('1970/01/449362AF') }
+  end
+
   describe 'the attachment' do
     let(:attachment){ mail.attachments.last }
 


### PR DESCRIPTION
Instead of the generic `someone` we want the applicant full name to appear in the email sent to court (if there are more than 1 applicant only the first one is considered).

Reorganised a bit the code and specs as a side effect of this.