### PR TITLE
Fix bug involving OtherChild residence

### DIFF
--- a/app/services/people_decision_tree.rb
+++ b/app/services/people_decision_tree.rb
@@ -14,7 +14,7 @@ class PeopleDecisionTree < BaseDecisionTree
   end
 
   def edit_first_child_relationships
-    edit(:relationship, id: record, child_id: first_child_id)
+    edit(:relationship, id: record, child_id: first_minor_id)
   end
 
   def children_relationships
@@ -29,7 +29,14 @@ class PeopleDecisionTree < BaseDecisionTree
     next_record_id(c100_application.minor_ids, current: record.minor)
   end
 
-  def first_child_id
+  # Minors collection include `Child` and `OtherChild` types.
+  def first_minor_id
     c100_application.minor_ids.first
+  end
+
+  # Children collection only include `Child` type. This should be used in
+  # the residence loop, as we only need the residence of the main children.
+  def first_child_id
+    c100_application.child_ids.first
   end
 end

--- a/spec/services/c100_app/other_parties_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_parties_decision_tree_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
 
     context 'when all parties have been edited' do
       let(:record) { double('OtherParty', id: 3) }
+      let(:c100_application) { instance_double(C100Application, other_party_ids: [1, 2, 3], child_ids: [1, 2, 3]) }
 
       it 'goes to edit the residence of the first child' do
         expect(subject.destination).to eq(controller: '/steps/children/residence', action: :edit, id: 1)

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe C100App::RespondentDecisionTree do
 
     context 'and the answer is `no`' do
       let(:value) { 'no' }
+      let(:c100_application) { instance_double(C100Application, child_ids: [1, 2, 3]) }
 
       it 'goes to edit the residence of the first child' do
         expect(subject.destination).to eq(controller: '/steps/children/residence', action: :edit, id: 1)


### PR DESCRIPTION
There was a bug that only now has made appearance due to a Sentry error trace, where we were using the 'minors' collection instead of the 'children' collection in the Residence step.

https://sentry.service.dsd.io/mojds/c100-application-prod/issues/33305/

It was working fine because when using `minor_ids.first` it was always returning a `Child` type first, instead of an `OtherChild`, but, as an edge case, if the applicant deleted some or all of the Child and added later some OtherChild, will alter the returned elements.

This has now been corrected by using always the proper collection (child_ids) for residence, so regardless the order, it can't return an `OtherChild`.