### PR TITLE
Implement custom date validator

### DIFF
--- a/app/forms/steps/applicant/personal_details_form.rb
+++ b/app/forms/steps/applicant/personal_details_form.rb
@@ -17,6 +17,8 @@ module Steps
       validates_presence_of :birthplace, :dob
       validates_presence_of :previous_name, if: -> { has_previous_name&.yes? }
 
+      validates :dob, sensible_date: true
+
       private
 
       def persist!

--- a/app/forms/steps/children/personal_details_form.rb
+++ b/app/forms/steps/children/personal_details_form.rb
@@ -13,6 +13,8 @@ module Steps
       validates_inclusion_of :gender, in: Gender.values
       validates_presence_of :dob, unless: :dob_unknown?
 
+      validates :dob, sensible_date: true, unless: :dob_unknown?
+
       private
 
       def persist!

--- a/app/forms/steps/miam/certification_date_form.rb
+++ b/app/forms/steps/miam/certification_date_form.rb
@@ -9,6 +9,8 @@ module Steps
 
       validates_presence_of :miam_certification_date
 
+      validates :miam_certification_date, sensible_date: true
+
       private
 
       def persist!

--- a/app/forms/steps/other_children/personal_details_form.rb
+++ b/app/forms/steps/other_children/personal_details_form.rb
@@ -13,6 +13,8 @@ module Steps
       validates_inclusion_of :gender, in: Gender.values
       validates_presence_of :dob, unless: :dob_unknown?
 
+      validates :dob, sensible_date: true, unless: :dob_unknown?
+
       private
 
       def persist!

--- a/app/forms/steps/other_parties/personal_details_form.rb
+++ b/app/forms/steps/other_parties/personal_details_form.rb
@@ -18,6 +18,8 @@ module Steps
       validates_presence_of  :previous_name, if: -> { has_previous_name&.yes? }
       validates_presence_of  :dob, unless: :dob_unknown?
 
+      validates :dob, sensible_date: true, unless: :dob_unknown?
+
       private
 
       def persist!

--- a/app/forms/steps/respondent/personal_details_form.rb
+++ b/app/forms/steps/respondent/personal_details_form.rb
@@ -19,6 +19,8 @@ module Steps
       validates_presence_of  :previous_name, if: -> { has_previous_name&.yes? }
       validates_presence_of  :dob, unless: :dob_unknown?
 
+      validates :dob, sensible_date: true, unless: :dob_unknown?
+
       private
 
       def persist!

--- a/app/validators/sensible_date_validator.rb
+++ b/app/validators/sensible_date_validator.rb
@@ -1,0 +1,29 @@
+class SensibleDateValidator < ActiveModel::EachValidator
+  DEFAULT_OPTIONS ||= {
+    on_or_after_year: 1920,
+    allow_future: false,
+  }.freeze
+
+  def initialize(options)
+    super
+    @_year = options[:on_or_after_year] || DEFAULT_OPTIONS[:on_or_after_year]
+    @_allow_future = options[:allow_future] || DEFAULT_OPTIONS[:allow_future]
+  end
+
+  def validate_each(record, attribute, value)
+    return unless value.is_a?(Date)
+
+    record.errors.add(attribute, :invalid) unless valid_year?(value)
+    record.errors.add(attribute, :future)  unless valid_future?(value)
+  end
+
+  private
+
+  def valid_year?(date)
+    date.year.to_i >= @_year
+  end
+
+  def valid_future?(date)
+    @_allow_future || Date.today >= date
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,8 @@ en:
         blank: Enter the previous name
       dob:
         blank: Enter the date of birth
+        invalid: Date of birth is not valid
+        future: Date of birth is in the future
       birthplace:
         blank: Enter the place of birth
       address:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -981,6 +981,10 @@ en:
       children_postcodes:
         invalid: Enter a valid full postcode, with or without a space
         blank: Enter a full postcode, with or without a space
+      miam_certification_date:
+        blank: Enter the certification date
+        invalid: Certification date is not valid
+        future: Certification date is in the future
       hwf_reference_number:
         invalid: "Enter a valid 'Help with fees' reference number"
         blank: "Enter your 'Help with fees' reference number"

--- a/spec/forms/steps/applicant/personal_details_form_spec.rb
+++ b/spec/forms/steps/applicant/personal_details_form_spec.rb
@@ -34,72 +34,15 @@ RSpec.describe Steps::Applicant::PersonalDetailsForm do
     end
 
     context 'has previous name' do
-      context 'when attribute is not given' do
-        let(:has_previous_name) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:has_previous_name]).to_not be_empty
-        end
-      end
-
-      context 'when attribute is given and requires previous name' do
-        let(:has_previous_name) { 'yes' }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the `previous_name` field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:previous_name]).to_not be_empty
-        end
-      end
-
-      context 'when attribute value is not valid' do
-        let(:has_previous_name) {'INVALID VALUE'}
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:has_previous_name]).to_not be_empty
-        end
-      end
+      it_behaves_like 'a previous name validation'
     end
 
     context 'gender' do
