### PR TITLE
Ensuring consistent abuse concerns order

### DIFF
--- a/app/models/abuse_concern.rb
+++ b/app/models/abuse_concern.rb
@@ -7,4 +7,9 @@ class AbuseConcern < ApplicationRecord
   has_value_object :behaviour_ongoing, class_name: 'GenericYesNo'
   has_value_object :asked_for_help,    class_name: 'GenericYesNo'
   has_value_object :help_provided,     class_name: 'GenericYesNo'
+
+  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID.
+  # For some time we will have records with null `created_at`, so we sort by
+  # the secondary column `kind`. We can get rid of `kind` in the future.
+  default_scope { order(created_at: :asc, kind: :desc) }
 end

--- a/app/presenters/summary/html_sections/base_abuse_details.rb
+++ b/app/presenters/summary/html_sections/base_abuse_details.rb
@@ -29,10 +29,11 @@ module Summary
 
       private
 
+      # Abuses are returned in the same order we ask them (`created_at`)
       def abuses_suffered
         c100.abuse_concerns.where(
           subject: subject,
-        ).reverse
+        )
       end
     end
   end

--- a/app/presenters/summary/sections/c1a_base_abuse_details.rb
+++ b/app/presenters/summary/sections/c1a_base_abuse_details.rb
@@ -27,13 +27,14 @@ module Summary
         []
       end
 
+      # Abuses are returned in the same order we ask them (`created_at`)
       def abuses_suffered
         c100.abuse_concerns.where(
           answer: GenericYesNo::YES,
           subject: subject,
         ).where.not(
           kind: filtered_abuses.map(&:to_s)
-        ).reverse
+        )
       end
     end
   end

--- a/db/migrate/20181015101148_add_timestamps_to_abuse_concerns.rb
+++ b/db/migrate/20181015101148_add_timestamps_to_abuse_concerns.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToAbuseConcerns < ActiveRecord::Migration[5.1]
+  def change
+    add_column :abuse_concerns, :created_at, :datetime
+    add_column :abuse_concerns, :updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180712101836) do
+ActiveRecord::Schema.define(version: 20181015101148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,8 @@ ActiveRecord::Schema.define(version: 20180712101836) do
     t.string "help_provided"
     t.text "help_description"
     t.uuid "c100_application_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["c100_application_id"], name: "index_abuse_concerns_on_c100_application_id"
   end
 

--- a/spec/presenters/summary/html_sections/applicant_abuse_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicant_abuse_details_spec.rb
@@ -38,8 +38,7 @@ module Summary
     # of sync, which means a quite solid safety net for any maintainers in the future.
     #
     describe '#answers' do
-      let(:found_abuses_resultset) { double('found_abuses_resultset') }
-      let(:final_resultset) { [abuse_concern] }
+      let(:found_abuses_resultset) { [abuse_concern] }
 
       before do
         allow(
@@ -47,8 +46,6 @@ module Summary
         ).to receive(:where).with(
           subject: AbuseSubject::APPLICANT
         ).and_return(found_abuses_resultset)
-
-        allow(found_abuses_resultset).to receive(:reverse).and_return(final_resultset)
       end
 
       it 'has the correct number of rows' do

--- a/spec/presenters/summary/html_sections/children_abuse_details_spec.rb
+++ b/spec/presenters/summary/html_sections/children_abuse_details_spec.rb
@@ -38,8 +38,7 @@ module Summary
     # of sync, which means a quite solid safety net for any maintainers in the future.
     #
     describe '#answers' do
-      let(:found_abuses_resultset) { double('found_abuses_resultset') }
-      let(:final_resultset) { [abuse_concern] }
+      let(:found_abuses_resultset) { [abuse_concern] }
 
       before do
         allow(
@@ -47,8 +46,6 @@ module Summary
         ).to receive(:where).with(
           subject: AbuseSubject::CHILDREN
         ).and_return(found_abuses_resultset)
-
-        allow(found_abuses_resultset).to receive(:reverse).and_return(final_resultset)
       end
 
       it 'has the correct number of rows' do

--- a/spec/presenters/summary/sections/c1a_applicant_abuse_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_applicant_abuse_details_spec.rb
@@ -42,8 +42,7 @@ module Summary
     #
     describe '#answers' do
       let(:found_abuses_resultset) { double('found_abuses_resultset') }
-      let(:filtered_abuses_resultset) { double('filtered_abuses_resultset') }
-      let(:final_resultset) { [abuse_concern] }
+      let(:filtered_abuses_resultset) { [abuse_concern] }
 
       before do
         allow(
@@ -57,8 +56,6 @@ module Summary
         ).to receive_message_chain(:where, :not).with(
           kind: []
         ).and_return(filtered_abuses_resultset)
-
-        allow(filtered_abuses_resultset).to receive(:reverse).and_return(final_resultset)
       end
 
       it 'has the correct number of rows' do

--- a/spec/presenters/summary/sections/c1a_children_abuse_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_children_abuse_details_spec.rb
@@ -42,8 +42,7 @@ module Summary
     #
     describe '#answers' do
       let(:found_abuses_resultset) { double('found_abuses_resultset') }
-      let(:filtered_abuses_resultset) { double('filtered_abuses_resultset') }
-      let(:final_resultset) { [abuse_concern] }
+      let(:filtered_abuses_resultset) { [abuse_concern] }
 
       before do
         allow(
@@ -57,8 +56,6 @@ module Summary
         ).to receive_message_chain(:where, :not).with(
           kind: ['other']
         ).and_return(filtered_abuses_resultset)
-
-        allow(filtered_abuses_resultset).to receive(:reverse).and_return(final_resultset)
       end
 
       it 'has the correct number of rows' do

--- a/spec/presenters/summary/sections/c1a_children_other_abuse_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_children_other_abuse_details_spec.rb
@@ -37,8 +37,7 @@ module Summary
 
     describe '#answers' do
       let(:found_abuses_resultset) { double('found_abuses_resultset') }
-      let(:filtered_abuses_resultset) { double('filtered_abuses_resultset') }
-      let(:final_resultset) { [abuse_concern] }
+      let(:filtered_abuses_resultset) { [abuse_concern] }
 
       before do
         allow(
@@ -52,8 +51,6 @@ module Summary
         ).to receive_message_chain(:where, :not).with(
           kind: %w(physical emotional psychological sexual financial)
         ).and_return(filtered_abuses_resultset)
-
-        allow(filtered_abuses_resultset).to receive(:reverse).and_return(final_resultset)
       end
 
       it 'has the correct number of rows' do


### PR DESCRIPTION
We can't rely on the default sorting by ID as we are using UUIDs.

This had no major impact other than the CYA page showing the abuse concerns in a slighly different order to the one we use when asking for these.

With the addition of timestamps now we can start using it to ensure we show the abuses in the same order they are created.