### PR TITLE
Show the name of the court in confirmation and email

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -5,13 +5,21 @@
     <style>
       /* Email styles need to be inline */
       body {
-        font-family: "nta", Arial, sans-serif;
+        font-family: Arial, Helvetica, sans-serif;
+      }
+      h2 {
+        margin-top: 40px;
+      }
+      .wide-margin {
+        width: 60%;
+        margin: 0 auto;
       }
       .govuk-box-highlight {
         padding: 1em 1em;
         color: #fff;
         background: #28a197;
         text-align: center;
+        margin-bottom: 30px;
       }
     </style>
   </head>

--- a/app/views/mailers/receipt_mailer/copy_to_user.en.html.erb
+++ b/app/views/mailers/receipt_mailer/copy_to_user.en.html.erb
@@ -1,23 +1,25 @@
-<div class="grid_content_header govuk-box-highlight">
-  <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge">Your application has been submitted</h1>
-  <p>Your reference code is:<br/><strong><%= @reference_code %></strong></p>
+<div class="wide-margin">
+  <div class="grid_content_header govuk-box-highlight">
+    <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge">Your application has been submitted</h1>
+    <p>Your reference code is:<br/><strong><%= @reference_code %></strong></p>
+  </div>
+
+  <p>Your completed application has been sent to <%= @court.name %>. After your payment has been processed, the court will be in touch with what happens next.</p>
+
+  <strong>A copy of your application is attached to this email.</strong>
+
+  <h2>Pay the application fee</h2>
+  <p>You need to pay the £215 court fee. The court will telephone you within 3 working days of receiving your
+    application to take payment using a credit or debit card. If you did not enter a telephone number, please contact
+    the court to pay.</p>
+
+  <p>You can also pay by post with a cheque made out to ‘HM Courts and Tribunals Service’, or in person at the court by
+    cheque, cash or card.</p>
+
+  <p>You may not need to pay the full amount if you have a
+    <a href="https://www.gov.uk/get-help-with-court-fees">‘Help with fees’</a> reference.</p>
+
+  <%= render partial: 'mailers/shared/court_help', locals: {court: @court} %>
+
+  <%= render partial: 'mailers/shared/feedback' %>
 </div>
-
-<p>Your completed application has been sent to the court. After your payment has been processed, the court will be in touch with what happens next.</p>
-
-<strong>A copy of your application is attached to this email.</strong>
-
-<h2>Pay the application fee</h2>
-<p>You need to pay the £215 court fee. The court will telephone you within 3 working days of receiving your
-  application to take payment using a credit or debit card. If you did not enter a telephone number, please contact
-  the court to pay.</p>
-
-<p>You can also pay by post with a cheque made out to ‘HM Courts and Tribunals Service’, or in person at the court by
-  cheque, cash or card.</p>
-
-<p>You may not need to pay the full amount if you have a
-  <a href="https://www.gov.uk/get-help-with-court-fees">‘Help with fees’</a> reference.</p>
-
-<%= render partial: 'mailers/shared/court_help', locals: {court: @court} %>
-
-<%= render partial: 'mailers/shared/feedback' %>

--- a/app/views/mailers/receipt_mailer/copy_to_user.en.text.erb
+++ b/app/views/mailers/receipt_mailer/copy_to_user.en.text.erb
@@ -2,8 +2,8 @@ Your application has been submitted
 
 Your reference code is: <%= @reference_code %>
 
-Your completed application has been sent to the court. After your payment
-has been processed, the court will be in touch with what happens next.
+Your completed application has been sent to <%= @court.name -%>.
+After your payment has been processed, the court will be in touch with what happens next.
 
 A copy of your application is attached to this email.
 

--- a/app/views/mailers/shared/_court_help.en.html.erb
+++ b/app/views/mailers/shared/_court_help.en.html.erb
@@ -4,7 +4,6 @@
   need to <a href="https://solicitors.lawsociety.org.uk/">find a legal advisor</a> if you have any issues.
 </p>
 
-<% if court.present? -%>
 <dl>
   <%- unless court.email.blank? %>
     <dt><strong>Email</strong></dt>
@@ -27,4 +26,3 @@
 <p>
   <%= link_to "More information about #{court.name}", C100App::CourtfinderAPI.new.court_url(court.slug) %>
 </p>
-<% end %>

--- a/app/views/mailers/shared/_court_help.en.text.erb
+++ b/app/views/mailers/shared/_court_help.en.text.erb
@@ -4,7 +4,6 @@ You can contact the court if you need help with your application. Court staff
 can’t give legal advice so you’ll need to find a legal advisor if you have any
 issues: https://solicitors.lawsociety.org.uk
 
-<% if court.present? -%>
 <%- unless court.email.blank? %>
 Email: <%= court.email -%>
 <%- end %>
@@ -22,4 +21,3 @@ Opening times:
 
 More information about <%= court.name -%>:
 <%= C100App::CourtfinderAPI.new.court_url(court.slug) %>
-<%- end %>

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -10,7 +10,7 @@
     <br/>
 
     <p class="lede gv-u-text-lede">
-      Your application has been sent to the court.
+      Your application has been sent to <%= @court.name %>.
 
       <% if current_c100_application.receipt_email? %>
         We’ve emailed a confirmation of this with a copy of your application to

--- a/spec/mailers/receipt_mailer_spec.rb
+++ b/spec/mailers/receipt_mailer_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe ReceiptMailer, type: :mailer do
   describe '#copy_to_user' do
     before do
       allow(File).to receive(:read).with(pdf_file).and_return('file content')
+
+      allow(
+        c100_application
+      ).to receive(:screener_answers_court).and_return(
+        double('Court', name: 'Court XYZ', slug: 'court-xyz', present?: true).as_null_object
+      )
     end
 
     context 'given all required arguments' do
@@ -37,14 +43,6 @@ RSpec.describe ReceiptMailer, type: :mailer do
         end
 
         context 'assigns the court data' do
-          before do
-            allow(
-              c100_application
-            ).to receive(:screener_answers_court).and_return(
-              double('Court', name: 'Court XYZ', slug: 'court-xyz', present?: true).as_null_object
-            )
-          end
-
           it { expect(mail.body.encoded).to match('Court XYZ') }
           it { expect(mail.body.encoded).to match('https://courttribunalfinder.service.gov.uk/courts/court-xyz') }
         end


### PR DESCRIPTION
For electronic submissions, do not just say 'your application has been sent to the court' but instead show the actual name of the court.

And a bit of styling amendments.

<img width="874" alt="screen shot 2018-06-25 at 12 27 50" src="https://user-images.githubusercontent.com/687910/41847795-3787b042-7873-11e8-889f-1cf4379d4f98.png">
