### PR TITLE
Extend split names to all parties

### DIFF
--- a/app/controllers/crud_step_controller.rb
+++ b/app/controllers/crud_step_controller.rb
@@ -10,6 +10,10 @@ class CrudStepController < StepController
     raise 'implement in subclasses'
   end
 
+  # Until we've migrated all database records to the new first/last name
+  # structure, we must maintain backward-compatibility. Only c100 records
+  # greater than this version will be eligible for the new split format.
+  #
   def split_names?
     current_c100_application.version > 1 || ENV.key?('SPLIT_NAMES')
   end

--- a/app/controllers/steps/applicant_step_controller.rb
+++ b/app/controllers/steps/applicant_step_controller.rb
@@ -7,6 +7,7 @@ module Steps
     end
 
     def names_form_class
+      return Applicant::NamesSplitForm if split_names?
       Applicant::NamesForm
     end
 

--- a/app/controllers/steps/children_step_controller.rb
+++ b/app/controllers/steps/children_step_controller.rb
@@ -6,10 +6,6 @@ module Steps
       C100App::ChildrenDecisionTree
     end
 
-    # Until we've migrated all database records to the new first/last name
-    # structure, we must maintain backward-compatibility. Only c100 records
-    # with version greater than 1 will be eligible for the new split format.
-    #
     def names_form_class
       return Children::NamesSplitForm if split_names?
       Children::NamesForm

--- a/app/controllers/steps/other_children_step_controller.rb
+++ b/app/controllers/steps/other_children_step_controller.rb
@@ -7,6 +7,7 @@ module Steps
     end
 
     def names_form_class
+      return OtherChildren::NamesSplitForm if split_names?
       OtherChildren::NamesForm
     end
 

--- a/app/controllers/steps/other_parties_step_controller.rb
+++ b/app/controllers/steps/other_parties_step_controller.rb
@@ -7,6 +7,7 @@ module Steps
     end
 
     def names_form_class
+      return OtherParties::NamesSplitForm if split_names?
       OtherParties::NamesForm
     end
 

--- a/app/controllers/steps/respondent_step_controller.rb
+++ b/app/controllers/steps/respondent_step_controller.rb
@@ -7,6 +7,7 @@ module Steps
     end
 
     def names_form_class
+      return Respondent::NamesSplitForm if split_names?
       Respondent::NamesForm
     end
 

--- a/app/forms/steps/applicant/names_split_form.rb
+++ b/app/forms/steps/applicant/names_split_form.rb
@@ -1,0 +1,11 @@
+module Steps
+  module Applicant
+    class NamesSplitForm < NamesSplitBaseForm
+      private
+
+      def record_collection
+        @_record_collection ||= c100_application.applicants
+      end
+    end
+  end
+end

--- a/app/forms/steps/other_children/names_split_form.rb
+++ b/app/forms/steps/other_children/names_split_form.rb
@@ -1,0 +1,11 @@
+module Steps
+  module OtherChildren
+    class NamesSplitForm < NamesSplitBaseForm
+      private
+
+      def record_collection
+        @_record_collection ||= c100_application.other_children
+      end
+    end
+  end
+end

--- a/app/forms/steps/other_parties/names_split_form.rb
+++ b/app/forms/steps/other_parties/names_split_form.rb
@@ -1,0 +1,11 @@
+module Steps
+  module OtherParties
+    class NamesSplitForm < NamesSplitBaseForm
+      private
+
+      def record_collection
+        @_record_collection ||= c100_application.other_parties
+      end
+    end
+  end
+end

--- a/app/forms/steps/respondent/names_split_form.rb
+++ b/app/forms/steps/respondent/names_split_form.rb
@@ -1,0 +1,11 @@
+module Steps
+  module Respondent
+    class NamesSplitForm < NamesSplitBaseForm
+      private
+
+      def record_collection
+        @_record_collection ||= c100_application.respondents
+      end
+    end
+  end
+end

