### PR TITLE
Using the new `service` domain

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,8 @@
   <![endif]-->
   <meta name="robots" content="noindex, nofollow"/>
   <meta name="msapplication-config" content="none"/>
-  <meta name="google-site-verification" content="lriduWRhNzjNWRLiG66idMmhQA9UaaOWS3_dFTQoips"/>
+  <meta name="google-site-verification" content="lriduWRhNzjNWRLiG66idMmhQA9UaaOWS3_dFTQoips"/> <!-- dsd -->
+  <meta name="google-site-verification" content="Ed6XKLFCCovwl_3gUpR5owg8AvgINOhiWWNGeJhHyio"/> <!-- service -->
 <% end %>
 
 <% content_for(:header_class) do %>with-proposition<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,8 +32,13 @@ end
 Rails.application.routes.draw do
   constraints host: 'c100.dsd.io' do
     get '/(*path)' => redirect(
-      ShortUrlExpander.new('https://apply-to-court-about-child-arrangements.dsd.io'), status: 302
+      ShortUrlExpander.new('https://apply-to-court-about-child-arrangements.service.justice.gov.uk'), status: 302
     )
+  end
+
+  # Maintain this for some time until all our traffic is coming directly from `justice` domain
+  constraints host: 'apply-to-court-about-child-arrangements.dsd.io' do
+    get '/(*path)' => redirect('https://apply-to-court-about-child-arrangements.service.justice.gov.uk', status: 301)
   end
 
   devise_for :users,

--- a/lib/tasks/short_urls.rake
+++ b/lib/tasks/short_urls.rake
@@ -41,5 +41,5 @@ def default_host_domain
 end
 
 def default_target_url
-  'https://apply-to-court-about-child-arrangements.dsd.io'.freeze
+  'https://apply-to-court-about-child-arrangements.service.justice.gov.uk'.freeze
 end


### PR DESCRIPTION
This will ensure we redirect to the new service domain and stop using the dsd.io, which will continue working for some time anyway.