### PR TITLE
Add legend text to radio buttons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.5.3'
 
 gem 'devise', '~> 4.4.3'
 gem 'email_validator'
-gem 'govuk_elements_form_builder', '~> 1.3.0'
+gem 'govuk_elements_form_builder', git: "https://github.com/ministryofjustice/govuk_elements_form_builder.git"
 gem 'govuk_elements_rails', '~> 3.0'
 gem 'govuk_frontend_toolkit', '< 8.0.0'
 gem 'govuk_notify_rails', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
+  revision: 3049c945f46e61a1a2264346f3ce5f7b60a7c8f4
+  specs:
+    govuk_elements_form_builder (1.3.0)
+      govuk_elements_rails (>= 3.0.0)
+      govuk_frontend_toolkit (>= 6.0.0)
+      rails (>= 4.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -138,10 +147,6 @@ GEM
       activesupport (>= 4.2.0)
     gov_uk_date_fields (3.1.0)
       rails (>= 5.0)
-    govuk_elements_form_builder (1.3.0)
-      govuk_elements_rails (>= 3.0.0)
-      govuk_frontend_toolkit (>= 6.0.0)
-      rails (>= 4.2)
     govuk_elements_rails (3.1.3)
       govuk_frontend_toolkit (>= 6.0.2)
       rails (>= 4.1.0)
@@ -405,7 +410,7 @@ DEPENDENCIES
   dotenv-rails
   email_validator
   gov_uk_date_fields (~> 3.1.0)
-  govuk_elements_form_builder (~> 1.3.0)
+  govuk_elements_form_builder!
   govuk_elements_rails (~> 3.0)
   govuk_frontend_toolkit (< 8.0.0)
   govuk_notify_rails (~> 2.1.0)

--- a/app/views/steps/abduction/children_have_passport/edit.html.erb
+++ b/app/views/steps/abduction/children_have_passport/edit.html.erb
@@ -7,7 +7,7 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :children_have_passport, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :children_have_passport, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/abduction/international/edit.html.erb
+++ b/app/views/steps/abduction/international/edit.html.erb
@@ -8,7 +8,7 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :passport_office_notified, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :passport_office_notified, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
         <p><%=t '.contact_info_html' %></p>

--- a/app/views/steps/abduction/previous_attempt/edit.html.erb
+++ b/app/views/steps/abduction/previous_attempt/edit.html.erb
@@ -7,7 +7,7 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :previous_attempt, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :previous_attempt, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/abuse_concerns/question/edit.html.erb
+++ b/app/views/steps/abuse_concerns/question/edit.html.erb
@@ -1,10 +1,11 @@
 <% title t(".page_title.#{@form_object.i18n_key}") %>
+<% heading = t(".heading.#{@form_object.i18n_key}") %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= step_header %>
     <p class="app__section_heading">Safety concerns</p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t ".heading.#{@form_object.i18n_key}" %></h1>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%= heading %></h1>
 
     <div class="govuk-govspeak gv-s-prose">
       <p><%=t ".lead_text.#{@form_object.i18n_key}_html" %></p>
@@ -14,7 +15,10 @@
       <%= f.hidden_field :subject %>
       <%= f.hidden_field :kind %>
 
-      <%= f.radio_button_fieldset :answer, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t(".heading.#{@form_object.i18n_key}") } %>
+      <%= f.radio_button_fieldset :answer, 
+        inline: true, 
+        choices: GenericYesNo.values, 
+        legend_options: { class: 'visually-hidden', text: heading } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/abuse_concerns/question/edit.html.erb
+++ b/app/views/steps/abuse_concerns/question/edit.html.erb
@@ -14,7 +14,7 @@
       <%= f.hidden_field :subject %>
       <%= f.hidden_field :kind %>
 
-      <%= f.radio_button_fieldset :answer, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :answer, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t(".heading.#{@form_object.i18n_key}") } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/applicant/has_solicitor/edit.html.erb
+++ b/app/views/steps/applicant/has_solicitor/edit.html.erb
@@ -1,17 +1,18 @@
 <% title t('.page_title') %>