--- a/app/views/steps/applicant/names/edit.html.erb
+++ b/app/views/steps/applicant/names/edit.html.erb
@@ -14,12 +14,11 @@
       <% @existing_records.each.with_index do |applicant, index| %>
         <%= f.fields_for :names_attributes, applicant, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-          <%= c.hidden_field :id %>
-          <%= c.text_field :full_name %>
+          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
         <% end %>
       <% end %>
 
-      <%= f.text_field :new_name %>
+      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/applicant/names/edit.html.erb
+++ b/app/views/steps/applicant/names/edit.html.erb
@@ -14,11 +14,11 @@
       <% @existing_records.each.with_index do |applicant, index| %>
         <%= f.fields_for :names_attributes, applicant, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
         <% end %>
       <% end %>
 
-      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
+      <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/children/names/edit.html.erb
+++ b/app/views/steps/children/names/edit.html.erb
@@ -14,24 +14,11 @@
       <% @existing_records.each.with_index do |child, index| %>
         <%= f.fields_for :names_attributes, child, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-
-          <%= c.hidden_field :id %>
-
-          <% if f.object.split_names? %>
-            <%= c.text_field :first_name, class: 'narrow' %>
-            <%= c.text_field :last_name, class: 'narrow' %>
-          <% else %>
-            <%= c.text_field :full_name %>
-          <% end %>
+          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
         <% end %>
       <% end %>
 
-      <% if f.object.split_names? %>
-        <%= f.text_field :new_first_name, class: 'narrow' %>
-        <%= f.text_field :new_last_name, class: 'narrow' %>
-      <% else %>
-        <%= f.text_field :new_name %>
-      <% end %>
+      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/children/names/edit.html.erb
+++ b/app/views/steps/children/names/edit.html.erb
@@ -14,11 +14,11 @@
       <% @existing_records.each.with_index do |child, index| %>
         <%= f.fields_for :names_attributes, child, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
         <% end %>
       <% end %>
 
-      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
+      <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/other_children/names/edit.html.erb
+++ b/app/views/steps/other_children/names/edit.html.erb
@@ -10,12 +10,11 @@
       <% @existing_records.each.with_index do |child, index| %>
         <%= f.fields_for :names_attributes, child, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-          <%= c.hidden_field :id %>
-          <%= c.text_field :full_name %>
+          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
         <% end %>
       <% end %>
 
-      <%= f.text_field :new_name %>
+      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/other_children/names/edit.html.erb
+++ b/app/views/steps/other_children/names/edit.html.erb
@@ -10,11 +10,11 @@
       <% @existing_records.each.with_index do |child, index| %>
         <%= f.fields_for :names_attributes, child, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
         <% end %>
       <% end %>
 
-      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
+      <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/other_parties/names/edit.html.erb
+++ b/app/views/steps/other_parties/names/edit.html.erb
@@ -10,12 +10,11 @@
       <% @existing_records.each.with_index do |party, index| %>
         <%= f.fields_for :names_attributes, party, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-          <%= c.hidden_field :id %>
-          <%= c.text_field :full_name %>
+          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
         <% end %>
       <% end %>
 
-      <%= f.text_field :new_name %>
+      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/other_parties/names/edit.html.erb
+++ b/app/views/steps/other_parties/names/edit.html.erb
@@ -10,11 +10,11 @@
       <% @existing_records.each.with_index do |party, index| %>
         <%= f.fields_for :names_attributes, party, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
         <% end %>
       <% end %>
 
-      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
+      <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/respondent/names/edit.html.erb
+++ b/app/views/steps/respondent/names/edit.html.erb
@@ -14,11 +14,11 @@
       <% @existing_records.each.with_index do |respondent, index| %>
         <%= f.fields_for :names_attributes, respondent, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
         <% end %>
       <% end %>
 
-      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
+      <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/respondent/names/edit.html.erb
+++ b/app/views/steps/respondent/names/edit.html.erb
@@ -14,12 +14,11 @@
       <% @existing_records.each.with_index do |respondent, index| %>
         <%= f.fields_for :names_attributes, respondent, index: index do |c| %>
           <span><%= t('.record_index', index: index + 1) %></span>
