### PR TITLE
Add FMC postcode lookup to MIAM kickout page

### DIFF
--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -4,6 +4,7 @@ moj.Modules.gaEvents = {
     radioFormClass: '.multiple-choice input[type="radio"]',
     checkboxClass:  '.multiple-choice input[type="checkbox"]',
     linkClass: '.ga-pageLink',
+    clickActionClass: '.ga-clickAction',
     revealingLinkClass: 'summary span.summary',
     submitFormClass: '.ga-submitForm',
     submitButtons: 'button[type="submit"], input[type="submit"]',
@@ -34,6 +35,9 @@ moj.Modules.gaEvents = {
             if ($(self.revealingLinkClass).length) {
                 self.trackRevealingLinks();
             }
+            if ($(self.clickActionClass).length) {
+                self.trackClickActions();
+            }
             if ($(self.submitFormClass).length) {
                 self.trackSubmitForms();
             }
@@ -46,9 +50,11 @@ moj.Modules.gaEvents = {
 
     addSubmitValueParamOnClick: function() {
         $(this.submitButtons).on('click', function() {
-            $('<input>',
-                { type: 'hidden', name: $(this).attr('name'), value: $(this).attr('value') }
-            ).appendTo($(this).closest('form'));
+            if ($(this).attr('name')) {
+                $('<input>',
+                    {type: 'hidden', name: $(this).attr('name'), value: $(this).attr('value')}
+                ).appendTo($(this).closest('form'));
+            }
         });
     },
 
@@ -163,6 +169,24 @@ moj.Modules.gaEvents = {
             if ($link.closest('details:not([open])').length && eventData.eventCategory) {
                 self.sendAnalyticsEvent(eventData, options);
             }
+        });
+    },
+
+    trackClickActions: function() {
+        var self = this,
+            $elements = $(self.clickActionClass);
+
+        $elements.on('click', function() {
+            var $el = $(this),
+                eventData;
+
+            eventData = {
+                eventCategory: $el.data('ga-category'),
+                eventAction: $el.data('ga-action'),
+                eventLabel: $el.data('ga-label')
+            };
+
+            self.sendAnalyticsEvent(eventData, {});
         });
     },
 

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -81,6 +81,15 @@
   background-color: #dddddd;
 }
 
+form.fmc-lookup-form {
+  padding-bottom: 0;
+  margin-bottom: 0;
+
+  label {
+    font-weight: normal;
+  }
+}
+
 // This will hide the Sentry user-feedback attribution. There is a setting
 // to hide it but currently it is not working, so this is an alternative.
 div.sentry-error-embed-wrapper p.powered-by {

--- a/app/assets/stylesheets/local/utilities.scss
+++ b/app/assets/stylesheets/local/utilities.scss
@@ -18,6 +18,10 @@
   margin-bottom: 25px;
 }
 
+.util_mb-small {
+  margin-bottom: 10px;
+}
+
 .util_mb-none {
   margin-bottom: 0px;
 }

--- a/app/views/steps/miam_exemptions/exit_page/show.en.html.erb
+++ b/app/views/steps/miam_exemptions/exit_page/show.en.html.erb
@@ -15,12 +15,24 @@
       <p>You need to follow these steps before continuing with your application:</p>
       <section class="numbered-list">
         <ol class="list list-number">
-          <li><a href="https://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external" target="_blank">Find a mediator</a> and book a MIAM</li>
+          <li>
+            <form class="fmc-lookup-form" action="https://www.familymediationcouncil.org.uk/find-local-mediator/" target="_blank">
+              <input type="hidden" name="di" value="5">
+              <div class="form-group util_mb-small">
+                <label class="form-label" for="pc">Enter your postcode to find a mediator</label>
+                <input class="form-control narrow" type="text" name="pc" id="pc" required>
+              </div>
+              <input type="submit" class="button ga-clickAction" value="Find a mediator" data-disable-with="Find a mediator" data-ga-category="miam kickout" data-ga-action="submit" data-ga-label="fmc postcode"/>
+            </form>
+          </li>
+          <li>Book initial meeting with mediator</li>
           <li>Attend the MIAM</li>
           <li>Ask the mediator for a document confirming your attendance</li>
         </ol>
       </section>
     </div>
+
+    <p><%=t 'steps.shared.screener_exit_actions.cait_info_html' %></p>
 
     <%= render partial: 'steps/shared/kickout_survey' %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -951,7 +951,7 @@ en:
       terms_and_conditions: Terms and conditions
     phase_banner:
       phase_info_email_html: |
-        This is a new service. <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Feedback">Report a problem</a> and help improve it for others.
+        This is a new service. <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Feedback" class="ga-clickAction" data-ga-category="feedback" data-ga-action="click" data-ga-label="report a problem">Report a problem</a> and help improve it for others.
     current_user_menu:
       logout: Sign out
       change_password: Change password


### PR DESCRIPTION
Same as we did in CAIT, we are going to let the user enter a postcode
and do a (GET) request to FMC website to preload results.

Some other copy changes, and extra JS code to cope with new tracking.

<img width="583" alt="screen shot 2018-10-18 at 11 03 07" src="https://user-images.githubusercontent.com/687910/47222232-17b04b80-d3ae-11e8-95b9-f1303df7c67f.png">
