### PR TITLE
Restore target attribute in external links

### DIFF
--- a/app/views/about/cookies.en.html.erb
+++ b/app/views/about/cookies.en.html.erb
@@ -20,7 +20,7 @@
 
     <p>You'll normally see a message on the site before we store a cookie on your computer.</p>
 
-    <p>Find out more about <a rel="external" href="https://www.aboutcookies.org">how to manage cookies</a>.</p>
+    <p>Find out more about <a rel="external" target="_blank" href="https://www.aboutcookies.org">how to manage cookies</a>.</p>
 
     <h2 class="heading-medium">How cookies are used on <%= service_name -%></h2>
 
@@ -71,7 +71,7 @@
 
     <p>We use Google Analytics software to collect information about how you use <%= service_name -%>. We do this
       to help make sure the site is meeting the needs of its users and to help us make improvements, for example
-      <a rel="external" href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/">improving site search</a>.</p>
+      <a rel="external" target="_blank" href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/">improving site search</a>.</p>
 
     <p>Google Analytics stores information about:</p>
 
@@ -158,7 +158,7 @@
     </table>
 
     <p>You can
-      <a rel="external" href="https://tools.google.com/dlpage/gaoptout">opt out of Google Analytics cookies</a>.
+      <a rel="external" target="_blank" href="https://tools.google.com/dlpage/gaoptout">opt out of Google Analytics cookies</a>.
     </p>
   </div>
 </div>

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -18,9 +18,9 @@
 
     <p>
       You should read this privacy notice alongside the
-      <a href="https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter" rel="external">MOJ
+      <a href="https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter" rel="external" target="_blank">MOJ
         personal information charter</a>, which sets out how you can request a copy of your personal data, and the
-      <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external">HM
+      <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external" target="_blank">HM
         Courts and Tribunals Service (HMCTS) privacy policy for family forms</a>, which provides more information about
       the use of your personal data in family court cases.
     </p>
@@ -59,7 +59,7 @@
       <div class="Section__content govuk-govspeak gv-s-prose">
         <p>We only collect personal data that you directly enter into this online service, although additional personal
           data may be gathered from other sources throughout the case (see the
-          <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external">HMCTS
+          <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external" target="_blank">HMCTS
             privacy policy for family forms</a>).</p>
 
         <p>We only collect the information we need to deliver this service to you. The personal data collected
@@ -92,7 +92,7 @@
       <div class="Section__content govuk-govspeak gv-s-prose">
         <p>We collect data in this online service to allow you to make an application about child arrangements online
           rather than complete a
-          <a href="https://www.gov.uk/government/publications/form-c100-application-under-the-children-act-1989-for-a-child-arrangements-prohibited-steps-specific-issue-section-8-order-or-to-vary-or-discharge" rel="external">paper
+          <a href="https://www.gov.uk/government/publications/form-c100-application-under-the-children-act-1989-for-a-child-arrangements-prohibited-steps-specific-issue-section-8-order-or-to-vary-or-discharge" rel="external" target="_blank">paper
             application form</a>. Both this online service and the paper application form collect
           the same types of personal data. The processing of your personal data is necessary for the administration of
           justice and legal claims. This is part of the work we do.</p>
@@ -114,25 +114,25 @@
 
         <ul class="list list-bullet">
           <li>
-            <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#hmcts-privacy-policy" rel="external">Her
+            <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#hmcts-privacy-policy" rel="external" target="_blank">Her
               Majesty’s Courts and Tribunals Service (HMCTS)</a>, who will process your application and send it to a
             judge
           </li>
           <li>
-            <a href="https://www.cafcass.gov.uk/about-cafcass/policies/privacy-data-protection/privacy-notice-service-users/" rel="external">Cafcass</a>,
+            <a href="https://www.cafcass.gov.uk/about-cafcass/policies/privacy-data-protection/privacy-notice-service-users/" rel="external" target="_blank">Cafcass</a>,
             the Children and Family Court Advisory and Support Service, who will carry out safeguarding checks and
             submit information to the court to help the judge make a decision that is in the best interests of the
             children. They’re required to do so by law.
-            <a href="https://www.cafcass.gov.uk/about-cafcass/policies/privacy-data-protection/privacy-notice-service-users/" rel="external">Read
+            <a href="https://www.cafcass.gov.uk/about-cafcass/policies/privacy-data-protection/privacy-notice-service-users/" rel="external" target="_blank">Read
               more about who Cafcass may share your personal data with</a></li>
         </ul>
 
         <p>Your personal data will not usually be shared with anyone who is not a party to the case unless this is
           specifically ordered by the court or permitted by the
