### PR TITLE
Validate Help with fees format

### DIFF
--- a/app/forms/steps/application/payment_form.rb
+++ b/app/forms/steps/application/payment_form.rb
@@ -10,6 +10,8 @@ module Steps
       validates_presence_of :hwf_reference_number, if: :help_with_fees_payment?
       validates_presence_of :solicitor_account_number, if: :solicitor_payment?
 
+      validates :hwf_reference_number, allow_blank: true, help_with_fees_reference: true, if: :help_with_fees_payment?
+
       private
 
       def help_with_fees_payment?

--- a/app/validators/help_with_fees_reference_validator.rb
+++ b/app/validators/help_with_fees_reference_validator.rb
@@ -1,0 +1,7 @@
+class HelpWithFeesReferenceValidator < ActiveModel::EachValidator
+  HWF_REFERENCE_REGEX ||= /^HWF([- ])?[[:alnum:]]{3}([- ])?[[:alnum:]]{3}$/i
+
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, :invalid) unless value.strip.match?(HWF_REFERENCE_REGEX)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -971,8 +971,11 @@ en:
         invalid: *invalid_email_error
         blank: *blank_email_error
       children_postcodes:
-        invalid: Please enter a valid full postcode, with or without a space
-        blank: Please enter a full postcode, with or without a space
+        invalid: Enter a valid full postcode, with or without a space
+        blank: Enter a full postcode, with or without a space
+      hwf_reference_number:
+        invalid: "Enter a valid 'Help with fees' reference number"
+        blank: "Enter your 'Help with fees' reference number"
     format: "%{message}"
     messages:
       blank: Enter an answer
@@ -1333,7 +1336,7 @@ en:
           solicitor_html: '<strong>Through a solicitor’s fee account</strong><br>If you have a solicitor representing you, they may pay the court by direct debit. You’ll need to provide their ‘fee account number’.'
           self_payment_card_html: '<strong>I am paying myself by credit or debit card</strong><br>Court staff will contact you within 3 working days to take payment over the phone.'
           self_payment_cheque_html: '<strong>I am paying myself by cheque or cash</strong><br>You can send a cheque or pay in person at the court.'
-        hwf_reference_number: Enter your reference number
+        hwf_reference_number: Reference number
         solicitor_account_number: Enter solicitor’s fee account number
       steps_application_submission_form:
         submission_type:
@@ -1518,6 +1521,8 @@ en:
         participation_other_factors_details: For example, a learning disability or other mental or physical health problem
       steps_application_details_form:
         application_details: You do not have to give a full statement although you may be asked to provide one later.
+      steps_application_payment_form:
+        hwf_reference_number: 'This will be in the format: HWF-XXX-XXX'
       steps_application_submission_form:
         receipt_email: We will send an copy of your application to this address
       steps_abduction_passport_details_form:

--- a/spec/forms/steps/application/payment_form_spec.rb
+++ b/spec/forms/steps/application/payment_form_spec.rb
@@ -32,6 +32,46 @@ RSpec.describe Steps::Application::PaymentForm do
         let(:payment_type) { PaymentType::SOLICITOR.to_s }
         it { should validate_presence_of(:solicitor_account_number) }
       end
+
+      context 'Help with fees format validation' do
+        let(:payment_type) { PaymentType::HELP_WITH_FEES.to_s }
+
+        context 'valid format with dashes' do
+          let(:hwf_reference_number) { 'HWF-123-456' }
+          it { expect(subject.valid?).to eq(true) }
+        end
+
+        context 'valid format with spaces' do
+          let(:hwf_reference_number) { 'HWF 123 ABC' }
+          it { expect(subject.valid?).to eq(true) }
+        end
+
+        context 'valid format without spaces, case insensitive' do
+          let(:hwf_reference_number) { 'hwf123abc' }
+          it { expect(subject.valid?).to eq(true) }
+        end
+
+        context 'for invalid format' do
+          before do
+            subject.valid?
+          end
+
+          context 'invalid format 1' do
+            let(:hwf_reference_number) { 'ABC-123-456' }
+            it { expect(subject.errors.added?(:hwf_reference_number, :invalid)).to eq(true) }
+          end
+
+          context 'invalid format 2' do
+            let(:hwf_reference_number) { 'HWF-123' }
+            it { expect(subject.errors.added?(:hwf_reference_number, :invalid)).to eq(true) }
+          end
+
+          context 'invalid format 3' do
+            let(:hwf_reference_number) { 'HWF-123-456-789' }
+            it { expect(subject.errors.added?(:hwf_reference_number, :invalid)).to eq(true) }
+          end
+        end
+      end
     end
 
     context 'when no c100_application is associated with the form' do
@@ -44,7 +84,7 @@ RSpec.describe Steps::Application::PaymentForm do
 
     context 'when form is valid' do
       let(:payment_type) { PaymentType::SELF_PAYMENT_CARD.to_s }
-      let(:hwf_reference_number) { 'HWF-12345' }
+      let(:hwf_reference_number) { 'HWF-123-456' }
       let(:solicitor_account_number) { 'SOL-12345' }
 
       it 'saves the record' do
@@ -63,7 +103,7 @@ RSpec.describe Steps::Application::PaymentForm do
         it 'saves the record' do
           expect(c100_application).to receive(:update).with(
             payment_type: 'help_with_fees',
-            hwf_reference_number: 'HWF-12345',
+            hwf_reference_number: 'HWF-123-456',
             solicitor_account_number: nil,
           ).and_return(true)
 


### PR DESCRIPTION
To avoid obvious malformed or fake HWF reference numbers, introduce a simple validation in the Payment form.

<img width="649" alt="screen shot 2018-08-24 at 12 28 29" src="https://user-images.githubusercontent.com/687910/44582340-3b358c00-a799-11e8-8bd4-b9ee3b8484eb.png">
