### PR TITLE
Reduce chances of court email being marked as spam

### DIFF
--- a/app/mailer_previews/submission_mailer_preview.rb
+++ b/app/mailer_previews/submission_mailer_preview.rb
@@ -4,13 +4,13 @@ class SubmissionMailerPreview < ActionMailer::Preview
   def submission_to_court
     CourtMailer.with(
       application_details
-    ).submission_to_court(recipients)
+    ).submission_to_court(to: 'court@example.com')
   end
 
   def copy_to_user
     ReceiptMailer.with(
       application_details
-    ).copy_to_user(recipients)
+    ).copy_to_user(to: 'user@example.com', reply_to: 'court@example.com',)
   end
 
   private
@@ -30,13 +30,6 @@ class SubmissionMailerPreview < ActionMailer::Preview
     {
       c100_application: c100_application,
       c100_pdf: MOCK_PDF_PATH,
-    }
-  end
-
-  def recipients
-    {
-      to: 'to-address@example.com',
-      reply_to: 'reply-to@example.com',
     }
   end
 

--- a/app/mailers/court_mailer.rb
+++ b/app/mailers/court_mailer.rb
@@ -1,5 +1,5 @@
 class CourtMailer < SubmissionMailer
-  def submission_to_court(to:, reply_to:)
+  def submission_to_court(to:)
     attach_c100_pdf!
 
     # A 'real' application would never reach this point without having at
@@ -9,7 +9,6 @@ class CourtMailer < SubmissionMailer
 
     mail(
       to: to,
-      reply_to: reply_to,
       subject: submission_to_court_subject,
     )
   end

--- a/app/services/c100_app/pdf_email_submission.rb
+++ b/app/services/c100_app/pdf_email_submission.rb
@@ -31,11 +31,8 @@ module C100App
     def submission_to_court
       return unless email_submission.message_id.nil?
 
-      # if the court case worker hits reply, it should go to
-      # the email given by the user (if present)
       response = CourtMailer.with(application_details).submission_to_court(
         to: court_address,
-        reply_to: receipt_address,
       ).deliver_now!
 
       audit_data(

--- a/app/views/mailers/court_mailer/submission_to_court.en.html.erb
+++ b/app/views/mailers/court_mailer/submission_to_court.en.html.erb
@@ -1,5 +1,5 @@
-<p><%= @applicant_full_name -%> has submitted the attached C100 application through the ‘<%= link_to @service_name, root_url %>’ online
-  service. You can find their details in the attached PDF application.</p>
+<p><%= @applicant_full_name -%> has submitted the attached C100 application through the ‘<%= @service_name %>’ online
+  service.<br/>You can find their details in the attached PDF application.</p>
 
 <p>Their reference code is: <strong><%= @reference_code %></strong></p>
 

--- a/app/views/mailers/court_mailer/submission_to_court.en.text.erb
+++ b/app/views/mailers/court_mailer/submission_to_court.en.text.erb
@@ -1,4 +1,4 @@
-<%= @applicant_full_name -%> has submitted the attached C100 application through the ‘<%= @service_name %>’ online service at <%= url_for root_url %>
+<%= @applicant_full_name -%> has submitted the attached C100 application through the ‘<%= @service_name %>’ online service.
 You can find their details in the attached PDF application.
 
 Their reference code is: <%= @reference_code %>

--- a/app/views/mailers/shared/_technical_help.en.html.erb
+++ b/app/views/mailers/shared/_technical_help.en.html.erb
@@ -1,4 +1,6 @@
-<!-- TODO: decide if we want this, and which email address -->
-
-<p>For any technical questions about this email, please
-  contact: <%= mail_to 'c100helpdesk@digital.justice.gov.uk', 'c100helpdesk@digital.justice.gov.uk' %></p>
+<p>
+  This is an automated message. Please do not reply directly to this email.
+  <br/>
+  For any technical questions about this email, please
+  contact: <%= mail_to 'c100helpdesk@digital.justice.gov.uk', 'c100helpdesk@digital.justice.gov.uk' %>
+</p>

--- a/app/views/mailers/shared/_technical_help.en.text.erb
+++ b/app/views/mailers/shared/_technical_help.en.text.erb
@@ -1,1 +1,2 @@
+This is an automated message. Please do not reply directly to this email.
 For any technical questions about this email, please contact: c100helpdesk@digital.justice.gov.uk

--- a/lib/court_email_interceptor.rb
+++ b/lib/court_email_interceptor.rb
@@ -21,12 +21,8 @@ class CourtEmailInterceptor
     end
 
     def intercept_email!(message)
-      # If the user chose to receive a confirmation receipt, we will use this
-      # `reply-to` address as the new recipient of the intercepted email.
-      # Otherwise we will default to the `from` address.
-      #
       message.subject = "#{message.subject} | (Original recipient: #{message.to.join(',')})"
-      message.to = message.reply_to.presence || message.from
+      message.to = message.from
     end
   end
 end

--- a/spec/lib/court_email_interceptor_spec.rb
+++ b/spec/lib/court_email_interceptor_spec.rb
@@ -6,10 +6,8 @@ describe CourtEmailInterceptor do
       subject: 'Test email',
       from: ['from@example.com'],
       to: ['recipient@example.com'],
-      reply_to: reply_to,
     )
   }
