### PR TITLE
Add a forgery protection test in callbacks controller

### DIFF
--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe CallbacksController, type: :controller do
     let(:cb_double) { double.as_null_object }
 
     context 'unauthorized requests' do
+      it 'does not call forgery protection' do
+        expect(controller).not_to receive(:verify_authenticity_token)
+        post :notify, body: payload
+      end
+
       it 'returns 401 Unauthorized' do
         post :notify, body: payload
         expect(response.status).to eq(401)
@@ -25,6 +30,11 @@ RSpec.describe CallbacksController, type: :controller do
       context 'for a successful callback' do
         before do
           request.content_type = 'application/json'
+        end
+
+        it 'does not call forgery protection' do
+          expect(controller).not_to receive(:verify_authenticity_token)
+          post :notify, body: payload
         end
 
         it 'returns 200 OK' do


### PR DESCRIPTION
## What

It was too easy to break the `#notify` callback endpoint (which receives a POST) just by messing around with the `protect_from_forgery` config.

Ensure we cover this scenario in case it happens again in the future.
This endpoint must not have forgery protection enabled because we are using instead a Bearer token for a custom authentication.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
