### PR TITLE
Add the info link in more places

### DIFF
--- a/app/views/steps/safety_questions/children_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/children_abuse/edit.html.erb
@@ -18,5 +18,16 @@
 
       <%= f.continue_button %>
     <% end %>
+
+    <details data-block-name="safety-concerns-reasons">
+      <summary>
+        <span class="summary" data-ga-category="explanations" data-ga-label="safety questions">
+          <%=t 'shared.cafcass.safety_title' %>
+        </span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <%=t 'shared.cafcass.safety_content_html' %>
+      </div>
+    </details>
   </div>
 </div>

--- a/app/views/steps/safety_questions/domestic_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/domestic_abuse/edit.html.erb
@@ -18,10 +18,22 @@
     <div role="note" aria-label="Information" class=" panel panel-border-wide info-notice TODO">
       <%=t '.info_note_html' %>
     </div>
+
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :domestic_abuse, inline: true, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>
+
+    <details data-block-name="safety-concerns-reasons">
+      <summary>
+        <span class="summary" data-ga-category="explanations" data-ga-label="safety questions">
+          <%=t 'shared.cafcass.safety_title' %>
+        </span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <%=t 'shared.cafcass.safety_content_html' %>
+      </div>
+    </details>
   </div>
 </div>


### PR DESCRIPTION
Add the `Why do we need this information and what will we do with it?` section in these screens.

<img width="569" alt="screen shot 2018-08-16 at 11 49 44" src="https://user-images.githubusercontent.com/687910/44204457-853fc180-a14a-11e8-8e05-1af4f084707f.png">