-      context 'when attribute is not given' do
-        let(:gender) { nil }
+      it_behaves_like 'a gender validation'
+    end
 
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:gender]).to_not be_empty
-        end
-      end
-
-      context 'when attribute value is not valid' do
-        let(:gender) {'INVALID VALUE'}
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:gender]).to_not be_empty
-        end
-      end
+    context 'date of birth' do
+      it_behaves_like 'a mandatory date of birth validation'
     end
 
     context 'for valid details' do

--- a/spec/forms/steps/children/personal_details_form_spec.rb
+++ b/spec/forms/steps/children/personal_details_form_spec.rb
@@ -32,35 +32,11 @@ RSpec.describe Steps::Children::PersonalDetailsForm do
     end
 
     context 'gender' do
-      context 'when attribute is not given' do
-        let(:gender) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:gender]).to_not be_empty
-        end
-      end
-
-      context 'when attribute value is not valid' do
-        let(:gender) {'INVALID VALUE'}
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:gender]).to_not be_empty
-        end
-      end
+      it_behaves_like 'a gender validation'
     end
 
-    context 'validations on field presence unless `unknown`' do
-      it {should validate_presence_unless_unknown_of(:dob)}
+    context 'date of birth' do
+      it_behaves_like 'a date of birth validation with unknown checkbox'
     end
 
     context 'for valid details' do

--- a/spec/forms/steps/miam/certification_date_form_spec.rb
+++ b/spec/forms/steps/miam/certification_date_form_spec.rb
@@ -21,6 +21,47 @@ RSpec.describe Steps::Miam::CertificationDateForm do
       end
     end
 
+    context 'certification date validation' do
+      context 'when date is not given' do
+        let(:miam_certification_date) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:miam_certification_date, :blank)).to eq(true)
+        end
+      end
+
+      context 'when date is invalid' do
+        let(:miam_certification_date) { Date.new(18, 10, 31) } # 2-digits year (18)
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:miam_certification_date, :invalid)).to eq(true)
+        end
+      end
+
+      context 'when date is in the future' do
+        let(:miam_certification_date) { Date.tomorrow }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:miam_certification_date, :future)).to eq(true)
+        end
+      end
+    end
+
     context 'when form is valid' do
       it 'saves the record' do
         expect(c100_application).to receive(:update).with(

--- a/spec/forms/steps/other_children/personal_details_form_spec.rb
+++ b/spec/forms/steps/other_children/personal_details_form_spec.rb
@@ -32,35 +32,11 @@ RSpec.describe Steps::OtherChildren::PersonalDetailsForm do
     end
 
     context 'gender' do
-      context 'when attribute is not given' do
-        let(:gender) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:gender]).to_not be_empty
-        end
-      end
-
-      context 'when attribute value is not valid' do
-        let(:gender) {'INVALID VALUE'}
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:gender]).to_not be_empty
-        end
-      end
+      it_behaves_like 'a gender validation'
     end
 
-    context 'validations on field presence unless `unknown`' do
-      it {should validate_presence_unless_unknown_of(:dob)}
+    context 'date of birth' do
+      it_behaves_like 'a date of birth validation with unknown checkbox'
     end
 
     context 'for valid details' do

--- a/spec/forms/steps/other_parties/personal_details_form_spec.rb
+++ b/spec/forms/steps/other_parties/personal_details_form_spec.rb
@@ -36,48 +36,11 @@ RSpec.describe Steps::OtherParties::PersonalDetailsForm do
     end
 
     context 'has previous name' do
-      context 'when attribute is not given' do
-        let(:has_previous_name) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:has_previous_name]).to_not be_empty
-        end
-      end
-
-      context 'when attribute is given and requires previous name' do
-        let(:has_previous_name) { 'yes' }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the `previous_name` field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:previous_name]).to_not be_empty
-        end
-      end
-
-      context 'when attribute value is not valid' do
-        let(:has_previous_name) {'INVALID VALUE'}
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:has_previous_name]).to_not be_empty
-        end
-      end
+      it_behaves_like 'a previous name validation'
     end
 
-    context 'validations on field presence unless `unknown`' do
-      it { should validate_presence_unless_unknown_of(:dob) }
+    context 'date of birth' do
+      it_behaves_like 'a date of birth validation with unknown checkbox'
     end
 
     context 'for valid details' do

--- a/spec/forms/steps/respondent/personal_details_form_spec.rb
+++ b/spec/forms/steps/respondent/personal_details_form_spec.rb
@@ -38,48 +38,15 @@ RSpec.describe Steps::Respondent::PersonalDetailsForm do
     end
 
     context 'has previous name' do
-      context 'when attribute is not given' do
-        let(:has_previous_name) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:has_previous_name]).to_not be_empty
-        end
-      end
-
-      context 'when attribute is given and requires previous name' do
-        let(:has_previous_name) { 'yes' }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the `previous_name` field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:previous_name]).to_not be_empty
-        end
-      end
-
-      context 'when attribute value is not valid' do
-        let(:has_previous_name) {'INVALID VALUE'}
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:has_previous_name]).to_not be_empty
-        end
-      end
+      it_behaves_like 'a previous name validation'
     end
 