-          <a href="https://www.justice.gov.uk/courts/procedure-rules/family/rules_pd_menu" rel="external">Family
+          <a href="https://www.justice.gov.uk/courts/procedure-rules/family/rules_pd_menu" rel="external" target="_blank">Family
             Procedure Rules 2010</a>. There are strict rules about when information in family cases may be disclosed
           outside the court proceedings. The
-          <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external">HMCTS
+          <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external" target="_blank">HMCTS
             privacy policy for family court forms</a> provides general information about the use of your personal data
           in family court cases.</p>
 
@@ -157,7 +157,7 @@
 
         <p>For information about what happens once your application has been completed online and your information is
           submitted to the court, you should read the
-          <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external">HMCTS
+          <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external" target="_blank">HMCTS
             privacy policy for family court forms</a>.</p>
       </div>
     </section>
@@ -208,7 +208,7 @@
           Cheshire, SK9 5AF<br/><br/>
           <p>
             Tel: 0303 123 1113<br/>
-            <a href="https://www.ico.org.uk" rel="external">www.ico.org.uk</a>
+            <a href="https://www.ico.org.uk" rel="external" target="_blank">www.ico.org.uk</a>
           </p>
         </div>
       </div>

--- a/app/views/about/terms_and_conditions.en.html.erb
+++ b/app/views/about/terms_and_conditions.en.html.erb
@@ -52,8 +52,8 @@
         <div class="Section__content govuk-govspeak gv-s-prose">
           <p>Some parts of this service only apply to England and Wales.</p>
           <p>For example, if you want to go to court the process is different in
-            <a href="https://www.mygov.scot/crime-justice-and-the-law/courts-and-sentencing" rel="external">Scotland</a> and
-            <a href="https://www.nidirect.gov.uk/articles/solicitors-and-courts" rel="external">Northern Ireland</a>.
+            <a href="https://www.mygov.scot/crime-justice-and-the-law/courts-and-sentencing" rel="external" target="_blank">Scotland</a> and
+            <a href="https://www.nidirect.gov.uk/articles/solicitors-and-courts" rel="external" target="_blank">Northern Ireland</a>.
           </p>
         </div>
       </section>

--- a/app/views/entrypoint/v1.en.html.erb
+++ b/app/views/entrypoint/v1.en.html.erb
@@ -11,8 +11,8 @@
         can be for a child arrangements order, a prohibited steps order and a specific issue order.</p>
 
       <p>The process is different if you're applying in
-        <a href="https://www.mygov.scot/crime-justice-and-the-law/courts-and-sentencing" rel="external">Scotland</a> and
-        <a href="https://www.nidirect.gov.uk/articles/solicitors-and-courts" rel="external">Northern Ireland</a>.</p>
+        <a href="https://www.mygov.scot/crime-justice-and-the-law/courts-and-sentencing" rel="external" target="_blank">Scotland</a> and
+        <a href="https://www.nidirect.gov.uk/articles/solicitors-and-courts" rel="external" target="_blank">Northern Ireland</a>.</p>
         <div role="note" aria-label="Information" class=" panel panel-border-wide info-notice TODO">
           <p>This service is the digital version of the C100 paper application form.</p>
         </div>
@@ -21,10 +21,10 @@
       <h2 class="gv-u-heading-xlarge">Fees</h2>
       <div class="Section__content  govuk-govspeak gv-s-prose">
         <p>The court fee is £215. Only the person applying to court (the applicant) needs to pay. Check if you can
-            <a href="https://www.gov.uk/get-help-with-court-fees" rel="external">get help paying the court
+            <a href="https://www.gov.uk/get-help-with-court-fees" rel="external" target="_blank">get help paying the court
               fee</a>.</p>
         <p>You can pay by credit or debit card over the phone, sending a cheque, or by cash, cheque or card in person at the court.</p>
-        <p>Legal aid may be available. <a href="https://www.gov.uk/check-legal-aid" rel="external">Check if you can get legal aid</a>.</p>
+        <p>Legal aid may be available. <a href="https://www.gov.uk/check-legal-aid" rel="external" target="_blank">Check if you can get legal aid</a>.</p>
       </div>
     </section>
 
@@ -34,13 +34,13 @@
         <p>Follow these steps before you start.</p>
         <ol>
           <li><strong>Look at alternative ways of resolving your dispute</strong><br>
