### PR TITLE
Protect from nil user

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -4,7 +4,7 @@ module ErrorHandling
   included do
     rescue_from Exception do |exception|
       case exception
-      when Errors::InvalidSession # , ActionController::InvalidAuthenticityToken
+      when Errors::InvalidSession, ActionController::InvalidAuthenticityToken
         redirect_to invalid_session_errors_path
       when Errors::ApplicationNotFound
         redirect_to application_not_found_errors_path

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,7 +7,7 @@ module Users
     after_action :reset_c100_application_session, only: [:save_confirmation]
 
     def save_confirmation
-      @email_address = current_c100_application.user.email
+      @email_address = current_c100_application.user&.email
     end
 
     def update_confirmation; end


### PR DESCRIPTION
If, after saving an application, the user starts a new session, there is no associated user anymore and if they go back in the browser history, they might get an exception.

Also, restore `InvalidAuthenticityToken` exceptions as invalid session errors.