### PR TITLE
split contact details and address into separate forms for the respondent

### DIFF
--- a/app/controllers/steps/respondent/address_details_controller.rb
+++ b/app/controllers/steps/respondent/address_details_controller.rb
@@ -1,6 +1,6 @@
 module Steps
-  module Applicant
-    class AddressDetailsController < Steps::RespondentStepController
+  module Respondent
+    class AddressDetailsController < Steps::ApplicantStepController
       def edit
         @form_object = AddressDetailsForm.build(
           current_record, c100_application: current_c100_application

--- a/app/forms/steps/respondent/address_details_form.rb
+++ b/app/forms/steps/respondent/address_details_form.rb
@@ -1,0 +1,26 @@
+module Steps
+  module Respondent
+    class AddressDetailsForm < BaseForm
+      attribute :address, StrippedString
+      attribute :address_unknown, Boolean
+      attribute :residence_requirement_met, YesNoUnknown
+      attribute :residence_history, String
+
+      validates_presence_of :address, unless: :address_unknown?
+
+      validates_inclusion_of :residence_requirement_met, in: GenericYesNoUnknown.values
+      validates_presence_of  :residence_history, if: -> { residence_requirement_met&.no? }
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        respondent = c100_application.respondents.find_or_initialize_by(id: record_id)
+        respondent.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/respondent/contact_details_form.rb
+++ b/app/forms/steps/respondent/contact_details_form.rb
@@ -1,18 +1,9 @@
 module Steps
   module Respondent
     class ContactDetailsForm < BaseForm
-      attribute :address, StrippedString
-      attribute :address_unknown, Boolean
       attribute :home_phone, StrippedString
       attribute :mobile_phone, StrippedString
       attribute :email, NormalisedEmail
-      attribute :residence_requirement_met, YesNoUnknown
-      attribute :residence_history, String
-
-      validates_presence_of :address, unless: :address_unknown?
-
-      validates_inclusion_of :residence_requirement_met, in: GenericYesNoUnknown.values
-      validates_presence_of  :residence_history, if: -> { residence_requirement_met&.no? }
 
       validates :email, email: true, allow_blank: true
 

--- a/app/presenters/summary/html_sections/respondents_details.rb
+++ b/app/presenters/summary/html_sections/respondents_details.rb
@@ -20,7 +20,7 @@ module Summary
       end
 
       def contact_details_path(person)
-        edit_steps_respondent_contact_details_path(person)
+        edit_steps_respondent_address_details_path(person)
       end
 
       def child_relationship_path(person, child)

--- a/app/services/c100_app/respondent_decision_tree.rb
+++ b/app/services/c100_app/respondent_decision_tree.rb
@@ -14,6 +14,8 @@ module C100App
         edit_first_child_relationships
       when :relationship
         children_relationships
+      when :address_details
+        edit_contact_details
       when :contact_details
         after_contact_details
       when :has_other_parties
@@ -24,6 +26,14 @@ module C100App
     end
 
     private
+
+    def children_relationships
+      if next_child_id
+        edit(:relationship, id: record.person, child_id: next_child_id)
+      else
+        edit_address_details
+      end
+    end
 
     def after_contact_details
       if next_respondent_id

--- a/app/views/steps/respondent/address_details/edit.html.erb
+++ b/app/views/steps/respondent/address_details/edit.html.erb
@@ -1,0 +1,28 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
+
+    <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
+      <p><%=t '.body_info' %></p>
+    </div>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.single_check_box :address_unknown, class: 'util_mb-large dont-know' %>
+
+      <%=
+        f.radio_button_fieldset :residence_requirement_met, inline: true do |fieldset|
+          fieldset.radio_input GenericYesNoUnknown::YES
+          fieldset.radio_input GenericYesNoUnknown::NO, panel_id: :residence_history_panel
+          fieldset.radio_input GenericYesNoUnknown::UNKNOWN
+          fieldset.revealing_panel(:residence_history_panel) { |panel| panel.text_area :residence_history, size: '40x4', class: 'form-control-3-4' }
+        end
+      %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/respondent/contact_details/edit.html.erb
+++ b/app/views/steps/respondent/contact_details/edit.html.erb
@@ -11,17 +11,6 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
-      <%= f.single_check_box :address_unknown, class: 'util_mb-large dont-know' %>
-
-      <%=
-        f.radio_button_fieldset :residence_requirement_met, inline: true do |fieldset|
-          fieldset.radio_input GenericYesNoUnknown::YES
-          fieldset.radio_input GenericYesNoUnknown::NO, panel_id: :residence_history_panel
-          fieldset.radio_input GenericYesNoUnknown::UNKNOWN
-          fieldset.revealing_panel(:residence_history_panel) { |panel| panel.text_area :residence_history, size: '40x4', class: 'form-control-3-4' }
-        end
-      %>
 
       <%= f.text_field :home_phone %>
       <%= f.text_field :mobile_phone %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,6 +187,11 @@ en:
           page_title: Respondent contact details
           heading: "Contact details of %{name}"
           body_info: Include as much detail as you can. This will help us process your application more quickly.
+      address_details:
+        edit:
+          page_title: Respondent address details
+          heading: "Address details of %{name}"
+          body_info: Include as much detail as you can. This will help us process your application more quickly.
       has_other_parties:
         edit:
           page_title: Other parties who should know about the application
@@ -1065,7 +1070,7 @@ en:
         has_previous_name: Have they changed their name?
         gender: Sex
         dob_unknown_html: ""
-      steps_respondent_contact_details_form:
+      steps_respondent_address_details_form:
         residence_requirement_met: Have they lived at this address for more than 5 years?
       steps_children_personal_details_form:
         dob_unknown_html: ""
@@ -1206,6 +1211,8 @@ en:
         residence_history: Provide details and dates of all previous addresses for the last 5 years
       steps_respondent_contact_details_form:
         <<: *PERSONAL_CONTACT_FIELDS
+      steps_respondent_address_details_form:
+        <<: *PERSONAL_ADDRESS_FIELDS
         residence_history: Please provide details of all previous addresses for the last 5 years below (if known, including the dates and starting with the most recent)
       steps_other_children_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
@@ -1339,7 +1346,7 @@ en:
         has_previous_name: For example, through marriage or adoption or by deed poll. This includes first name, surname and any middle names
         previous_name: *previous_name_hint
         birthplace: *birthplace_hint
-      steps_respondent_contact_details_form:
+      steps_respondent_address_details_form:
         address: *address_hint
       steps_other_parties_contact_details_form:
         address: *address_hint

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -359,6 +359,9 @@ en:
         steps/respondent/contact_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
+        steps/respondent/address_details_form:
+          attributes:
+            <<: *PERSONAL_DETAILS_ERRORS
             residence_requirement_met:
               inclusion: Select yes if they’ve lived at the address for more than 5 years
         steps/children/personal_details_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,6 +210,7 @@ Rails.application.routes.draw do
       crud_step :personal_details, only: [:edit, :update]
       crud_step :under_age,        only: [:edit, :update]
       crud_step :contact_details,  only: [:edit, :update]
+      crud_step :address_details,  only: [:edit, :update]
       edit_step :has_other_parties
       edit_step :relationship, only: [] do
         edit_routes ':id/child/:child_id'

--- a/spec/forms/steps/respondent/address_details_form_spec.rb
+++ b/spec/forms/steps/respondent/address_details_form_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Respondent::AddressDetailsForm do
+    let(:arguments) { {
+    c100_application: c100_application,
+    record: record,
+    address: address,
+    address_unknown: address_unknown,
+    residence_requirement_met: residence_requirement_met,
+    residence_history: residence_history
+  } }
+
+  let(:c100_application) { instance_double(C100Application, respondents: respondents_collection) }
+  let(:respondents_collection) { double('respondents_collection') }
+  let(:respondent) { double('Respondent', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe9') }
+
+  let(:record) { nil }
+  let(:address) { 'address' }
+  let(:address_unknown) { false }
+  let(:residence_requirement_met) { 'no' }
+  let(:residence_history) { 'history' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'residence_requirement_met' do
+      context 'when attribute is not given' do
+        let(:residence_requirement_met) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:residence_requirement_met]).to_not be_empty
+        end
+      end
+
+      context 'when attribute is given and requires residency history' do
+        let(:residence_requirement_met) { 'no' }
+        let(:residence_history) { nil }
+
+        it 'has a validation error on the `residence_history` field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:residence_history]).to_not be_empty
+        end
+      end
+
+      context 'when attribute is given and does not requires residency history' do
+        let(:residence_requirement_met) { 'yes' }
+        let(:residence_history) { nil }
+
+        it 'has no validation errors' do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    context 'validations on field presence unless `unknown`' do
+      it { should validate_presence_unless_unknown_of(:address) }
+    end
+
+
+    context 'for valid details' do
+      let(:expected_attributes) {
+        {
+          address: 'address',
+          address_unknown: false,
+          residence_requirement_met: GenericYesNoUnknown::NO,
+          residence_history: 'history'
+        }
+      }
+
+      context 'when record does not exist' do
+        let(:record) { nil }
+
+        it 'creates the record if it does not exist' do
+          expect(respondents_collection).to receive(:find_or_initialize_by).with(
+            id: nil
+          ).and_return(respondent)
+
+          expect(respondent).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when record already exists' do
+        let(:record) { respondent }
+
+        it 'updates the record if it already exists' do
+          expect(respondents_collection).to receive(:find_or_initialize_by).with(
+            id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe9'
+          ).and_return(respondent)
+
+          expect(respondent).to receive(:update).with(
+            expected_attributes
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/respondent/contact_details_form_spec.rb
+++ b/spec/forms/steps/respondent/contact_details_form_spec.rb
@@ -4,13 +4,9 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
   let(:arguments) { {
     c100_application: c100_application,
     record: record,
-    address: address,
-    address_unknown: address_unknown,
     home_phone: home_phone,
     mobile_phone: mobile_phone,
-    email: email,
-    residence_requirement_met: residence_requirement_met,
-    residence_history: residence_history
+    email: email
   } }
 
   let(:c100_application) { instance_double(C100Application, respondents: respondents_collection) }
@@ -18,13 +14,9 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
   let(:respondent) { double('Respondent', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
 
   let(:record) { nil }
-  let(:address) { 'address' }
-  let(:address_unknown) { false }
   let(:home_phone) { nil }
   let(:mobile_phone) { nil }
   let(:email) { 'test@test.com' }
-  let(:residence_requirement_met) { 'no' }
-  let(:residence_history) { 'history' }
 
   subject { described_class.new(arguments) }
 
@@ -35,44 +27,6 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
       it 'raises an error' do
         expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
       end
-    end
-
-    context 'residence_requirement_met' do
-      context 'when attribute is not given' do
-        let(:residence_requirement_met) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:residence_requirement_met]).to_not be_empty
-        end
-      end
-
-      context 'when attribute is given and requires residency history' do
-        let(:residence_requirement_met) { 'no' }
-        let(:residence_history) { nil }
-
-        it 'has a validation error on the `residence_history` field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:residence_history]).to_not be_empty
-        end
-      end
-
-      context 'when attribute is given and does not requires residency history' do
-        let(:residence_requirement_met) { 'yes' }
-        let(:residence_history) { nil }
-
-        it 'has no validation errors' do
-          expect(subject).to be_valid
-        end
-      end
-    end
-
-    context 'validations on field presence unless `unknown`' do
-      it { should validate_presence_unless_unknown_of(:address) }
     end
 
     context 'email validation' do
@@ -93,13 +47,9 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
     context 'for valid details' do
       let(:expected_attributes) {
         {
-          address: 'address',
-          address_unknown: false,
           home_phone: '',
           mobile_phone: '',
-          email: 'test@test.com',
-          residence_requirement_met: GenericYesNoUnknown::NO,
-          residence_history: 'history'
+          email: 'test@test.com'
         }
       }
 

--- a/spec/presenters/summary/html_sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/html_sections/respondents_details_spec.rb
@@ -103,7 +103,7 @@ module Summary
 
         expect(answers[3]).to be_an_instance_of(AnswersGroup)
         expect(answers[3].name).to eq(:person_contact_details)
-        expect(answers[3].change_path).to eq('/steps/respondent/contact_details/uuid-123')
+        expect(answers[3].change_path).to eq('/steps/respondent/address_details/uuid-123')
         expect(answers[3].answers.count).to eq(6)
 
           # personal_details group answers ###

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -103,8 +103,18 @@ RSpec.describe C100App::RespondentDecisionTree do
       let(:child) { double('Child', id: 3) }
 
       it 'goes to edit the contact details of the current respondent' do
-        expect(subject.destination).to eq(controller: :contact_details, action: :edit, id: respondent)
+        expect(subject.destination).to eq(controller: :address_details, action: :edit, id: respondent)
       end
+    end
+  end
+
+
+  context 'when the step is `address_details`' do
+    let(:step_params) {{'address_details' => 'anything'}}
+    let(:record) { double('Respondent', id: 3) }
+
+    it 'goes to edit the contact details of the current applicant' do
+      expect(subject.destination).to eq(controller: :contact_details, action: :edit, id: record)
     end
   end
 


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/15321247)

Split contact details form into two separate form one for address details another for contact details for the respondent, the same as i have done for the applicant in PR[#60](https://github.com/ministryofjustice/c100-application/pull/640)
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
