### PR TITLE
Restore brakeman exemption

### DIFF
--- a/app/controllers/bare_application_controller.rb
+++ b/app/controllers/bare_application_controller.rb
@@ -3,8 +3,6 @@ class BareApplicationController < ActionController::Base
   # any special session/cookies handling nor error handling.
   # For any other controller, use `ApplicationController` instead.
 
-  protect_from_forgery with: :exception, prepend: true
-
   rescue_from StandardError do |exception|
     Raven.capture_exception(exception)
     head 500

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,25 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Cross-Site Request Forgery",
+      "warning_code": 7,
+      "fingerprint": "f242fb9c017a95e2e38d907553322a524ca99a62df1307c7d77eedd88122b880",
+      "check_name": "ForgerySetting",
+      "message": "`protect_from_forgery` should be called in `BareApplicationController`",
+      "file": "app/controllers/bare_application_controller.rb",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross-site_request_forgery/",
+      "code": null,
+      "render_path": null,
+      "location": {
+        "type": "controller",
+        "controller": "BareApplicationController"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "note": "No need for a CSRF token as we only use GET endpoints or bearer token."
+    }
+  ],
+  "updated": "2019-03-06 15:58:04 +0000",
+  "brakeman_version": "4.4.0"
+}


### PR DESCRIPTION
## What

The callbacks #notify endpoint receives a POST, and we are authenticating it with a bearer token already, so we don't need the `protect_from_forgery`

The status controller only uses GET endpoints.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.