+<% heading = t(".heading", count: current_c100_application.applicants.count) %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= step_header %>
 
     <h1 class="heading-xlarge gv-u-heading-xxlarge">
-      <%=t '.heading', count: current_c100_application.applicants.count %>
+      <%= heading %>
     </h1>
 
     <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :has_solicitor, inline: true, legend_options: { class: 'visually-hidden', text: t('.heading', count: current_c100_application.applicants.count ) }, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :has_solicitor, inline: true, legend_options: { class: 'visually-hidden', text: heading }, choices: GenericYesNo.values %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/applicant/has_solicitor/edit.html.erb
+++ b/app/views/steps/applicant/has_solicitor/edit.html.erb
@@ -11,7 +11,7 @@
     <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :has_solicitor, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :has_solicitor, inline: true, legend_options: { class: 'visually-hidden', text: t('.heading', count: current_c100_application.applicants.count ) }, choices: GenericYesNo.values %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/applicant/relationship/edit.html.erb
+++ b/app/views/steps/applicant/relationship/edit.html.erb
@@ -4,6 +4,6 @@
   <div class="column-two-thirds">
     <%= step_header %>
 
-    <%= render partial: 'steps/shared/relationship_step', locals: { form_object: @form_object } %>
+    <%= render partial: 'steps/shared/relationship_step', locals: { form_object: @form_object }%>
   </div>
 </div>

--- a/app/views/steps/application/intermediary/edit.html.erb
+++ b/app/views/steps/application/intermediary/edit.html.erb
@@ -13,7 +13,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :intermediary_help, inline: true do |fieldset|
+        f.radio_button_fieldset :intermediary_help, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES, panel_id: :intermediary_help_panel)
           fieldset.radio_input(GenericYesNo::NO)
           fieldset.revealing_panel(:intermediary_help_panel) do |panel|

--- a/app/views/steps/application/language/edit.html.erb
+++ b/app/views/steps/application/language/edit.html.erb
@@ -11,7 +11,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :language_help, inline: true do |fieldset|
+        f.radio_button_fieldset :language_help, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES, panel_id: :language_help_panel)
           fieldset.radio_input(GenericYesNo::NO)
           fieldset.revealing_panel(:language_help_panel) do |panel|

--- a/app/views/steps/application/litigation_capacity/edit.html.erb
+++ b/app/views/steps/application/litigation_capacity/edit.html.erb
@@ -12,7 +12,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :reduced_litigation_capacity, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :reduced_litigation_capacity, inline: true, legend_options: { class: 'visually-hidden', text: t('.heading') }, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/application/payment/edit.html.erb
+++ b/app/views/steps/application/payment/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :payment_type do |fieldset|
+        f.radio_button_fieldset :payment_type, legend_options: { class: 'visually-hidden', text: t('.heading') } do |fieldset|
           fieldset.radio_input(PaymentType::SELF_PAYMENT_CARD)
           fieldset.radio_input(PaymentType::SELF_PAYMENT_CHEQUE)
           fieldset.radio_input(PaymentType::HELP_WITH_FEES) { f.text_field :hwf_reference_number, class: 'narrow' }

--- a/app/views/steps/application/previous_proceedings/edit.html.erb
+++ b/app/views/steps/application/previous_proceedings/edit.html.erb
@@ -12,7 +12,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :children_previous_proceedings, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :children_previous_proceedings, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/application/special_arrangements/edit.html.erb
+++ b/app/views/steps/application/special_arrangements/edit.html.erb
@@ -13,7 +13,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :special_arrangements, inline: true do |fieldset|
+        f.radio_button_fieldset :special_arrangements, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES, panel_id: :special_arrangements_panel)
           fieldset.radio_input(GenericYesNo::NO)
           fieldset.revealing_panel(:special_arrangements_panel) do |panel|

--- a/app/views/steps/application/special_assistance/edit.html.erb
+++ b/app/views/steps/application/special_assistance/edit.html.erb
@@ -13,7 +13,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :special_assistance, inline: true do |fieldset|
+        f.radio_button_fieldset :special_assistance, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES, panel_id: :special_assistance_panel)
           fieldset.radio_input(GenericYesNo::NO)
           fieldset.revealing_panel(:special_assistance_panel) do |panel|

