### PR TITLE
Add the purge of orphan applications to the daily tasks

### DIFF
--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -32,11 +32,12 @@ class C100Application < ApplicationRecord
 
   scope :with_owner,    -> { where.not(user: nil) }
   scope :not_completed, -> { where.not(status: :completed) }
+  scope :not_eligible_orphans, -> { joins(:screener_answers).where('screener_answers.local_court': nil) }
 
   delegate :court, to: :screener_answers, prefix: true, allow_nil: true
 
   def self.purge!(date)
-    where('created_at <= :date', date: date).destroy_all
+    where('c100_applications.created_at <= :date', date: date).destroy_all
   end
 
   def online_submission?

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,11 @@ class Application < Rails::Application
   config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 60).to_i
   config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 
+  # As part of the postcode screening, an empty C100Application record is created.
+  # If the postcode is not eligible, these records are left orphans and have no use.
+  # We will only leave them for up to 3 days. Can be configured here.
+  config.x.orphans.expire_in_days = 3
+
   # We maintain C100 applications for this number of days, regardless of their status,
   # and if it has an owner (it was saved for later), we send up to two email reminders
   # before we delete the application. If you change this number make sure to also update

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -4,6 +4,7 @@ task :daily_tasks do
   Rake::Task['purge:users'].invoke
 
   Rake::Task['purge:applications'].invoke
+  Rake::Task['purge:orphans'].invoke
 
   Rake::Task['draft_reminders:first_email'].invoke
   Rake::Task['draft_reminders:last_email'].invoke
@@ -24,6 +25,13 @@ namespace :purge do
     log "Purging applications older than #{expire_after} days"
     purged = C100Application.purge!(expire_after.days.ago)
     log "Purged #{purged.size} applications"
+  end
+
+  task orphans: :environment do
+    expire_after = Rails.configuration.x.orphans.expire_in_days
+    log "Purging orphan applications older than #{expire_after} days"
+    purged = C100Application.not_eligible_orphans.purge!(expire_after.days.ago)
+    log "Purged #{purged.size} orphan applications"
   end
 end
 

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe C100Application, type: :model do
 
     it 'picks records equal to or older than the passed-in date' do
       expect(described_class).to receive(:where).with(
-        'created_at <= :date', date: 28.days.ago
+        'c100_applications.created_at <= :date', date: 28.days.ago
       ).and_return(finder_double)
 
       described_class.purge!(28.days.ago)


### PR DESCRIPTION
These orphans are leftovers with no use for us, not even analytics, as they are not eligible due to invalid postcode or not part of the court areas taking part.

Instead of waiting up to 28 days to delete these leftovers, we can get rid of them much quicker as part of our automated daily cleaning tasks.