### PR TITLE
Tune a bit puma killer

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,8 +23,11 @@ before_fork do
   require 'puma_worker_killer'
 
   PumaWorkerKiller.config do |config|
-    config.ram = ENV.fetch("CONTAINER_AVAILABLE_RAM") { 512 }
-    config.frequency = 15 # seconds
+    # Note: in Heroku, the available ram is not very accurate.
+    # The env variable can be set higher to minimise this inaccuracy and
+    # avoid killing the workers unnecessarily.
+    config.ram = ENV.fetch("CONTAINER_AVAILABLE_RAM") { 512 }.to_i
+    config.frequency = 30 # seconds
     config.percent_usage = 0.98
     config.reaper_status_logs = true
     config.rolling_restart_frequency = false


### PR DESCRIPTION
Puma killer is quite pessimistic with the amount of available free memory, so it would kill the workers when there is still enough memory.

We can use the env variable to set the available ram slighly higher (about 120mb higher) than the actual ram, so puma killer do a more accurate job.