### PR TITLE
Add Barnstaple court to the trial

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -29,10 +29,14 @@ class Court
   def best_enquiries_email
     # There's no consistency to how courts list their email address descriptions,
     # so we try to find the most suitable email address, by looking at the `description`
-    # or the `explanation` for each of the emails, and if none found, use the first one
+    # or the `explanation` for each of the emails, or the actual email address,
+    # and if none is found, use the first entry.
 
     emails = retrieve_emails_from_api
-    best = best_match_for(emails, 'description') || best_match_for(emails, 'explanation') || emails.first
+    best = best_match_for(emails, 'description') ||
+           best_match_for(emails, 'explanation') ||
+           best_match_for(emails, 'address') ||
+           emails.first
 
     # We want this to raise a `KeyError` exception when no email is found
     best ||= {}

--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -28,6 +28,7 @@ module C100App
       liverpool-civil-and-family-court
       plymouth-combined-court
       peterborough-combined-court-centre
+      barnstaple-magistrates-county-and-family-court
     ].freeze
 
     # Separate multiple postcodes/postcode areas by "\n"

--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -6,7 +6,7 @@
       We’re trialling a new online service to apply to court about child arrangements
     </h1>
 
-    <p>The court areas currently taking part are: Blackburn, Blackpool, Bristol, Cambridgeshire, Exeter, Gateshead,
+    <p>The court areas currently taking part are: Barnstaple, Blackburn, Blackpool, Bristol, Cambridgeshire, Exeter, Gateshead,
       Grimsby, Guildford, Hull, Kent, Lancaster, Leicester, Liverpool, London, Mansfield, Milton Keynes, Newcastle,
       Nottingham, Oxford, Plymouth, Preston, Reading, Slough, Southampton, Sunderland, Watford and West Yorkshire.</p>
 

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -275,6 +275,26 @@ describe Court do
         end
       end
 
+      context 'containing email addresses matching "children" or "family"' do
+        let(:emails){
+          [
+            {
+              'description' => 'Anything',
+              'address' => 'Family@email'
+            },
+            {
+              'description' => '',
+              'explanation' => 'Explanation',
+              'address' => 'Children@email',
+            },
+          ]
+        }
+
+        it 'returns the matching email address based on priority' do
+          expect(subject.best_enquiries_email).to eq('Children@email')
+        end
+      end
+
       context 'that is not empty but matches no other criterion' do
         let(:emails){
           [

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe C100App::CourtPostcodeChecker do
   describe 'COURT_SLUGS_USING_THIS_APP' do
     it 'returns the expected number of court slugs taking part in the trial' do
-      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(24)
+      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(25)
     end
   end
 


### PR DESCRIPTION
Also, extended the `best_enquiries_email` method to take into consideration also the actual email addresses, as a fallback in case no description or explanation matches.