-          Read the <a href="https://helpwithchildarrangements.service.justice.gov.uk" rel="external">child arrangements guide</a> to see if there’s a more suitable option than going to court.
+          Read the <a href="https://helpwithchildarrangements.service.justice.gov.uk" rel="external" target="_blank">child arrangements guide</a> to see if there’s a more suitable option than going to court.
           </li>
           <li><strong>Check if you have a valid reason for not attending a Mediation Information and Assessment Meeting (<abbr title="Mediation Information and Assessment Meeting">MIAM</abbr>)</strong><br>
-          A <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> is an introductory meeting that explains how <a href="https://helpwithchildarrangements.service.justice.gov.uk/professional-mediation" rel="external">mediation</a> can help resolve your dispute. You’re legally required to attend one if you want to go to court, unless <a href="/miam_exemptions" target="_blank">you’re exempt</a>.
+          A <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> is an introductory meeting that explains how <a href="https://helpwithchildarrangements.service.justice.gov.uk/professional-mediation" rel="external" target="_blank">mediation</a> can help resolve your dispute. You’re legally required to attend one if you want to go to court, unless <a href="/miam_exemptions" target="_blank">you’re exempt</a>.
           </li>
           <li><strong>Find a mediator and book a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr></strong><br>
-          If you have to attend a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> you’ll need to <a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external">find a mediator</a> to book one.
+          If you have to attend a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> you’ll need to <a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external" target="_blank">find a mediator</a> to book one.
           </li>
           <li><strong>Get a document signed by your mediator</strong><br>When you attend your <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> you’ll need a signed document confirming this. Bring the document to your first court hearing.
           </li>

--- a/app/views/home/miam_exemptions.en.html.erb
+++ b/app/views/home/miam_exemptions.en.html.erb
@@ -28,14 +28,14 @@
       <p class="heading-medium">You have evidence of domestic abuse and violence</p>
 
       <p>
-        <a href="https://www.gov.uk/government/collections/sample-letters-to-get-evidence-of-domestic-violence" rel="external">Sample
+        <a href="https://www.gov.uk/government/collections/sample-letters-to-get-evidence-of-domestic-violence" rel="external" target="_blank">Sample
           letters to get evidence of domestic violence</a>
       </p>
 
       <p>
         <strong>The police have been involved</strong>
         <br/>
-        For example, you or the other people in this application (the respondents) have been arrested, cautioned, charged or convicted for <a href="https://www.gov.uk/government/publications/domestic-violence-and-child-abuse-offences" rel="external">domestic or child abuse offences</a>.
+        For example, you or the other people in this application (the respondents) have been arrested, cautioned, charged or convicted for <a href="https://www.gov.uk/government/publications/domestic-violence-and-child-abuse-offences" rel="external" target="_blank">domestic or child abuse offences</a>.
       </p>
       <details>
         <summary>
@@ -164,7 +164,7 @@
         </summary>
         <div class="panel panel-border-narrow">
           <ul class="list list-bullet">
-            <li>a letter from the Secretary of State for the Home Department confirming that a prospective party has been granted leave to remain in the UK under <a href="https://www.gov.uk/guidance/immigration-rules/immigration-rules-part-8-family-members#pt8violence" rel="external">paragraph 289B of the Rules made by the Home Secretary under section 3(2) of the Immigration Act 1971</a></li>
+            <li>a letter from the Secretary of State for the Home Department confirming that a prospective party has been granted leave to remain in the UK under <a href="https://www.gov.uk/guidance/immigration-rules/immigration-rules-part-8-family-members#pt8violence" rel="external" target="_blank">paragraph 289B of the Rules made by the Home Secretary under section 3(2) of the Immigration Act 1971</a></li>
           </ul>
         </div>
       </details>

--- a/app/views/steps/abuse_concerns/applicant_info/show.en.html.erb
+++ b/app/views/steps/abuse_concerns/applicant_info/show.en.html.erb
@@ -10,7 +10,7 @@
       <p>The court needs to know if you have suffered, or are at risk of suffering, any form of domestic violence or abuse.</p>
       <p>The following questions will ask whether you have suffered, or are at risk of suffering, any form of harm.</p>
       <p>
-        <a href="https://www.refuge.org.uk/get-help-now/help-for-women/recognising-abuse/" rel="external">Find
+        <a href="https://www.refuge.org.uk/get-help-now/help-for-women/recognising-abuse/" rel="external" target="_blank">Find
           out about the signs of domestic violence or abuse</a>
       </p>
     </div>