--- a/app/views/steps/application/submission/edit.html.erb
+++ b/app/views/steps/application/submission/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :submission_type, inline: true do |fieldset|
+        f.radio_button_fieldset :submission_type, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(SubmissionType::ONLINE, panel_id: :receipt_email_panel)
           fieldset.radio_input(SubmissionType::PRINT_AND_POST)
           fieldset.revealing_panel(:receipt_email_panel) do |panel|

--- a/app/views/steps/application/urgent_hearing/edit.html.erb
+++ b/app/views/steps/application/urgent_hearing/edit.html.erb
@@ -25,7 +25,7 @@
     </details>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :urgent_hearing, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :urgent_hearing, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/application/without_notice/edit.html.erb
+++ b/app/views/steps/application/without_notice/edit.html.erb
@@ -20,7 +20,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :without_notice, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :without_notice, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/children/has_other_children/edit.html.erb
+++ b/app/views/steps/children/has_other_children/edit.html.erb
@@ -7,7 +7,7 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :has_other_children, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :has_other_children, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') }%>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/court_orders/has_orders/edit.html.erb
+++ b/app/views/steps/court_orders/has_orders/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <%= step_form @form_object, inline: true do |f| %>
-      <%= f.radio_button_fieldset :has_court_orders, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :has_court_orders, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/international/jurisdiction/edit.html.erb
+++ b/app/views/steps/international/jurisdiction/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :international_jurisdiction, inline: true do |fieldset|
+        f.radio_button_fieldset :international_jurisdiction, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES, panel_id: :international_jurisdiction_panel)
           fieldset.radio_input(GenericYesNo::NO)
           fieldset.revealing_panel(:international_jurisdiction_panel) do |panel|

--- a/app/views/steps/international/request/edit.html.erb
+++ b/app/views/steps/international/request/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :international_request, inline: true do |fieldset|
+        f.radio_button_fieldset :international_request, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES, panel_id: :international_request_panel)
           fieldset.radio_input(GenericYesNo::NO)
           fieldset.revealing_panel(:international_request_panel) do |panel|

--- a/app/views/steps/international/resident/edit.html.erb
+++ b/app/views/steps/international/resident/edit.html.erb
@@ -12,7 +12,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :international_resident, inline: true do |fieldset|
+        f.radio_button_fieldset :international_resident, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES, panel_id: :international_resident_panel)
           fieldset.radio_input(GenericYesNo::NO)
         end

--- a/app/views/steps/miam/attended/edit.html.erb
+++ b/app/views/steps/miam/attended/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :miam_attended, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :miam_attended, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam/certification/edit.html.erb
+++ b/app/views/steps/miam/certification/edit.html.erb
@@ -9,7 +9,7 @@
     <div class="govuk-govspeak gv-s-prose"><%=t '.body_html' %></div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :miam_certification, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :miam_certification, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam/certification_date/edit.html.erb
+++ b/app/views/steps/miam/certification_date/edit.html.erb
@@ -20,5 +20,3 @@
     <% end %>
   </div>
 </div>
-
-# TODO: Sort out making the hint text visually unhidden when the legend is visually hidden

--- a/app/views/steps/miam/certification_date/edit.html.erb
+++ b/app/views/steps/miam/certification_date/edit.html.erb
@@ -20,3 +20,5 @@
     <% end %>
   </div>
 </div>
+
+# TODO: Sort out making the hint text visually unhidden when the legend is visually hidden

--- a/app/views/steps/miam/child_protection_cases/edit.html.erb
+++ b/app/views/steps/miam/child_protection_cases/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :child_protection_cases, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :child_protection_cases, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam/consent_order/edit.html.erb
+++ b/app/views/steps/miam/consent_order/edit.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :consent_order, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :consent_order, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam/exemption_claim/edit.html.erb
+++ b/app/views/steps/miam/exemption_claim/edit.html.erb
@@ -11,7 +11,7 @@
     <%=t '.info_notice_html' %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :miam_exemption_claim, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :miam_exemption_claim, inline: true, legend_options: { class: 'visually-hidden', text: t('.heading') }, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/petition/protection/edit.html.erb