-  let(:reply_to) { nil }
 
   def deliver_email!
     described_class.delivering_email(message)
@@ -40,26 +38,13 @@ describe CourtEmailInterceptor do
       expect(message.subject).to eq('Test email | (Original recipient: recipient@example.com)')
     end
 
+    it 'changes the recipient to be the `FROM` address' do
+      deliver_email!
+      expect(message.to).to eq(['from@example.com'])
+    end
+
     it 'should perform deliveries' do
       expect(message.perform_deliveries).to eq(true)
-    end
-
-    context 'message with reply-to' do
-      let(:reply_to) { ['replies@example.com'] }
-
-      it 'changes the recipient to be the `REPLY-TO` address' do
-        deliver_email!
-        expect(message.to).to eq(reply_to)
-      end
-    end
-
-    context 'message without reply-to' do
-      let(:reply_to) { nil }
-
-      it 'changes the recipient to be the `FROM` address' do
-        deliver_email!
-        expect(message.to).to eq(['from@example.com'])
-      end
     end
   end
 end

--- a/spec/mailers/court_mailer_spec.rb
+++ b/spec/mailers/court_mailer_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe CourtMailer, type: :mailer do
   let(:recipient_args) {
     {
       to: 'testto@example.com',
-      reply_to: 'replyto@example.com',
     }
   }
 
@@ -33,6 +32,10 @@ RSpec.describe CourtMailer, type: :mailer do
         end
 
         it_behaves_like 'a Submission mailer'
+
+        it 'does not have a reply_to address' do
+          expect(mail.reply_to).to be_nil
+        end
 
         describe 'subject' do
           context 'for an urgent hearing application' do

--- a/spec/mailers/receipt_mailer_spec.rb
+++ b/spec/mailers/receipt_mailer_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe ReceiptMailer, type: :mailer do
           expect(mail.subject).to eq('C100 new application - child arrangements')
         end
 
+        it 'has the given reply_to address' do
+          expect(mail.reply_to).to eq(['replyto@example.com'])
+        end
+
         context 'assigns the court data' do
           it { expect(mail.body.encoded).to match('Court XYZ') }
           it { expect(mail.body.encoded).to match('https://courttribunalfinder.service.gov.uk/courts/court-xyz') }

--- a/spec/services/c100_app/pdf_email_submission_spec.rb
+++ b/spec/services/c100_app/pdf_email_submission_spec.rb
@@ -43,9 +43,7 @@ RSpec.describe C100App::PdfEmailSubmission do
       it 'delivers the email to the court' do
         expect(
           mailer
-        ).to receive(:submission_to_court).with(
-          to: 'court@example.com', reply_to: 'user@example.com'
-        )
+        ).to receive(:submission_to_court).with(to: 'court@example.com')
 
         expect(subject).to receive(:audit_data) # we test this separately
 

--- a/spec/support/submission_mailer_shared_examples.rb
+++ b/spec/support/submission_mailer_shared_examples.rb
@@ -23,10 +23,6 @@ RSpec.shared_examples 'a Submission mailer' do
     expect(mail.to).to eq(['testto@example.com'])
   end
 
-  it 'has the given reply_to address' do
-    expect(mail.reply_to).to eq(['replyto@example.com'])
-  end
-
   it 'has one attachment' do
     expect(mail.attachments.size).to eq(1)
   end


### PR DESCRIPTION
* Removed the `reply_to` header in the court email, as that was potentially flagging the email as spam.

* Added a generic message to let court know they shouldn't reply directly to the email.

* Removed the service URL from court email body, as that might also be causing spam issues.