### PR TITLE
Copy changes to C1A journeys

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -89,3 +89,4 @@ div.sentry-error-embed-wrapper p.powered-by {
 
 @import 'app/flash_card';
 @import 'app/pros_cons';
+@import 'app/sidebar';

--- a/app/assets/stylesheets/local/app/pros_cons.scss
+++ b/app/assets/stylesheets/local/app/pros_cons.scss
@@ -11,7 +11,7 @@ main#content {
 .ProsCons{
   padding:24px 24px 0;
   padding:1.5rem 1.5rem 0;
-  background:#f6f6f6;
+  background: #dee0e2;
   margin-top:32px;
   margin-top:2rem;
 }

--- a/app/assets/stylesheets/local/app/sidebar.scss
+++ b/app/assets/stylesheets/local/app/sidebar.scss
@@ -1,0 +1,57 @@
+.SideBar {
+  a {
+    font-size: 90%;
+  }
+  ul {
+    margin-top: 5px;
+  }
+  li {
+    margin: 0px;
+    padding: 0px;
+  }
+}
+
+.SideBarGrey {
+  padding: 15px;
+  background: #dee0e2;
+
+  p, a {
+    font-size: 90%;
+  }
+}
+
+.SideBar__blue-bar {
+  padding: 3px;
+  background-color: #005ea5;
+  margin-bottom: 10px;
+}
+
+@media (min-width: 740px){
+  body:not(.flowchart) .SideBar{
+    margin-top:0;
+    position:absolute;
+    top:11.7rem;
+    right:0;
+    width:30%;
+  }
+}
+.SideBar .SideBar--header{
+  margin-top:52px;
+  margin-top:3.25rem;
+}
+
+.SideBar__heading {
+  font-size: 1.2em;
+}
+
+@media (min-width: 641px){
+  .SideBar .SideBar__heading{
+    line-height:1.31579;
+    margin-top:1.05263em;
+  }
+}
+@media (min-width: 740px){
+  .SideBar .SideBar__heading{
+    margin-top:0;
+  }
+}

--- a/app/assets/stylesheets/local/utilities.scss
+++ b/app/assets/stylesheets/local/utilities.scss
@@ -18,6 +18,10 @@
   margin-bottom: 25px;
 }
 
+.util_mb-none {
+  margin-bottom: 0px;
+}
+
 .sticky-wrapper {
   clear: both;
 }

--- a/app/forms/steps/abuse_concerns/details_form.rb
+++ b/app/forms/steps/abuse_concerns/details_form.rb
@@ -10,17 +10,6 @@ module Steps
       attribute :help_provided, YesNo
       attribute :help_description, String
 
-      validates_inclusion_of :behaviour_ongoing, in: GenericYesNo.values
-      validates_inclusion_of :asked_for_help,    in: GenericYesNo.values
-      validates_inclusion_of :help_provided,     in: GenericYesNo.values, if: -> { asked_for_help&.yes? }
-
-      validates_presence_of :behaviour_description
-      validates_presence_of :behaviour_start
-      validates_presence_of :behaviour_stop, if: -> { behaviour_ongoing&.no? }
-
-      validates_presence_of :help_party,
-                            :help_description, if: -> { asked_for_help&.yes? }
-
       private
 
       def persist!

