### PR TITLE
Copy change for C1A details absense

### DIFF
--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -534,7 +534,7 @@ en:
       question: Details
     c1a_abuse_behaviour_description:
       question: Nature of behaviour / what happened
-      absence_answer: '[The applicant has chosen not to provide details at this time. Please follow up in due course]'
+      absence_answer: '[No details entered]'
     c1a_abuse_behaviour_start:
       question: When did behaviour start?
     c1a_abuse_behaviour_ongoing:


### PR DESCRIPTION
This copy (and the ones in the previous PR) has now been signed off.

<img width="819" alt="screen shot 2018-07-09 at 14 26 01" src="https://user-images.githubusercontent.com/687910/42453426-969aaae6-8384-11e8-95cc-a115abfbc550.png">


