### PR TITLE
Tidy up checkbox legends

### DIFF
--- a/app/value_objects/petition_order.rb
+++ b/app/value_objects/petition_order.rb
@@ -1,8 +1,8 @@
 class PetitionOrder < ValueObject
   VALUES = [
     CHILD_ARRANGEMENTS = [
-      new(:child_arrangements_home),
-      new(:child_arrangements_time),
+      CHILD_ARRANGEMENTS_HOME = new(:child_arrangements_home),
+      CHILD_ARRANGEMENTS_TIME = new(:child_arrangements_time),
     ].freeze,
 
     GROUP_PROHIBITED_STEPS = new(:group_prohibited_steps),

--- a/app/views/steps/abuse_concerns/details/edit.html.erb
+++ b/app/views/steps/abuse_concerns/details/edit.html.erb
@@ -36,11 +36,14 @@
           f.radio_button_fieldset :asked_for_help, inline: true do |fieldset|
             fieldset.radio_input(GenericYesNo::YES, panel_id: :asked_for_help_panel)
             fieldset.radio_input(GenericYesNo::NO)
-            fieldset.revealing_panel(:asked_for_help_panel) do |panel|
-              panel.text_field(:help_party)
-              panel.radio_button_fieldset(:help_provided, inline: true, choices: GenericYesNo.values)
-              panel.text_area(:help_description, size: '40x4', class: 'form-control-3-4')
-            end
+          end
+        %>
+
+        <%
+          f.revealing_panel(:asked_for_help_panel) do |panel|
+            panel.text_field(:help_party)
+            panel.radio_button_fieldset(:help_provided, inline: true, choices: GenericYesNo.values)
+            panel.text_area(:help_description, size: '40x4', class: 'form-control-3-4')
           end
         %>
 

--- a/app/views/steps/children/orders/edit.html.erb
+++ b/app/views/steps/children/orders/edit.html.erb
@@ -1,15 +1,15 @@
 <% title t('.page_title') %>
 
+<% heading = t '.heading', name: @form_object.record.full_name %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= step_header %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
-
-    <p><%=t '.info_html' %></p>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%= heading %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.check_box_fieldset :orders, @petition.all_selected_orders %>
+      <%= f.check_box_fieldset :orders, @petition.all_selected_orders, legend_options: {class: "visually-hidden", text: heading} %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/children/residence/edit.html.erb
+++ b/app/views/steps/children/residence/edit.html.erb
@@ -1,15 +1,17 @@
 <% title t('.page_title') %>
 
+<% heading = t '.heading', name: @form_object.record.child.full_name %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= step_header %>
 
     <h1 class="heading-xlarge gv-u-heading-xxlarge">
-      <%=t '.heading', name: @form_object.record.child.full_name %>
+      <%= heading %>
     </h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.collection_check_boxes :person_ids, @form_object.people, :id, :full_name %>
+      <%= f.collection_check_boxes :person_ids, @form_object.people, :id, :full_name, legend_options: { class: 'visually-hidden', text: heading } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/petition/orders/edit.html.erb
+++ b/app/views/steps/petition/orders/edit.html.erb
@@ -6,33 +6,17 @@
 
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
-
     <%= step_form @form_object do |f| %>
-      <%= f.check_box_fieldset :orders, PetitionOrder::CHILD_ARRANGEMENTS %>
-
       <%=
-        f.check_box_fieldset :orders, [
-          PetitionOrder::PROHIBITED_STEPS,
-        ] do |fieldset|
+        f.check_box_fieldset :orders, [], legend_options: { class: 'visually-hidden', text: t('.heading') } do |fieldset|
+          fieldset.check_box_input(PetitionOrder::CHILD_ARRANGEMENTS_HOME)
+          fieldset.check_box_input(PetitionOrder::CHILD_ARRANGEMENTS_TIME)
           fieldset.check_box_input(PetitionOrder::GROUP_PROHIBITED_STEPS) {
             f.check_box_fieldset :orders_prohibited_steps, PetitionOrder::PROHIBITED_STEPS
           }
-        end
-      %>
-
-      <%=
-        f.check_box_fieldset :orders, [
-          PetitionOrder::SPECIFIC_ISSUES,
-        ] do |fieldset|
           fieldset.check_box_input(PetitionOrder::GROUP_SPECIFIC_ISSUES) {
             f.check_box_fieldset :orders_specific_issues, PetitionOrder::SPECIFIC_ISSUES
           }
-        end
-      %>
-
-      <%=
-        f.check_box_fieldset :orders, [PetitionOrder::OTHER_ISSUE] do |fieldset|
           fieldset.check_box_input(PetitionOrder::OTHER_ISSUE) {
             f.text_area :orders_additional_details, size: '40x4', class: 'form-control-3-4'
           }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,10 +9,10 @@ en:
     address_hint: &address_hint "Court documents will be sent here. Include the postcode if you have it"
     middle_names_hint: &middle_names_hint "Include all middle names here"
     order_current: &order_current "Is the order current?"
-    order_current_error: &order_current_error "Answer if the order is current"
     order_length: &order_length "How long was the order for?"
     order_court_name: &order_court_name "Which court issued the order?"
     provide_details: &provide_details "Provide details"
+    select_all_that_apply: &select_all_that_apply "Select all that apply"
     select_all_that_apply_or_none: &select_all_that_apply_or_none "Select all that apply or ‘None of these’"
     blank_exemptions_error: &blank_exemptions_error "Select at least one exemption or ‘None of these‘"
     account_purge_info: &account_purge_info "If you have not signed in for %{expire_in_days} days we delete your account for security reasons."
@@ -439,7 +439,7 @@ en:
           page_title: Orders details
           section: Safety concerns
           heading: What orders have been made?
-          lead_text: Select all that apply
+          lead_text: *select_all_that_apply
     safety_questions:
       risk_of_abduction:
         edit:
@@ -574,7 +574,6 @@ en:
         edit:
           page_title: What are you asking the court to decide?
           heading: What are you asking the court to decide about the children involved?
-          lead_text: Select all that apply
       other_issue:
         edit:
           page_title: Provide details of the issue
@@ -1161,14 +1160,14 @@ en:
         domestic_exemptions_html: "Do you have any of the following evidence of domestic violence or abuse?"
         exemptions_group_html: ""
       steps_miam_exemptions_protection_form:
-        protection_exemptions_html: "Do any of the following apply?"
+        protection_exemptions_html: "Do you confirm any of the following child protection concerns?"
       steps_miam_exemptions_urgency_form:
-        urgency_exemptions_html: "Do any of the following apply?"
+        urgency_exemptions_html: "Do you confirm any of the following urgency reasons?"
       steps_miam_exemptions_adr_form:
-        adr_exemptions_html: "Do any of the following apply?"
+        adr_exemptions_html: "Do you confirm any of the following reasons for not attending a MIAM?"
         exemptions_group_html: ""
       steps_miam_exemptions_misc_form:
-        misc_exemptions_html: "Do any of the following apply?"
+        misc_exemptions_html: "Do you have any other valid reasons for not attending a MIAM?"
         exemptions_group_html: ""
       steps_petition_orders_form:
         orders_html: ""
@@ -1466,14 +1465,15 @@ en:
       steps_application_submission_form:
         receipt_email: We will send an copy of your application to this address
       steps_abduction_passport_details_form:
-        passport_possesion: Select all that apply
+        passport_possesion: *select_all_that_apply
       steps_abduction_risk_details_form:
         current_location: If they're outside England or Wales, include what country they're in and how long they've been there. You don't need to include any addresses.
       steps_abduction_previous_attempt_details_form:
         previous_attempt_agency_involved: Including in the UK or abroad
       steps_petition_orders_form:
-        orders_prohibited_steps: Select all that apply
-        orders_specific_issues: Select all that apply
+        orders: *select_all_that_apply
+        orders_prohibited_steps: *select_all_that_apply
+        orders_specific_issues: *select_all_that_apply
       steps_applicant_personal_details_form:
         has_previous_name: For example, through marriage or adoption or by deed poll. This includes first name, surname and any middle names
         previous_name: *previous_name_hint
@@ -1503,9 +1503,9 @@ en:
         children_protection_plan_html: |
           A child protection plan is prepared by a local authority where a child is thought to be at risk of significant harm. It sets out steps to be taken to protect the child and support the family
       steps_children_residence_form:
-        person_ids_html: Select all that apply
+        person_ids_html: *select_all_that_apply
       steps_children_orders_form:
-        orders_html: Select all that apply
+        orders_html: *select_all_that_apply
       steps_other_parties_personal_details_form:
         has_previous_name: For example, through marriage or adoption or by deed poll. This includes first name, surname and any middle names
         previous_name: *previous_name_hint

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,7 +246,6 @@ en:
         edit:
           page_title: Which orders apply to the child
           heading: "Which of the decisions you’re asking the court to resolve relate to %{name}?"
-          info_html: Select all that apply
       residence:
         edit:
           page_title: Child residence
@@ -1175,8 +1174,6 @@ en:
         orders_html: ""
         orders_prohibited_steps_html: ""
         orders_specific_issues_html: ""
-      steps_safety_questions_address_confidentiality_form:
-        address_confidentiality_html: "Do you want to keep your contact details private from the other people named in the application (the respondents)?"
       steps_abduction_passport_details_form:
         children_multiple_passports_html: "Do the children have more than one passport?"
         passport_possesion_html: "Who is in possession of the children’s passports?"
@@ -1222,11 +1219,6 @@ en:
       steps_children_personal_details_form:
         dob_unknown_html: ""
         gender: Sex
-      steps_children_orders_form:
-        orders_html: ""
-      steps_children_residence_form:
-        person_ids_html: ""
-        other_html: ""
       steps_children_additional_details_form:
         children_known_to_authorities: Are any of the children known to social services?
         children_protection_plan: Are any of the children the subject of a child protection plan?
@@ -1512,6 +1504,8 @@ en:
           A child protection plan is prepared by a local authority where a child is thought to be at risk of significant harm. It sets out steps to be taken to protect the child and support the family
       steps_children_residence_form:
         person_ids_html: Select all that apply
+      steps_children_orders_form:
+        orders_html: Select all that apply
       steps_other_parties_personal_details_form:
         has_previous_name: For example, through marriage or adoption or by deed poll. This includes first name, surname and any middle names
         previous_name: *previous_name_hint

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
         female: Female
         male: Male
         unspecified: Unspecified
-      dob_unknown: *dont_know
+      dob_unknown: I don't know their date of birth
       age_estimate: Approximate age or year born
       birthplace: Place of birth
 

--- a/spec/value_objects/petition_order_spec.rb
+++ b/spec/value_objects/petition_order_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe PetitionOrder do
     end
   end
 
+  describe 'CHILD_ARRANGEMENTS_HOME' do
+    it 'returns the expected values' do
+      expect(described_class::CHILD_ARRANGEMENTS_HOME.to_s).to eq('child_arrangements_home')
+    end
+  end
+
+  describe 'CHILD_ARRANGEMENTS_TIME' do
+    it 'returns the expected values' do
+      expect(described_class::CHILD_ARRANGEMENTS_TIME.to_s).to eq('child_arrangements_time')
+    end
+  end
+
   describe 'PROHIBITED_STEPS' do
     it 'returns the expected values' do
       expect(described_class::PROHIBITED_STEPS.map(&:to_s)).to eq(%w(


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/14567208)

Some of the checkboxes don't need legends, so this removes some of the unneccessary yml strings for them. It also adds in legends for checkbox fieldsets that need them.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
