### PR TITLE
Textarea date labels

### DIFF
--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -49,10 +49,6 @@ form {
   }
 }
 
-label[for="steps_safety_questions_substance_abuse_details_form_substance_abuse_details"] {
-  color: transparent;
-}
-
 .button-add,
 .button-remove {
   padding-left: 0;

--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -135,16 +135,13 @@ fieldset + .form-group {
   }
 }
 
-// This is a workaround to make the fieldset legends visually hidden, as `govuk_elements_form_builder`
-// doesn't support this in their current version.
-//
-// Update: it turns out, WE NEED labels sometimes, so can't hide all or nothing. Commenting out for now and
-// we might need to revisit PR: https://github.com/ministryofjustice/govuk_elements_form_builder/pull/89
-//
-//fieldset {
-//  legend {
-//    span.form-label-bold {
-//      @extend .visuallyhidden
-//    }
-//  }
-//}
+// This is a workaround to visually hide the top part of the miam certification date legend
+// We need it there for screen reader users, but we need to visually hide it because it 
+// duplicates the header. We need the form hint (which is part of the legend) to still be visible
+// so we can't hide the entire legend
+
+#steps_miam_certification_date_form_miam_certification_date {
+  span.form-label-bold {
+    @extend .visuallyhidden
+  }
+}

--- a/app/views/steps/miam/certification_date/edit.html.erb
+++ b/app/views/steps/miam/certification_date/edit.html.erb
@@ -13,7 +13,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.gov_uk_date_field :miam_certification_date,
                               placeholders: true,
-                              legend_text: nil,
+                              legend_text: t('.heading'),
                               form_hint_text: t('shared.form_elements.certification_date_hint') %>
 
       <%= f.continue_button %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -432,7 +432,7 @@ en:
         edit:
           page_title: Substance abuse details
           section: Safety concerns
-          heading: Provide details of the drug, alcohol or substance abuse
+          heading: Drug, alcohol or substance abuse
       children_abuse:
         edit:
           page_title: Children abuse
@@ -1214,7 +1214,7 @@ en:
           <<: *YESNO
         children_known_to_authorities_details: State which child and the name of the local authority and social worker (if known)
       steps_safety_questions_substance_abuse_details_form:
-        substance_abuse_details: Substance abuse details
+        substance_abuse_details: Give a short description of the drug, alcohol or substance abuse
       steps_abuse_concerns_details_form:
         behaviour_description: Briefly describe what happened and who was involved, if you feel able to
         behaviour_start: When did this behaviour start?
@@ -1352,8 +1352,6 @@ en:
       steps_other_parties_personal_details_form:
         has_previous_name: For example, through marriage or adoption or by deed poll. This includes first name, surname and any middle names
         previous_name: *previous_name_hint
-      steps_safety_questions_substance_abuse_details_form:
-        substance_abuse_details: Give a short description
       steps_abuse_concerns_details_form:
         behaviour_description: This information will be treated sensitively and you’ll have the opportunity to give further details later in the court proceedings if you wish
         behaviour_start: Add an approximate date if you’re unsure


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/14567229)

Two questions had issues with their legends: MIAM Certification Date and Substance Abuse Details. Both were excluded from the previous `<legend>` PRs ([621](https://github.com/ministryofjustice/c100-application/pull/621) and [616](https://github.com/ministryofjustice/c100-application/pull/616)) because they were both a bit more complex. Both had a form hint that would have been hidden by the solution used in that previous PR.

`/steps/miam/certification_date`has now had the question added into the legend. This has been visually hidden by extending the visually hidden class in the CSS using a (grand)child selector, rather than via the HTML.

`steps/safety_questions/substance_abuse_details` has a different solution. The Content Designer Amanda and I have changed it from:

<img width="739" alt="image" src="https://user-images.githubusercontent.com/16868713/54750931-40dd3e00-4bd1-11e9-91c8-b36af066b924.png">

to: 
![image](https://user-images.githubusercontent.com/16868713/54750859-08d5fb00-4bd1-11e9-998e-ad92dba8a81c.png)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
