### PR TITLE
Bump `rack` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,7 +280,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.2)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)


### PR DESCRIPTION
Fixes CVE-2018-16470 and CVE-2018-16471.