--- a/app/views/steps/abuse_concerns/children_info/show.en.html.erb
+++ b/app/views/steps/abuse_concerns/children_info/show.en.html.erb
@@ -10,7 +10,7 @@
       <p>The court needs to know if any of the other people in this application, or anyone connected to them who has contact with the children, poses a risk to the safety of the children.</p>
       <p>The following questions will ask whether the children have experienced, or are at risk of experiencing, any form of harm.</p>
       <p>
-        <a href="https://www.nspcc.org.uk/preventing-abuse/child-abuse-and-neglect/" rel="external">Find
+        <a href="https://www.nspcc.org.uk/preventing-abuse/child-abuse-and-neglect/" rel="external" target="_blank">Find
           out about the signs of child abuse</a>
       </p>
     </div>

--- a/app/views/steps/abuse_concerns/details/edit.html.erb
+++ b/app/views/steps/abuse_concerns/details/edit.html.erb
@@ -62,10 +62,10 @@
           <p class="util_mb-none">If it is not an emergency, you can:</p>
 
           <ul class="list list-bullet">
-            <li><a href="https://www.gov.uk/report-child-abuse" rel="external">report child
+            <li><a href="https://www.gov.uk/report-child-abuse" rel="external" target="_blank">report child
               abuse</a></li>
             <li>
-              <a href="https://www.gov.uk/report-domestic-abuse" rel="external">report domestic
+              <a href="https://www.gov.uk/report-domestic-abuse" rel="external" target="_blank">report domestic
                 abuse</a></li>
           </ul>
         </div>
@@ -81,17 +81,17 @@
           <strong>Child safety</strong>
         </p>
         <ul>
-          <li><a href="https://www.nspcc.org.uk" rel="external">NSPCC</a></li>
-          <li><a href="https://www.childline.org.uk" rel="external">Childline</a></li>
+          <li><a href="https://www.nspcc.org.uk" rel="external" target="_blank">NSPCC</a></li>
+          <li><a href="https://www.childline.org.uk" rel="external" target="_blank">Childline</a></li>
         </ul>
 
         <p class="util_mt-medium util_mb-none">
           <strong>Domestic abuse</strong>
         </p>
         <ul>
-          <li><a href="http://www.nationaldomesticviolencehelpline.org.uk" rel="external">National Domestic Violence Helpline</a></li>
-          <li><a href="https://www.womensaid.org.uk" rel="external">Women’s Aid</a></li>
-          <li><a href="http://www.mensadviceline.org.uk" rel="external">Men’s Advice Line</a></li>
+          <li><a href="http://www.nationaldomesticviolencehelpline.org.uk" rel="external" target="_blank">National Domestic Violence Helpline</a></li>
+          <li><a href="https://www.womensaid.org.uk" rel="external" target="_blank">Women’s Aid</a></li>
+          <li><a href="http://www.mensadviceline.org.uk" rel="external" target="_blank">Men’s Advice Line</a></li>
         </ul>
       </div>
     </div>

--- a/app/views/steps/alternatives/collaborative_law/edit.en.html.erb
+++ b/app/views/steps/alternatives/collaborative_law/edit.en.html.erb
@@ -42,7 +42,7 @@
         </div>
 
         <p class="CallToAction">
-          <a class="CallToAction__link" href="https://helpwithchildarrangements.service.justice.gov.uk/collaborative-law" rel="external">Find
+          <a class="CallToAction__link" href="https://helpwithchildarrangements.service.justice.gov.uk/collaborative-law" rel="external" target="_blank">Find
             out more about collaborative law</a>
         </p>
 

--- a/app/views/steps/alternatives/court/edit.en.html.erb
+++ b/app/views/steps/alternatives/court/edit.en.html.erb
@@ -16,19 +16,19 @@
        <h2 class="gv-u-heading-xlarge">What happens at court</h2>
       <p>A judge must, by law, put the children first. The court will decide on what it thinks is best for the children. If you apply to court you must be prepared to follow the court’s decision, even if you don’t agree with it.</p>
       <p>The court’s decision will be set out in a ‘court order’ which you must stick to.</p>
-      <p><a href="https://helpwithchildarrangements.service.justice.gov.uk/going-to-court" rel="external">Find
+      <p><a href="https://helpwithchildarrangements.service.justice.gov.uk/going-to-court" rel="external" target="_blank">Find
         out more about going to court </a></p>
        <h2 class="gv-u-heading-xlarge">Changing or enforcing an order</h2>
       <p>A court order is not flexible. You’ll need to apply to court again if your situation changes.</p>
       <p>You or the other people involved can apply to court to enforce the order if any of you is not following the terms.</p>
        <h2 class="gv-u-heading-xlarge">Representing yourself in court</h2>
       <p>Most people no longer qualify for free legal help (legal aid). If you don’t qualify, or can’t afford a lawyer, you will need to learn
