### PR TITLE
Fix focus state on button-secondary links

### DIFF
--- a/app/assets/stylesheets/local/buttons.scss
+++ b/app/assets/stylesheets/local/buttons.scss
@@ -10,21 +10,40 @@
   cursor: pointer;
 }
 
-.button.button-secondary{
-  background:transparent;
-  color:#005ea5;
-  border-bottom-color:#fff;
-  box-shadow:none;
-  text-decoration:underline;
-  padding-left:0;
-  padding-right:0;
-  margin-left:96px;
-  margin-left:6rem
-}
-.button.button-secondary:hover{
-  background:transparent;
-  color:#2b8cc4;
-}
-.button.button-secondary:first-child{
-  margin-left:0;
+.button-secondary {
+  background: transparent;
+  color: $link-colour;
+  border-bottom-color: $white;
+  box-shadow: none;
+  text-decoration: underline;
+  padding-left: 0;
+  padding-right: 0;
+
+  // This targets in between adjacent siblings:  https://alistapart.com/article/axiomatic-css-and-lobotomized-owls
+  * + & {
+    margin-left: 96px;
+    margin-left: 6rem;
+  }
+
+  &:link,
+  &:active,
+  &:visited,
+  &:hover {
+    background: transparent;
+    color: $link-colour;
+  }
+
+  &:active {
+    color: $link-active-colour;
+  }
+
+  &:hover {
+    color: $link-hover-colour;
+  }
+
+  &:focus,
+  &:link:focus {
+    color: darken($link-colour, 3%);
+    background: $focus-colour;
+  }
 }


### PR DESCRIPTION
Some elements with the class of button-secondary are link tags, and when they are unvisited, their focus state made their text white and therefore unreadable against a whie background. This commit overrides that CSS by explicitely setting a button-secondary focus state text color.