### PR TITLE
Add link to contact page

### DIFF
--- a/app/views/about/contact.en.html.erb
+++ b/app/views/about/contact.en.html.erb
@@ -1,11 +1,17 @@
-<% title 'Contact us' %>
+<% title 'Contact' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">Contact us</h1>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Get in touch</h1>
 
-    <p class="lede">This is a placeholder.</p>
+    <p class="lede">
+      If you’d like to report a problem or have a suggestion to help improve this service for others, get in touch by
+      sending an email to:
+    </p>
 
+    <p class="lede">
+      <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Feedback" class="ga-clickAction" data-ga-category="feedback" data-ga-action="click" data-ga-label="report a problem">c100helpdesk@digital.justice.gov.uk</a>
+    </p>
   </div>
 </div>

--- a/app/views/layouts/_footer_links.html.erb
+++ b/app/views/layouts/_footer_links.html.erb
@@ -3,6 +3,9 @@
     <%= link_to t('.help'), 'https://www.gov.uk/help', class: 'ga-pageLink', data: {ga_category: 'footer', ga_label: 'help'} %>
   </li>
   <li>
+    <%= link_to t('.contact'), about_contact_path, class: 'ga-pageLink', data: {ga_category: 'footer', ga_label: 'contact'} %>
+  </li>
+  <li>
     <%= link_to t('.cookies'), about_cookies_path, class: 'ga-pageLink', data: {ga_category: 'footer', ga_label: 'cookies'} %>
   </li>
   <li>

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -2,7 +2,7 @@
   <p>
     <strong class="phase-tag">alpha</strong>
     <span>
-      <%= t('.phase_info_email_html') %>
+      <%= t('.feedback_contact_html') %>
     </span>
   </p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -957,8 +957,7 @@ en:
       privacy: Privacy
       terms_and_conditions: Terms and conditions
     phase_banner:
-      phase_info_email_html: |
-        This is a new service. <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Feedback" class="ga-clickAction" data-ga-category="feedback" data-ga-action="click" data-ga-label="report a problem">Report a problem</a> and help improve it for others.
+      feedback_contact_html: This is a new service. <a href="/about/contact">Report a problem</a> and help improve it for others.
     current_user_menu:
       logout: Sign out
       change_password: Change password


### PR DESCRIPTION
Expose a contact page showing the email they can use to get in touch with us.