-        <a href="https://www.gov.uk/represent-yourself-in-court" rel="external">how to represent yourself in
+        <a href="https://www.gov.uk/represent-yourself-in-court" rel="external" target="_blank">how to represent yourself in
           court</a> before you apply.</p>
        <h2 class="gv-u-heading-xlarge">Domestic violence or abuse and child abuse</h2>
       <p>You might be able to get legal aid if you have evidence that you or the children have been victims of abuse.</p>
-      <p>GOV.UK has more information on <a href="https://www.gov.uk/legal-aid/domestic-abuse-or-violence" rel="external">legal aid and domestic violence or abuse</a>.</p>
-      <p>Find out more about <a href="https://www.refuge.org.uk/get-help-now/help-for-women/recognising-abuse/" rel="external">domestic violence or abuse</a> and <a href="https://www.nspcc.org.uk/preventing-abuse/child-abuse-and-neglect/">child abuse</a>.</p>
+      <p>GOV.UK has more information on <a href="https://www.gov.uk/legal-aid/domestic-abuse-or-violence" rel="external" target="_blank">legal aid and domestic violence or abuse</a>.</p>
+      <p>Find out more about <a href="https://www.refuge.org.uk/get-help-now/help-for-women/recognising-abuse/" rel="external" target="_blank">domestic violence or abuse</a> and <a href="https://www.nspcc.org.uk/preventing-abuse/child-abuse-and-neglect/">child abuse</a>.</p>
     </div>
 
     <div class="govuk-govspeak gv-s-prose">

--- a/app/views/steps/alternatives/lawyer_negotiation/edit.en.html.erb
+++ b/app/views/steps/alternatives/lawyer_negotiation/edit.en.html.erb
@@ -41,7 +41,7 @@
         </div>
 
         <p class="CallToAction">
-          <a class="CallToAction__link" href="https://helpwithchildarrangements.service.justice.gov.uk/lawyer-negotiation" rel="external">Find
+          <a class="CallToAction__link" href="https://helpwithchildarrangements.service.justice.gov.uk/lawyer-negotiation" rel="external" target="_blank">Find
             out more about lawyer negotiation</a>
         </p>
 

--- a/app/views/steps/alternatives/mediation/edit.en.html.erb
+++ b/app/views/steps/alternatives/mediation/edit.en.html.erb
@@ -42,7 +42,7 @@
         </div>
 
         <p class="CallToAction">
-          <a class="CallToAction__link" href="https://helpwithchildarrangements.service.justice.gov.uk/professional-mediation" rel="external">Find
+          <a class="CallToAction__link" href="https://helpwithchildarrangements.service.justice.gov.uk/professional-mediation" rel="external" target="_blank">Find
             out more about professional mediation</a>
         </p>
 

--- a/app/views/steps/alternatives/negotiation_tools/edit.en.html.erb
+++ b/app/views/steps/alternatives/negotiation_tools/edit.en.html.erb
@@ -10,7 +10,7 @@
       <p>If you still communicate with the other person, and there are no concerns about domestic or child abuse, the
         cheapest and easiest way to make arrangements is to negotiate with each other.</p>
       <p>There are free tools and services such as
-        <a href="https://www.splittingup-putkidsfirst.org.uk/home" rel="external">parenting plans</a> that can
+        <a href="https://www.splittingup-putkidsfirst.org.uk/home" rel="external" target="_blank">parenting plans</a> that can
         help you reach an agreement.</p>
     </div>
 
@@ -43,7 +43,7 @@
         </div>
 
         <p class="CallToAction">
-          <a class="CallToAction__link" href="https://helpwithchildarrangements.service.justice.gov.uk/negotiating-between-parents" rel="external">Find
+          <a class="CallToAction__link" href="https://helpwithchildarrangements.service.justice.gov.uk/negotiating-between-parents" rel="external" target="_blank">Find
             out more about negotiation tools and services</a></p>
 
         <%= step_form @form_object do |f| %>

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -27,7 +27,7 @@
       <h2 class="heading-large gv-u-heading-large">Download a copy of your application</h2>
       <p>
         This will be a PDF. If you cannot open the PDF after downloading, try using
-        <a href="https://get.adobe.com/uk/reader/" rel="external">Adobe Acrobat Reader</a>.
+        <a href="https://get.adobe.com/uk/reader/" rel="external" target="_blank">Adobe Acrobat Reader</a>.
       </p>
 
       <% unless user_signed_in? || current_c100_application.receipt_email? %>

