### PR TITLE
Update some copy based on feedback

### DIFF
--- a/app/views/steps/abuse_concerns/details/edit.html.erb
+++ b/app/views/steps/abuse_concerns/details/edit.html.erb
@@ -6,6 +6,17 @@
     <p class="app__section_heading">Safety concerns</p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t ".heading.#{@form_object.i18n_key}" %></h1>
 
+    <details data-block-name="safety-concerns-reasons">
+      <summary>
+        <span class="summary" data-ga-category="explanations" data-ga-label="abuse <%= @form_object.i18n_key %>">
+          <%=t '.explanation_title' %>
+        </span>
+      </summary>
+      <div class="panel panel-border-narrow undefined">
+        <%=t '.explanation_content_html' %>
+      </div>
+    </details>
+
     <%= step_form @form_object do |f| %>
       <%= f.hidden_field :subject %>
       <%= f.hidden_field :kind %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -252,7 +252,7 @@ en:
 
     ### Safety concerns ###
     address_confidentiality:
-      question: Do you want to keep your contact details private?
+      question: Do you want to keep your contact details private from the other people named in the application (the respondents)?
       answers:
         <<: *YESNO
     risk_of_abduction:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -414,6 +414,16 @@ en:
               sexual: Provide details of the children’s sexual abuse
               financial: Provide details of the children’s financial abuse
               other: Provide details of the other concerns about the children
+          explanation_title: Why do we need to ask this?
+          explanation_content_html: |
+            <p>An advisor from the
+              <a href="https://www.cafcass.gov.uk/" target="external_link" rel="external">Children and Family Court Advisory and Support
+                Service (<abbr title="Children and Family Court Advisory and Support Service">Cafcass</abbr>)</a> or
+              <a href="https://cafcass.gov.wales/" target="external_link" rel="external">Cafcass Cymru</a> protects and promotes the
+              interests of children involved in family court cases. They will look at your answers as part of their safeguarding checks.
+            </p>
+            <p>As part of their enquiries, they will contact organisations such as the police and local authorities for any relevant information about you, any other person or the children.</p>
+            <p>They will submit information to the court before your first hearing. Their assessment helps the judge make a decision that is in the best interests of the children.</p>
       contact:
         edit:
           page_title: Concerns contact
@@ -1164,7 +1174,7 @@ en:
       steps_petition_protection_form:
         protection_orders_html: ""
       steps_safety_questions_address_confidentiality_form:
-        address_confidentiality_html: "Do you want to keep your contact details private?"
+        address_confidentiality_html: "Do you want to keep your contact details private from the other people named in the application (the respondents)?"
       steps_safety_questions_risk_of_abduction_form:
         risk_of_abduction_html: ""
       steps_safety_questions_substance_abuse_form:


### PR DESCRIPTION
C8 confidentiality question, and add an explanation block to abuse detail pages.

* In the address confidentiality question:

<img width="650" alt="screen shot 2018-07-03 at 16 23 51" src="https://user-images.githubusercontent.com/687910/42229078-80f4941e-7edd-11e8-92fb-f47d30f9f989.png">

* In each of the abuse detail pages:

<img width="552" alt="screen shot 2018-07-03 at 16 24 41" src="https://user-images.githubusercontent.com/687910/42229120-9c5004aa-7edd-11e8-8b6b-e83e683c9929.png">
