### PR TITLE
Increase min pass length

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -68,7 +68,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..128
+  config.password_length = 10..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1506,7 +1506,7 @@ en:
 
     hint:
       user:
-        password: Must be at least 8 characters
+        password: Must be at least 10 characters
         current_password: We need your current password to confirm your changes
       steps_applicant_names_form:
         new_name_html: *name_instructions

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Users::RegistrationsController do
       def do_post
         post :create, params: { 'user' => {
           'email' => 'foo@bar.com',
-          'password' => 'passw0rd'
+          'password' => 'mypassw0rd'
         } }
       end
 


### PR DESCRIPTION
Following ICO guidance on passwords for online services under GDPR.