### PR TITLE
Improve payment instructions copy

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -11,6 +11,7 @@ module CompletionStep
 
   def show
     @court = current_c100_application.screener_answers_court
+    @c100_application = current_c100_application
   end
 
   private

--- a/app/mailer_previews/submission_mailer_preview.rb
+++ b/app/mailer_previews/submission_mailer_preview.rb
@@ -22,12 +22,14 @@ class SubmissionMailerPreview < ActionMailer::Preview
       :reference_code,
       :urgent_hearing,
       :confidentiality_enabled?,
+      :payment_type,
       :screener_answers_court,
       :applicants,
     ).new(
       '12345',
       'no',
       true,
+      PaymentType::SELF_PAYMENT_CARD.to_s,
       local_court_fixture,
       applicants_fixture,
     )

--- a/app/views/mailers/receipt_mailer/copy_to_user.en.html.erb
+++ b/app/views/mailers/receipt_mailer/copy_to_user.en.html.erb
@@ -9,17 +9,9 @@
   <strong>A copy of your application is attached to this email.</strong>
 
   <h2>Pay the application fee</h2>
-  <p>You need to pay the £215 court fee. The court will telephone you (it may come from a ‘private number’) within 3
-    working days of receiving your application to take payment using a credit or debit card. If you did not enter a
-    telephone number or you do not get a call, please contact the court to pay.</p>
-
-  <p>You can also pay by post with a cheque made out to ‘HM Courts and Tribunals Service’, or in person at the court by
-    cheque, cash or card.</p>
-
-  <p>The court will not be able to process your application until payment has been received.</p>
-
-  <p>You may not need to pay the full amount if you have a
-    <a href="https://www.gov.uk/get-help-with-court-fees">‘Help with fees’</a> reference.</p>
+  <%= render partial: 'steps/shared/payment_instructions', locals: {
+    c100_application: @c100_application
+  } %>
 
   <%= render partial: 'mailers/shared/court_help', locals: {court: @court} %>
 

--- a/app/views/mailers/receipt_mailer/copy_to_user.en.text.erb
+++ b/app/views/mailers/receipt_mailer/copy_to_user.en.text.erb
@@ -10,17 +10,9 @@ A copy of your application is attached to this email.
 
 Pay the application fee:
 
-You need to pay the £215 court fee. The court will telephone you (it may come from a
-‘private number’) within 3 working days of receiving your application to take payment
-using a credit or debit card. If you did not enter a telephone number or you do not
-get a call, please contact the court to pay.
-
-You can also pay by post with a cheque made out to ‘HM Courts and Tribunals
-Service’, or in person at the court by cheque, cash or card.
-
-The court will not be able to process your application until payment has been received.
-
-You may not need to pay the full amount if you have a ‘Help with fees’ reference.
+<%= render partial: 'steps/shared/payment_instructions', locals: {
+  c100_application: @c100_application
+} %>
 
 
 <%= render partial: 'mailers/shared/court_help', locals: {court: @court} %>

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -20,7 +20,9 @@
 
     <div class="govuk-govspeak gv-s-prose">
       <h2 class="heading-large gv-u-heading-large">Pay the application fee</h2>
-      <%= render partial: 'steps/shared/payment_instructions' %>
+      <%= render partial: 'steps/shared/payment_instructions', locals: {
+        c100_application: @c100_application
+      } %>
     </div>
 
     <div class="govuk-govspeak gv-s-prose">

--- a/app/views/steps/completion/what_next/show.en.html.erb
+++ b/app/views/steps/completion/what_next/show.en.html.erb
@@ -46,16 +46,16 @@
 
           <li class="util_mt-medium">
             <h3 class="heading-medium">Post it to the court</h3>
-            <p>Post all 3 printed copies (and cheque, if that’s how you choose to pay) of your application to:</p>
-
-            <div class="panel panel-border-narrow">
-              <%= simple_format(@court.full_address.join("\n")) %>
-            </div>
+            <%= render partial: 'steps/shared/post_instructions', locals: {
+              c100_application: @c100_application, court: @court
+            } %>
           </li>
 
           <li class="util_mt-medium">
             <h3 class="heading-medium">Pay the application fee</h3>
-            <%= render partial: 'steps/shared/payment_instructions' %>
+            <%= render partial: 'steps/shared/payment_instructions', locals: {
+              c100_application: @c100_application
+            } %>
           </li>
         </ol>
       </div>

