### PR TITLE
Revert the removal of legal rep screening question

### DIFF
--- a/app/controllers/steps/screener/legal_representation_controller.rb
+++ b/app/controllers/steps/screener/legal_representation_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Screener
+    class LegalRepresentationController < Steps::ScreenerStepController
+      def edit
+        @form_object = LegalRepresentationForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(LegalRepresentationForm)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/screener/legal_representation_exit_controller.rb
+++ b/app/controllers/steps/screener/legal_representation_exit_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Screener
+    class LegalRepresentationExitController < Steps::ScreenerStepController
+      def show; end
+    end
+  end
+end

--- a/app/forms/steps/screener/legal_representation_form.rb
+++ b/app/forms/steps/screener/legal_representation_form.rb
@@ -1,0 +1,21 @@
+module Steps
+  module Screener
+    class LegalRepresentationForm < BaseForm
+      include SingleQuestionForm
+      include HasOneAssociationForm
+
+      has_one_association :screener_answers
+      yes_no_attribute :legal_representation
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record_to_persist.update(
+          legal_representation: legal_representation
+        )
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_sections/solicitor_details.rb
+++ b/app/presenters/summary/html_sections/solicitor_details.rb
@@ -16,7 +16,7 @@ module Summary
       private
 
       def solicitor
-        c100_application.solicitor || Solicitor.new
+        @_solicitor ||= (c100_application.solicitor || Solicitor.new)
       end
 
       def solicitor_personal_details

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -16,8 +16,9 @@ module C100App
         children_relationships
       when :contact_details
         after_contact_details
-      when :has_solicitor
-        after_has_solicitor
+      # TODO: the solicitor details steps are not enabled currently
+      # when :has_solicitor
+      #   after_has_solicitor
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
@@ -29,17 +30,17 @@ module C100App
       if next_applicant_id
         edit(:personal_details, id: next_applicant_id)
       else
-        edit(:has_solicitor)
-      end
-    end
-
-    def after_has_solicitor
-      if question(:has_solicitor).yes?
-        edit('/steps/solicitor/personal_details')
-      else
         edit('/steps/respondent/names')
       end
     end
+
+    # def after_has_solicitor
+    #   if question(:has_solicitor).yes?
+    #     edit('/steps/solicitor/personal_details')
+    #   else
+    #     edit('/steps/respondent/names')
+    #   end
+    # end
 
     def next_applicant_id
       next_record_id(c100_application.applicant_ids)

--- a/app/services/c100_app/screener_decision_tree.rb
+++ b/app/services/c100_app/screener_decision_tree.rb
@@ -10,6 +10,8 @@ module C100App
         after_parent
       when :over18
         after_over18
+      when :legal_representation
+        after_legal_representation
       when :written_agreement
         after_written_agreement
       when :email_consent
@@ -46,9 +48,17 @@ module C100App
 
     def after_over18
       if question(:over18, c100_application.screener_answers).yes?
-        edit(:written_agreement)
+        edit(:legal_representation)
       else
         show(:over18_exit)
+      end
+    end
+
+    def after_legal_representation
+      if question(:legal_representation, c100_application.screener_answers).no?
+        edit(:written_agreement)
+      else
+        show(:legal_representation_exit)
       end
     end
 

--- a/app/views/entrypoint/v1.en.html.erb
+++ b/app/views/entrypoint/v1.en.html.erb
@@ -24,7 +24,6 @@
             <a href="https://www.gov.uk/get-help-with-court-fees" target="external_link" rel="external">get help paying the court
               fee</a>.</p>
         <p>You can pay by credit or debit card over the phone, sending a cheque, or by cash, cheque or card in person at the court.</p>
-        <p>You may have to pay additional costs if, for example, you choose to hire a solicitor to represent you.</p>
         <p>Legal aid may be available. <a href="https://www.gov.uk/check-legal-aid" target="external_link" rel="external">Check if you can get legal aid</a>.</p>
       </div>
     </section>

--- a/app/views/entrypoint/what_is_needed.en.html.erb
+++ b/app/views/entrypoint/what_is_needed.en.html.erb
@@ -14,7 +14,6 @@
         <p>You will need the following:</p>
         <ul class="list list-bullet">
           <li>details of the other people (the respondents), including address and contact details</li>
-          <li>solicitor details (if you’re using one)</li>
           <li>details of any previous family court cases</li>
           <li>details confirming <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> attendance (if applicable)</li>
           <li>the child’s or children’s details, including date of birth</li>