--- a/app/views/steps/completion/shared/_c1a_getting_support.en.pdf.erb
+++ b/app/views/steps/completion/shared/_c1a_getting_support.en.pdf.erb
@@ -5,14 +5,14 @@
   If you have any concerns about your safety and that of the children you can call the
   <strong>National Domestic Violence
     Helpline</strong> on <strong>freephone 0808 2000 247</strong> or you get more information from
-  <a href="https://www.nationaldomesticviolencehelpline.org.uk" rel="external">www.nationaldomesticviolencehelpline.org.uk</a>
+  <a href="https://www.nationaldomesticviolencehelpline.org.uk" rel="external" target="_blank">www.nationaldomesticviolencehelpline.org.uk</a>
 </p>
 
 <p>
   If you are a man and have concerns for your safety and that of the children you can call the
   <strong>Men’s Advice Line and
     Enquiry</strong> on <strong>freephone 0808 801 0327</strong> or you get more information from
-  <a href="https://www.mensadviceline.org.uk" rel="external">www.mensadviceline.org.uk</a>
+  <a href="https://www.mensadviceline.org.uk" rel="external" target="_blank">www.mensadviceline.org.uk</a>
 </p>
 
 <p>

--- a/app/views/steps/completion/what_next/show.en.html.erb
+++ b/app/views/steps/completion/what_next/show.en.html.erb
@@ -21,7 +21,7 @@
             <h3 class="heading-medium">Download your application</h3>
             <p>
               This will be a PDF. If you cannot open the PDF after downloading, try using
-              <a href="https://get.adobe.com/uk/reader/" rel="external">Adobe Acrobat Reader</a>.
+              <a href="https://get.adobe.com/uk/reader/" rel="external" target="_blank">Adobe Acrobat Reader</a>.
             </p>
 
             <% unless user_signed_in? %>

--- a/app/views/steps/miam/acknowledgement/edit.en.html.erb
+++ b/app/views/steps/miam/acknowledgement/edit.en.html.erb
@@ -10,8 +10,8 @@
     </div>
 
     <div class="govuk-govspeak gv-s-prose">
-      <p>A <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> is an initial meeting where you'll be given information about <a href="https://helpwithchildarrangements.service.justice.gov.uk/professional-mediation" rel="external">mediation</a> and alternative ways of reaching an agreement without going to court. A mediator will consider with you whether these other ways are suitable in your case.</p>
-      <p><a href="https://www.gov.uk/check-legal-aid" rel="external">Check if you’re eligible for legal aid during mediation</a></p>
+      <p>A <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> is an initial meeting where you'll be given information about <a href="https://helpwithchildarrangements.service.justice.gov.uk/professional-mediation" rel="external" target="_blank">mediation</a> and alternative ways of reaching an agreement without going to court. A mediator will consider with you whether these other ways are suitable in your case.</p>
+      <p><a href="https://www.gov.uk/check-legal-aid" rel="external" target="_blank">Check if you’re eligible for legal aid during mediation</a></p>
 
       <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
         <p>A <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> is a one-off meeting and not the same as mediation.</p>
@@ -27,7 +27,7 @@
         <li>if you may qualify for help with the costs of mediation and legal advice</li>
         <li>other options you could use to help you reach an agreement</li>
       </ul>
-      <p><a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external">Find a mediator to book a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr></a></p>
+      <p><a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external" target="_blank">Find a mediator to book a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr></a></p>
 
       <h2 class="gv-u-heading-xlarge">If you’ve already attended a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr></h2>
       <p>If you have attended a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> it must have taken place within the past 4 months. It must also have been about the same or a very similar dispute. You should have a document signed by the mediator confirming this (which you should bring to your first hearing).</p>

--- a/app/views/steps/miam/certification_expired_info/show.html.erb
+++ b/app/views/steps/miam/certification_expired_info/show.html.erb
@@ -21,7 +21,7 @@
       <section class="numbered-list">
         <ol class="list list-number">
           <li>
-            <a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external">Find
+            <a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external" target="_blank">Find
               a mediator</a> and book a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr>
           </li>
           <li>Attend the <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr></li>

--- a/app/views/steps/miam_exemptions/exit_page/show.en.html.erb
+++ b/app/views/steps/miam_exemptions/exit_page/show.en.html.erb
@@ -15,7 +15,7 @@
       <p>You need to follow these steps before continuing with your application:</p>
       <section class="numbered-list">
         <ol class="list list-number">
