### PR TITLE
Make C100, C1A and C8 fillable inputs

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -41,21 +41,21 @@
       height: 20px;
     }
 
-    input.box-to-fill {
+    .box-to-fill {
       border: 1px solid $dark-grey;
       background-color: #fff;
       color: $dark-grey;
       padding: 3px;
       width: 100%;
     }
-
-    input.date-box {
+    .date-box {
       display: inline-block;
       margin-right: -4px;
       width: 14px;
     }
-    div.text-area-box {
-      height: 40px;
+    .text-area-box {
+      overflow: hidden;
+      resize: none;
     }
 
     span.separator {

--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -41,16 +41,18 @@
       height: 20px;
     }
 
-    div.box-to-fill {
+    input.box-to-fill {
       border: 1px solid $dark-grey;
       background-color: #fff;
       color: $dark-grey;
       padding: 3px;
+      width: 100%;
     }
 
-    div.date-box {
+    input.date-box {
       display: inline-block;
       margin-right: -4px;
+      width: 14px;
     }
     div.text-area-box {
       height: 40px;

--- a/app/services/c100_app/pdf_generator.rb
+++ b/app/services/c100_app/pdf_generator.rb
@@ -17,7 +17,8 @@ module C100App
     def pdf_from_presenter(presenter)
       WickedPdf.new.pdf_from_string(
         render(presenter),
-        footer: { right: footer_line(presenter) }
+        footer: { right: footer_line(presenter) },
+        extra: '--enable-forms',
       )
     end
 

--- a/app/views/steps/completion/shared/_admin_court_and_case_number.pdf.erb
+++ b/app/views/steps/completion/shared/_admin_court_and_case_number.pdf.erb
@@ -4,7 +4,7 @@
   </td>
 
   <td class="answer answer-value">
-    <div class="box-to-fill">&nbsp;</div>
+    <input class="box-to-fill" type="text" name="admin-family-court" />
   </td>
 </tr>
 
@@ -14,6 +14,6 @@
   </td>
 
   <td class="answer answer-value">
-    <div class="box-to-fill">&nbsp;</div>
+    <input class="box-to-fill" type="text" name="admin-case-number"/>
   </td>
 </tr>

--- a/app/views/steps/completion/shared/_admin_date_issued.en.pdf.erb
+++ b/app/views/steps/completion/shared/_admin_date_issued.en.pdf.erb
@@ -4,15 +4,15 @@
   </td>
 
   <td class="answer answer-value">
-    <div class="box-to-fill date-box">D</div>
-    <div class="box-to-fill date-box">D</div>
+    <input class="box-to-fill date-box" type="text" maxlength="1" name="date-d1"/>
+    <input class="box-to-fill date-box" type="text" maxlength="1" name="date-d2"/>
     <span class="separator"></span>
-    <div class="box-to-fill date-box">M</div>
-    <div class="box-to-fill date-box">M</div>
+    <input class="box-to-fill date-box" type="text" maxlength="1" name="date-m1"/>
+    <input class="box-to-fill date-box" type="text" maxlength="1" name="date-m2"/>
     <span class="separator"></span>
-    <div class="box-to-fill date-box">Y</div>
-    <div class="box-to-fill date-box">Y</div>
-    <div class="box-to-fill date-box">Y</div>
-    <div class="box-to-fill date-box">Y</div>
+    <input class="box-to-fill date-box" type="text" maxlength="1" name="date-y1"/>
+    <input class="box-to-fill date-box" type="text" maxlength="1" name="date-y2"/>
+    <input class="box-to-fill date-box" type="text" maxlength="1" name="date-y3"/>
+    <input class="box-to-fill date-box" type="text" maxlength="1" name="date-y4"/>
   </td>
 </tr>

--- a/app/views/steps/completion/shared/_admin_orders_applied_for.pdf.erb
+++ b/app/views/steps/completion/shared/_admin_orders_applied_for.pdf.erb
@@ -3,7 +3,8 @@
     <%=t 'shared.admin_orders_applied_for' %>
   </td>
 
+  <!-- DO NOT use `<textarea/>`, as it creates incorrect PDF markup -->
   <td class="answer answer-value">
-    <div class="box-to-fill text-area-box">&nbsp;</div>
+    <textarea class="box-to-fill text-area-box" rows="5" name="admin-orders"></textarea>
   </td>
 </tr>

--- a/app/views/steps/completion/shared/_answer_box.pdf.erb
+++ b/app/views/steps/completion/shared/_answer_box.pdf.erb
@@ -4,6 +4,6 @@
   </td>
 
   <td class="answer answer-value">
-    <div class="box-to-fill">&nbsp;</div>
+    <input class="box-to-fill" type="text" name="<%= answer_box.object_id %>"/>
   </td>
 </tr>

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -66,7 +66,7 @@ en:
   shared:
     admin_family_court: The family court sitting at
     admin_case_number: Case number
-    admin_date_issued: Date issued
+    admin_date_issued: Date issued (DD MM YYYY)
     admin_orders_applied_for: Order(s) applied for
     intentional_blank_page: This page is intentionally left blank
     c8_confidential_answer: *c8_attached
@@ -598,7 +598,7 @@ en:
       answers:
         <<: *COURT_ORDER_TYPES
     c1a_order_issue_date:
-      question: Date issued
+      question: Date issued (DD MM YYY)
     c1a_order_length:
       question: Length of order
     c1a_order_is_current:

--- a/spec/services/c100_app/pdf_generator_spec.rb
+++ b/spec/services/c100_app/pdf_generator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe C100App::PdfGenerator do
       ).and_return(document)
 
       expect(wicked_pdf).to receive(:pdf_from_string).with(
-        document, { footer: { right: '12345/XYZ   Test   [xx]/[yy]' } }
+        document, { footer: { right: '12345/XYZ   Test   [xx]/[yy]' }, extra: '--enable-forms' }
       ).and_return(document)
 
       # Using 0 copies just to make this test scenario simpler to mock,


### PR DESCRIPTION
In each of these forms, there is an area to be filled by the court.
We can make these inputs fillable in the generated PDF with some minor changes to our markup.

<img width="827" alt="screen shot 2018-06-19 at 13 16 32" src="https://user-images.githubusercontent.com/687910/41596678-008f99a6-73c3-11e8-8a32-14852918d3ac.png">