--- a/app/presenters/summary/sections/c1a_base_abuse_details.rb
+++ b/app/presenters/summary/sections/c1a_base_abuse_details.rb
@@ -6,7 +6,7 @@ module Summary
         abuses_suffered.map do |abuse|
           [
             Answer.new(:c1a_abuse_type, "#{abuse.subject}.#{abuse.kind}"),
-            FreeTextAnswer.new(:c1a_abuse_behaviour_description, abuse.behaviour_description),
+            FreeTextAnswer.new(:c1a_abuse_behaviour_description, abuse.behaviour_description, show: true),
             FreeTextAnswer.new(:c1a_abuse_behaviour_start, abuse.behaviour_start),
             Answer.new(:c1a_abuse_behaviour_ongoing, abuse.behaviour_ongoing),
             FreeTextAnswer.new(:c1a_abuse_behaviour_stop, abuse.behaviour_stop),

--- a/app/views/steps/abuse_concerns/applicant_info/show.en.html.erb
+++ b/app/views/steps/abuse_concerns/applicant_info/show.en.html.erb
@@ -18,5 +18,18 @@
     <div class="xform-group form-submit">
       <%= link_to 'Continue', edit_steps_abuse_concerns_question_path(subject: AbuseSubject::APPLICANT), class: 'button', role: 'button' %>
     </div>
+
+    <div class="govuk-govspeak gv-s-prose util_mt-medium">
+      <details data-block-name="safety-concerns-reasons">
+        <summary>
+        <span class="summary" data-ga-category="explanations" data-ga-label="applicant abuse info">
+          <%=t 'shared.cafcass.safety_title' %>
+        </span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <%=t 'shared.cafcass.safety_content_html' %>
+        </div>
+      </details>
+    </div>
   </div>
 </div>

--- a/app/views/steps/abuse_concerns/children_info/show.en.html.erb
+++ b/app/views/steps/abuse_concerns/children_info/show.en.html.erb
@@ -18,5 +18,18 @@
     <div class="xform-group form-submit">
       <%= link_to 'Continue', edit_steps_abuse_concerns_question_path, class: 'button', role: 'button' %>
     </div>
+
+    <div class="govuk-govspeak gv-s-prose util_mt-medium">
+      <details data-block-name="safety-concerns-reasons">
+        <summary>
+        <span class="summary" data-ga-category="explanations" data-ga-label="children abuse info">
+          <%=t 'shared.cafcass.safety_title' %>
+        </span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <%=t 'shared.cafcass.safety_content_html' %>
+        </div>
+      </details>
+    </div>
   </div>
 </div>

--- a/app/views/steps/abuse_concerns/details/edit.html.erb
+++ b/app/views/steps/abuse_concerns/details/edit.html.erb
@@ -1,49 +1,99 @@
 <% title t(".page_title.#{@form_object.i18n_key}") %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="grid-row gv-o-grid-row">
+  <div class="column-two-thirds gv-o-grid-item gv-u-two-thirds">
     <%= step_header %>
     <p class="app__section_heading">Safety concerns</p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t ".heading.#{@form_object.i18n_key}" %></h1>
 
-    <details data-block-name="safety-concerns-reasons">
-      <summary>
-        <span class="summary" data-ga-category="explanations" data-ga-label="abuse <%= @form_object.i18n_key %>">
-          <%=t '.explanation_title' %>
+    <div class="govuk-govspeak gv-s-prose">
+      <details data-block-name="safety-concerns-reasons">
+        <summary>
+        <span class="summary" data-ga-category="explanations" data-ga-label="abuse details">
+          <%=t 'shared.cafcass.safety_title' %>
         </span>
-      </summary>
-      <div class="panel panel-border-narrow undefined">
-        <%=t '.explanation_content_html' %>
-      </div>
-    </details>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <%=t 'shared.cafcass.safety_content_html' %>
+        </div>
+      </details>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.hidden_field :subject %>
-      <%= f.hidden_field :kind %>
+      <%= step_form @form_object do |f| %>
+        <%= f.hidden_field :subject %>
+        <%= f.hidden_field :kind %>
 
-      <%= f.text_area :behaviour_description, size: '40x4', class: 'form-control-3-4' %>
-      <%= f.text_field :behaviour_start %>
+        <%= f.text_area :behaviour_description, size: '40x4', class: 'form-control-3-4' %>
+        <%= f.text_field :behaviour_start %>
 
-      <%=
-        f.radio_button_fieldset :behaviour_ongoing, inline: true do |fieldset|
-          fieldset.radio_input(GenericYesNo::YES)
-          fieldset.radio_input(GenericYesNo::NO) { f.text_field :behaviour_stop }
-        end
-      %>
-
-      <%=
-        f.radio_button_fieldset :asked_for_help, inline: true do |fieldset|
-          fieldset.radio_input(GenericYesNo::YES, panel_id: :asked_for_help_panel)
-          fieldset.radio_input(GenericYesNo::NO)
-          fieldset.revealing_panel(:asked_for_help_panel) do |panel|
-            panel.text_field(:help_party)
-            panel.radio_button_fieldset(:help_provided, inline: true, choices: GenericYesNo.values)
-            panel.text_area(:help_description, size: '40x4', class: 'form-control-3-4')
+        <%=
+          f.radio_button_fieldset :behaviour_ongoing, inline: true do |fieldset|
+            fieldset.radio_input(GenericYesNo::YES)
+            fieldset.radio_input(GenericYesNo::NO) { f.text_field :behaviour_stop }
           end
-        end
-      %>
+        %>
 
-      <%= f.continue_button %>
-    <% end %>
+        <%=
+          f.radio_button_fieldset :asked_for_help, inline: true do |fieldset|
+            fieldset.radio_input(GenericYesNo::YES, panel_id: :asked_for_help_panel)
+            fieldset.radio_input(GenericYesNo::NO)
+            fieldset.revealing_panel(:asked_for_help_panel) do |panel|
+              panel.text_field(:help_party)
+              panel.radio_button_fieldset(:help_provided, inline: true, choices: GenericYesNo.values)
+              panel.text_area(:help_description, size: '40x4', class: 'form-control-3-4')
+            end
+          end
+        %>
+
+        <%= f.continue_button %>
+      <% end %>
+    </div>
+
+    <div class="govuk-govspeak gv-s-prose">
+      <div class="SideBar">
+        <div class="SideBarGrey">
+          <h2 class="SideBar__heading heading-small gv-u-heading-small">
+            Report an incident
+          </h2>
+
+          <p>
+            Always call 999 if there’s an emergency or if you think a child’s in danger.
+          </p>
+
+          <p class="util_mb-none">If it is not an emergency, you can:</p>
+
+          <ul class="list list-bullet">
+            <li><a href="https://www.gov.uk/report-child-abuse" target="external_link" rel="external">report child
+              abuse</a></li>
+            <li>
+              <a href="https://www.gov.uk/report-domestic-abuse" target="external_link" rel="external">report domestic
+                abuse</a></li>
+          </ul>
+        </div>
+
+        <br/>
+        <div class="SideBar__blue-bar"></div>
+
+        <h2 class="SideBar__heading heading-small gv-u-heading-small">
+          Get support
+        </h2>
+
+        <p class="util_mt-medium util_mb-none">
+          <strong>Child safety</strong>
+        </p>
+        <ul>
+          <li><a href="https://www.nspcc.org.uk" target="external_link" rel="external">NSPCC</a></li>
+          <li><a href="https://www.childline.org.uk" target="external_link" rel="external">Childline</a></li>
+        </ul>
+
+        <p class="util_mt-medium util_mb-none">
+          <strong>Domestic abuse</strong>
+        </p>
+        <ul>
+          <li><a href="http://www.nationaldomesticviolencehelpline.org.uk" target="external_link" rel="external">National Domestic Violence Helpline</a></li>
+          <li><a href="https://www.womensaid.org.uk" target="external_link" rel="external">Women’s Aid</a></li>
+          <li><a href="http://www.mensadviceline.org.uk" target="external_link" rel="external">Men’s Advice Line</a></li>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/steps/abuse_concerns/start/show.html.erb
+++ b/app/views/steps/abuse_concerns/start/show.html.erb
@@ -20,5 +20,18 @@
     <div class="xform-group form-submit">
       <%= link_to t('.continue'), steps_abuse_concerns_children_info_path, class: 'button', role: 'button' %>
     </div>
+
+    <div class="govuk-govspeak gv-s-prose util_mt-medium">
+      <details data-block-name="safety-concerns-reasons">
+        <summary>
+        <span class="summary" data-ga-category="explanations" data-ga-label="safety concerns">
+          <%=t 'shared.cafcass.safety_title' %>
+        </span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <%=t 'shared.cafcass.safety_content_html' %>
+        </div>
+      </details>
+    </div>
   </div>
 </div>

--- a/app/views/steps/children/has_other_children/edit.html.erb
+++ b/app/views/steps/children/has_other_children/edit.html.erb
@@ -12,17 +12,15 @@
       <%= f.continue_button %>
     <% end %>
 
-    <div class="extraBlocks  govuk-govspeak gv-s-prose">
-      <div>
-        <details data-block-name="has_other_children">
-          <summary>
-            <span class="summary" data-ga-category="explanations" data-ga-label="has other children"><%=t '.block_title' %></span>
-          </summary>
-          <div class=" panel panel-border-narrow undefined">
-            <%=t '.block_content_html' %>
-          </div>
-        </details>
+    <details data-block-name="safety-concerns-reasons">
+      <summary>
+        <span class="summary" data-ga-category="explanations" data-ga-label="has other children">
+          <%=t 'shared.cafcass.safety_title' %>
+        </span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <%=t 'shared.cafcass.safety_content_html' %>
       </div>
-    </div>
+    </details>
   </div>
 </div>

--- a/app/views/steps/safety_questions/start/show.en.html.erb
+++ b/app/views/steps/safety_questions/start/show.en.html.erb
@@ -21,24 +21,13 @@
           abuse</a>.</p>
     </div>
 
+    <p class="util_mt-large">
+      <strong><%=t 'shared.cafcass.safety_title' %></strong>
+    </p>
+    <%=t 'shared.cafcass.safety_content_html' %>
+
     <div class="xform-group form-submit">
       <%= link_to 'Continue', edit_steps_safety_questions_address_confidentiality_path, class: 'button', role: 'button' %>
     </div>
-
-    <details data-block-name="safety-concerns-reasons">
-      <summary>
-        <span class="summary" data-ga-category="explanations" data-ga-label="safety questions">Why do we need to ask this?</span>
-      </summary>
-      <div class=" panel panel-border-narrow undefined">
-        <p>An advisor from the
-          <a href="https://www.cafcass.gov.uk/" target="external_link" rel="external">Children and Family Court Advisory and Support
-            Service (<abbr title="Children and Family Court Advisory and Support Service">Cafcass</abbr>)</a> or
-          <a href="https://cafcass.gov.wales/" target="external_link" rel="external">Cafcass Cymru</a> protects and promotes the
-          interests of children involved in family court cases. They will look at your answers as part of their
-          safeguarding checks.</p>
-        <p>As part of their enquiries, they will contact organisations such as the police and local authorities for any relevant information about you, any other person or the children.</p>
-        <p>They will submit information to the court before your first hearing. Their assessment helps the judge make a decision that is in the best interests of the children.</p>
-      </div>
-    </details>
   </div>
 </div>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -345,13 +345,13 @@ en:
     abuse_behaviour_description:
       question: What happened?
     abuse_behaviour_start:
-      question: When did your concerns start?
+      question: When did this behaviour start?
     abuse_behaviour_ongoing:
-      question: Are you concerned the issue is still ongoing?
+      question: Is the behaviour still ongoing?
       answers:
         <<: *YESNO
     abuse_behaviour_stop:
-      question: When did you stop being concerned about the issue?
+      question: When did the behaviour stop?
     abuse_asked_for_help:
       question: Have you ever asked for help?
       answers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,11 +228,6 @@ en:
         edit:
           page_title: Other children required
           heading: Do you or the other people in this application (the respondents) have other children (separately or together) who aren’t part of this application?
-          block_title: Why do we need to ask this?
-          block_content_html: |
-            <p>The <a href="https://www.cafcass.gov.uk/" target="external_link" rel="external">Children and Family Court Advisory and Support Service (<abbr title="Children and Family Court Advisory and Support Service">Cafcass</abbr>)</a> or <a href="https://cafcass.gov.wales/" target="external_link" rel="external">Cafcass Cymru</a> protects and promotes the interests of children who are involved in family court cases. They will look at your answers as part of their safeguarding checks.</p>
-            <p>As part of their enquiries, they will contact the police and local authorities for any relevant information about the other children. They will also speak with you and the other people involved in the application (the respondents) before the first hearing.</p>
-            <p>They will submit information to the court before your first hearing. Their assessment helps the judge make a decision that is in the best interests of the children.</p>
       orders:
         edit:
           page_title: Which orders apply to the child
@@ -293,7 +288,7 @@ en:
             <p>You told us:</p>
           further_questions_info_html: |
             <p>We’ll need to ask you some further questions about your concerns.</p>
-            <p>Your answers will help the court consider any risks to you or the children.</p>
+            <p>Your answers will help the court consider any risks to you or the children. This information forms part of your court application and will be dealt with sensitively.</p>
             <p>You may find some of the following questions difficult or upsetting to answer. Please complete them as best you can.</p>
           continue: Continue
       question:
@@ -386,44 +381,34 @@ en:
         edit:
           page_title:
             applicant:
-              physical: Details of the physical abuse
-              emotional: Details of the emotional abuse
-              psychological: Details of the psychological abuse
-              sexual: Details of the sexual abuse
-              financial: Details of the financial abuse
-              other: Details of your other concerns
+              physical: About the physical abuse
+              emotional: About the emotional abuse
+              psychological: About the psychological abuse
+              sexual: About the sexual abuse
+              financial: About the financial abuse
+              other: Other concerns
             children:
-              physical: Details of the children’s physical abuse
-              emotional: Details of the children’s emotional abuse
-              psychological: Details of the children’s psychological abuse
-              sexual: Details of the children’s sexual abuse
-              financial: Details of the children’s financial abuse
-              other: Details of other concerns about the children
+              physical: About the children’s physical abuse
+              emotional: About the children’s emotional abuse
+              psychological: About the children’s psychological abuse
+              sexual: About the children’s sexual abuse
+              financial: About the children’s financial abuse
+              other: Other concerns about the children
           heading:
             applicant:
-              physical: Provide details of the physical abuse
-              emotional: Provide details of the emotional abuse
-              psychological: Provide details of the psychological abuse
-              sexual: Provide details of the sexual abuse
-              financial: Provide details of the financial abuse
-              other: Provide details of your other concerns
+              physical: About the physical abuse
+              emotional: About the emotional abuse
+              psychological: About the psychological abuse
+              sexual: About the sexual abuse
+              financial: About the financial abuse
+              other: Other concerns
             children:
-              physical: Provide details of the children’s physical abuse
-              emotional: Provide details of the children’s emotional abuse
-              psychological: Provide details of the children’s psychological abuse
-              sexual: Provide details of the children’s sexual abuse
-              financial: Provide details of the children’s financial abuse
-              other: Provide details of the other concerns about the children
-          explanation_title: Why do we need to ask this?
-          explanation_content_html: |
-            <p>An advisor from the
-              <a href="https://www.cafcass.gov.uk/" target="external_link" rel="external">Children and Family Court Advisory and Support
-                Service (<abbr title="Children and Family Court Advisory and Support Service">Cafcass</abbr>)</a> or
-              <a href="https://cafcass.gov.wales/" target="external_link" rel="external">Cafcass Cymru</a> protects and promotes the
-              interests of children involved in family court cases. They will look at your answers as part of their safeguarding checks.
-            </p>
-            <p>As part of their enquiries, they will contact organisations such as the police and local authorities for any relevant information about you, any other person or the children.</p>
-            <p>They will submit information to the court before your first hearing. Their assessment helps the judge make a decision that is in the best interests of the children.</p>
+              physical: About the children’s physical abuse
+              emotional: About the children’s emotional abuse
+              psychological: About the children’s psychological abuse
+              sexual: About the children’s sexual abuse
+              financial: About the children’s financial abuse
+              other: Other concerns about the children
       contact:
         edit:
           page_title: Concerns contact
@@ -1214,7 +1199,7 @@ en:
         injunctive_is_current: *order_current
         undertaking_is_current: *order_current
       steps_abuse_concerns_details_form:
-        behaviour_ongoing_html: Are you concerned the issue is still ongoing?
+        behaviour_ongoing_html: Is the behaviour still ongoing?
         asked_for_help_html: Have you ever asked for help?
         help_provided_html: Did they help you?
       steps_alternatives_negotiation_tools_form:
@@ -1428,9 +1413,9 @@ en:
       steps_safety_questions_substance_abuse_details_form:
         substance_abuse_details:
       steps_abuse_concerns_details_form:
-        behaviour_description: Give a short description of what happened and who was involved
-        behaviour_start: When did your concerns start?
-        behaviour_stop: When did you stop being concerned about the issue?
+        behaviour_description: Briefly describe what happened and who was involved, if you feel able to
+        behaviour_start: When did this behaviour start?
+        behaviour_stop: When did the behaviour stop?
         help_party: Who did you ask for help?
         help_description: What did they do?
         behaviour_ongoing:
@@ -1566,7 +1551,7 @@ en:
       steps_safety_questions_substance_abuse_details_form:
         substance_abuse_details: Give a short description
       steps_abuse_concerns_details_form:
-        behaviour_description: You’ll have further opportunities to make a detailed statement
+        behaviour_description: This information will be treated sensitively and you’ll have the opportunity to give further details later in the court proceedings if you wish
         behaviour_start: Add an approximate date if you’re unsure
         behaviour_stop: Add an approximate date if you’re unsure
         asked_for_help: For example, your GP
@@ -1644,6 +1629,16 @@ en:
           <p>We use ‘children’ as a general term to mean whether you have a child or children. We do this to avoid repetition.</p>
         </div>
       </details>
+    cafcass:
+      safety_title: Why do we need this information and what will we do with it?
+      safety_content_html: |
+        <p>The court needs to know if any of the other people in this application, or anyone connected to them who has contact with the children, poses a risk to the safety of the children.</p>
+        <p>If you provide information about this now, it will make it easier for the court to make sure your case is dealt with appropriately at the earliest opportunity. If you do not want to provide details of the abuse at this stage, you will be able to do so when you speak to Cafcass or at a later stage in the court proceedings.</p>
+        <p>The <a href="https://www.cafcass.gov.uk/" target="external_link" rel="external">Children and Family Court Advisory and Support Service (Cafcass)</a>, in England, and <a href="https://cafcass.gov.wales/" target="external_link" rel="external">Cafcass Cymru</a>, in Wales, protect and promote the interests of children involved in family court cases. An advisor from Cafcass or Cafcass Cymru will look at your answers as part of their safeguarding checks, and may need to ask you further questions.</p>
+        <p>As part of their enquiries they will contact organisations such as the police and local authorities for any relevant information about you, any other person or the children.</p>
+        <p>They will submit information to the court before your first hearing. Their assessment helps the judge make a decision that is in the best interests of the children.</p>
+        <p>The information you provide in this section will also be shared with the respondents so that they have the opportunity to respond to your allegations.</p>
+        <p>There are strict rules in place to protect the privacy of those involved in family court cases, particularly children. The information you provide in this section will be treated sensitively by the court and Cafcass.</p>
 
   session:
     note:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -534,6 +534,7 @@ en:
       question: Details
     c1a_abuse_behaviour_description:
       question: Nature of behaviour / what happened
+      absence_answer: '[The applicant has chosen not to provide details at this time. Please follow up in due course]'
     c1a_abuse_behaviour_start:
       question: When did behaviour start?
     c1a_abuse_behaviour_ongoing:

--- a/spec/forms/steps/abuse_concerns/details_form_spec.rb
+++ b/spec/forms/steps/abuse_concerns/details_form_spec.rb
@@ -53,46 +53,6 @@ RSpec.describe Steps::AbuseConcerns::DetailsForm do
       end
     end
 
-    context 'validations on field presence' do
-      it { should validate_presence_of(:subject, :inclusion) }
-      it { should validate_presence_of(:kind, :inclusion) }
-
-      it { should validate_presence_of(:behaviour_description) }
-      it { should validate_presence_of(:behaviour_start) }
-      it { should validate_presence_of(:behaviour_ongoing, :inclusion) }
-      it { should validate_presence_of(:behaviour_description) }
-      it { should validate_presence_of(:asked_for_help, :inclusion) }
-    end
-
-    context 'validation on field `behaviour_stop`' do
-      context 'when abuse is ongoing' do
-        let(:behaviour_ongoing) { 'yes' }
-        it { should_not validate_presence_of(:behaviour_stop) }
-      end
-      context 'when abuse has stopped' do
-        let(:behaviour_ongoing) { 'no' }
-        it { should validate_presence_of(:behaviour_stop) }
-      end
-    end
-
-    context 'validation on help fields' do
-      context 'when `asked_for_help` is yes' do
-        let(:asked_for_help) { 'yes' }
-
-        it { should validate_presence_of(:help_party) }
-        it { should validate_presence_of(:help_provided, :inclusion) }
-        it { should validate_presence_of(:help_description) }
-      end
-
-      context 'when `asked_for_help` is no' do
-        let(:asked_for_help) { 'no' }
-
-        it { should_not validate_presence_of(:help_party) }
-        it { should_not validate_presence_of(:help_provided, :inclusion) }
-        it { should_not validate_presence_of(:help_description) }
-      end
-    end
-
     context 'for valid details' do
       before do
         allow(concerns_collection).to receive(:find_or_initialize_by).with(


### PR DESCRIPTION
Implemeting some copy changes and other user interface elements to streamline and make more clear why we are gathering some of the data.

Make all fields in the abuse details optional.

Still WIP and requires policy sign-off.