-          <%= c.hidden_field :id %>
-          <%= c.text_field :full_name %>
+          <%= render partial: 'steps/shared/existing_names', locals: { f: f, c: c } %>
         <% end %>
       <% end %>
 
-      <%= f.text_field :new_name %>
+      <%= render partial: 'steps/shared/new_name', locals: { f: f } %>
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 

--- a/app/views/steps/shared/_existing_names.html.erb
+++ b/app/views/steps/shared/_existing_names.html.erb
@@ -1,0 +1,8 @@
+<%= c.hidden_field :id %>
+
+<% if f.object.split_names? %>
+  <%= c.text_field :first_name, class: 'narrow' %>
+  <%= c.text_field :last_name, class: 'narrow' %>
+<% else %>
+  <%= c.text_field :full_name %>
+<% end %>

--- a/app/views/steps/shared/_existing_names.html.erb
+++ b/app/views/steps/shared/_existing_names.html.erb
@@ -1,8 +1,8 @@
-<%= c.hidden_field :id %>
+<%= person.hidden_field :id %>
 
-<% if f.object.split_names? %>
-  <%= c.text_field :first_name, class: 'narrow' %>
-  <%= c.text_field :last_name, class: 'narrow' %>
+<% if names_form.object.split_names? %>
+  <%= person.text_field :first_name, class: 'narrow' %>
+  <%= person.text_field :last_name, class: 'narrow' %>
 <% else %>
-  <%= c.text_field :full_name %>
+  <%= person.text_field :full_name %>
 <% end %>

--- a/app/views/steps/shared/_new_name.html.erb
+++ b/app/views/steps/shared/_new_name.html.erb
@@ -1,0 +1,6 @@
+<% if f.object.split_names? %>
+  <%= f.text_field :new_first_name, class: 'narrow' %>
+  <%= f.text_field :new_last_name, class: 'narrow' %>
+<% else %>
+  <%= f.text_field :new_name %>
+<% end %>

--- a/app/views/steps/shared/_new_name.html.erb
+++ b/app/views/steps/shared/_new_name.html.erb
@@ -1,6 +1,6 @@
-<% if f.object.split_names? %>
-  <%= f.text_field :new_first_name, class: 'narrow' %>
-  <%= f.text_field :new_last_name, class: 'narrow' %>
+<% if names_form.object.split_names? %>
+  <%= names_form.text_field :new_first_name, class: 'narrow' %>
+  <%= names_form.text_field :new_last_name, class: 'narrow' %>
 <% else %>
-  <%= f.text_field :new_name %>
+  <%= names_form.text_field :new_name %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
     birthplace_hint: &birthplace_hint "For example, town or city"
     address_hint: &address_hint "Court documents will be sent here. Include the postcode if you have it"
     name_instructions: &name_instructions "This should be the full legal name (including any middle names)"
+    middle_names_hint: &middle_names_hint "Include all middle names here"
     order_current: &order_current "Is the order current?"
     order_current_error: &order_current_error "Answer if the order is current"
     order_length: &order_length "How long was the order for?"
@@ -107,6 +108,20 @@ en:
         blank: Enter the address
       mobile_phone:
         blank: Enter the mobile phone
+
+    # Fields shared in all the split first/last name forms
+    NAMES_FORM_FIELDS: &NAMES_FORM_FIELDS
+      first_name: First name(s)
+      new_first_name: First name(s)
+      last_name: Last name(s)
+      new_last_name: Last name(s)
+
+    # Errors shared in all the split first/last name forms
+    NAMES_FORM_ERRORS: &NAMES_FORM_ERRORS
+      new_first_name:
+        blank: Enter the first name
+      new_last_name:
+        blank: Enter the last name
 
     # This is common abuse concerns `lead_text` copy, for applicant and for children.
     # The specific copy is in their corresponding sections.
@@ -1068,12 +1083,21 @@ en:
         steps/solicitor/contact_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
