### PR TITLE
Tweak the court email finder

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -63,17 +63,18 @@ class Court
   end
 
   def best_enquiries_email(emails)
-    # return unless emails
     # There's no consistency to how courts list their email address descriptions
     # So the order of priority is:
+    #
     # 1. anything mentioning 'children'
-    # 2. anything mentioning 'family'
+    # 2. anything mentioning 'family applications' or 'family', in that order
     # 3. a general 'enquiries' address
     # 4. just take the first
 
     emails = Array(emails).compact
 
     best =  emails.find { |e| e['description'] =~ /children/i }                  || \
+            emails.find { |e| e['description'] =~ /family applications/i }       || \
             emails.find { |e| e['description'] =~ /family/i }                    || \
             emails.find { |e| e['description'].to_s.casecmp('enquiries').zero? } || \
             emails.first

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -461,6 +461,7 @@ describe Court do
           expect(subject.send(:best_enquiries_email, emails)).to eq('my@email')
         end
       end
+
       context 'containing an email with description matching "children"' do
         let(:emails){
           [
@@ -514,6 +515,25 @@ describe Court do
           it 'returns the email address of the description matching children' do
             expect(subject.send(:best_enquiries_email, emails)).to eq('children@email')
           end
+        end
+      end
+
+      context 'containing an email with description matching "family applications"' do
+        let(:emails){
+          [
+              {
+                  'description' => 'All family things',
+                  'address' => 'family@email'
+              },
+              {
+                  'description' => 'Family Applications',
+                  'address' => 'familyapplications@email'
+              }
+          ]
+        }
+
+        it 'returns the email address of the matching description' do
+          expect(subject.send(:best_enquiries_email, emails)).to eq('familyapplications@email')
         end
       end
 


### PR DESCRIPTION
If there is an email address with `Family Applications` in the description, we pick that one first, and if not, we try to find as before anything with `Family` in the description.