+++ b/app/views/steps/petition/protection/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.radio_button_fieldset :protection_orders, inline: true do |fieldset|
+        f.radio_button_fieldset :protection_orders, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES, panel_id: :protection_orders_panel)
           fieldset.radio_input(GenericYesNo::NO)
           fieldset.revealing_panel(:protection_orders_panel) do |panel|

--- a/app/views/steps/respondent/has_other_parties/edit.html.erb
+++ b/app/views/steps/respondent/has_other_parties/edit.html.erb
@@ -9,7 +9,7 @@
     <p><%=t '.info_html' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :has_other_parties, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :has_other_parties, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/safety_questions/address_confidentiality/edit.html.erb
+++ b/app/views/steps/safety_questions/address_confidentiality/edit.html.erb
@@ -9,7 +9,7 @@
     <p class="lede gv-u-text-lede"><%=t '.lead_text_html' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :address_confidentiality, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :address_confidentiality, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/safety_questions/children_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/children_abuse/edit.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :children_abuse, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :children_abuse, inline: true, legend_options: { class: 'visually-hidden', text: t('.heading') }, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/safety_questions/domestic_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/domestic_abuse/edit.html.erb
@@ -20,7 +20,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :domestic_abuse, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :domestic_abuse, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/safety_questions/other_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/other_abuse/edit.html.erb
@@ -7,7 +7,7 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :other_abuse, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :other_abuse, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/safety_questions/risk_of_abduction/edit.html.erb
+++ b/app/views/steps/safety_questions/risk_of_abduction/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :risk_of_abduction, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :risk_of_abduction, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/safety_questions/substance_abuse/edit.html.erb
+++ b/app/views/steps/safety_questions/substance_abuse/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :substance_abuse, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :substance_abuse, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/email_consent/edit.html.erb
+++ b/app/views/steps/screener/email_consent/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-    <%= f.radio_button_fieldset :email_consent, inline: true do |fieldset|
+    <%= f.radio_button_fieldset :email_consent, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
           fieldset.radio_input(GenericYesNo::YES, panel_id: :email_address_panel)
           fieldset.radio_input(GenericYesNo::NO)
           fieldset.revealing_panel(:email_address_panel) do |panel|

--- a/app/views/steps/screener/legal_representation/edit.html.erb
+++ b/app/views/steps/screener/legal_representation/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :legal_representation, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :legal_representation, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/over18/edit.html.erb
+++ b/app/views/steps/screener/over18/edit.html.erb
@@ -7,7 +7,7 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :over18, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :over18, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/parent/edit.html.erb
+++ b/app/views/steps/screener/parent/edit.html.erb
@@ -7,7 +7,7 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :parent, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :parent, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/written_agreement/edit.html.erb
+++ b/app/views/steps/screener/written_agreement/edit.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :written_agreement, inline: true, choices: GenericYesNo.values %>
+      <%= f.radio_button_fieldset :written_agreement, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/shared/_relationship_step.html.erb
+++ b/app/views/steps/shared/_relationship_step.html.erb
@@ -1,12 +1,12 @@
+<% heading = t('.heading', person_name: form_object.record.person.full_name, child_name:  form_object.record.minor.full_name) %>
+
 <h1 class="heading-xlarge gv-u-heading-xxlarge">
-  <%= t('.heading',
-    person_name: form_object.record.person.full_name,
-    child_name:  form_object.record.minor.full_name) %>
+  <%=  heading %>
 </h1>
 
 <%= step_form form_object do |f| %>
   <%=
-    f.radio_button_fieldset :relation, { legend_options: { class: 'visually-hidden', text: t('.heading', person_name: form_object.record.person.full_name, child_name:  form_object.record.minor.full_name) } } do |fieldset|
+    f.radio_button_fieldset :relation, { legend_options: { class: 'visually-hidden', text: heading } } do |fieldset|
       fieldset.radio_input Relation::MOTHER
       fieldset.radio_input Relation::FATHER
       fieldset.radio_input(Relation::OTHER) { f.text_field :relation_other_value }

