### PR TITLE
Remove unnecessary code from Google Analytics file

### DIFF
--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -7,10 +7,5 @@
   ga('create', '<%= analytics_tracking_id %>', 'auto');
   ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
-
-  <% if content_for?(:transaction_data) %>
-  ga('require', 'ecommerce');
-  ga('ecommerce:addItem', <%= yield(:transaction_data) %>);
-  ga('ecommerce:send');
-  <% end %>
+  
 </script>


### PR DESCRIPTION
## What

There is some unnecessary code in the Google Analytics script, that was brought over from Tax Tribunal. This isn't needed so this removes it. This is a quick fix for something @zheileman and I noticed whilst working on Google Analytics for Disclosure Checker, so there isn't a ticket for it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
