### PR TITLE
Unhide label on abduction textarea form field

### DIFF
--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -53,10 +53,6 @@ label[for="steps_safety_questions_substance_abuse_details_form_substance_abuse_d
   color: transparent;
 }
 
-label[for="steps_abduction_risk_details_form_risk_details"] {
-  display: none;
-}
-
 .button-add,
 .button-remove {
   padding-left: 0;

--- a/app/views/steps/abduction/risk_details/edit.html.erb
+++ b/app/views/steps/abduction/risk_details/edit.html.erb
@@ -10,7 +10,7 @@
       <%=t '.info_html' %>
     </div>
     <%= step_form @form_object do |f| %>
-      <%= f.text_area :risk_details, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.text_area :risk_details, size: '40x4', class: 'form-control-3-4', label_options: { class: 'visually-hidden' } %>
       <%= f.text_area :current_location, size: '40x4', class: 'form-control-3-4' %>
 
       <%= f.continue_button %>


### PR DESCRIPTION
The label for the text area at steps/abduction/risk_details was completely hidden rather than just visually hidden. This makes it available to screen readers again.