### PR TITLE
Bump version of the c100_application records

### DIFF
--- a/app/controllers/crud_step_controller.rb
+++ b/app/controllers/crud_step_controller.rb
@@ -15,7 +15,7 @@ class CrudStepController < StepController
   # greater than this version will be eligible for the new split format.
   #
   def split_names?
-    current_c100_application.version > 1 || ENV.key?('SPLIT_NAMES')
+    current_c100_application.version > 1
   end
   # :nocov:
 

--- a/db/migrate/20190123094339_bump_c100_application_version.rb
+++ b/db/migrate/20190123094339_bump_c100_application_version.rb
@@ -1,0 +1,7 @@
+class BumpC100ApplicationVersion < ActiveRecord::Migration[5.1]
+  def change
+    # Version 2 introduces `full_name` split into `first_name` and `last_name`.
+    # New records will be created with version=2
+    change_column_default :c100_applications, :version, from: 1, to: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190121093537) do
+ActiveRecord::Schema.define(version: 20190123094339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,7 +132,7 @@ ActiveRecord::Schema.define(version: 20190121093537) do
     t.string "urgent_hearing_short_notice"
     t.text "urgent_hearing_short_notice_details"
     t.string "has_solicitor"
-    t.integer "version", default: 1
+    t.integer "version", default: 2
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end


### PR DESCRIPTION
All existing `c100_application` records are in version 1, and with this change new ones will be created with version 2.

This allow us to introduce the splitting of the names in a progressive and backward compatible way, as existing records (those saved for later) will continue using the `full_name` format, and new records created from now on, will use the `first_name` and `last_name` format.

In the future, we could use this same mechanism to deliver other features that require different behaviour for existing records and new records.