### PR TITLE
Add Medway family court to the pilot

### DIFF
--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -20,10 +20,11 @@ module C100App
       cardiff-civil-and-family-justice-centre
       leicester-county-court-and-family-court
       east-london-family-court
-      newport-gwent-civil-and-family-court
+      newport-south-wales-county-court-and-family-court
       southampton-combined-court-centre
       swansea-civil-and-family-justice-centre
       exeter-combined-court-centre
+      medway-county-court-and-family-court
     ].freeze
 
     # Separate multiple postcodes/postcode areas by "\n"

--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -7,8 +7,8 @@
     </h1>
 
     <p>The court areas currently taking part are: Blackburn, Blackpool, Bristol, Exeter, Gateshead, Grimsby, Guildford,
-      Hull, Lancaster, Leicester, London, Mansfield, Milton Keynes, Newcastle, Nottingham, Oxford, Preston, Reading,
-      Slough, Southampton, Sunderland, Watford and West Yorkshire.</p>
+      Hull, Kent, Lancaster, Leicester, London, Mansfield, Milton Keynes, Newcastle, Nottingham, Oxford, Preston,
+      Reading, Slough, Southampton, Sunderland, Watford and West Yorkshire.</p>
 
     <p>This trial is also taking place in Cardiff, Newport and Swansea. A Welsh language version will be available after
       the trial is completed.</p>

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -255,7 +255,7 @@ describe Court do
         end
       end
 
-      context 'containing an email with description matching "enquiries"' do
+      context 'containing an email with explanation matching "family"' do
         let(:emails){
           [
             {
@@ -263,7 +263,8 @@ describe Court do
               'address' => 'other@email'
             },
             {
-              'description' => 'Enquiries',
+              'description' => '',
+              'explanation' => 'Family enquiries',
               'address' => 'my@email',
             },
           ]

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe C100App::CourtPostcodeChecker do
   describe 'COURT_SLUGS_USING_THIS_APP' do
     it 'returns the expected number of court slugs taking part in the trial' do
-      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(20)
+      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(21)
     end
   end
 


### PR DESCRIPTION
Also some improvements to the way we seek the most suitable court email address, due to the fact some courts are starting to use explanations instead of descriptions.

Updated Newport slug.