-          <li><a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external">Find a mediator</a> and book a MIAM</li>
+          <li><a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external" target="_blank">Find a mediator</a> and book a MIAM</li>
           <li>Attend the MIAM</li>
           <li>Ask the mediator for a document confirming your attendance</li>
         </ol>

--- a/app/views/steps/safety_questions/start/show.en.html.erb
+++ b/app/views/steps/safety_questions/start/show.en.html.erb
@@ -15,9 +15,9 @@
         any form of harm. Harm to a child means ill treatment or damage to health and development, including, for
         example, damage suffered from seeing or hearing the ill treatment of another.</p>
       <p>Find out about the
-        <a href="https://www.nspcc.org.uk/preventing-abuse/child-abuse-and-neglect/" rel="external">signs
+        <a href="https://www.nspcc.org.uk/preventing-abuse/child-abuse-and-neglect/" rel="external" target="_blank">signs
           of child abuse</a> and
-        <a href="https://www.refuge.org.uk/get-help-now/help-for-women/recognising-abuse/" rel="external">domestic
+        <a href="https://www.refuge.org.uk/get-help-now/help-for-women/recognising-abuse/" rel="external" target="_blank">domestic
           abuse</a>.</p>
     </div>
 

--- a/app/views/steps/shared/_court_help.en.html.erb
+++ b/app/views/steps/shared/_court_help.en.html.erb
@@ -3,7 +3,7 @@
   <p>
     You can contact the court if you need help with your application. Court staff can’t give legal advice so you’ll
     need to
-    <a href="https://solicitors.lawsociety.org.uk/" rel="external">find a legal advisor</a> if
+    <a href="https://solicitors.lawsociety.org.uk/" rel="external" target="_blank">find a legal advisor</a> if
     you have any issues.
   </p>
 

--- a/app/views/steps/shared/_payment_instructions.en.html.erb
+++ b/app/views/steps/shared/_payment_instructions.en.html.erb
@@ -8,5 +8,5 @@
 <p>The court will not be able to process your application until payment has been received.</p>
 
 <p>You may not need to pay the full amount if you have a
-  <a href="https://www.gov.uk/get-help-with-court-fees" rel="external">‘Help with fees’</a>
+  <a href="https://www.gov.uk/get-help-with-court-fees" rel="external" target="_blank">‘Help with fees’</a>
   reference.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,7 @@ en:
           heading: What to do now
           copy: To submit your application, you’ll need to complete the C100 paper application form, print it and send it by post.
         download_c100_link: Download the form (PDF)
-        cait_info_html: Alternatively you can <a href="https://helpwithchildarrangements.service.justice.gov.uk" rel="external">read the child arrangements guide</a> to see if there’s a more suitable option than going to court.
+        cait_info_html: Alternatively you can <a href="https://helpwithchildarrangements.service.justice.gov.uk" rel="external" target="_blank">read the child arrangements guide</a> to see if there’s a more suitable option than going to court.
     applicant:
       names:
         edit:
@@ -463,7 +463,7 @@ en:
               <li>sexual abuse</li>
               <li>witnessing domestic violence or abuse</li>
             </ul>
-            <p><a href="https://www.nspcc.org.uk/preventing-abuse/child-abuse-and-neglect/" rel="external">Find out about the signs of child abuse</a></p>
+            <p><a href="https://www.nspcc.org.uk/preventing-abuse/child-abuse-and-neglect/" rel="external" target="_blank">Find out about the signs of child abuse</a></p>
           info_note_html: |
             <p>Only include abuse by the people in this application or someone connected to them who has contact with the children.</p>
       domestic_abuse:
@@ -705,7 +705,7 @@ en:
               <li>your reasons for bringing this application to court</li>
               <li>what you want the court to decide (what outcome you want)</li>
               <li>why the other person disagrees</li>
-              <li>any previous <a href="https://www.splittingup-putkidsfirst.org.uk/home" rel="external">parenting plans</a> or agreements (formal or informal), and why they broke down</li>
+              <li>any previous <a href="https://www.splittingup-putkidsfirst.org.uk/home" rel="external" target="_blank">parenting plans</a> or agreements (formal or informal), and why they broke down</li>
             </ul>
           timeout_warning: For your security, your session ends after %{session_timeout} minutes if there’s no activity on your application. To avoid losing your application, make sure you save it. Any unsaved details will be deleted.
       language:
@@ -777,7 +777,7 @@ en:
         edit:
           page_title: Details of urgent hearing
           heading: Details of urgent hearing
