### PR TITLE
Fix focus state on button-secondary class

### DIFF
--- a/app/assets/stylesheets/local/buttons.scss
+++ b/app/assets/stylesheets/local/buttons.scss
@@ -25,6 +25,9 @@
   background:transparent;
   color:#2b8cc4;
 }
+.button.button-secondary:focus{
+  color:#005ea5;
+}
 .button.button-secondary:first-child{
   margin-left:0;
 }


### PR DESCRIPTION
Some elements with the class of button-secondary are a tags, and when they are unvisited, their focus state made their text white and therefore unreadable against a white background. This commit overrides that CSS by explicitely setting a button-secondary focus state text color.