### PR TITLE
Update contact page copy

### DIFF
--- a/app/views/about/contact.en.html.erb
+++ b/app/views/about/contact.en.html.erb
@@ -5,13 +5,20 @@
 
     <h1 class="heading-xlarge gv-u-heading-xxlarge">Get in touch</h1>
 
-    <p class="lede">
+    <p>
       If you’d like to report a problem or have a suggestion to help improve this service for others, get in touch by
       sending an email to:
     </p>
 
     <p class="lede">
-      <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Feedback" class="ga-clickAction" data-ga-category="feedback" data-ga-action="click" data-ga-label="report a problem">c100helpdesk@digital.justice.gov.uk</a>
+      <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Feedback" class="ga-clickAction" data-ga-category="feedback"
+         data-ga-action="click" data-ga-label="report a problem">c100helpdesk@digital.justice.gov.uk</a>
     </p>
+
+    <p>This email address should only be used for feedback on the digital service.</p>
+
+    <p>We cannot answer any questions about applications that have already been submitted. You can
+      <a href="https://courttribunalfinder.service.gov.uk/search/spoe?aol=Children" rel="external" target="_blank">contact
+        the relevant court</a> if you need to discuss your case.</p>
   </div>
 </div>


### PR DESCRIPTION
Add a bit more copy to clarify what the email address is for, and a link to court tribunal finder.