### PR TITLE
Hide phone/email in C1A if C8 was triggered

### DIFF
--- a/app/presenters/summary/sections/c1a_applicant_details.rb
+++ b/app/presenters/summary/sections/c1a_applicant_details.rb
@@ -31,7 +31,11 @@ module Summary
       private
 
       def applicant
-        @_applicant ||= c100.applicants.first
+        @_applicant ||= record_collection.first
+      end
+
+      def record_collection
+        C8CollectionProxy.new(c100, c100.applicants)
       end
     end
   end

--- a/spec/presenters/summary/sections/c1a_applicant_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_applicant_details_spec.rb
@@ -40,6 +40,10 @@ module Summary
     # of sync, which means a quite solid safety net for any maintainers in the future.
     #
     describe '#answers' do
+      before do
+        allow(c100_application).to receive(:confidentiality_enabled?).and_return(false)
+      end
+
       it 'has the correct number of rows' do
         expect(answers.count).to eq(10)
       end
@@ -88,6 +92,36 @@ module Summary
 
         it 'has the correct number of rows' do
           expect(answers.count).to eq(0)
+        end
+      end
+
+      context 'when address confidentiality is enabled' do
+        let(:address_confidentiality) { 'yes' }
+
+        before do
+          allow(c100_application).to receive(:confidentiality_enabled?).and_return(true)
+        end
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(10)
+        end
+
+        it 'hides the contact details' do
+          expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[5].question).to eq(:person_home_phone)
+          expect(answers[5].value).to eq('[See C8 attached at the end of this form]')
+
+          expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[6].question).to eq(:person_mobile_phone)
+          expect(answers[6].value).to eq('[See C8 attached at the end of this form]')
+
+          expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[7].question).to eq(:person_email)
+          expect(answers[7].value).to eq('[See C8 attached at the end of this form]')
+
+          expect(answers[9]).to be_an_instance_of(Answer)
+          expect(answers[9].question).to eq(:c1a_address_confidentiality)
+          expect(answers[9].value).to eq('yes')
         end
       end
     end


### PR DESCRIPTION
These are considered contact details and should be hidden too in the C1A as we are doing in the C100.

<img width="826" alt="screen shot 2018-07-25 at 14 30 01" src="https://user-images.githubusercontent.com/687910/43205254-de48c722-901a-11e8-9960-e960833cb19b.png">