--- a/app/views/steps/screener/legal_representation/edit.html.erb
+++ b/app/views/steps/screener/legal_representation/edit.html.erb
@@ -1,0 +1,19 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%=t '.lead_text' %></p>
+    </div>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :legal_representation, inline: true, choices: GenericYesNo.values %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/screener/legal_representation_exit/show.html.erb
+++ b/app/views/steps/screener/legal_representation_exit/show.html.erb
@@ -1,0 +1,13 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= render partial: '/steps/shared/screener_exit_actions' %>
+  </div>
+</div>

--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -13,8 +13,8 @@
         <li>the child or children must live within a specified court area (you’ll be able to check this on the next page)</li>
         <li>you are a parent of the child or children</li>
         <li>you and the other person (the respondent) are both over 18</li>
-        <li>you do not have a signed draft court order you want the court to consider making legally binding</li>
         <li>you do not have a solicitor representing you</li>
+        <li>you do not have a signed draft court order you want the court to consider making legally binding</li>
       </ul>
     </div>
 

--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -14,6 +14,7 @@
         <li>you are a parent of the child or children</li>
         <li>you and the other person (the respondent) are both over 18</li>
         <li>you do not have a signed draft court order you want the court to consider making legally binding</li>
+        <li>you do not have a solicitor representing you</li>
       </ul>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -900,6 +900,16 @@ en:
           page_title: Sorry, you’re not eligible to apply online
           heading: Sorry, you’re not eligible to apply online
           lead_text: You can only use this online service if both you and the other person (the respondent) are over 18.
+      legal_representation:
+        edit:
+          page_title: Do you have a solicitor?
+          heading: Do you have a solicitor?
+          lead_text: You can only use this online service if you do not have a solicitor representing you in these proceedings.
+      legal_representation_exit:
+        show:
+          page_title: Sorry, you’re not eligible to apply online
+          heading: Sorry, you’re not eligible to apply online
+          lead_text: You can only use this online service if you do not have a solicitor representing you or filling this form on your behalf.
       written_agreement:
         edit:
           page_title: Consent order
@@ -1264,6 +1274,8 @@ en:
         parent_html: ""
       steps_screener_over18_form:
         over18_html: ""
+      steps_screener_legal_representation_form:
+        legal_representation_html: ""
       steps_screener_written_agreement_form:
         written_agreement_html: ""
       steps_screener_email_consent_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,8 @@ Rails.application.routes.draw do
       show_step :parent_exit
       edit_step :over18
       show_step :over18_exit
+      edit_step :legal_representation
+      show_step :legal_representation_exit
       edit_step :written_agreement
       show_step :written_agreement_exit
       edit_step :email_consent

--- a/db/migrate/20180612135807_remove_legal_representation_field_from_screener_answers.rb
+++ b/db/migrate/20180612135807_remove_legal_representation_field_from_screener_answers.rb
@@ -1,0 +1,5 @@
+class RemoveLegalRepresentationFieldFromScreenerAnswers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :screener_answers, :legal_representation, :string
+  end
+end

--- a/db/migrate/20180612135807_remove_legal_representation_field_from_screener_answers.rb
+++ b/db/migrate/20180612135807_remove_legal_representation_field_from_screener_answers.rb
@@ -1,5 +1,0 @@
-class RemoveLegalRepresentationFieldFromScreenerAnswers < ActiveRecord::Migration[5.1]
-  def change
-    remove_column :screener_answers, :legal_representation, :string
-  end
-end

--- a/db/migrate/20180622102800_add_screener_answers_legal_rep_again.rb
+++ b/db/migrate/20180622102800_add_screener_answers_legal_rep_again.rb
@@ -1,0 +1,5 @@
+class AddScreenerAnswersLegalRepAgain < ActiveRecord::Migration[5.1]
+  def change
+    add_column :screener_answers, :legal_representation, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -267,6 +267,7 @@ ActiveRecord::Schema.define(version: 20180622093834) do
     t.json "local_court"
     t.string "parent"
     t.string "over18"
+    t.string "legal_representation"
     t.string "written_agreement"
     t.string "email_consent"
     t.string "email_address"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180622093834) do