--- a/app/views/steps/shared/_relationship_step.html.erb
+++ b/app/views/steps/shared/_relationship_step.html.erb
@@ -6,7 +6,7 @@
 
 <%= step_form form_object do |f| %>
   <%=
-    f.radio_button_fieldset :relation do |fieldset|
+    f.radio_button_fieldset :relation, { legend_options: { class: 'visually-hidden', text: t('.heading', person_name: form_object.record.person.full_name, child_name:  form_object.record.minor.full_name) } } do |fieldset|
       fieldset.radio_input Relation::MOTHER
       fieldset.radio_input Relation::FATHER
       fieldset.radio_input(Relation::OTHER) { f.text_field :relation_other_value }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1153,52 +1153,18 @@ en:
 
   helpers:
     fieldset:
-      steps_shared_relationship_form:
-        relation_html: ""
-      steps_application_previous_proceedings_form:
-        children_previous_proceedings_html: ""
-      steps_application_urgent_hearing_form:
-        urgent_hearing_html: ""
       steps_application_urgent_hearing_details_form:
         urgent_hearing_short_notice_html: Do you need a hearing within the next 48 hours?
-      steps_application_without_notice_form:
-        without_notice_html: ""
       steps_application_without_notice_details_form:
         without_notice_frustrate_html: Are you asking for a without notice hearing because the other person or people may do something that would obstruct the order you are asking for if they knew about the application?
         without_notice_impossible_html: Are you asking for a without notice hearing because there is literally no time to give notice of the application to the other person or people?
-      steps_application_litigation_capacity_form:
-        reduced_litigation_capacity_html: ""
-      steps_application_special_assistance_form:
-        special_assistance_html: ""
-      steps_application_special_arrangements_form:
-        special_arrangements_html: ""
-      steps_application_language_form:
-        language_help_html: ""
-      steps_application_intermediary_form:
-        intermediary_help_html: ""
-      steps_application_declaration_form:
-        declaration_made_html: ""
-      steps_miam_consent_order_form:
-        consent_order_html: ""
-      steps_miam_child_protection_cases_form:
-        child_protection_cases_html: ""
-      steps_miam_acknowledgement_form:
-        miam_acknowledgement_html: ""
-      steps_miam_attended_form:
-        miam_attended_html: ""
-      steps_miam_exemption_claim_form:
-        miam_exemption_claim_html: ""
-      steps_miam_certification_form:
-        miam_certification_html: ""
       steps_miam_exemptions_domestic_form:
         domestic_exemptions_html: "Do you have any of the following evidence of domestic violence or abuse?"
         exemptions_group_html: ""
       steps_miam_exemptions_protection_form:
         protection_exemptions_html: "Do any of the following apply?"
-        exemptions_group_html: ""
       steps_miam_exemptions_urgency_form:
         urgency_exemptions_html: "Do any of the following apply?"
-        exemptions_group_html: ""
       steps_miam_exemptions_adr_form:
         adr_exemptions_html: "Do any of the following apply?"
         exemptions_group_html: ""
@@ -1209,40 +1175,19 @@ en:
         orders_html: ""
         orders_prohibited_steps_html: ""
         orders_specific_issues_html: ""
-      steps_petition_protection_form:
-        protection_orders_html: ""
       steps_safety_questions_address_confidentiality_form:
         address_confidentiality_html: "Do you want to keep your contact details private from the other people named in the application (the respondents)?"
-      steps_safety_questions_risk_of_abduction_form:
-        risk_of_abduction_html: ""
-      steps_safety_questions_substance_abuse_form:
-        substance_abuse_html: ""
-      steps_safety_questions_children_abuse_form:
-        children_abuse_html: ""
-      steps_safety_questions_domestic_abuse_form:
-        domestic_abuse_html: ""
-      steps_safety_questions_other_abuse_form:
-        other_abuse_html: ""
-      steps_abduction_children_have_passport_form:
-        children_have_passport_html: ""
       steps_abduction_passport_details_form:
         children_multiple_passports_html: "Do the children have more than one passport?"
         passport_possesion_html: "Who is in possession of the children’s passports?"
       steps_abduction_international_form:
-        passport_office_notified_html: ""
         children_multiple_passports_html: "Do the children have more than one passport?"
         passport_possesion_html: "Who is in possession of the children’s passports?"
-      steps_abduction_previous_attempt_form:
-        previous_attempt_html: ""
       steps_abduction_previous_attempt_details_form:
         previous_attempt_agency_involved_html: "Were the police, private investigators or any other organisation involved?"
-      steps_abuse_concerns_question_form:
-        answer_html: ""
       steps_abuse_concerns_contact_form:
         concerns_contact_type_html: "Do you agree to the children spending time with the other people in this application?"
         concerns_contact_other_html: "Do you agree to the other people in this application being in touch with the children in other ways?"
-      steps_court_orders_has_orders_form:
-        has_court_orders_html: ""
       steps_court_orders_details_form:
         <<: *COURT_ORDER_TYPES
         non_molestation_is_current: *order_current
@@ -1263,26 +1208,17 @@ en:
         alternative_lawyer_negotiation: Have you tried lawyer negotiation?
       steps_alternatives_collaborative_law_form:
         alternative_collaborative_law: Have you tried collaborative law?
-      steps_alternatives_court_form:
-        court_acknowledgement_html: ""
       steps_applicant_personal_details_form:
         has_previous_name: Have they changed their name?
         gender: Sex
       steps_applicant_contact_details_form:
         residence_requirement_met: Have you lived at your current address for more than 5 years?
-      steps_applicant_has_solicitor_form:
-        has_solicitor_html: ""
       steps_respondent_personal_details_form:
         has_previous_name: Have they changed their name?
         gender: Sex
         dob_unknown_html: ""
       steps_respondent_contact_details_form:
         residence_requirement_met: Have they lived at this address for more than 5 years?
-        address_unknown_html: ""
-        mobile_phone_unknown_html: ""
-        email_unknown_html: ""
-      steps_respondent_has_other_parties_form:
-        has_other_parties_html: ""
       steps_children_personal_details_form:
         dob_unknown_html: ""
         gender: Sex
@@ -1294,8 +1230,6 @@ en:
       steps_children_additional_details_form:
         children_known_to_authorities: Are any of the children known to social services?
         children_protection_plan: Are any of the children the subject of a child protection plan?
-      steps_children_has_other_children_form:
-        has_other_children_html: ""
       steps_other_children_personal_details_form:
         dob_unknown_html: ""
         gender: Sex
@@ -1303,31 +1237,6 @@ en:
         has_previous_name: Have they changed their name?
         gender: Sex
         dob_unknown_html: ""
-      steps_other_parties_contact_details_form:
-        address_unknown_html: ""
-      steps_international_resident_form:
-        international_resident_html: ""
-      steps_international_jurisdiction_form:
-        international_jurisdiction_html: ""
-      steps_international_request_form:
-        international_request_html: ""
-      steps_application_payment_form:
-        payment_type_html: ""
-      steps_application_submission_form:
-        submission_type_html: ""
-
-      ### SCREENER ###
-      #
-      steps_screener_parent_form:
-        parent_html: ""
-      steps_screener_over18_form:
-        over18_html: ""
-      steps_screener_legal_representation_form:
-        legal_representation_html: ""
-      steps_screener_written_agreement_form:
-        written_agreement_html: ""
-      steps_screener_email_consent_form:
-        email_consent_html: ""
 
     label:
       steps_shared_relationship_form:
@@ -1471,7 +1380,7 @@ en:
           <<: *YESNO
         children_known_to_authorities_details: State which child and the name of the local authority and social worker (if known)
       steps_safety_questions_substance_abuse_details_form:
-        substance_abuse_details:
+        substance_abuse_details: Substance abuse details
       steps_abuse_concerns_details_form:
         behaviour_description: Briefly describe what happened and who was involved, if you feel able to
         behaviour_start: When did this behaviour start?


### PR DESCRIPTION
Some of the radio buttons don't currently have the question in the legend. This addresses that so that for screen reader users, the question is directly associated with the input field.

## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/14030794)

@zheileman has updated the gem, so that text can be added to radio button legends. This PR goes through the individual views so that they use this new functionality, and removes now unnecessary strings from the YAML.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
