### PR TITLE
Disable `enter` keypress in names form

### DIFF
--- a/app/assets/javascripts/modules/disable-enter-key.js
+++ b/app/assets/javascripts/modules/disable-enter-key.js
@@ -1,0 +1,18 @@
+'use strict';
+
+moj.Modules.disableEnterKey = {
+  init: function() {
+    var self = this;
+    self.bindEvents();
+  },
+
+  bindEvents: function() {
+    $("form[data-disable-enter] input[type='text']").on('keyup keypress', function(e) {
+      var keyCode = e.keyCode || e.which;
+      if (keyCode === 13) {
+        e.preventDefault();
+        return false;
+      }
+    });
+  },
+};

--- a/app/views/steps/applicant/names/edit.html.erb
+++ b/app/views/steps/applicant/names/edit.html.erb
@@ -10,7 +10,7 @@
       <p><%=t '.body_info_html' %></p>
     </div>
 
-    <%= step_form @form_object do |f| %>
+    <%= step_form @form_object, data: { 'disable-enter': 1 } do |f| %>
       <% @existing_records.each.with_index do |applicant, index| %>
         <%= f.fields_for :names_attributes, applicant, index: index do |c| %>
           <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>

--- a/app/views/steps/children/names/edit.html.erb
+++ b/app/views/steps/children/names/edit.html.erb
@@ -10,7 +10,7 @@
       <p><%=t '.body_info' %></p>
     </div>
 
-    <%= step_form @form_object do |f| %>
+    <%= step_form @form_object, data: { 'disable-enter': 1 } do |f| %>
       <% @existing_records.each.with_index do |child, index| %>
         <%= f.fields_for :names_attributes, child, index: index do |c| %>
           <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>

--- a/app/views/steps/other_children/names/edit.html.erb
+++ b/app/views/steps/other_children/names/edit.html.erb
@@ -6,7 +6,7 @@
 
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <%= step_form @form_object do |f| %>
+    <%= step_form @form_object, data: { 'disable-enter': 1 } do |f| %>
       <% @existing_records.each.with_index do |child, index| %>
         <%= f.fields_for :names_attributes, child, index: index do |c| %>
           <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>

--- a/app/views/steps/other_parties/names/edit.html.erb
+++ b/app/views/steps/other_parties/names/edit.html.erb
@@ -6,7 +6,7 @@
 
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <%= step_form @form_object do |f| %>
+    <%= step_form @form_object, data: { 'disable-enter': 1 } do |f| %>
       <% @existing_records.each.with_index do |party, index| %>
         <%= f.fields_for :names_attributes, party, index: index do |c| %>
           <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>

--- a/app/views/steps/respondent/names/edit.html.erb
+++ b/app/views/steps/respondent/names/edit.html.erb
@@ -10,7 +10,7 @@
       <p><%=t '.body_info' %></p>
     </div>
 
-    <%= step_form @form_object do |f| %>
+    <%= step_form @form_object, data: { 'disable-enter': 1 } do |f| %>
       <% @existing_records.each.with_index do |respondent, index| %>
         <%= f.fields_for :names_attributes, respondent, index: index do |c| %>
           <%= render partial: 'steps/shared/existing_names', locals: { names_form: f, person: c, legend: t('.record_index', index: index + 1) } %>

--- a/app/views/steps/shared/_existing_names.html.erb
+++ b/app/views/steps/shared/_existing_names.html.erb
@@ -12,7 +12,7 @@
     <%= person.text_field :full_name %>
   <% end %>
 
-  <%= names_form.button t('.remove_name') + " " + legend.downcase, type: :submit,
+  <%= names_form.button t('.remove_name', legend: legend.downcase), type: :submit,
                         class: %w(button-remove link-button),
                         name: :remove_name, value: person.object.id %>
 </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,7 +154,7 @@ en:
         download_c100_link: Download the form (PDF)
         cait_info_html: Alternatively you can <a href="https://helpwithchildarrangements.service.justice.gov.uk" rel="external" target="_blank">read the child arrangements guide</a> to see if there’s a more suitable option than going to court.
       existing_names:
-        remove_name: Remove
+        remove_name: "Remove %{legend}"
     applicant:
       names:
         edit:


### PR DESCRIPTION
A side effect of having individual 'remove' buttons is, on `enter` keypress in any of the text inputs, this submit action is actioned, removing the active name.

In order to stop this behaviour, we are going to disable form submits on enter keypress, only on text inputs, and only for the names form, not other forms.