### PR TITLE
Use StringIO instead of Tempfile

### DIFF
--- a/app/mailers/smtp_submission_mailer.rb
+++ b/app/mailers/smtp_submission_mailer.rb
@@ -17,7 +17,7 @@ class SmtpSubmissionMailer < ActionMailer::Base
   protected
 
   def attach_c100_pdf!
-    attachments[pdf_attachment_filename] = File.read(@c100_pdf)
+    attachments[pdf_attachment_filename] = @c100_pdf.read
   end
 
   private

--- a/app/services/c100_app/online_submission.rb
+++ b/app/services/c100_app/online_submission.rb
@@ -20,17 +20,13 @@ module C100App
       presenter = Summary::PdfPresenter.new(c100_application)
       presenter.generate
 
-      @pdf_content = presenter.to_pdf
+      @pdf_content = StringIO.new(presenter.to_pdf)
     end
 
     def deliver_email
-      Tempfile.create do |tmpfile|
-        File.binwrite(tmpfile, pdf_content)
-
-        PdfEmailSubmission.new(
-          c100_application, pdf_file: tmpfile
-        ).deliver!(recipient)
-      end
+      PdfEmailSubmission.new(
+        c100_application, pdf_content: pdf_content
+      ).deliver!(recipient)
     end
   end
 end

--- a/app/services/c100_app/pdf_email_submission.rb
+++ b/app/services/c100_app/pdf_email_submission.rb
@@ -1,11 +1,11 @@
 module C100App
   class PdfEmailSubmission
     attr_reader :c100_application
-    attr_reader :pdf_file
+    attr_reader :pdf_content
 
-    def initialize(c100_application, pdf_file:)
+    def initialize(c100_application, pdf_content:)
       @c100_application = c100_application
-      @pdf_file = pdf_file
+      @pdf_content = pdf_content
     end
 
     def deliver!(recipient)
@@ -58,7 +58,7 @@ module C100App
     def application_details
       {
         c100_application: c100_application,
-        c100_pdf: pdf_file,
+        c100_pdf: pdf_content,
       }
     end
 

--- a/spec/mailers/court_mailer_spec.rb
+++ b/spec/mailers/court_mailer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CourtMailer, type: :mailer do
 
   let(:urgent_hearing) { nil }
   let(:address_confidentiality) { nil }
-  let(:pdf_file) { '/my/test/file' }
+  let(:pdf_content) { instance_double(StringIO, 'pdf content') }
 
   let(:recipient_args) {
     {
@@ -22,14 +22,14 @@ RSpec.describe CourtMailer, type: :mailer do
 
   describe '#submission_to_court' do
     before do
-      allow(File).to receive(:read).with(pdf_file).and_return('file content')
+      allow(pdf_content).to receive(:read).and_return('file content')
     end
 
     context 'given all required arguments' do
       describe 'the generated mail' do
         let(:mail) do
           described_class.with(
-            c100_application: c100_application, c100_pdf: pdf_file
+            c100_application: c100_application, c100_pdf: pdf_content
           ).submission_to_court(recipient_args)
         end
 

--- a/spec/mailers/receipt_mailer_spec.rb
+++ b/spec/mailers/receipt_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ReceiptMailer, type: :mailer do
     )
   }
 
-  let(:pdf_file) { '/my/test/file' }
+  let(:pdf_content) { instance_double(StringIO, 'pdf content') }
 
   let(:recipient_args) {
     {
@@ -19,7 +19,7 @@ RSpec.describe ReceiptMailer, type: :mailer do
 
   describe '#copy_to_user' do
     before do
-      allow(File).to receive(:read).with(pdf_file).and_return('file content')
+      allow(pdf_content).to receive(:read).and_return('file content')
 
       allow(
         c100_application
@@ -32,7 +32,7 @@ RSpec.describe ReceiptMailer, type: :mailer do
       describe 'the generated mail' do
         let(:mail) do
           described_class.with(
-            c100_application: c100_application, c100_pdf: pdf_file
+            c100_application: c100_application, c100_pdf: pdf_content
           ).copy_to_user(recipient_args)
         end
 

--- a/spec/services/c100_app/online_submission_spec.rb
+++ b/spec/services/c100_app/online_submission_spec.rb
@@ -18,14 +18,13 @@ RSpec.describe C100App::OnlineSubmission do
 
       expect(pdf_presenter).to receive(:generate)
       subject.process
-      expect(subject.pdf_content).to eq('pdf content')
+      expect(subject.pdf_content).to be_a(StringIO)
+      expect(subject.pdf_content.read).to eq('pdf content')
     end
 
     it 'sends the emails' do
-      expect(File).to receive(:binwrite).with(kind_of(File), 'pdf content')
-
       expect(C100App::PdfEmailSubmission).to receive(:new).with(
-        c100_application, pdf_file: kind_of(File)
+        c100_application, pdf_content: kind_of(StringIO)
       ).and_return(pdf_email_submission)
 
       expect(pdf_email_submission).to receive(:deliver!).with('recipient')

--- a/spec/services/c100_app/pdf_email_submission_spec.rb
+++ b/spec/services/c100_app/pdf_email_submission_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe C100App::PdfEmailSubmission do
     )
   }
 
-  let(:pdf_file) { '/path/to/pdf' }
+  let(:pdf_content) { 'pdf content' }
   let(:screener_answers_court) { double('screener_answers_court', email: 'court@example.com') }
   let(:email_submission) { instance_double(EmailSubmission, sent_at: sent_at, user_copy_sent_at: user_copy_sent_at) }
 
@@ -19,7 +19,7 @@ RSpec.describe C100App::PdfEmailSubmission do
 
   let(:mailer) { spy('mailer') }
 
-  subject { described_class.new(c100_application, pdf_file: pdf_file) }
+  subject { described_class.new(c100_application, pdf_content: pdf_content) }
 
   before do
     travel_to Time.at(0)
@@ -29,7 +29,7 @@ RSpec.describe C100App::PdfEmailSubmission do
     let(:application_details) {
       {
         c100_application: c100_application,
-        c100_pdf: pdf_file,
+        c100_pdf: pdf_content,
       }
     }
 


### PR DESCRIPTION
We don't really need a temporary file in disk, and this way we avoid some extra processing/memory overhead.