### PR TITLE
Protect against JS inadvertently expiring the session

### DIFF
--- a/app/assets/javascripts/modules/session-timeout.js
+++ b/app/assets/javascripts/modules/session-timeout.js
@@ -134,14 +134,20 @@ moj.Modules.sessionTimeout = {
   },
 
   forceAbort: function() {
-    var self = this;
+    // Important: originally, this function would destroy the session, similar to
+    // the above `abort()` function, when the expire timeout reached the limit.
+    //
+    // But we've discovered there might be some scenarios, where an user opens multiple
+    // tabs, and then continue filling the form in one of the tabs, forgetting about
+    // the other(s). The javascript timer is still running on those forgotten tabs,
+    // and when reaching the limit, call this function, destroying silently the session.
+    // By the time the user clicks continue in their active tab, there is no session
+    // anymore, and they would be shown the expiration error page.
+    //
+    // So we've decided to make this function non-destructive. Just close the modal
+    // and do not trigger any further server-side requests. Still the server will check
+    // the validity of the session on each request (refer to module `SecurityHandling`).
 
-    $.ajax({
-      url: this.config.destroySessionUrl,
-      type: "DELETE",
-      dataType: "json"
-    }).always(function() {
-      window.location.href = self.config.expiredUrl;
-    });
+    this.hideModal();
   }
 };

--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -32,7 +32,6 @@ module SecurityHandling
     epoch = Time.now.to_i
 
     if epoch - session.fetch(:last_seen, epoch) > session_expire_in_seconds
-      sentry_debug_session_expire(epoch) # Temporary for debug purposes
       reset_session
     end
 
@@ -57,22 +56,4 @@ module SecurityHandling
       'Strict-Transport-Security' => 'max-age=15768000; includeSubDomains',
     }
   end
-
-  # :nocov:
-  def sentry_debug_session_expire(epoch)
-    return if Rails.application.config.consider_all_requests_local || session[:c100_application_id].nil?
-
-    exception = StandardError.new('ensure_session_validity')
-
-    Raven.extra_context(
-      epoch_time: epoch,
-      session_last_seen: session[:last_seen],
-      session_expire_in_seconds: session_expire_in_seconds,
-      session_id: session[:session_id],
-      c100_application_id: session[:c100_application_id],
-    )
-
-    Raven.capture_exception(exception)
-  end
-  # :nocov:
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe ApplicationController do
       context 'when cookie is present but expired' do
         before do
           session[:last_seen] = Time.now.to_i - 155
-          expect(controller).to receive(:sentry_debug_session_expire).with(555555) # Temporary for debug purposes
         end
 
         it 'sets the `last_seen` value' do


### PR DESCRIPTION
TL;DR: if opening multiple tabs, the session can be inadvertently expired in one of the non-active tabs, while the user is still filling the form in another tab, because of the javascript timers.

This small change makes the `forceAbort()` function non-destructive to avoid this scenario.