### PR TITLE
Add periodic purge of email submissions audit

### DIFF
--- a/app/models/email_submissions_audit.rb
+++ b/app/models/email_submissions_audit.rb
@@ -6,6 +6,10 @@ class EmailSubmissionsAudit < ApplicationRecord
   class << self
     require 'bcrypt'
 
+    def purge!(date)
+      where('completed_at <= :date', date: date).destroy_all
+    end
+
     # Note: reference is the email reference, and starts with prefix
     # `user` or `court`, followed by the application reference code.
     # Refer to `mailers/notify_submission_mailer.rb`
@@ -17,7 +21,7 @@ class EmailSubmissionsAudit < ApplicationRecord
     # :nocov:
     def find_records(reference, email = nil)
       EmailSubmissionsAudit.where(reference: reference).select do |record|
-        email.blank? || BCrypt::Password.new(record.to) == email.downcase
+        email.blank? || BCrypt::Password.new(record.to) == email
       end
     end
     # :nocov:

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,4 +62,9 @@ class Application < Rails::Application
 
   # When a user is purged, any saved C100 applications belonging to them, are also purged.
   config.x.users.expire_in_days = 30
+
+  # Applicant confirmation email, and court email, are sent via Notify, but Notify has a
+  # very limited retention period. We maintain an audit (with no personal details) of the
+  # delivery result of these emails for diagnostic and debug purposes.
+  config.x.email_submissions_audit.expire_in_days = 90
 end

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -6,6 +6,7 @@ task daily_tasks: :environment do
 
   Rake::Task['purge:applications'].invoke
   Rake::Task['purge:orphans'].invoke
+  Rake::Task['purge:email_submissions_audit'].invoke
 
   Rake::Task['draft_reminders:first_email'].invoke
   Rake::Task['draft_reminders:last_email'].invoke
@@ -34,6 +35,13 @@ namespace :purge do
     log "Purging orphan applications older than #{expire_after} days"
     purged = C100Application.not_eligible_orphans.purge!(expire_after.days.ago)
     log "Purged #{purged.size} orphan applications"
+  end
+
+  task email_submissions_audit: :environment do
+    expire_after = Rails.configuration.x.email_submissions_audit.expire_in_days
+    log "Purging email submissions audit older than #{expire_after} days"
+    purged = EmailSubmissionsAudit.purge!(expire_after.days.ago)
+    log "Purged #{purged.size} email submissions audit records"
   end
 end
 

--- a/spec/models/email_submissions_audit_spec.rb
+++ b/spec/models/email_submissions_audit_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe EmailSubmissionsAudit, type: :model do
+  describe '.purge!' do
+    let(:finder_double) { double.as_null_object }
+    let(:days_ago) { 123.days.ago }
+
+    it 'picks records equal to or older than the passed-in date' do
+      expect(described_class).to receive(:where).with(
+        'completed_at <= :date', date: days_ago
+      ).and_return(finder_double)
+
+      described_class.purge!(days_ago)
+    end
+
+    it 'calls #destroy_all on the records it finds' do
+      allow(described_class).to receive(:where).and_return(finder_double)
+      expect(finder_double).to receive(:destroy_all)
+
+      described_class.purge!(days_ago)
+    end
+  end
+end


### PR DESCRIPTION
Applicant confirmation email, and court email, are sent via Notify, but Notify has a very limited retention period.

We maintain an audit (with no personal details) of the delivery result of these emails for diagnostic and debug purposes.

The purge retention period can be configured but initially will be 90 days. This purge will run together with the rest of daily tasks over night.

Also, as a minor fix, removed the downcase of the email argument in the `find_records` method because we really want to ensure case sensitivity in the search.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
