### PR TITLE
Bump version of sprockets due to vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'rails', '~> 5.1.6'
 gem 'responders'
 gem 'sass-rails'
 gem 'sentry-raven'
+gem 'sprockets', '~> 3.7.2' # CVE-2018-3760
 gem 'uglifier'
 gem 'uk_postcode'
 gem 'virtus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ GEM
     simplecov-html (0.10.2)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -477,6 +477,7 @@ DEPENDENCIES
   sentry-raven
   simplecov
   simplecov-rcov
+  sprockets (~> 3.7.2)
   uglifier
   uk_postcode
   virtus


### PR DESCRIPTION
A known vulnerability was found in version `3.7.1` so declaring `3.7.2` in Gemfile until Rails bump their dependencies.