### PR TITLE
Move code inside task definition

### DIFF
--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -1,17 +1,17 @@
 # Pass a match expression as an optional argument to only run mutant
 # on classes that match. Example: `rake mutant TaxTribs::ZendeskSender`
 #
-vars = 'RAILS_ENV=test NOCOVERAGE=true'
-flags = '--use rspec --fail-fast'
-source_ref = 'origin/master'
-
-# This is to avoid running the mutant with flag `--since master` when
-# we are already on master, as otherwise it will not work on Travis
-current_branch = ENV['TRAVIS_BRANCH'] || `git rev-parse --abbrev-ref HEAD`
-current_branch = ENV['TRAVIS_PULL_REQUEST_BRANCH'] if ENV.fetch('TRAVIS_PULL_REQUEST', 'false') != 'false'
-
 task :mutant => :environment do
   mutation_type = ARGV[1]
+
+  vars = 'RAILS_ENV=test NOCOVERAGE=true'
+  flags = '--use rspec --fail-fast'
+  source_ref = 'origin/master'
+
+  # This is to avoid running the mutant with flag `--since master` when
+  # we are already on master, as otherwise it will not work on Travis
+  current_branch = ENV['TRAVIS_BRANCH'] || `git rev-parse --abbrev-ref HEAD`
+  current_branch = ENV['TRAVIS_PULL_REQUEST_BRANCH'] if ENV.fetch('TRAVIS_PULL_REQUEST', 'false') != 'false'
 
   if mutation_type == 'master'
     puts "> current branch: #{current_branch}"


### PR DESCRIPTION
Having this code outside the task means it was running every time any task (not only this one) was invoked. There is no need for this.