### PR TITLE
Remove message_id from email submissions

### DIFF
--- a/app/models/email_submission.rb
+++ b/app/models/email_submission.rb
@@ -7,12 +7,12 @@ class EmailSubmission < ApplicationRecord
   #
   # :nocov:
   def resend_court_email!
-    update_column(:message_id, nil)
+    update_column(:sent_at, nil)
     OnlineSubmissionJob.perform_later(c100_application)
   end
 
   def resend_user_email!
-    update_column(:user_copy_message_id, nil)
+    update_column(:user_copy_sent_at, nil)
     OnlineSubmissionJob.perform_later(c100_application)
   end
   # :nocov:

--- a/db/migrate/20181206160610_remove_message_id_from_email_submissions.rb
+++ b/db/migrate/20181206160610_remove_message_id_from_email_submissions.rb
@@ -1,0 +1,6 @@
+class RemoveMessageIdFromEmailSubmissions < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :email_submissions, :message_id, :string
+    remove_column :email_submissions, :user_copy_message_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181129153804) do
+ActiveRecord::Schema.define(version: 20181206160610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,9 +209,7 @@ ActiveRecord::Schema.define(version: 20181129153804) do
     t.string "to_address"
     t.string "email_copy_to"
     t.datetime "sent_at"
-    t.string "message_id"
     t.datetime "user_copy_sent_at"
-    t.string "user_copy_message_id"
     t.uuid "c100_application_id"
     t.index ["c100_application_id"], name: "index_email_submissions_on_c100_application_id"
   end


### PR DESCRIPTION
This bit of information is not really useful, and we are going to stop relying on it anyway once we move the submission emails to Notify.