-    context 'validations on field presence unless `unknown`' do
-      it { should validate_presence_unless_unknown_of(:dob) }
+    context 'gender' do
+      it_behaves_like 'a gender validation'
+    end
+
+    context 'date of birth' do
+      it_behaves_like 'a date of birth validation with unknown checkbox'
     end
 
     context 'for valid details' do

--- a/spec/support/personal_details_shared_examples.rb
+++ b/spec/support/personal_details_shared_examples.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'a mandatory date of birth validation' do
+  context 'when date is not given' do
+    let(:dob) { nil }
+
+    it 'returns false' do
+      expect(subject.save).to be(false)
+    end
+
+    it 'has a validation error on the field' do
+      expect(subject).to_not be_valid
+      expect(subject.errors.added?(:dob, :blank)).to eq(true)
+    end
+  end
+
+  context 'when date is invalid' do
+    let(:dob) { Date.new(18, 10, 31) } # 2-digits year (18)
+
+    it 'returns false' do
+      expect(subject.save).to be(false)
+    end
+
+    it 'has a validation error on the field' do
+      expect(subject).to_not be_valid
+      expect(subject.errors.added?(:dob, :invalid)).to eq(true)
+    end
+  end
+
+  context 'when date is too old' do
+    let(:dob) { Date.new(1919, 10, 31) }
+
+    it 'returns false' do
+      expect(subject.save).to be(false)
+    end
+
+    it 'has a validation error on the field' do
+      expect(subject).to_not be_valid
+      expect(subject.errors.added?(:dob, :invalid)).to eq(true)
+    end
+  end
+
+  context 'when date is in the future' do
+    let(:dob) { Date.tomorrow }
+
+    it 'returns false' do
+      expect(subject.save).to be(false)
+    end
+
+    it 'has a validation error on the field' do
+      expect(subject).to_not be_valid
+      expect(subject.errors.added?(:dob, :future)).to eq(true)
+    end
+  end
+end
+
+RSpec.shared_examples 'a date of birth validation with unknown checkbox' do
+  context 'validate presence unless `unknown` is selected' do
+    it { should validate_presence_unless_unknown_of(:dob) }
+  end
+
+  include_examples 'a mandatory date of birth validation'
+end
+
+RSpec.shared_examples 'a gender validation' do
+  context 'when attribute is not given' do
+    let(:gender) { nil }
+
+    it 'returns false' do
+      expect(subject.save).to be(false)
+    end
+
+    it 'has a validation error on the field' do
+      expect(subject).to_not be_valid
+      expect(subject.errors[:gender]).to_not be_empty
+    end
+  end
+
+  context 'when attribute value is not valid' do
+    let(:gender) {'INVALID VALUE'}
+
+    it 'returns false' do
+      expect(subject.save).to be(false)
+    end
+
+    it 'has a validation error on the field' do
+      expect(subject).to_not be_valid
+      expect(subject.errors[:gender]).to_not be_empty
+    end
+  end
+end
+
+RSpec.shared_examples 'a previous name validation' do
+  context 'when attribute is not given' do
+    let(:has_previous_name) { nil }
+
+    it 'returns false' do
+      expect(subject.save).to be(false)
+    end
+
+    it 'has a validation error on the field' do
+      expect(subject).to_not be_valid
+      expect(subject.errors[:has_previous_name]).to_not be_empty
+    end
+  end
+
+  context 'when attribute is given and requires previous name' do
+    let(:has_previous_name) { 'yes' }
+
+    it 'returns false' do
+      expect(subject.save).to be(false)
+    end
+
+    it 'has a validation error on the `previous_name` field' do
+      expect(subject).to_not be_valid
+      expect(subject.errors[:previous_name]).to_not be_empty
+    end
+  end
+
+  context 'when attribute value is not valid' do
+    let(:has_previous_name) {'INVALID VALUE'}
+
+    it 'returns false' do
+      expect(subject.save).to be(false)
+    end
+
+    it 'has a validation error on the field' do
+      expect(subject).to_not be_valid
+      expect(subject.errors[:has_previous_name]).to_not be_empty
+    end
+  end
+end


### PR DESCRIPTION
This will validate it is a sensible date, i.e. not in the future, and not older than some given year.

Main purpose is to avoid single or double digit years, as, with the gem we are using, these are left-padded with 0 when printing in the PDF making the date wrong, for example, single digit `8` becomes `0008`.
And also stop clear typos like year `0218` for `2018`.

This is implemented in all parties DOB, and in the MIAM certification date.

<img width="306" alt="screen shot 2018-11-07 at 12 31 11" src="https://user-images.githubusercontent.com/687910/48131738-08277280-e289-11e8-9b83-51cb7602deb7.png">