--- a/app/views/steps/shared/_payment_instructions.en.html.erb
+++ b/app/views/steps/shared/_payment_instructions.en.html.erb
@@ -1,12 +1,24 @@
-<p>You need to pay the £215 court fee. The court will telephone you (it may come from a ‘private number’) within 3
-  working days of receiving your application to take payment using a credit or debit card. If you did not enter a
-  telephone number or you do not get a call, please contact the court to pay.</p>
+<% if c100_application.payment_type.eql?(PaymentType::HELP_WITH_FEES.to_s) %>
 
-<p>You can also pay by post with a cheque made out to ‘HM Courts and Tribunals Service’, or in person at the court by
-  cheque, cash or card.</p>
+  <p>You may not need to pay the full amount if you have a
+    <a href="https://www.gov.uk/get-help-with-court-fees" rel="external" target="_blank">‘Help with fees’</a> reference.
+    The court will phone you (it may come from a ‘private number’) if they require payment.</p>
+  <p>The court will not be able to process your application until payment has been received.</p>
 
-<p>The court will not be able to process your application until payment has been received.</p>
+<% elsif c100_application.payment_type.eql?(PaymentType::SELF_PAYMENT_CHEQUE.to_s) %>
 
-<p>You may not need to pay the full amount if you have a
-  <a href="https://www.gov.uk/get-help-with-court-fees" rel="external" target="_blank">‘Help with fees’</a>
-  reference.</p>
+  <p>You need to pay the £215 court fee. Post a cheque made out to ‘HM Courts and Tribunals Service’. Write your
+    reference code (<%= c100_application.reference_code -%>), last name and ‘C100’ on the back of your cheque.</p>
+  <p>You may also pay in person at the court by cheque or cash.</p>
+  <p>Send your cheque or pay in person within 3 working days. The court will not be able to process your application
+    until payment has been received.</p>
+
+<% else %>
+
+  <p>You need to pay the £215 court fee. The court will phone you (it may come from a ‘private number’) within 3 working
+    days of receiving your application to take payment using a credit or debit card.</p>
+  <p>If you did not enter a telephone number or you do not get a call, please contact the court to pay. You may also pay
+    by card in person at the court.</p>
+  <p>The court will not be able to process your application until payment has been received.</p>
+
+<% end %>

--- a/app/views/steps/shared/_payment_instructions.en.text.erb
+++ b/app/views/steps/shared/_payment_instructions.en.text.erb
@@ -1,0 +1,29 @@
+<% if c100_application.payment_type.eql?(PaymentType::HELP_WITH_FEES.to_s) %>
+
+You may not need to pay the full amount if you have a ‘Help with fees’ reference.
+The court will phone you (it may come from a ‘private number’) if they require payment.
+
+The court will not be able to process your application until payment has been received.
+
+<% elsif c100_application.payment_type.eql?(PaymentType::SELF_PAYMENT_CHEQUE.to_s) %>
+
+You need to pay the £215 court fee. Post a cheque made out to ‘HM Courts and Tribunals Service’.
+Write your reference code (<%= c100_application.reference_code -%>), last name
+and ‘C100’ on the back of your cheque.
+
+You may also pay in person at the court by cheque or cash.
+
+Send your cheque or pay in person within 3 working days. The court will not be able to process
+your application until payment has been received.
+
+<% else %>
+
+You need to pay the £215 court fee. The court will phone you (it may come from a ‘private number’)
+within 3 working days of receiving your application to take payment using a credit or debit card.
+
+If you did not enter a telephone number or you do not get a call, please contact the court to pay.
+You may also pay by card in person at the court.
+
+The court will not be able to process your application until payment has been received.
+
+<% end %>

--- a/app/views/steps/shared/_post_instructions.en.html.erb
+++ b/app/views/steps/shared/_post_instructions.en.html.erb
@@ -1,0 +1,9 @@
+<% if c100_application.payment_type.eql?(PaymentType::SELF_PAYMENT_CHEQUE.to_s) %>
+  <p>Post all 3 printed copies of your application (and cheque, if that’s how you choose to pay) to:</p>
+<% else %>
+  <p>Post all 3 printed copies of your application to:</p>
+<% end %>
+
+<div class="panel panel-border-narrow">
+  <%= simple_format(court.full_address.join("\n")) %>
+</div>

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -409,6 +409,7 @@ RSpec.shared_examples 'a completion step controller' do
     it 'assigns the court data' do
       get :show, session: { c100_application_id: existing_c100.id }
       expect(assigns[:court]).to eq('court data')
+      expect(assigns[:c100_application]).to eq(existing_c100)
     end
 
     describe 'marking as completed and saving audit' do


### PR DESCRIPTION
Instead of a big catch-all payment instructions block, we are now giving specific payment instructions depending on the payment method (and in some cases the submission method) the applicant chose.

This affects the confirmation pages (online and print&post) and the confirmation email (only for online submission).