### PR TITLE
Update markup for safety concerns to be heading

### DIFF
--- a/app/views/steps/safety_questions/start/show.en.html.erb
+++ b/app/views/steps/safety_questions/start/show.en.html.erb
@@ -21,9 +21,9 @@
           abuse</a>.</p>
     </div>
 
-    <p class="util_mt-large">
-      <strong><%=t 'shared.cafcass.safety_title' %></strong>
-    </p>
+    <h2 class="heading-medium gv-u-heading-medium">
+      <%=t 'shared.cafcass.safety_title' %>
+    </h2>
     <%=t 'shared.cafcass.safety_content_html' %>
 
     <div class="xform-group form-submit">


### PR DESCRIPTION
The current markup for the safety concerns page styles a paragraph
element to visually appear like a heading rather than using a heading
element.

This change swaps the `<p>` and nested `<strong>` tag for a `<h2>`
which makes more sense semantically.

**Note:** It now appears slightly differently visually but this fits the existing
heading styles better.

## Before
![image](https://user-images.githubusercontent.com/3327997/52060743-c561f780-2564-11e9-9cf9-cdfd1bc60ea6.png)

## After
![image](https://user-images.githubusercontent.com/3327997/52060693-a499a200-2564-11e9-947a-985eb9bf627c.png)