+        steps/applicant/names_split_form:
+          attributes:
+            <<: *NAMES_FORM_ERRORS
+        steps/respondent/names_split_form:
+          attributes:
+            <<: *NAMES_FORM_ERRORS
         steps/children/names_split_form:
           attributes:
-            new_first_name:
-              blank: Enter the first name
-            new_last_name:
-              blank: Enter the last name
+            <<: *NAMES_FORM_ERRORS
+        steps/other_children/names_split_form:
+          attributes:
+            <<: *NAMES_FORM_ERRORS
+        steps/other_parties/names_split_form:
+          attributes:
+            <<: *NAMES_FORM_ERRORS
         steps/children/residence_form:
           attributes:
             person_ids:
@@ -1316,10 +1340,6 @@ en:
         relation_other_value: Please specify
         relation:
           <<: *RELATIONS
-      steps_applicant_names_form:
-        new_name: Full name of applicant
-      steps_applicant_names_form[names_attributes]:
-        full_name: Full name of applicant
       steps_application_court_proceedings_form:
         children_names: Names of children involved
         court_name: Name of court
@@ -1405,16 +1425,21 @@ en:
       steps_abduction_risk_details_form:
         risk_details: Give a short description
         current_location: Where are the children now?
-      steps_children_names_form[names_attributes]:
-        full_name: Full name of child
+      #
+      # begin - full names forms (soon to be deprecated)
+      #
+      steps_applicant_names_form:
+        new_name: Full name of applicant
+      steps_applicant_names_form[names_attributes]:
+        full_name: Full name of applicant
+      steps_respondent_names_form:
+        new_name: Full name of respondent
+      steps_respondent_names_form[names_attributes]:
+        full_name: Full name of respondent
       steps_children_names_form:
         new_name: Full name of child
-      steps_children_names_split_form:
-        new_first_name: First name(s)
-        new_last_name: Last name(s)
-      steps_children_names_split_form[names_attributes]:
-        first_name: First name(s)
-        last_name: Last name(s)
+      steps_children_names_form[names_attributes]:
+        full_name: Full name of child
       steps_other_children_names_form:
         new_name: Full name of child
       steps_other_children_names_form[names_attributes]:
@@ -1423,6 +1448,34 @@ en:
         new_name: Full name of other person
       steps_other_parties_names_form[names_attributes]:
         full_name: Full name of other person
+      #
+      # end - full names forms (soon to be deprecated)
+      #
+      # begin - split names forms (c100 application v2)
+      #
+      steps_applicant_names_split_form:
+        <<: *NAMES_FORM_FIELDS
+      steps_applicant_names_split_form[names_attributes]:
+        <<: *NAMES_FORM_FIELDS
+      steps_respondent_names_split_form:
+        <<: *NAMES_FORM_FIELDS
+      steps_respondent_names_split_form[names_attributes]:
+        <<: *NAMES_FORM_FIELDS
+      steps_children_names_split_form:
+        <<: *NAMES_FORM_FIELDS
+      steps_children_names_split_form[names_attributes]:
+        <<: *NAMES_FORM_FIELDS
+      steps_other_children_names_split_form:
+        <<: *NAMES_FORM_FIELDS
+      steps_other_children_names_split_form[names_attributes]:
+        <<: *NAMES_FORM_FIELDS
+      steps_other_parties_names_split_form:
+        <<: *NAMES_FORM_FIELDS
+      steps_other_parties_names_split_form[names_attributes]:
+        <<: *NAMES_FORM_FIELDS
+      #
+      # end - split names forms (c100 application v2)
+      #
       steps_applicant_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
         previous_name: Enter their previous name
@@ -1492,10 +1545,6 @@ en:
         international_jurisdiction_details: *provide_details
       steps_international_request_form:
         international_request_details: *provide_details
-      steps_respondent_names_form:
-        new_name: Full name of respondent
-      steps_respondent_names_form[names_attributes]:
-        full_name: Full name of respondent
       steps_solicitor_personal_details_form:
         full_name: Full name of solicitor
         firm_name: Name of firm
