### PR TITLE
Add East London family court to the pilot

### DIFF
--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -19,6 +19,7 @@ module C100App
       west-london-family-court
       cardiff-civil-and-family-justice-centre
       leicester-county-court-and-family-court
+      east-london-family-court
     ].freeze
 
     # Separate multiple postcodes/postcode areas by "\n"

--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -7,8 +7,8 @@
     </h1>
 
     <p>The court areas currently taking part are: Blackburn, Blackpool, Bristol, Gateshead, Grimsby, Guildford, Hull,
-      Lancaster, Leicester, Mansfield, Milton Keynes, Newcastle, Nottingham, Oxford, Preston, Reading, Slough, Sunderland,
-      Watford, West London and West Yorkshire.</p>
+      Lancaster, Leicester, London, Mansfield, Milton Keynes, Newcastle, Nottingham, Oxford, Preston, Reading, Slough,
+      Sunderland, Watford and West Yorkshire.</p>
 
     <p>This trial is also taking place in Cardiff. A Welsh language version will be available after the trial is
       completed.</p>

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 describe C100App::CourtPostcodeChecker do
+  describe 'COURT_SLUGS_USING_THIS_APP' do
+    it 'returns the expected number of court slugs taking part in the trial' do
+      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(16)
+    end
+  end
+
   describe '#courts_for' do
     before do
       allow(subject).to receive(:court_for).and_return( 'call1', 'call2', 'call3' )


### PR DESCRIPTION
A new court is joining the pilot. Added the slug and updated copy in the screener start page.