+ActiveRecord::Schema.define(version: 20180622102800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -267,10 +267,10 @@ ActiveRecord::Schema.define(version: 20180622093834) do
     t.json "local_court"
     t.string "parent"
     t.string "over18"
-    t.string "legal_representation"
     t.string "written_agreement"
     t.string "email_consent"
     t.string "email_address"
+    t.string "legal_representation"
     t.index ["c100_application_id"], name: "index_screener_answers_on_c100_application_id"
     t.index ["email_address"], name: "index_screener_answers_on_email_address"
     t.index ["email_consent"], name: "index_screener_answers_on_email_consent"

--- a/features/screener.feature
+++ b/features/screener.feature
@@ -18,6 +18,9 @@ Feature: Screener
     Then I should see "Are you and the other parent both over 18?"
     And I choose "Yes"
 
+    Then I should see "Do you have a solicitor?"
+    And I choose "No"
+
     Then I should see "Do you have a signed draft court order you want the court to consider making legally binding?"
     And I choose "No"
 

--- a/spec/controllers/steps/screener/legal_representation_controller_spec.rb
+++ b/spec/controllers/steps/screener/legal_representation_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Screener::LegalRepresentationController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Screener::LegalRepresentationForm, C100App::ScreenerDecisionTree
+end

--- a/spec/controllers/steps/screener/legal_representation_exit_controller_spec.rb
+++ b/spec/controllers/steps/screener/legal_representation_exit_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Screener::LegalRepresentationExitController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/forms/steps/screener/legal_representation_form_spec.rb
+++ b/spec/forms/steps/screener/legal_representation_form_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Screener::LegalRepresentationForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    legal_representation: GenericYesNo::YES
+  } }
+
+  let(:c100_application){ instance_double(C100Application) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:legal_representation, :inclusion) }
+    end
+    it_behaves_like 'a has-one-association form',
+                    association_name: :screener_answers,
+                    expected_attributes: {
+                      legal_representation: GenericYesNo::YES
+                    }
+
+  end
+end

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -105,25 +105,26 @@ RSpec.describe C100App::ApplicantDecisionTree do
 
     context 'when all applicants have been edited' do
       let(:record) { double('Applicant', id: 3) }
-      it {is_expected.to have_destination(:has_solicitor, :edit)}
+      it {is_expected.to have_destination('/steps/respondent/names', :edit)}
     end
   end
 
-  context 'when the step is `has_solicitor`' do
-    let(:step_params) { { has_solicitor: 'anything' } }
-
-    before do
-      allow(c100_application).to receive(:has_solicitor).and_return(value)
-    end
-
-    context 'and the answer is `yes`' do
-      let(:value) { 'yes' }
-      it { is_expected.to have_destination('/steps/solicitor/personal_details', :edit) }
-    end
-
-    context 'and the answer is `no`' do
-      let(:value) { 'no' }
-      it { is_expected.to have_destination('/steps/respondent/names', :edit) }
-    end
-  end
+  # TODO: the solicitor's details steps are not enabled currently
+  # context 'when the step is `has_solicitor`' do
+  #   let(:step_params) { { has_solicitor: 'anything' } }
+  #
+  #   before do
+  #     allow(c100_application).to receive(:has_solicitor).and_return(value)
+  #   end
+  #
+  #   context 'and the answer is `yes`' do
+  #     let(:value) { 'yes' }
+  #     it { is_expected.to have_destination('/steps/solicitor/personal_details', :edit) }
+  #   end
+  #
+  #   context 'and the answer is `no`' do
+  #     let(:value) { 'no' }
+  #     it { is_expected.to have_destination('/steps/respondent/names', :edit) }
+  #   end
+  # end
 end

--- a/spec/services/c100_app/screener_decision_tree_spec.rb
+++ b/spec/services/c100_app/screener_decision_tree_spec.rb
@@ -89,13 +89,30 @@ RSpec.describe C100App::ScreenerDecisionTree do
     context 'and over18 is "yes"' do
       let(:over18){ GenericYesNo::YES }
 
-      it { is_expected.to have_destination(:written_agreement, :edit) }
+      it { is_expected.to have_destination(:legal_representation, :edit) }
     end
 
     context 'and over18 is "no"' do
       let(:over18){ GenericYesNo::NO }
 
       it { is_expected.to have_destination(:over18_exit, :show) }
+    end
+  end
+
+  context 'when the step is `legal_representation`' do
+    let(:step_params){ {legal_representation: legal_representation} }
+    let(:screener_answers) { double('screener_answers', legal_representation: legal_representation) }
+
+    context 'and legal_representation is "no"' do
+      let(:legal_representation){ GenericYesNo::NO }
+
+      it { is_expected.to have_destination(:written_agreement, :edit) }
+    end
+
+    context 'and legal_representation is "yes"' do
+      let(:legal_representation){ GenericYesNo::YES }
+
+      it { is_expected.to have_destination(:legal_representation_exit, :show) }
     end
   end
 


### PR DESCRIPTION
As we are not releasing just yet the solicitor details steps, we must introduce again the screening question, and do not show the solicitor steps.

Also some other copy changes for consistency.
