### PR TITLE
Add warning about C8 in email to court

### DIFF
--- a/app/mailer_previews/submission_mailer_preview.rb
+++ b/app/mailer_previews/submission_mailer_preview.rb
@@ -10,7 +10,7 @@ class SubmissionMailerPreview < ActionMailer::Preview
   def copy_to_user
     ReceiptMailer.with(
       application_details
-    ).copy_to_user(to: 'user@example.com', reply_to: 'court@example.com',)
+    ).copy_to_user(to: 'user@example.com', reply_to: 'court@example.com')
   end
 
   private
@@ -18,9 +18,16 @@ class SubmissionMailerPreview < ActionMailer::Preview
   # We don't have a factory, so just building (not need to persist)
   # a bare minimum C100 application struct for the purpose of the preview
   def c100_application
-    Struct.new(:reference_code, :urgent_hearing, :screener_answers_court, :applicants).new(
+    Struct.new(
+      :reference_code,
+      :urgent_hearing,
+      :confidentiality_enabled?,
+      :screener_answers_court,
+      :applicants,
+    ).new(
       '12345',
       'no',
+      true,
       local_court_fixture,
       applicants_fixture,
     )

--- a/app/views/mailers/court_mailer/submission_to_court.en.html.erb
+++ b/app/views/mailers/court_mailer/submission_to_court.en.html.erb
@@ -5,4 +5,6 @@
 
 <p>Please contact the applicant to take their payment within 3 working days, if required.</p>
 
+<%= render partial: 'mailers/shared/application_warnings', locals: { c100_application: @c100_application } -%>
+
 <%= render partial: 'mailers/shared/technical_help' %>

--- a/app/views/mailers/court_mailer/submission_to_court.en.text.erb
+++ b/app/views/mailers/court_mailer/submission_to_court.en.text.erb
@@ -5,4 +5,6 @@ Their reference code is: <%= @reference_code %>
 
 Please contact the applicant to take their payment within 3 working days, if required.
 
+<%= render partial: 'mailers/shared/application_warnings', locals: { c100_application: @c100_application } -%>
+
 <%= render partial: 'mailers/shared/technical_help' %>

--- a/app/views/mailers/shared/_application_warnings.en.html.erb
+++ b/app/views/mailers/shared/_application_warnings.en.html.erb
@@ -1,0 +1,7 @@
+<% if c100_application.confidentiality_enabled? %>
+  <hr/>
+  <p>
+    <strong>IMPORTANT:</strong> The applicant does not wish to reveal their contact details. The C8 form is included in the PDF.
+  </p>
+  <hr/>
+<% end %>

--- a/app/views/mailers/shared/_application_warnings.en.text.erb
+++ b/app/views/mailers/shared/_application_warnings.en.text.erb
@@ -1,0 +1,3 @@
+<% if c100_application.confidentiality_enabled? %>
+IMPORTANT: The applicant does not wish to reveal their contact details. The C8 form is included in the PDF.
+<% end %>

--- a/app/views/mailers/shared/_technical_help.en.html.erb
+++ b/app/views/mailers/shared/_technical_help.en.html.erb
@@ -1,6 +1,5 @@
 <p>
   This is an automated message. Please do not reply directly to this email.
   <br/>
-  For any technical questions about this email, please
-  contact: <%= mail_to 'c100helpdesk@digital.justice.gov.uk', 'c100helpdesk@digital.justice.gov.uk' %>
+  For any technical questions, please contact: <%= mail_to 'c100helpdesk@digital.justice.gov.uk', 'c100helpdesk@digital.justice.gov.uk' %>
 </p>

--- a/app/views/mailers/shared/_technical_help.en.text.erb
+++ b/app/views/mailers/shared/_technical_help.en.text.erb
@@ -1,2 +1,2 @@
 This is an automated message. Please do not reply directly to this email.
-For any technical questions about this email, please contact: c100helpdesk@digital.justice.gov.uk
+For any technical questions, please contact: c100helpdesk@digital.justice.gov.uk

--- a/spec/mailers/court_mailer_spec.rb
+++ b/spec/mailers/court_mailer_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe CourtMailer, type: :mailer do
       id: '449362af-0bc3-4953-82a7-1363d479b876',
       created_at: Time.at(0),
       urgent_hearing: urgent_hearing,
+      address_confidentiality: address_confidentiality,
     )
   }
 
   let(:urgent_hearing) { nil }
+  let(:address_confidentiality) { nil }
   let(:pdf_file) { '/my/test/file' }
 
   let(:recipient_args) {
@@ -56,6 +58,18 @@ RSpec.describe CourtMailer, type: :mailer do
                 mail.subject
               ).to eq('C100 new application - child arrangements')
             end
+          end
+        end
+
+        describe 'C8 application warning in email body' do
+          context 'when C8 was triggered' do
+            let(:address_confidentiality) { GenericYesNo::YES }
+            it { expect(mail.body.encoded).to match('C8 form is included') }
+          end
+
+          context 'when C8 was not triggered' do
+            let(:address_confidentiality) { GenericYesNo::NO }
+            it { expect(mail.body.encoded).not_to match('C8 form is included') }
           end
         end
 


### PR DESCRIPTION
Just as a heads up, based on some feedback, and because the C8 is included in the application PDF, not as a separated file.

<img width="910" alt="screen shot 2018-08-03 at 12 50 43" src="https://user-images.githubusercontent.com/687910/43641511-e4857f2e-971b-11e8-9f6d-dd103b77cd91.png">
