### PR TITLE
Make online submission email code idempotent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ group :development do
 end
 
 group :development, :test do
-  gem 'byebug', platform: :mri
   gem 'dotenv-rails'
   gem 'launchy'
   gem 'mutant-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       debug_inspector (>= 0.0.1)
     brakeman (4.2.0)
     builder (3.2.3)
-    byebug (10.0.0)
+    byebug (10.0.2)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -438,7 +438,6 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   brakeman
-  byebug
   capybara
   combine_pdf (~> 1.0.10)
   cucumber

--- a/app/models/email_submission.rb
+++ b/app/models/email_submission.rb
@@ -1,3 +1,19 @@
 class EmailSubmission < ApplicationRecord
   belongs_to :c100_application
+
+  # The following are utility methods used to manually trigger the emails.
+  # Do not rely on these methods other than to force manual submissions in
+  # case of bounces or errors.
+  #
+  # :nocov:
+  def resend_court_email!
+    update_column(:message_id, nil)
+    OnlineSubmissionJob.perform_later(c100_application)
+  end
+
+  def resend_user_email!
+    update_column(:user_copy_message_id, nil)
+    OnlineSubmissionJob.perform_later(c100_application)
+  end
+  # :nocov:
 end

--- a/app/services/c100_app/pdf_email_submission.rb
+++ b/app/services/c100_app/pdf_email_submission.rb
@@ -29,6 +29,8 @@ module C100App
     end
 
     def submission_to_court
+      return unless email_submission.message_id.nil?
+
       # if the court case worker hits reply, it should go to
       # the email given by the user (if present)
       response = CourtMailer.with(application_details).submission_to_court(
@@ -44,6 +46,8 @@ module C100App
     end
 
     def send_copy_to_user
+      return unless email_submission.user_copy_message_id.nil?
+
       # if the user hits reply, it should go to the court
       response = ReceiptMailer.with(application_details).copy_to_user(
         to: receipt_address,


### PR DESCRIPTION
This basically is so we don't inadvertently send duplicated emails that were already sent.

But also, so we can manually `nil` the corresponding `message_id` attribute (for court or for user copy) and let us send a manual duplicate email, which in some cases, like bounces, we need to do.