### PR TITLE
Split contact details and address into separate forms for only the applicant

### DIFF
--- a/app/controllers/steps/applicant/address_details_controller.rb
+++ b/app/controllers/steps/applicant/address_details_controller.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Applicant
+    class AddressDetailsController < Steps::ApplicantStepController
+      def edit
+        @form_object = AddressDetailsForm.build(
+          current_record, c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(
+          AddressDetailsForm,
+          record: current_record,
+          as: :address_details
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/applicant/address_details_form.rb
+++ b/app/forms/steps/applicant/address_details_form.rb
@@ -1,0 +1,25 @@
+module Steps
+  module Applicant
+    class AddressDetailsForm < BaseForm
+      attribute :address, StrippedString
+      attribute :residence_requirement_met, YesNo
+      attribute :residence_history, String
+
+      validates_presence_of :address
+
+      validates_inclusion_of :residence_requirement_met, in: GenericYesNo.values
+      validates_presence_of  :residence_history, if: -> { residence_requirement_met&.no? }
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        applicant = c100_application.applicants.find_or_initialize_by(id: record_id)
+        applicant.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/applicant/contact_details_form.rb
+++ b/app/forms/steps/applicant/contact_details_form.rb
@@ -1,17 +1,9 @@
 module Steps
   module Applicant
     class ContactDetailsForm < BaseForm
-      attribute :address, StrippedString
       attribute :home_phone, StrippedString
       attribute :mobile_phone, StrippedString
       attribute :email, NormalisedEmail
-      attribute :residence_requirement_met, YesNo
-      attribute :residence_history, String
-
-      validates_presence_of :address
-
-      validates_inclusion_of :residence_requirement_met, in: GenericYesNo.values
-      validates_presence_of  :residence_history, if: -> { residence_requirement_met&.no? }
 
       validates :email, email: true, allow_blank: true
 

--- a/app/presenters/summary/html_sections/applicants_details.rb
+++ b/app/presenters/summary/html_sections/applicants_details.rb
@@ -20,7 +20,7 @@ module Summary
       end
 
       def contact_details_path(person)
-        edit_steps_applicant_contact_details_path(person)
+        edit_steps_applicant_address_details_path(person)
       end
 
       def child_relationship_path(person, child)

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -14,6 +14,8 @@ module C100App
         edit_first_child_relationships
       when :relationship
         children_relationships
+      when :address_details
+        edit_contact_details
       when :contact_details
         after_contact_details
       # TODO: the solicitor details steps are not enabled currently
@@ -25,6 +27,14 @@ module C100App
     end
 
     private
+
+    def children_relationships
+      if next_child_id
+        edit(:relationship, id: record.person, child_id: next_child_id)
+      else
+        edit_address_details
+      end
+    end
 
     def after_contact_details
       if next_applicant_id

--- a/app/services/people_decision_tree.rb
+++ b/app/services/people_decision_tree.rb
@@ -25,6 +25,14 @@ class PeopleDecisionTree < BaseDecisionTree
     end
   end
 
+  def edit_contact_details
+    edit(:contact_details, id: record)
+  end
+
+  def edit_address_details
+    edit(:address_details, id: record.person)
+  end
+
   def next_child_id
     next_record_id(c100_application.minor_ids, current: record.minor)
   end

--- a/app/views/steps/applicant/address_details/edit.html.erb
+++ b/app/views/steps/applicant/address_details/edit.html.erb
@@ -1,0 +1,22 @@
+<% title t('.page_title') %>
+
+ <div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
+
+     <%= step_form @form_object do |f| %>
+        <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
+
+        <%=
+          f.radio_button_fieldset :residence_requirement_met, inline: true do |fieldset|
+            fieldset.radio_input(GenericYesNo::YES)
+            fieldset.radio_input(GenericYesNo::NO) { f.text_area :residence_history, size: '40x4', class: 'form-control-3-4' }
+          end
+        %>
+
+       <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/applicant/contact_details/edit.html.erb
+++ b/app/views/steps/applicant/contact_details/edit.html.erb
@@ -7,15 +7,6 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
-
-      <%=
-        f.radio_button_fieldset :residence_requirement_met, inline: true do |fieldset|
-          fieldset.radio_input(GenericYesNo::YES)
-          fieldset.radio_input(GenericYesNo::NO) { f.text_area :residence_history, size: '40x4', class: 'form-control-3-4' }
-        end
-      %>
-
       <%= f.text_field :home_phone %>
       <%= f.text_field :mobile_phone %>
       <%= f.text_field :email %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,11 @@ en:
       residence_requirement_met:
         <<: *YESNO
 
+    PERSONAL_ADDRESS_FIELDS: &PERSONAL_ADDRESS_FIELDS
+      address: Address
+      residence_requirement_met:
+        <<: *YESNO
+
     # Fields shared in all the split first/last name forms
     NAMES_FORM_FIELDS: &NAMES_FORM_FIELDS
       first_name: First name(s)
@@ -144,6 +149,10 @@ en:
         edit:
           page_title: Applicant contact details
           heading: "Contact details of %{name}"
+      address_details:
+        edit:
+          page_title: Applicant address details
+          heading: "Address details of %{name}"
       relationship:
         edit:
           page_title: Applicant relationship
@@ -1050,7 +1059,7 @@ en:
       steps_applicant_personal_details_form:
         has_previous_name: Have they changed their name?
         gender: Sex
-      steps_applicant_contact_details_form:
+      steps_applicant_address_details_form:
         residence_requirement_met: Have you lived at your current address for more than 5 years?
       steps_respondent_personal_details_form:
         has_previous_name: Have they changed their name?
@@ -1192,6 +1201,8 @@ en:
         <<: *PERSONAL_DETAILS_FIELDS
       steps_applicant_contact_details_form:
         <<: *PERSONAL_CONTACT_FIELDS
+      steps_applicant_address_details_form:
+        <<: *PERSONAL_ADDRESS_FIELDS
         residence_history: Provide details and dates of all previous addresses for the last 5 years
       steps_respondent_contact_details_form:
         <<: *PERSONAL_CONTACT_FIELDS
@@ -1321,7 +1332,7 @@ en:
         has_previous_name: For example, through marriage or adoption or by deed poll. This includes first name, surname and any middle names
         previous_name: *previous_name_hint
         birthplace: *birthplace_hint
-      steps_applicant_contact_details_form:
+      steps_applicant_address_details_form:
         address: Enter your full address including postcode
         residence_history: Start with the most recent
       steps_respondent_personal_details_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -345,11 +345,14 @@ en:
         steps/applicant/personal_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
-        steps/applicant/contact_details_form:
+        steps/applicant/address_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
             residence_requirement_met:
               inclusion: Select yes if you’ve lived at the address for more than 5 years
+        steps/applicant/contact_details_form:
+          attributes:
+            <<: *PERSONAL_DETAILS_ERRORS
         steps/respondent/personal_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,6 +195,7 @@ Rails.application.routes.draw do
       crud_step :personal_details, only: [:edit, :update]
       crud_step :under_age,        only: [:edit, :update]
       crud_step :contact_details,  only: [:edit, :update]
+      crud_step :address_details,  only: [:edit, :update]
       edit_step :has_solicitor
       edit_step :relationship, only: [] do
         edit_routes ':id/child/:child_id'

--- a/spec/forms/steps/applicant/address_details_form_spec.rb
+++ b/spec/forms/steps/applicant/address_details_form_spec.rb
@@ -1,26 +1,20 @@
 require 'spec_helper'
 
-RSpec.describe Steps::Applicant::ContactDetailsForm do
+RSpec.describe Steps::Applicant::AddressDetailsForm do
   let(:arguments) { {
     c100_application: c100_application,
     record: record,
     address: address,
-    home_phone: home_phone,
-    mobile_phone: mobile_phone,
-    email: email,
     residence_requirement_met: residence_requirement_met,
     residence_history: residence_history
   } }
 
   let(:c100_application) { instance_double(C100Application, applicants: applicants_collection) }
   let(:applicants_collection) { double('applicants_collection') }
-  let(:applicant) { double('Applicant', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
+  let(:applicant) { double('Applicant', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe9') }
 
   let(:record) { nil }
   let(:address) { 'address' }
-  let(:home_phone) { nil }
-  let(:mobile_phone) { nil }
-  let(:email) { 'test@test.com' }
   let(:residence_requirement_met) { 'no' }
   let(:residence_history) { 'history' }
 
@@ -35,27 +29,46 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
       end
     end
 
-    context 'email validation' do
-      context 'email is not validated if not present' do
-        let(:email) { nil }
-        it { expect(subject).to be_valid }
+    context 'residence_requirement_met' do
+      context 'when attribute is not given' do
+        let(:residence_requirement_met) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:residence_requirement_met]).to_not be_empty
+        end
       end
 
-      context 'email is validated if present' do
-        let(:email) { 'xxx' }
-        it {
-          expect(subject).not_to be_valid
-          expect(subject.errors[:email]).to_not be_empty
-        }
+      context 'when attribute is given and requires residency history' do
+        let(:residence_requirement_met) { 'no' }
+        let(:residence_history) { nil }
+
+        it 'has a validation error on the `residence_history` field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:residence_history]).to_not be_empty
+        end
+      end
+
+      context 'when attribute is given and does not requires residency history' do
+        let(:residence_requirement_met) { 'yes' }
+        let(:residence_history) { nil }
+
+        it 'has no validation errors' do
+          expect(subject).to be_valid
+        end
       end
     end
 
     context 'for valid details' do
       let(:expected_attributes) {
         {
-          home_phone: '',
-          mobile_phone: '',
-          email: 'test@test.com'
+          address: 'address',
+          residence_requirement_met: GenericYesNo::NO,
+          residence_history: 'history'
         }
       }
 
@@ -80,7 +93,7 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
 
         it 'updates the record if it already exists' do
           expect(applicants_collection).to receive(:find_or_initialize_by).with(
-            id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6'
+            id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe9'
           ).and_return(applicant)
 
           expect(applicant).to receive(:update).with(

--- a/spec/presenters/summary/html_sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicants_details_spec.rb
@@ -103,7 +103,7 @@ module Summary
 
         expect(answers[3]).to be_an_instance_of(AnswersGroup)
         expect(answers[3].name).to eq(:person_contact_details)
-        expect(answers[3].change_path).to eq('/steps/applicant/contact_details/uuid-123')
+        expect(answers[3].change_path).to eq('/steps/applicant/address_details/uuid-123')
         expect(answers[3].answers.count).to eq(6)
 
           # personal_details group answers ###

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -86,9 +86,18 @@ RSpec.describe C100App::ApplicantDecisionTree do
     context 'when all child relationships have been edited' do
       let(:child) { double('Child', id: 3) }
 
-      it 'goes to edit the contact details of the current applicant' do
-        expect(subject.destination).to eq(controller: :contact_details, action: :edit, id: applicant)
+      it 'goes to edit the address details of the current applicant' do
+        expect(subject.destination).to eq(controller: :address_details, action: :edit, id: applicant)
       end
+    end
+  end
+
+  context 'when the step is `address_details`' do
+    let(:step_params) {{'address_details' => 'anything'}}
+    let(:record) { double('Applicant', id: 3) }
+
+    it 'goes to edit the contact details of the current applicant' do
+      expect(subject.destination).to eq(controller: :contact_details, action: :edit, id: record)
     end
   end
 
@@ -108,6 +117,7 @@ RSpec.describe C100App::ApplicantDecisionTree do
       it {is_expected.to have_destination('/steps/respondent/names', :edit)}
     end
   end
+
 
   # TODO: the solicitor's details steps are not enabled currently
   # context 'when the step is `has_solicitor`' do


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/15321247)

This first PR will separate only contact details and address into separate forms only for applicant.  There will be other PRs for respondents, other parties and check your answers to separate contact details and address details form.

For now, only C100 Application records with version greater than 3 will have the splitting of the contact details and address forms enabled. This will allow us to release this in a controlled way as we need to ensure backward compatibility with existing saved applications in the database.

For testing purposes, in local, an ENV variable named SPLIT_ADDRESS can be set (to any value) to enable the splitting of the applicant contact and address forms regardless of the version.

The address details form does not save anything at the moment, this will come as another PR at a later note.  Also the design of the address form isn't 100% on point.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
