### PR TITLE
Warn applicant if application fails to submit

### DIFF
--- a/app/jobs/online_submission_job.rb
+++ b/app/jobs/online_submission_job.rb
@@ -1,7 +1,21 @@
 class OnlineSubmissionJob < ApplicationJob
   queue_as :submissions
 
+  rescue_from StandardError, with: :log_and_notify_error
+
   def perform(c100_application)
     C100App::OnlineSubmission.new(c100_application).process
+  end
+
+  private
+
+  def log_and_notify_error(exception)
+    # arguments[0] refers to the first argument passed to the `perform` method
+    c100_application = arguments[0]
+
+    NotifyMailer.submission_error(c100_application).deliver_later if c100_application.receipt_email.present?
+
+    Raven.extra_context(c100_application_id: c100_application.id)
+    Raven.capture_exception(exception)
   end
 end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -47,6 +47,16 @@ class NotifyMailer < GovukNotifyRails::Mailer
     mail(to: c100_application.user.email)
   end
 
+  def submission_error(c100_application)
+    set_template(:submission_error)
+
+    set_personalisation(
+      reference_code: c100_application.reference_code,
+    )
+
+    mail(to: c100_application.receipt_email)
+  end
+
   def draft_expire_reminder(c100_application, template_name)
     set_template(template_name)
 

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -12,6 +12,7 @@ integration:
   reset_password: '73d0804a-2302-4307-a431-e4a0fd7087ec'
   change_password: '97ea3c24-0b40-4b8e-8fc6-a54f7f1718e9'
   application_saved: '1252b250-541c-456a-b98b-c568aef05e5f'
+  submission_error: 'c99df4a0-5655-4ef8-aaf4-0a5b83397785'
   draft_first_reminder: 'fcd87b1c-a3a0-4a2a-9b4e-524857e3bf8c'
   draft_last_reminder: '8e622f55-4be8-49cc-8a94-0ab3fd868067'
 
@@ -19,5 +20,6 @@ production:
   reset_password: '0f55e48a-ae27-464c-b30f-272fd3850296'
   change_password: 'c6be1e37-feee-4d18-9552-ed4e4772ad16'
   application_saved: '267ace56-230f-4b07-902f-b993dfc69143'
+  submission_error: '9ded5ada-9e33-4b7b-bdaf-daa85b6c7063'
   draft_first_reminder: 'bf271379-6158-407d-b09a-cc6d8b275f1e'
   draft_last_reminder: '30dedd21-e7da-4794-b66c-94729cfa3180'

--- a/spec/jobs/online_submission_job_spec.rb
+++ b/spec/jobs/online_submission_job_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe OnlineSubmissionJob, type: :job do
-  let(:c100_application) { instance_double(C100Application) }
+  let(:c100_application) { instance_double(C100Application, id: '123-456', receipt_email: receipt_email) }
+  let(:receipt_email) { nil }
 
   before do
     ActiveJob::Base.queue_adapter = :test
@@ -11,6 +12,37 @@ RSpec.describe OnlineSubmissionJob, type: :job do
     it 'calls the `SendApplicationToCourt` service to process the application' do
       expect_any_instance_of(C100App::OnlineSubmission).to receive(:process)
       OnlineSubmissionJob.perform_now(c100_application)
+    end
+
+    context 'an exception occurs' do
+      before do
+        allow_any_instance_of(C100App::OnlineSubmission).to receive(:process).and_raise(NoMethodError)
+      end
+
+      it 'captures the error' do
+        expect(Raven).to receive(:extra_context).with({ c100_application_id: '123-456' })
+        expect(Raven).to receive(:capture_exception).with(NoMethodError)
+
+        OnlineSubmissionJob.perform_now(c100_application)
+      end
+
+      context 'there is a receipt email' do
+        let(:receipt_email) { 'receipt@example.com' }
+        let(:mailer_double) { double.as_null_object }
+
+        before do
+          allow(
+            NotifyMailer
+          ).to receive(:submission_error).with(
+            c100_application
+          ).and_return(mailer_double)
+        end
+
+        it 'sends an email to the user do' do
+          OnlineSubmissionJob.perform_now(c100_application)
+          expect(mailer_double).to have_received(:deliver_later)
+        end
+      end
     end
   end
 end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe NotifyMailer, type: :mailer do
       reset_password: 'reset_password_template_id',
       change_password: 'change_password_template_id',
       application_saved: 'application_saved_template_id',
+      submission_error: 'submission_error_template_id',
       draft_first_reminder: 'draft_first_reminder_template_id',
       draft_last_reminder: 'draft_last_reminder_template_id',
     )
@@ -34,6 +35,26 @@ RSpec.describe NotifyMailer, type: :mailer do
         service_name: 'Apply to court about child arrangements',
         resume_draft_url: 'https://c100.justice.uk/users/drafts/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume',
         draft_expire_in_days: 28,
+      })
+    end
+  end
+
+  describe '#submission_error' do
+    before do
+      allow(c100_application).to receive(:created_at).and_return(Time.at(0))
+      allow(c100_application).to receive(:receipt_email).and_return('receipt@example.com')
+    end
+
+    let(:mail) { described_class.submission_error(c100_application) }
+
+    it_behaves_like 'a Notify mail', template_id: 'submission_error_template_id'
+
+    it { expect(mail.to).to eq(['receipt@example.com']) }
+
+    it 'has the right personalisation' do
+      expect(mail.govuk_notify_personalisation).to eq({
+        service_name: 'Apply to court about child arrangements',
+        reference_code: '1970/01/4A362E1C',
       })
     end
   end


### PR DESCRIPTION
In some rare occasions, the generation of the PDF could fail due to incomplete or inconsistent data, and the emails to the applicant/court are not sent.

We can send an automated email to the applicant warning them of this situation, while we investigate the root cause.