### PR TITLE
Check for valid session on some error paths

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,6 @@
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
+  before_action :check_c100_application_presence, only: [:application_screening, :application_completed]
 
   def invalid_session
     respond_with_status(:not_found)


### PR DESCRIPTION
Some error pages rely on having a valid session to show different copy depending on the C100 application status.

But in rare occasions users leave these error pages open. When they come back and the browser (mostly mobile devices) auto reloads the URL, the session is gone, and a Sentry exception is thrown:

https://sentry.service.dsd.io/mojds/c100-application-prod/issues/33394/

We can avoid these exceptions if we check for a valid session in the particular error routes where we should have one.