### PR TITLE
Parametrise the PDF generation

### DIFF
--- a/app/presenters/summary/pdf_presenter.rb
+++ b/app/presenters/summary/pdf_presenter.rb
@@ -1,19 +1,28 @@
 module Summary
   class PdfPresenter
+    DEFAULT_BUNDLE_FORMS ||= [:c100, :c1a, :c8].freeze
+
     attr_reader :c100_application
     attr_reader :pdf_generator
 
-    delegate :to_pdf, to: :pdf_generator
+    delegate :to_pdf, :has_forms_data?, to: :pdf_generator
 
     def initialize(c100_application, generator = C100App::PdfGenerator.new)
       @c100_application = c100_application
       @pdf_generator = generator
     end
 
-    def generate
-      generate_c100_form
-      generate_c1a_form
-      generate_c8_form
+    # Gentle reminder this method does not return anything of value. Its purpose
+    # is to generate one or more forms, which will be bundled together.
+    # Once all the required forms have been generated, it is neccessary to call
+    # the instance method `#to_pdf` to return the final, combined PDF.
+    #
+    def generate(*args)
+      forms = args.presence || DEFAULT_BUNDLE_FORMS
+
+      generate_c100_form if forms.include?(:c100)
+      generate_c1a_form  if forms.include?(:c1a)
+      generate_c8_form   if forms.include?(:c8)
     end
 
     def filename
@@ -31,9 +40,8 @@ module Summary
     def generate_c1a_form
       return unless c100_application.has_safety_concerns?
 
-      pdf_generator.generate(
-        Summary::BlankPage.new(c100_application), copies: 1
-      )
+      add_blank_page_if_needed
+
       pdf_generator.generate(
         Summary::C1aForm.new(c100_application), copies: 1
       )
@@ -42,12 +50,20 @@ module Summary
     def generate_c8_form
       return unless c100_application.confidentiality_enabled?
 
-      pdf_generator.generate(
-        Summary::BlankPage.new(c100_application), copies: 1
-      )
+      add_blank_page_if_needed
+
       pdf_generator.generate(
         Summary::C8Form.new(c100_application), copies: 1
       )
+    end
+
+    # Avoid adding unnecessary blank pages if there are no preceding forms,
+    # for example in the case we are generating individual forms like the C8.
+    #
+    def add_blank_page_if_needed
+      pdf_generator.generate(
+        Summary::BlankPage.new(c100_application), copies: 1
+      ) if has_forms_data?
     end
   end
 end

--- a/app/services/c100_app/pdf_generator.rb
+++ b/app/services/c100_app/pdf_generator.rb
@@ -12,6 +12,10 @@ module C100App
       end
     end
 
+    def has_forms_data?
+      combiner.forms_data.present?
+    end
+
     private
 
     def pdf_from_presenter(presenter)

--- a/spec/presenters/summary/pdf_presenter_spec.rb
+++ b/spec/presenters/summary/pdf_presenter_spec.rb
@@ -10,6 +10,10 @@ describe Summary::PdfPresenter do
   subject { described_class.new(c100_application, generator) }
 
   describe '#generate' do
+    before do
+      allow(generator).to receive(:has_forms_data?).and_return(true)
+    end
+
     it 'generates the C100 form' do
       expect(generator).to receive(:generate).with(
         an_instance_of(Summary::C100Form), copies: 1
@@ -57,12 +61,50 @@ describe Summary::PdfPresenter do
         subject.generate
       end
     end
+
+    context 'customisation of the bundle' do
+      let(:domestic_abuse) { 'yes' }
+      let(:address_confidentiality) { 'yes' }
+
+      it 'generates the C100 and C1A forms, but not the C8 form' do
+        expect(subject).to receive(:generate_c100_form)
+        expect(subject).to receive(:generate_c1a_form)
+        expect(subject).not_to receive(:generate_c8_form)
+
+        subject.generate(:c100, :c1a)
+      end
+
+      context 'blank pages' do
+        before do
+          expect(generator).to receive(:has_forms_data?).and_return(false)
+        end
+
+        it 'does not add unnecessary blank pages when generating individual forms' do
+          expect(generator).to receive(:generate).with(
+            an_instance_of(Summary::C8Form), copies: 1
+          )
+
+          expect(generator).not_to receive(:generate).with(
+            an_instance_of(Summary::BlankPage), copies: 1
+          )
+
+          subject.generate(:c8)
+        end
+      end
+    end
   end
 
   describe '#to_pdf' do
     it 'delegates method to the generator' do
       expect(generator).to receive(:to_pdf)
       subject.to_pdf
+    end
+  end
+
+  describe '#has_forms_data?' do
+    it 'delegates method to the generator' do
+      expect(generator).to receive(:has_forms_data?)
+      subject.has_forms_data?
     end
   end
 

--- a/spec/services/c100_app/pdf_generator_spec.rb
+++ b/spec/services/c100_app/pdf_generator_spec.rb
@@ -75,4 +75,18 @@ RSpec.describe C100App::PdfGenerator do
       subject.to_pdf
     end
   end
+
+  describe '#has_forms_data?' do
+    let(:combiner) { double('Combiner', forms_data: forms_data) }
+
+    context 'there is data in the combiner' do
+      let(:forms_data) { {whatever: 'xyz'} }
+      it { expect(subject.has_forms_data?).to eq(true) }
+    end
+
+    context 'there is no data yet in the combiner' do
+      let(:forms_data) { nil }
+      it { expect(subject.has_forms_data?).to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
We have a requirement to split out the C8 form from the other forms.

This PR prepares for it, making the PDF generation more flexible to allow for different combinations of bundle and individual also forms, for example:

* `#generate` -- will generate the whole bundle (current behaviour)

* `#generate(:c100, :c1a)` -- will generate a bundle with the C100 and C1A (if triggered).

* `#generate(:c8)` -- will generate only the C8 (if triggered)

No breaking changes in this PR. Current behaviour is maintained.

A follow-up PR will continue the necessary work to split the forms in the email to court.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
