### PR TITLE
Prefix page title when form has errors

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,12 +26,16 @@ module ApplicationHelper
   end
 
   def error_summary(form_object)
-    return if form_object.nil?
+    return unless GovukElementsErrorsHelper.errors_exist?(form_object)
+
+    content_for(:page_title, flush: true) do
+      content_for(:page_title).insert(0, t('errors.page_title_prefix'))
+    end
 
     GovukElementsErrorsHelper.error_summary(
       form_object,
-      translate('errors.error_summary.heading'),
-      translate('errors.error_summary.text')
+      t('errors.error_summary.heading'),
+      t('errors.error_summary.text')
     )
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1011,6 +1011,7 @@ en:
     error_summary:
       heading: There was a problem on the page
       text: ''
+    page_title_prefix: 'Error: '
     invalid_session:
       heading: Sorry, you'll have to start again
       <<: *START_FINISH

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1009,7 +1009,7 @@ en:
       present: Leave empty
       inclusion: Select an option
     error_summary:
-      heading: There was a problem on the page
+      heading: There is a problem on this page
       text: ''
     page_title_prefix: 'Error: '
     invalid_session:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -7,7 +7,7 @@ class ActionView::TestCase::TestController
   end
 end
 
-RSpec.describe ApplicationHelper do
+RSpec.describe ApplicationHelper, type: :helper do
   let(:record) { C100Application.new }
 
   describe '#step_form' do
@@ -63,14 +63,34 @@ RSpec.describe ApplicationHelper do
       end
     end
 
-    context 'when a form object is given' do
-      let(:form_object) { double('form object') }
+    context 'when a form object without errors is given' do
+      let(:form_object) { double('form object', errors: []) }
+
+      it 'returns nil' do
+        expect(helper.error_summary(form_object)).to be_nil
+      end
+    end
+
+    context 'when a form object with errors is given' do
+      let(:form_object) { double('form object', errors: [:blank]) }
       let(:summary) { double('error summary') }
+
+      let(:title) { helper.content_for(:page_title) }
+
+      before do
+        helper.title('A page')
+      end
 
       it 'delegates to GovukElementsErrorsHelper' do
         expect(GovukElementsErrorsHelper).to receive(:error_summary).with(form_object, anything, anything).and_return(summary)
 
         expect(helper.error_summary(form_object)).to eq(summary)
+      end
+
+      it 'prepends the page title with an error hint' do
+        expect(GovukElementsErrorsHelper).to receive(:error_summary)
+        helper.error_summary(form_object)
+        expect(title).to start_with('Error: A page')
       end
     end
   end


### PR DESCRIPTION
As part of the accessibility audit and being a recommendation by the Design System, if we detect the current page form has errors, we prefix the title with a hint so screen readers know.

https://design-system.service.gov.uk/components/error-summary/

Also, a minor copy change in the error summary title based on the design guidelines.

<img width="377" alt="screen shot 2019-01-29 at 12 13 14" src="https://user-images.githubusercontent.com/687910/51907623-48e1e400-23bf-11e9-80bd-32eb29485898.png">
