### PR TITLE
Only mark as completed if `in_progress`

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -6,7 +6,7 @@ module CompletionStep
   extend ActiveSupport::Concern
 
   included do
-    before_action :mark_completed, unless: :completed?
+    before_action :mark_completed, if: :in_progress?
   end
 
   def show
@@ -15,8 +15,8 @@ module CompletionStep
 
   private
 
-  def completed?
-    current_c100_application.completed?
+  def in_progress?
+    current_c100_application.in_progress?
   end
 
   def mark_completed

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -433,6 +433,15 @@ RSpec.shared_examples 'a completion step controller' do
           get :show, session: {c100_application_id: existing_c100.id}
         end
       end
+
+      context 'when the application is still `screening`' do
+        let(:status) { :screening }
+
+        it 'does not call the `mark_completed` method' do
+          expect(controller).not_to receive(:mark_completed)
+          get :show, session: {c100_application_id: existing_c100.id}
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Make this a bit more strict and only mark as completed (and thus audit it) applications `in_progress`, and not like now, those also including the `screening` stage.