### PR TITLE
Remove unused SMTP config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,16 +33,6 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
   config.action_mailer.perform_caching = false
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    user_name: ENV['SMTP_USERNAME'],
-    password: ENV['SMTP_PASSWORD'],
-    address: ENV['SMTP_HOST'],
-    domain:  ENV['SMTP_DOMAIN'],
-    port: ENV['SMTP_PORT'],
-    authentication: 'login',
-    enable_starttls_auto: true
-  }
 
   # https://github.com/ruby-i18n/i18n/releases/tag/v1.1.0
   config.i18n.fallbacks = [I18n.default_locale]


### PR DESCRIPTION
## What

We are no longer sending emails via SMTP. Instead we use GOV.UK Notify.

Remove these leftovers (will also be removed from the k8s deploy config map).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
