### PR TITLE
Do not run mutant on CI master

### DIFF
--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -2,6 +2,14 @@
 # on classes that match. Example: `rake mutant TaxTribs::ZendeskSender`
 #
 task :mutant => :environment do
+  # Do not run mutant on CI master branch.
+  # Mutant will only run on pull requests against modified files.
+  #
+  if ENV['CIRCLE_BRANCH'] == 'master'
+    puts "> CI master branch -- mutant will not run"
+    exit
+  end
+
   mutation_type = ARGV[1]
 
   vars = 'RAILS_ENV=test NOCOVERAGE=true'


### PR DESCRIPTION
## What

When raising a pull request, mutant will run in any modified class against master.

When merging to master, we will bypass running mutant again.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.