### PR TITLE
Warn user if an application is in progress

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,13 +6,10 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    # When redirecting to the survey, we want to logout the user. But when only taking the users to the home,
-    # we don't want to log them out but instead only reset the current case in session.
-    show_survey = params[:survey] == 'true'
-    show_survey ? reset_session : reset_c100_application_session
+    reset_session
 
     respond_to do |format|
-      format.html { redirect_to show_survey ? Rails.configuration.surveys[:success] : root_path }
+      format.html { redirect_to root_path }
       format.json { render json: {} }
     end
   end

--- a/app/controllers/steps/screener/start_controller.rb
+++ b/app/controllers/steps/screener/start_controller.rb
@@ -1,8 +1,8 @@
 module Steps
   module Screener
     class StartController < Steps::ScreenerStepController
-      skip_before_action :check_c100_application_presence
-      before_action :reset_c100_application_session
+      skip_before_action :check_c100_application_presence, :update_navigation_stack
+      before_action :existing_application_warning, :reset_c100_application_session
 
       def show; end
     end

--- a/app/controllers/steps/screener/warning_controller.rb
+++ b/app/controllers/steps/screener/warning_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Screener
+    class WarningController < Steps::ScreenerStepController
+      skip_before_action :update_navigation_stack
+
+      def show; end
+    end
+  end
+end

--- a/app/controllers/steps/screener_step_controller.rb
+++ b/app/controllers/steps/screener_step_controller.rb
@@ -7,5 +7,15 @@ module Steps
     def decision_tree_class
       C100App::ScreenerDecisionTree
     end
+
+    def in_progress_enough?
+      current_c100_application&.in_progress? &&
+        current_c100_application.navigation_stack.size > 2
+    end
+
+    def existing_application_warning
+      return unless in_progress_enough? && !params.key?(:new)
+      redirect_to steps_screener_warning_path
+    end
   end
 end

--- a/app/views/steps/screener/warning/show.html.erb
+++ b/app/views/steps/screener/warning/show.html.erb
@@ -1,0 +1,20 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <p>
+      <% if user_signed_in? %>
+        <%=t '.lead_signed_in' %>
+      <% else %>
+        <%=t '.lead_signed_off' %>
+      <% end %>
+    </p>
+
+    <div class="form-submit">
+      <%= link_to t('.resume_link'), previous_step_path, class: 'button ga-pageLink', data: {ga_category: 'in progress warning', ga_label: 'resume application'} %>
+      <%= link_to t('.restart_link'), root_path(new: 'y'), class: 'button button-secondary ga-pageLink', data: {ga_category: 'in progress warning', ga_label: 'new application'} %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/drafts/index.html.erb
+++ b/app/views/users/drafts/index.html.erb
@@ -32,7 +32,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <p>
-      <%= link_to t('.new_application'), root_path, class: 'ga-pageLink', data: {ga_category: 'save and return', ga_label: 'new application'} %>
+      <%= link_to t('.new_application'), root_path(new: 'y'), class: 'ga-pageLink', data: {ga_category: 'save and return', ga_label: 'new application'} %>
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -938,6 +938,14 @@ en:
           page_title: Contact by email
           heading: Are you willing to be contacted by email about your experience using this service?
           lead_text: This will help us to improve the service, and your answer here will not affect whether or not you can use this service.
+      warning:
+        show:
+          page_title: Application in progress
+          heading: It looks like you already have an application in progress
+          lead_signed_in: Your current application will remain as a draft in your account and you can resume it at any time, or you can start a new application.
+          lead_signed_off: You can resume your current application so you don't lose your progress, or you can start a new application.
+          resume_link: Resume application
+          restart_link: Start a new application
   home:
     index:
       heading: Start here

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
   namespace :steps do
     namespace :screener do
       show_step :start
+      show_step :warning
       edit_step :postcode
       show_step :error_but_continue
       show_step :no_court_found

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -9,42 +9,14 @@ RSpec.describe SessionsController, type: :controller do
   end
 
   describe '#destroy' do
-    context 'when survey param is not provided' do
-      it 'resets the application session' do
-        expect(subject).to receive(:reset_c100_application_session)
-        get :destroy
-      end
-
-      it 'redirects to the home page' do
-        get :destroy
-        expect(subject).to redirect_to(root_path)
-      end
+    it 'resets the session' do
+      expect(subject).to receive(:reset_session)
+      get :destroy
     end
 
-    context 'when survey param is provided' do
-      context 'for a `true` value' do
-        it 'resets the session' do
-          expect(subject).to receive(:reset_session)
-          get :destroy, params: {survey: true}
-        end
-
-        it 'redirects to the survey page' do
-          get :destroy, params: {survey: true}
-          expect(response.location).to match(/survey$/)
-        end
-      end
-
-      context 'for a `false` value' do
-        it 'resets the application session' do
-          expect(subject).to receive(:reset_c100_application_session)
-          get :destroy, params: {survey: false}
-        end
-
-        it 'redirects to the home page' do
-          get :destroy, params: {survey: false}
-          expect(subject).to redirect_to(root_path)
-        end
-      end
+    it 'redirects to the home page' do
+      get :destroy
+      expect(subject).to redirect_to(root_path)
     end
 
     context 'when a JSON request is made' do

