### PR TITLE
Update multiple names UI

### DIFF
--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -98,6 +98,10 @@ label[for="steps_abduction_risk_details_form_risk_details"]
   font-weight: bold;
 }
 
+.form-label-normal {
+  font-weight: normal;
+}
+
 fieldset + .form-group {
   margin-top: 30px;
   margin-bottom: 15px;
@@ -108,6 +112,14 @@ fieldset + .form-group {
   }
   fieldset + .form-group:last-child {
     margin-bottom: 0;
+  }
+}
+
+.fieldset-compact {
+  padding-bottom: 30px;
+
+  .form-group {
+    margin-bottom: 15px;
   }
 }
 

--- a/app/views/steps/applicant/names/edit.html.erb
+++ b/app/views/steps/applicant/names/edit.html.erb
@@ -13,8 +13,7 @@
     <%= step_form @form_object do |f| %>
       <% @existing_records.each.with_index do |applicant, index| %>
         <%= f.fields_for :names_attributes, applicant, index: index do |c| %>
-          <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>
         <% end %>
       <% end %>
 

--- a/app/views/steps/children/names/edit.html.erb
+++ b/app/views/steps/children/names/edit.html.erb
@@ -13,8 +13,7 @@
     <%= step_form @form_object do |f| %>
       <% @existing_records.each.with_index do |child, index| %>
         <%= f.fields_for :names_attributes, child, index: index do |c| %>
-          <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>
         <% end %>
       <% end %>
 

--- a/app/views/steps/other_children/names/edit.html.erb
+++ b/app/views/steps/other_children/names/edit.html.erb
@@ -9,8 +9,7 @@
     <%= step_form @form_object do |f| %>
       <% @existing_records.each.with_index do |child, index| %>
         <%= f.fields_for :names_attributes, child, index: index do |c| %>
-          <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>
         <% end %>
       <% end %>
 

--- a/app/views/steps/other_parties/names/edit.html.erb
+++ b/app/views/steps/other_parties/names/edit.html.erb
@@ -9,8 +9,7 @@
     <%= step_form @form_object do |f| %>
       <% @existing_records.each.with_index do |party, index| %>
         <%= f.fields_for :names_attributes, party, index: index do |c| %>
-          <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>
         <% end %>
       <% end %>
 

--- a/app/views/steps/respondent/names/edit.html.erb
+++ b/app/views/steps/respondent/names/edit.html.erb
@@ -13,8 +13,7 @@
     <%= step_form @form_object do |f| %>
       <% @existing_records.each.with_index do |respondent, index| %>
         <%= f.fields_for :names_attributes, respondent, index: index do |c| %>
-          <span><%= t('.record_index', index: index + 1) %></span>
-          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c } %>
+          <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>
         <% end %>
       <% end %>
 

--- a/app/views/steps/shared/_existing_names.html.erb
+++ b/app/views/steps/shared/_existing_names.html.erb
@@ -1,8 +1,14 @@
 <%= person.hidden_field :id %>
 
-<% if names_form.object.split_names? %>
-  <%= person.text_field :first_name, class: 'narrow' %>
-  <%= person.text_field :last_name, class: 'narrow' %>
-<% else %>
-  <%= person.text_field :full_name %>
-<% end %>
+<fieldset class="fieldset-compact">
+  <legend class="form-label-bold">
+    <%= legend %>
+  </legend>
+
+  <% if names_form.object.split_names? %>
+    <%= person.text_field :first_name, class: 'narrow', label_options: { class: 'form-label-normal' } %>
+    <%= person.text_field :last_name, class: 'narrow', label_options: { class: 'form-label-normal' } %>
+  <% else %>
+    <%= person.text_field :full_name %>
+  <% end %>
+</fieldset>

--- a/app/views/steps/shared/_new_name.html.erb
+++ b/app/views/steps/shared/_new_name.html.erb
@@ -1,6 +1,8 @@
-<% if names_form.object.split_names? %>
-  <%= names_form.text_field :new_first_name, class: 'narrow' %>
-  <%= names_form.text_field :new_last_name, class: 'narrow' %>
-<% else %>
-  <%= names_form.text_field :new_name %>
-<% end %>
+<fieldset class="fieldset-compact">
+  <% if names_form.object.split_names? %>
+    <%= names_form.text_field :new_first_name, class: 'narrow', label_options: { class: 'form-label-normal' } %>
+    <%= names_form.text_field :new_last_name, class: 'narrow', label_options: { class: 'form-label-normal' } %>
+  <% else %>
+    <%= names_form.text_field :new_name %>
+  <% end %>
+</fieldset>


### PR DESCRIPTION
We now ask for both first name and last name in separate text fields
rather than one.

This could potentially lead to confusion when there are multiple names
as there isn't as good distinction between groups of names.

This change switches the font weight to create a visual separation
between the form groups.

## Before
![localhost_3000_steps_children_names 2](https://user-images.githubusercontent.com/3327997/51550378-281c0a80-1e64-11e9-8d5e-8c4687cf8daa.png)

## After
![localhost_3000_steps_children_names 1](https://user-images.githubusercontent.com/3327997/51550404-2eaa8200-1e64-11e9-9690-4631a0951259.png)
