### PR TITLE
Revert "Only mark as completed if `in_progress`"

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -6,7 +6,7 @@ module CompletionStep
   extend ActiveSupport::Concern
 
   included do
-    before_action :mark_completed, if: :in_progress?
+    before_action :mark_completed, unless: :completed?
   end
 
   def show
@@ -15,8 +15,8 @@ module CompletionStep
 
   private
 
-  def in_progress?
-    current_c100_application.in_progress?
+  def completed?
+    current_c100_application.completed?
   end
 
   def mark_completed

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -433,15 +433,6 @@ RSpec.shared_examples 'a completion step controller' do
           get :show, session: {c100_application_id: existing_c100.id}
         end
       end
-
-      context 'when the application is still `screening`' do
-        let(:status) { :screening }
-
-        it 'does not call the `mark_completed` method' do
-          expect(controller).not_to receive(:mark_completed)
-          get :show, session: {c100_application_id: existing_c100.id}
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
This reverts commit 56b0b3fd274f91c3b5efcbf1a709b889732a9f57.

This was not a good idea, because there are other valid states that can be marked as completed, like the reminders `first_reminder_sent` or `last_reminder_sent`.

Reverting the changes and leaving as it was before.