@@ -1579,8 +1628,18 @@ en:
         address: *address_hint
       steps_children_names_form:
         new_name_html: *name_instructions
+      # begin - split names form
+      steps_applicant_names_split_form:
+        new_first_name_html: *middle_names_hint
+      steps_respondent_names_split_form:
+        new_first_name_html: *middle_names_hint
       steps_children_names_split_form:
-        new_first_name_html: Include all middle names here
+        new_first_name_html: *middle_names_hint
+      steps_other_children_names_split_form:
+        new_first_name_html: *middle_names_hint
+      steps_other_parties_names_split_form:
+        new_first_name_html: *middle_names_hint
+      # end - slit names form
       steps_children_additional_details_form:
         children_protection_plan_html: |
           A child protection plan is prepared by a local authority where a child is thought to be at risk of significant harm. It sets out steps to be taken to protect the child and support the family

--- a/spec/controllers/steps/applicant/names_controller_spec.rb
+++ b/spec/controllers/steps/applicant/names_controller_spec.rb
@@ -1,8 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Applicant::NamesController, type: :controller do
-  it_behaves_like 'an names CRUD step controller',
-                  Steps::Applicant::NamesForm,
-                  C100App::ApplicantDecisionTree,
-                  Applicant
+  context 'for v1 of C100 application (names are not split)' do
+    before do
+      allow(controller).to receive(:split_names?).and_return(false)
+    end
+
+    it_behaves_like 'a names CRUD step controller',
+                    Steps::Applicant::NamesForm,
+                    C100App::ApplicantDecisionTree,
+                    Applicant
+  end
+
+  context 'for v2+ of C100 application (names are split)' do
+    before do
+      allow(controller).to receive(:split_names?).and_return(true)
+    end
+
+    it_behaves_like 'a names CRUD step controller',
+                    Steps::Applicant::NamesSplitForm,
+                    C100App::ApplicantDecisionTree,
+                    Applicant
+  end
 end

--- a/spec/controllers/steps/children/names_controller_spec.rb
+++ b/spec/controllers/steps/children/names_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Steps::Children::NamesController, type: :controller do
       allow(controller).to receive(:split_names?).and_return(false)
     end
 
-    it_behaves_like 'an names CRUD step controller',
+    it_behaves_like 'a names CRUD step controller',
                     Steps::Children::NamesForm,
                     C100App::ChildrenDecisionTree,
                     Child
@@ -17,7 +17,7 @@ RSpec.describe Steps::Children::NamesController, type: :controller do
       allow(controller).to receive(:split_names?).and_return(true)
     end
 
-    it_behaves_like 'an names CRUD step controller',
+    it_behaves_like 'a names CRUD step controller',
                     Steps::Children::NamesSplitForm,
                     C100App::ChildrenDecisionTree,
                     Child

--- a/spec/controllers/steps/other_children/names_controller_spec.rb
+++ b/spec/controllers/steps/other_children/names_controller_spec.rb
@@ -1,8 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Steps::OtherChildren::NamesController, type: :controller do
-  it_behaves_like 'an names CRUD step controller',
-                  Steps::OtherChildren::NamesForm,
-                  C100App::OtherChildrenDecisionTree,
-                  OtherChild
+  context 'for v1 of C100 application (names are not split)' do
+    before do
+      allow(controller).to receive(:split_names?).and_return(false)
+    end
+
+    it_behaves_like 'a names CRUD step controller',
+                    Steps::OtherChildren::NamesForm,
+                    C100App::OtherChildrenDecisionTree,
+                    OtherChild
+  end
+
+  context 'for v2+ of C100 application (names are split)' do
+    before do
+      allow(controller).to receive(:split_names?).and_return(true)
+    end
+
+    it_behaves_like 'a names CRUD step controller',
+                    Steps::OtherChildren::NamesSplitForm,
+                    C100App::OtherChildrenDecisionTree,
+                    OtherChild
+  end
 end

