### PR TITLE
Add a visits counter to short urls

### DIFF
--- a/app/models/short_url.rb
+++ b/app/models/short_url.rb
@@ -1,8 +1,13 @@
 class ShortUrl < ApplicationRecord
+  def track_visit!
+    increment!(:visits) if persisted?
+  end
+
   class << self
     def resolve(path:, target_url:)
       url = find_or_initialize_by(path: path)
       url.target_url ||= target_url
+      url.track_visit!
       url
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,9 +31,11 @@ class Application < Rails::Application
 
   config.action_mailer.default_url_options = { host: ENV.fetch('EXTERNAL_URL') }
 
+  # We are using our own url-shortener. These short urls redirect to surveymonkey,
+  # and tracks visits, so we can see if they are being used.
   config.surveys = {
-    success: 'https://www.surveymonkey.co.uk/r/FHWYXHX',
-    kickout: 'https://www.surveymonkey.co.uk/r/NN8FJZ6',
+    success: 'https://c100.dsd.io/survey',
+    kickout: 'https://c100.dsd.io/exit_survey',
   }
 
   # This is the GDS-hosted homepage for our service, and the one with a `start` button

--- a/db/migrate/20180712101836_add_visits_to_short_urls_table.rb
+++ b/db/migrate/20180712101836_add_visits_to_short_urls_table.rb
@@ -1,0 +1,5 @@
+class AddVisitsToShortUrlsTable < ActiveRecord::Migration[5.1]
+  def change
+    add_column :short_urls, :visits, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180711151214) do
+ActiveRecord::Schema.define(version: 20180712101836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -285,6 +285,7 @@ ActiveRecord::Schema.define(version: 20180711151214) do
     t.string "utm_source"
     t.string "utm_medium"
     t.string "utm_campaign"
+    t.integer "visits", default: 0
   end
 
   create_table "solicitors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/short_urls.rake
+++ b/lib/tasks/short_urls.rake
@@ -4,7 +4,7 @@ namespace :short_urls do
   task list: :environment do
     ShortUrl.order(created_at: :asc).each do |url|
       url.target_url ||= default_target_url
-      puts "[created: #{url.created_at}] #{default_host_domain}/#{url.path} => #{url.to_str}"
+      puts "[created: #{url.created_at}][visits: #{url.visits}] #{default_host_domain}/#{url.path} => #{url.to_str}"
     end
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SessionsController, type: :controller do
 
         it 'redirects to the survey page' do
           get :destroy, params: {survey: true}
-          expect(response.location).to match(/surveymonkey.co.uk\/r\/FHWYXHX$/)
+          expect(response.location).to match(/survey$/)
         end
       end
 

--- a/spec/models/short_url_spec.rb
+++ b/spec/models/short_url_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe ShortUrl, type: :model do
       let!(:short_url) { ShortUrl.create(path: 'xyz', target_url: target_url) }
       let(:target_url) { nil }
 
+      it 'increases the visits counter' do
+        expect {
+          resolved_url
+        }.to change { short_url.reload.visits }.by(1)
+      end
+
       it 'returns the found URL' do
         expect(described_class).not_to receive(:new)
         expect(resolved_url).to eq(short_url)
@@ -80,6 +86,10 @@ RSpec.describe ShortUrl, type: :model do
       it 'initialises a new short URL' do
         expect(described_class).to receive(:new).with(path: 'xyz').and_call_original
         resolved_url
+      end
+
+      it 'does not increase the visits counter' do
+        expect(resolved_url.visits).to eq(0)
       end
     end
   end


### PR DESCRIPTION
This will allow us to track visits to external URLs where we don't have easy access to analytics (in particular, will be used as part of the bot experiment).