### PR TITLE
Improvements to email submission jobs

### DIFF
--- a/app/models/email_submission.rb
+++ b/app/models/email_submission.rb
@@ -7,12 +7,10 @@ class EmailSubmission < ApplicationRecord
   #
   # :nocov:
   def resend_court_email!
-    update_column(:sent_at, nil)
     CourtDeliveryJob.perform_later(c100_application)
   end
 
   def resend_user_email!
-    update_column(:user_copy_sent_at, nil)
     ApplicantDeliveryJob.perform_later(c100_application)
   end
   # :nocov:

--- a/app/services/c100_app/online_submission_queue.rb
+++ b/app/services/c100_app/online_submission_queue.rb
@@ -7,6 +7,11 @@ module C100App
     end
 
     def process
+      # Do not process again if we have a DB record, to avoid duplicating emails
+      return if processed?
+
+      initialize_audit!
+
       CourtDeliveryJob.perform_later(c100_application)
       ApplicantDeliveryJob.perform_later(c100_application) if receipt?
     end
@@ -14,7 +19,15 @@ module C100App
     private
 
     def receipt?
-      c100_application.receipt_email.present?
+      c100_application.receipt_email?
+    end
+
+    def processed?
+      c100_application.email_submission.present?
+    end
+
+    def initialize_audit!
+      c100_application.create_email_submission
     end
   end
 end

--- a/app/services/c100_app/pdf_email_submission.rb
+++ b/app/services/c100_app/pdf_email_submission.rb
@@ -17,11 +17,6 @@ module C100App
       end
     end
 
-    # This is the audit table where details about the emails are stored
-    def email_submission
-      c100_application.email_submission || c100_application.create_email_submission
-    end
-
     # TODO: temporary feature-flag until we decide about Notify attachments
     def use_notify?
       Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')
@@ -38,8 +33,6 @@ module C100App
     end
 
     def submission_to_court
-      return if email_submission.sent_at.present?
-
       # TODO: temporary feature-flag until we decide about Notify attachments to court
       if use_notify?
         NotifySubmissionMailer.with(application_details).application_to_court(
@@ -55,8 +48,6 @@ module C100App
     end
 
     def send_copy_to_user
-      return if email_submission.user_copy_sent_at.present?
-
       NotifySubmissionMailer.with(application_details).application_to_user(
         to_address: receipt_address
       ).deliver_now
@@ -72,7 +63,7 @@ module C100App
     end
 
     def audit_data(data)
-      email_submission.update(data)
+      c100_application.email_submission.update(data)
     end
   end
 end

--- a/db/migrate/20181211105507_add_timestamps_to_email_submissions.rb
+++ b/db/migrate/20181211105507_add_timestamps_to_email_submissions.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToEmailSubmissions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :email_submissions, :created_at, :datetime
+    add_column :email_submissions, :updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181206160610) do
+ActiveRecord::Schema.define(version: 20181211105507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,6 +211,8 @@ ActiveRecord::Schema.define(version: 20181206160610) do
     t.datetime "sent_at"
     t.datetime "user_copy_sent_at"
     t.uuid "c100_application_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["c100_application_id"], name: "index_email_submissions_on_c100_application_id"
   end
 

--- a/spec/services/c100_app/pdf_email_submission_spec.rb
+++ b/spec/services/c100_app/pdf_email_submission_spec.rb
@@ -39,17 +39,6 @@ RSpec.describe C100App::PdfEmailSubmission do
         allow(subject).to receive(:send_copy_to_user) # we test the user copy separately
       end
 
-      context 'there is already an audit of a previous submission' do
-        let(:sent_at) { Time.now }
-
-        it 'does not deliver another email to the court' do
-          expect(mailer).not_to receive(:submission_to_court)
-          expect(subject).not_to receive(:audit_data)
-
-          subject.deliver!(:court)
-        end
-      end
-
       context 'for a SMTP email' do
         it 'delivers the email to the court' do
           expect(
@@ -120,37 +109,6 @@ RSpec.describe C100App::PdfEmailSubmission do
         )
 
         subject.deliver!(:applicant)
-      end
-
-      context 'there is already an audit of a previous submission' do
-        let(:user_copy_sent_at) { Time.now }
-
-        it 'does not deliver another email to the applicant' do
-          expect(mailer).not_to receive(:copy_to_user)
-          expect(subject).not_to receive(:audit_data)
-
-          subject.deliver!(:applicant)
-        end
-      end
-    end
-  end
-
-  describe '`email_submission` audit table' do
-    context 'when table does not exist' do
-      let(:email_submission) { nil }
-
-      it 'creates a new `email_submission` if none exists' do
-        expect(c100_application).to receive(:create_email_submission)
-        subject.email_submission
-      end
-    end
-
-    context 'when table already exists' do
-      let(:email_submission) { double }
-
-      it 'creates a new `email_submission` if none exists' do
-        expect(c100_application).not_to receive(:create_email_submission)
-        subject.email_submission
       end
     end
   end


### PR DESCRIPTION
* Make sure there are no race conditions as 2 jobs try to update the same record in database, sometimes at the same time.

* Also, ensure we can't process by mistake again the jobs, if they were already processed.

* Add a couple timestamps to the DB table to make it easier to debug submissions, in case is needed.