-          court_info_html: If you need to go to court now, <a href="https://courttribunalfinder.service.gov.uk/search/" rel="external">contact your nearest family court</a> for assistance.
+          court_info_html: If you need to go to court now, <a href="https://courttribunalfinder.service.gov.uk/search/" rel="external" target="_blank">contact your nearest family court</a> for assistance.
     international:
       resident:
         edit:
@@ -868,7 +868,7 @@ en:
                 <span class="summary" data-ga-category="explanations" data-ga-label="screener postcode">If you do not know where the children live</span>
               </summary>
               <div class="panel panel-border-narrow">
-                <p>You can use <a href="https://www.gov.uk/government/publications/form-c4-application-for-an-order-for-disclosure-of-a-childs-whereabouts" rel="external">form C4</a>
+                <p>You can use <a href="https://www.gov.uk/government/publications/form-c4-application-for-an-order-for-disclosure-of-a-childs-whereabouts" rel="external" target="_blank">form C4</a>
                 to apply for an order for someone to give a court information about where a child is.</p>
               </div>
             </details>
@@ -1020,7 +1020,7 @@ en:
       lead_text: If you copied a web address, please check it’s correct.
       paper_form_html: |
         <p>You can also try starting again from the homepage.</p>
-        <p>If the problem continues, you can <a href="https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf" rel="external">download and
+        <p>If the problem continues, you can <a href="https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf" rel="external" target="_blank">download and
         complete a C100 paper application form</a>, print it and send it by post.</p>
       <<: *START_FINISH
 
@@ -1332,7 +1332,7 @@ en:
         intermediary_help_details: *provide_details
       steps_application_payment_form:
         payment_type:
-          help_with_fees_html: '<strong>Help with fees</strong><br>You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" rel="external">get help paying</a> if you’re on a low income, receive certain benefits or have little or no savings. If you do qualify, you’ll need to provide your reference number.'
+          help_with_fees_html: '<strong>Help with fees</strong><br>You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" rel="external" target="_blank">get help paying</a> if you’re on a low income, receive certain benefits or have little or no savings. If you do qualify, you’ll need to provide your reference number.'
           solicitor_html: '<strong>Through a solicitor’s fee account</strong><br>If you have a solicitor representing you, they may pay the court by direct debit. You’ll need to provide their ‘fee account number’.'
           self_payment_card_html: '<strong>I am paying myself by credit or debit card</strong><br>Court staff will contact you within 3 working days to take payment over the phone.'
           self_payment_cheque_html: '<strong>I am paying myself by cheque or cash</strong><br>You can send a cheque or pay in person at the court.'
@@ -1651,7 +1651,7 @@ en:
       safety_content_html: |
         <p>The court needs to know if any of the other people in this application, or anyone connected to them who has contact with the children, poses a risk to the safety of the children.</p>
         <p>If you provide information about this now, it will make it easier for the court to make sure your case is dealt with appropriately at the earliest opportunity. If you do not want to provide details of the abuse at this stage, you will be able to do so when you speak to Cafcass or at a later stage in the court proceedings.</p>
-        <p>The <a href="https://www.cafcass.gov.uk/" rel="external">Children and Family Court Advisory and Support Service (Cafcass)</a>, in England, and <a href="https://cafcass.gov.wales/" rel="external">Cafcass Cymru</a>, in Wales, protect and promote the interests of children involved in family court cases. An advisor from Cafcass or Cafcass Cymru will look at your answers as part of their safeguarding checks, and may need to ask you further questions.</p>
+        <p>The <a href="https://www.cafcass.gov.uk/" rel="external" target="_blank">Children and Family Court Advisory and Support Service (Cafcass)</a>, in England, and <a href="https://cafcass.gov.wales/" rel="external" target="_blank">Cafcass Cymru</a>, in Wales, protect and promote the interests of children involved in family court cases. An advisor from Cafcass or Cafcass Cymru will look at your answers as part of their safeguarding checks, and may need to ask you further questions.</p>
         <p>As part of their enquiries they will contact organisations such as the police and local authorities for any relevant information about you, any other person or the children.</p>
         <p>They will submit information to the court before your first hearing. Their assessment helps the judge make a decision that is in the best interests of the children.</p>
         <p>The information you provide in this section will also be shared with the respondents so that they have the opportunity to respond to your allegations.</p>


### PR DESCRIPTION
Mobile devices seem to handle properly the opening of these external links in a new tab, but desktop browsers (at least Safari and Chrome) are having trouble.

This has something to do with the JS code we are using to intercept these links and track hits to GA.

Adding back the target (it was there some time ago) to be a explicit link attribute in order to err on the side of caution so desktop browsers open new tabs.