### PR TITLE
Make `remove name` work without JS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,4 +448,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.17.0
+   1.17.3

--- a/app/assets/stylesheets/local/buttons.scss
+++ b/app/assets/stylesheets/local/buttons.scss
@@ -10,6 +10,10 @@
   cursor: pointer;
 }
 
+.button-alternative {
+  @include button($grey-3);
+}
+
 .button-secondary {
   background: transparent;
   color: $link-colour;

--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -2,7 +2,7 @@ form {
   .app_heading {
       margin-bottom: 3rem;
   }
-  
+
   &.button_to {
     padding-bottom: 0;
 
@@ -108,10 +108,10 @@ label[for="steps_abduction_risk_details_form_risk_details"] {
 fieldset + .form-group {
   margin-top: 30px;
   margin-bottom: 15px;
-  
+
   @media (min-width: 641px) {
     margin-bottom: 30px;
-    
+
     &:last-child {
       margin-bottom: 0;
     }
@@ -122,7 +122,15 @@ fieldset + .form-group {
   padding-bottom: 30px;
 
   .form-group {
-    margin-bottom: 15px;
+    margin-bottom: 0;
+  }
+
+  .form-group + .form-group {
+    margin-top: 15px;
+  }
+
+  .form-group + button {
+    margin-top: 5px;
   }
 }
 

--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -57,7 +57,8 @@ label[for="steps_abduction_risk_details_form_risk_details"] {
   display: none;
 }
 
-.button-add {
+.button-add,
+.button-remove {
   padding-left: 0;
 }
 

--- a/app/controllers/concerns/names_crud_step.rb
+++ b/app/controllers/concerns/names_crud_step.rb
@@ -12,18 +12,22 @@ module NamesCrudStep
   end
 
   def update
+    if params.key?(:remove_name)
+      destroy(params[:remove_name]) && return
+    end
+
     update_and_advance(
       names_form_class,
       as: params.fetch(:button, :names_finished)
     )
   end
 
-  def destroy
-    current_record.destroy
+  private
+
+  def destroy(uuid)
+    @existing_records.destroy(uuid)
     redirect_to action: :edit, id: nil
   end
-
-  private
 
   def additional_permitted_params
     [names_attributes: [:id, :first_name, :last_name, :full_name]]

--- a/app/views/steps/applicant/names/edit.html.erb
+++ b/app/views/steps/applicant/names/edit.html.erb
@@ -21,10 +21,6 @@
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 
-      <% if @existing_records.any? %>
-        <%= link_to t('.btn_remove'), steps_applicant_names_path(@existing_records.last), method: :delete, class: 'link-button' %>
-      <% end %>
-
       <div class="xform-group form-submit">
         <%= f.continue_button %>
       </div>

--- a/app/views/steps/applicant/names/edit.html.erb
+++ b/app/views/steps/applicant/names/edit.html.erb
@@ -19,7 +19,7 @@
 
       <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
-      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
+      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-alternative'] %>
 
       <div class="xform-group form-submit">
         <%= f.continue_button %>

--- a/app/views/steps/children/names/edit.html.erb
+++ b/app/views/steps/children/names/edit.html.erb
@@ -19,7 +19,7 @@
 
       <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
-      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
+      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-alternative'] %>
 
       <div class="xform-group form-submit">
         <%= f.continue_button %>

--- a/app/views/steps/children/names/edit.html.erb
+++ b/app/views/steps/children/names/edit.html.erb
@@ -21,10 +21,6 @@
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 
-      <% if @existing_records.any? %>
-        <%= link_to t('.btn_remove'), steps_children_names_path(@existing_records.last), method: :delete, class: 'link-button' %>
-      <% end %>
-
       <div class="xform-group form-submit">
         <%= f.continue_button %>
       </div>

--- a/app/views/steps/other_children/names/edit.html.erb
+++ b/app/views/steps/other_children/names/edit.html.erb
@@ -17,10 +17,6 @@
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 
-      <% if @existing_records.any? %>
-        <%= link_to t('.btn_remove'), steps_other_children_names_path(@existing_records.last), method: :delete, class: 'link-button' %>
-      <% end %>
-
       <div class="xform-group form-submit">
         <%= f.continue_button %>
       </div>

--- a/app/views/steps/other_children/names/edit.html.erb
+++ b/app/views/steps/other_children/names/edit.html.erb
@@ -15,7 +15,7 @@
 
       <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
-      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
+      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-alternative'] %>
 
       <div class="xform-group form-submit">
         <%= f.continue_button %>

--- a/app/views/steps/other_parties/names/edit.html.erb
+++ b/app/views/steps/other_parties/names/edit.html.erb
@@ -15,7 +15,7 @@
 
       <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
-      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
+      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-alternative'] %>
 
       <div class="xform-group form-submit">
         <%= f.continue_button %>

--- a/app/views/steps/other_parties/names/edit.html.erb
+++ b/app/views/steps/other_parties/names/edit.html.erb
@@ -17,10 +17,6 @@
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 
-      <% if @existing_records.any? %>
-        <%= link_to t('.btn_remove'), steps_other_parties_names_path(@existing_records.last), method: :delete, class: 'link-button' %>
-      <% end %>
-
       <div class="xform-group form-submit">
         <%= f.continue_button %>
       </div>

--- a/app/views/steps/respondent/names/edit.html.erb
+++ b/app/views/steps/respondent/names/edit.html.erb
@@ -21,10 +21,6 @@
 
       <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
 
-      <% if @existing_records.any? %>
-        <%= link_to t('.btn_remove'), steps_respondent_names_path(@existing_records.last), method: :delete, class: 'link-button' %>
-      <% end %>
-
       <div class="xform-group form-submit">
         <%= f.continue_button %>
       </div>

--- a/app/views/steps/respondent/names/edit.html.erb
+++ b/app/views/steps/respondent/names/edit.html.erb
@@ -19,7 +19,7 @@
 
       <%= render partial: 'steps/shared/new_name', locals: { names_form: f } %>
 
-      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-add', 'link-button'] %>
+      <%= f.button t('.btn_add_another'), type: :submit, value: :add_another_name, class: ['button-alternative'] %>
 
       <div class="xform-group form-submit">
         <%= f.continue_button %>

--- a/app/views/steps/shared/_existing_names.html.erb
+++ b/app/views/steps/shared/_existing_names.html.erb
@@ -11,4 +11,8 @@
   <% else %>
     <%= person.text_field :full_name %>
   <% end %>
+
+  <%= names_form.button t('.remove_name'), type: :submit,
+                        class: %w(button-remove link-button),
+                        name: :remove_name, value: person.object.id %>
 </fieldset>

--- a/app/views/steps/shared/_existing_names.html.erb
+++ b/app/views/steps/shared/_existing_names.html.erb
@@ -12,7 +12,7 @@
     <%= person.text_field :full_name %>
   <% end %>
 
-  <%= names_form.button t('.remove_name'), type: :submit,
+  <%= names_form.button t('.remove_name') + " " + legend.downcase, type: :submit,
                         class: %w(button-remove link-button),
                         name: :remove_name, value: person.object.id %>
 </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,8 @@ en:
           copy: To submit your application, you’ll need to complete the C100 paper application form, print it and send it by post.
         download_c100_link: Download the form (PDF)
         cait_info_html: Alternatively you can <a href="https://helpwithchildarrangements.service.justice.gov.uk" rel="external" target="_blank">read the child arrangements guide</a> to see if there’s a more suitable option than going to court.
+      existing_names:
+        remove_name: Remove
     applicant:
       names:
         edit:
@@ -163,7 +165,6 @@ en:
             The other people who will receive this application are known as the respondents. We will ask for their details later.
           record_index: "Applicant %{index}"
           btn_add_another: Add another applicant
-          btn_remove: Remove last applicant
       personal_details:
         edit:
           page_title: Applicant personal details
@@ -197,7 +198,6 @@ en:
           body_info: The other people who will receive this application are known as the respondents.
           record_index: "Respondent %{index}"
           btn_add_another: Add another respondent
-          btn_remove: Remove last respondent
       personal_details:
         edit:
           page_title: Respondent personal details
@@ -234,7 +234,6 @@ en:
           body_info: Only include the children you’re making this application about
           record_index: "Child %{index}"
           btn_add_another: Add another child
-          btn_remove: Remove last child
       personal_details:
         edit:
           page_title: Child personal details
@@ -264,7 +263,6 @@ en:
           heading: Enter the other child’s name
           record_index: "Child %{index}"
           btn_add_another: Add another child
-          btn_remove: Remove last child
       personal_details:
         edit:
           page_title: Child personal details
@@ -276,7 +274,6 @@ en:
           heading: Enter the other person’s name
           record_index: "Person %{index}"
           btn_add_another: Add another person
-          btn_remove: Remove last person
       personal_details:
         edit:
           page_title: Other person personal details

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -300,7 +300,7 @@ end
 RSpec.shared_examples 'a names CRUD step controller' do |form_class, decision_tree_class, resource_class|
   include_examples 'an intermediate step controller', form_class, decision_tree_class
 
-  describe '#destroy' do
+  describe 'remove a name' do
     context 'when no case exists in the session yet' do
       before do
         # Needed because some specs that include these examples stub current_c100_application,
@@ -309,7 +309,7 @@ RSpec.shared_examples 'a names CRUD step controller' do |form_class, decision_tr
       end
 
       it 'redirects to the invalid session error page' do
-        delete :destroy, params: {id: '123'}
+        put :update, params: {remove_name: '123'}
         expect(response).to redirect_to(invalid_session_errors_path)
       end
     end
@@ -322,9 +322,10 @@ RSpec.shared_examples 'a names CRUD step controller' do |form_class, decision_tr
         allow(controller).to receive(:current_c100_application).and_return(existing_case)
       end
 
-      it 'redirects to edit an empty resource' do
-        delete :destroy, params: {id: existing_resource.id}
+      it 'destroy the record and redirects to edit an empty resource' do
+        put :update, params: {remove_name: existing_resource.id}
         expect(response).to redirect_to(action: :edit, id: nil)
+        expect { existing_resource.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end


### PR DESCRIPTION
We had a functionality depending on JS being enabled. This is not ideal and we've refactor the code to get rid of the JS dependency and as a side effect enable the possibility of remove individual names, no matter their position in the list.

As a consequence of this change, there is now some styling TLC and possibly the need to disable the ENTER key with JS, which is a minor inconvenience.

<img width="330" alt="screen shot 2019-02-01 at 11 21 20" src="https://user-images.githubusercontent.com/687910/52120341-e5042900-2613-11e9-8398-fe87d49731c7.png">