--- a/spec/controllers/steps/screener/start_controller_spec.rb
+++ b/spec/controllers/steps/screener/start_controller_spec.rb
@@ -1,17 +1,96 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Screener::StartController, type: :controller do
+  let!(:existing_c100) { C100Application.create(status: status, navigation_stack: navigation_stack) }
+
+  before do
+    allow(controller).to receive(:current_c100_application).and_return(existing_c100)
+  end
+
   describe '#show' do
-    it 'responds with HTTP success' do
-      get :show
-      expect(response).to be_successful
+    context 'when an existing application in progress exists' do
+      let(:status) { :in_progress }
+
+      context 'with enough steps advanced' do
+        let(:navigation_stack) { %w(/1 /2 /3) }
+
+        context 'and user bypass the warning' do
+          it 'responds with HTTP success' do
+            get :show, session: { c100_application_id: existing_c100.id }, params: {new: 'y'}
+            expect(response).to be_successful
+          end
+
+          it 'resets the c100_application session data' do
+            expect(session).to receive(:delete).with(:c100_application_id).ordered
+            expect(session).to receive(:delete).with(:last_seen).ordered
+            expect(session).to receive(:delete) # any other deletes
+            get :show, session: { c100_application_id: existing_c100.id }, params: {new: 'y'}
+          end
+        end
+
+        context 'and user do not bypass the warning' do
+          it 'redirects to the warning page' do
+            get :show, session: { c100_application_id: existing_c100.id }
+            expect(response).to redirect_to(steps_screener_warning_path)
+          end
+
+          it 'does not reset any application session data' do
+            expect(session).not_to receive(:delete).with(:c100_application_id).ordered
+            expect(session).not_to receive(:delete).with(:last_seen).ordered
+            get :show, session: { c100_application_id: existing_c100.id }
+          end
+        end
+      end
+
+      context 'with not enough steps advanced' do
+        let(:navigation_stack) { %w(/1 /2) }
+
+        it 'responds with HTTP success' do
+          get :show, session: { c100_application_id: existing_c100.id }
+          expect(response).to be_successful
+        end
+
+        it 'resets the c100_application session data' do
+          expect(session).to receive(:delete).with(:c100_application_id).ordered
+          expect(session).to receive(:delete).with(:last_seen).ordered
+          expect(session).to receive(:delete) # any other deletes
+          get :show
+        end
+      end
     end
 
-    it 'resets the c100_application session data' do
-      expect(session).to receive(:delete).with(:c100_application_id).ordered
-      expect(session).to receive(:delete).with(:last_seen).ordered
-      expect(session).to receive(:delete) # any other deletes
-      get :show
+    context 'when an existing screening application exists' do
+      let(:status) { :screening }
+      let(:navigation_stack) { [] }
+
+      it 'responds with HTTP success' do
+        get :show, session: { c100_application_id: existing_c100.id }
+        expect(response).to be_successful
+      end
+
+      it 'resets the c100_application session data' do
+        expect(session).to receive(:delete).with(:c100_application_id).ordered
+        expect(session).to receive(:delete).with(:last_seen).ordered
+        expect(session).to receive(:delete) # any other deletes
+        get :show
+      end
+    end
+
+    context 'when no application exists in session' do
+      let!(:existing_c100) { nil }
+      let(:navigation_stack) { [] }
+
+      it 'responds with HTTP success' do
+        get :show
+        expect(response).to be_successful
+      end
+
+      it 'resets the c100_application session data' do
+        expect(session).to receive(:delete).with(:c100_application_id).ordered
+        expect(session).to receive(:delete).with(:last_seen).ordered
+        expect(session).to receive(:delete) # any other deletes
+        get :show
+      end
     end
   end
 end

--- a/spec/controllers/steps/screener/warning_controller_spec.rb
+++ b/spec/controllers/steps/screener/warning_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Screener::WarningController, type: :controller do
+  let!(:existing_c100) { C100Application.create(status: status, navigation_stack: []) }
+
+  before do
+    allow(controller).to receive(:current_c100_application).and_return(existing_c100)
+  end
+
+  describe '#show' do
+    context 'when an existing application exists in session' do
+      let(:status) { :in_progress }
+
+      it 'responds with HTTP success' do
+        get :show, session: { c100_application_id: existing_c100.id }
+        expect(response).to be_successful
+      end
+
+      it 'does not update the navigation stack' do
+        expect(controller).not_to receive(:update_navigation_stack)
+        get :show, session: { c100_application_id: existing_c100.id }
+      end
+    end
+
+    context 'when no application exists in session' do
+      let!(:existing_c100) { nil }
+
+      it 'redirects to the invalid session error page' do
+        get :show
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before resetting the session and thus risking losing all the progress,
we can warn the user and let them choose to continue with the current
application or to start a new one.