--- a/spec/controllers/steps/other_parties/names_controller_spec.rb
+++ b/spec/controllers/steps/other_parties/names_controller_spec.rb
@@ -1,8 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Steps::OtherParties::NamesController, type: :controller do
-  it_behaves_like 'an names CRUD step controller',
-                  Steps::OtherParties::NamesForm,
-                  C100App::OtherPartiesDecisionTree,
-                  OtherParty
+  context 'for v1 of C100 application (names are not split)' do
+    before do
+      allow(controller).to receive(:split_names?).and_return(false)
+    end
+
+    it_behaves_like 'a names CRUD step controller',
+                    Steps::OtherParties::NamesForm,
+                    C100App::OtherPartiesDecisionTree,
+                    OtherParty
+  end
+
+  context 'for v2+ of C100 application (names are split)' do
+    before do
+      allow(controller).to receive(:split_names?).and_return(true)
+    end
+
+    it_behaves_like 'a names CRUD step controller',
+                    Steps::OtherParties::NamesSplitForm,
+                    C100App::OtherPartiesDecisionTree,
+                    OtherParty
+  end
 end

--- a/spec/controllers/steps/respondent/names_controller_spec.rb
+++ b/spec/controllers/steps/respondent/names_controller_spec.rb
@@ -1,8 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Respondent::NamesController, type: :controller do
-  it_behaves_like 'an names CRUD step controller',
-                  Steps::Respondent::NamesForm,
-                  C100App::RespondentDecisionTree,
-                  Respondent
+  context 'for v1 of C100 application (names are not split)' do
+    before do
+      allow(controller).to receive(:split_names?).and_return(false)
+    end
+
+    it_behaves_like 'a names CRUD step controller',
+                    Steps::Respondent::NamesForm,
+                    C100App::RespondentDecisionTree,
+                    Respondent
+  end
+
+  context 'for v2+ of C100 application (names are split)' do
+    before do
+      allow(controller).to receive(:split_names?).and_return(true)
+    end
+
+    it_behaves_like 'a names CRUD step controller',
+                    Steps::Respondent::NamesSplitForm,
+                    C100App::RespondentDecisionTree,
+                    Respondent
+  end
 end

--- a/spec/forms/steps/applicant/names_split_form_spec.rb
+++ b/spec/forms/steps/applicant/names_split_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Applicant::NamesSplitForm do
+  it_behaves_like 'a names split CRUD form', Applicant
+end

--- a/spec/forms/steps/other_children/names_split_form_spec.rb
+++ b/spec/forms/steps/other_children/names_split_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::OtherChildren::NamesSplitForm do
+  it_behaves_like 'a names split CRUD form', OtherChild
+end

--- a/spec/forms/steps/other_parties/names_split_form_spec.rb
+++ b/spec/forms/steps/other_parties/names_split_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::OtherParties::NamesSplitForm do
+  it_behaves_like 'a names split CRUD form', OtherParty
+end

--- a/spec/forms/steps/respondent/names_split_form_spec.rb
+++ b/spec/forms/steps/respondent/names_split_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Respondent::NamesSplitForm do
+  it_behaves_like 'a names split CRUD form', Respondent
+end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -297,7 +297,7 @@ RSpec.shared_examples 'an intermediate step controller without update' do
   end
 end
 
-RSpec.shared_examples 'an names CRUD step controller' do |form_class, decision_tree_class, resource_class|
+RSpec.shared_examples 'a names CRUD step controller' do |form_class, decision_tree_class, resource_class|
   include_examples 'an intermediate step controller', form_class, decision_tree_class
 
   describe '#destroy' do


### PR DESCRIPTION
This will extend the work already done for children in previous PR #584 to all parties:

* applicant
* respondent
* other children
* other parties

Although it looks like A LOT of files, it actually is a very simple change, only multiplied by 4. Individual commits for easier read.

One could argue that's a lot of "duplicated" code, but in this case, given the life expectancy of most of this code will be less than 1 month (until all records in the database are using the new format) and then we are going to clean it up, it is not worth it coming up with another (more complicated) abstraction level.