### PR TITLE
Minor Cardiff copy change

### DIFF
--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -10,7 +10,8 @@
       Lancaster, Leeds, Mansfield, Milton Keynes, Newcastle, Nottingham, Oxford, Preston, Reading, Slough, Sunderland,
       Watford and West London.</p>
 
-    <p>The trial is also available in Cardiff. A Welsh language version will be available after the trial is completed.</p>
+    <p>This trial is also taking place in Cardiff. A Welsh language version will be available after the trial is
+      completed.</p>
 
     <p>To be able to try this service, the child or children must live within one of these court areas (you’ll be able
       to check this on the next page).</p>


### PR DESCRIPTION
New copy:

`This trial is also taking place in Cardiff. A Welsh language version will be available after the trial is completed.`