### PR TITLE
Replace Leeds with West Yorkshire

### DIFF
--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -7,8 +7,8 @@
     </h1>
 
     <p>The court areas currently taking part are: Blackburn, Blackpool, Bristol, Gateshead, Grimsby, Guildford, Hull,
-      Lancaster, Leeds, Mansfield, Milton Keynes, Newcastle, Nottingham, Oxford, Preston, Reading, Slough, Sunderland,
-      Watford and West London.</p>
+      Lancaster, Mansfield, Milton Keynes, Newcastle, Nottingham, Oxford, Preston, Reading, Slough, Sunderland,
+      Watford, West London and West Yorkshire.</p>
 
     <p>This trial is also taking place in Cardiff. A Welsh language version will be available after the trial is
       completed.</p>


### PR DESCRIPTION
In the screener start page. As that is really all the catchment area.