### PR TITLE
Speed up Mutant task by passing --since-master when on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
   - git remote set-branches origin master && git fetch
 
 script:
-  - MUTANT_EXTRA_FLAGS="--since=origin/master" bundle exec rake travis
+  - bundle exec rake travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
 
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
+  - git remote set-branches origin master && git fetch
 
 script:
-  - MUTANT_EXTRA_FLAGS="--since=master" bundle exec rake travis
+  - MUTANT_EXTRA_FLAGS="--since=origin/master" bundle exec rake travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
 
 script:
-  - bundle exec rake travis
+  - MUTANT_EXTRA_FLAGS="--since=master" bundle exec rake travis

--- a/lib/tasks/all_tests.rake
+++ b/lib/tasks/all_tests.rake
@@ -1,12 +1,19 @@
 
 namespace :test do
-  # test:all is already defined by rails
-  task all_the_things: :environment do
+  task all_standard_tests: :environment do
     Rake::Task['rubocop'].invoke
     Rake::Task['spec'].invoke
     Rake::Task['brakeman'].invoke
     Rake::Task['cucumber'].invoke
+  end
+
+  # test:all is already defined by rails
+  task all_the_things: :all_standard_tests do
     Rake::Task['mutant'].invoke
+  end
+
+  task all_the_things_since_master: :all_standard_tests do
+    Rake::Task['mutant_since_master'].invoke
   end
 end
 

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -3,7 +3,7 @@
 #
 task :mutant => :environment do
   vars = 'RAILS_ENV=test NOCOVERAGE=true'
-  flags = '--use rspec --fail-fast'
+  flags = "#{ENV['MUTANT_EXTRA_FLAGS']} --use rspec --fail-fast"
 
   unless system("#{vars} mutant #{flags} #{classes_to_mutate.join(' ')}")
     raise 'Mutation testing failed'

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -29,6 +29,7 @@ end
 private
 
 def all_classes_for_mutant
+  Rails.application.eager_load!
   form_objects + decision_trees_and_services + models
 end
 

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -1,9 +1,9 @@
 # Pass a match expression as an optional argument to only run mutant
 # on classes that match. Example: `rake mutant TaxTribs::ZendeskSender`
 #
-task :mutant => :environment do
+task :mutant => :environment do |task, args|
   vars = 'RAILS_ENV=test NOCOVERAGE=true'
-  flags = "#{ENV['MUTANT_EXTRA_FLAGS']} --use rspec --fail-fast"
+  flags = "--use rspec --fail-fast"
 
   unless system("#{vars} mutant #{flags} #{classes_to_mutate.join(' ')}")
     raise 'Mutation testing failed'
@@ -12,11 +12,28 @@ task :mutant => :environment do
   exit
 end
 
+task :mutant_since_master => :environment do
+  source_ref = 'origin/master'
+  vars = 'RAILS_ENV=test NOCOVERAGE=true'
+  flags = "--since=#{source_ref} --use rspec --fail-fast"
+
+  puts "> running complete mutant testing on all changes since #{source_ref}"
+
+  unless system("#{vars} mutant #{flags} #{all_classes_for_mutant.join(' ')}")
+    raise 'Mutation testing failed'
+  end
+
+  exit
+end
+
 private
+
+def all_classes_for_mutant
+  form_objects + decision_trees_and_services + models
+end
 
 def classes_to_mutate
   Rails.application.eager_load!
-
   case ARGV[1]
     when nil
       # Quicker run, reduced testing scope (random sample), default option

--- a/lib/tasks/travis.rake
+++ b/lib/tasks/travis.rake
@@ -1,3 +1,3 @@
 task :travis => :environment do
-  Rake::Task['test:all_the_things'].invoke
+  Rake::Task['test:all_the_things_since_master'].invoke
 end


### PR DESCRIPTION
The flag `--since=master` can be used to restrict Mutant to only those files which have changed in the current branch as compared to master.

This can massively speed up mutation testing runs (e.g. from 6m down to 100s on a previous PR - https://github.com/ministryofjustice/c100-application/pull/491 )