### PR TITLE
Split contact details block in check your answers into two blocks

### DIFF
--- a/app/presenters/summary/html_sections/applicants_details.rb
+++ b/app/presenters/summary/html_sections/applicants_details.rb
@@ -20,6 +20,10 @@ module Summary
       end
 
       def contact_details_path(person)
+        edit_steps_applicant_contact_details_path(person)
+      end
+
+      def address_details_path(person)
         edit_steps_applicant_address_details_path(person)
       end
 

--- a/app/presenters/summary/html_sections/other_parties_details.rb
+++ b/app/presenters/summary/html_sections/other_parties_details.rb
@@ -30,6 +30,11 @@ module Summary
         edit_steps_other_parties_personal_details_path(person)
       end
 
+      # Other parties do not have a contact details step
+      def contact_details_path(_person)
+        nil
+      end
+
       def address_details_path(person)
         edit_steps_other_parties_address_details_path(person)
       end

--- a/app/presenters/summary/html_sections/other_parties_details.rb
+++ b/app/presenters/summary/html_sections/other_parties_details.rb
@@ -30,7 +30,7 @@ module Summary
         edit_steps_other_parties_personal_details_path(person)
       end
 
-      def contact_details_path(person)
+      def address_details_path(person)
         edit_steps_other_parties_address_details_path(person)
       end
 

--- a/app/presenters/summary/html_sections/people_details.rb
+++ b/app/presenters/summary/html_sections/people_details.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 module Summary
   module HtmlSections
     class PeopleDetails < Sections::BaseSectionPresenter
@@ -18,6 +19,10 @@ module Summary
         raise 'must be implemented in subclasses'
       end
 
+      def address_details_path(*)
+        raise 'must be implemented in subclasses'
+      end
+
       def child_relationship_path(*)
         raise 'must be implemented in subclasses'
       end
@@ -33,11 +38,7 @@ module Summary
               personal_details_questions(person),
               change_path: personal_details_path(person)
             ),
-            AnswersGroup.new(
-              :person_contact_details,
-              contact_details_questions(person),
-              change_path: contact_details_path(person)
-            ),
+            person_address_contact_details_answers_groups(person),
             children_relationships(person),
           ]
         end.flatten.select(&:show?)
@@ -57,12 +58,17 @@ module Summary
 
       def contact_details_questions(person)
         [
-          FreeTextAnswer.new(:person_address, person.address, show: true),
-          Answer.new(:person_residence_requirement_met, person.residence_requirement_met),
-          FreeTextAnswer.new(:person_residence_history, person.residence_history),
           FreeTextAnswer.new(:person_home_phone, person.home_phone),
           FreeTextAnswer.new(:person_mobile_phone, person.mobile_phone),
           FreeTextAnswer.new(:person_email, person.email),
+        ]
+      end
+
+      def address_details_questions(person)
+        [
+          FreeTextAnswer.new(:person_address, person.address, show: true),
+          Answer.new(:person_residence_requirement_met, person.residence_requirement_met),
+          FreeTextAnswer.new(:person_residence_history, person.residence_history)
         ]
       end
 
@@ -72,6 +78,30 @@ module Summary
         else
           Answer.new(:person_previous_name, person.has_previous_name)
         end
+      end
+
+      def person_address_contact_details_answers_groups(person)
+        return person_address_details_answers_group(person) if person.class.name == "OtherParty"
+        [
+          person_address_details_answers_group(person),
+          person_contact_details_answers_group(person)
+        ]
+      end
+
+      def person_address_details_answers_group(person)
+        AnswersGroup.new(
+          :person_address_details,
+          address_details_questions(person),
+          change_path: address_details_path(person)
+        )
+      end
+
+      def person_contact_details_answers_group(person)
+        AnswersGroup.new(
+          :person_contact_details,
+          contact_details_questions(person),
+          change_path: contact_details_path(person)
+        )
       end
 
       def children_relationships(person)
@@ -95,3 +125,4 @@ module Summary
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/presenters/summary/html_sections/people_details.rb
+++ b/app/presenters/summary/html_sections/people_details.rb
@@ -33,14 +33,11 @@ module Summary
           [
             Separator.new("#{name}_index_title", index: index),
             FreeTextAnswer.new(:person_full_name, person.full_name, change_path: names_path),
-            AnswersGroup.new(
-              :person_personal_details,
-              personal_details_questions(person),
-              change_path: personal_details_path(person)
-            ),
-            person_address_contact_details_answers_groups(person),
+            person_personal_details_answers_group(person),
+            person_address_details_answers_group(person),
+            person_contact_details_answers_group(person),
             children_relationships(person),
-          ]
+          ].compact
         end.flatten.select(&:show?)
       end
 
@@ -80,12 +77,12 @@ module Summary
         end
       end
 
-      def person_address_contact_details_answers_groups(person)
-        return person_address_details_answers_group(person) if person.class.name == "OtherParty"
-        [
-          person_address_details_answers_group(person),
-          person_contact_details_answers_group(person)
-        ]
+      def person_personal_details_answers_group(person)
+        AnswersGroup.new(
+          :person_personal_details,
+          personal_details_questions(person),
+          change_path: personal_details_path(person)
+        )
       end
 
       def person_address_details_answers_group(person)
@@ -97,6 +94,8 @@ module Summary
       end
 
       def person_contact_details_answers_group(person)
+        return unless contact_details_path(person)
+
         AnswersGroup.new(
           :person_contact_details,
           contact_details_questions(person),

--- a/app/presenters/summary/html_sections/respondents_details.rb
+++ b/app/presenters/summary/html_sections/respondents_details.rb
@@ -20,6 +20,10 @@ module Summary
       end
 
       def contact_details_path(person)
+        edit_steps_respondent_contact_details_path(person)
+      end
+
+      def address_details_path(person)
         edit_steps_respondent_address_details_path(person)
       end
 

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -98,6 +98,7 @@ en:
       protection_orders: Is there anything else you are asking the court to decide, specifically to protect the safety of you or the children?
       person_personal_details: Personal details
       person_contact_details: Contact details
+      person_address_details: Address details
       other_court_cases_details: Other proceedings details
       urgent_hearing_details: Urgent hearing details
       without_notice_hearing_details: Without notice hearing details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
 
     # This is a compilation of all possible fields shared between Applicants and Respondents (maybe others later)
     PERSONAL_CONTACT_FIELDS: &PERSONAL_CONTACT_FIELDS
-      address: Address
+      address: Current Address
       address_unknown: I don’t know where they currently live
       home_phone: Home phone
       mobile_phone: Mobile phone
@@ -88,7 +88,7 @@ en:
         <<: *YESNO
 
     PERSONAL_ADDRESS_FIELDS: &PERSONAL_ADDRESS_FIELDS
-      address: Address
+      address: Current Address
       residence_requirement_met:
         <<: *YESNO
 
@@ -186,12 +186,12 @@ en:
         edit:
           page_title: Respondent contact details
           heading: "Contact details of %{name}"
-          body_info: Include as much detail as you can. This will help us process your application more quickly.
+          body_info: Include as much detail as you can. If there’s information missing, your application may take longer to process.
       address_details:
         edit:
           page_title: Respondent address details
           heading: "Address details of %{name}"
-          body_info: Include as much detail as you can. This will help us process your application more quickly.
+          body_info: Include as much detail as you can. If there’s information missing, your application may take longer to process.
       has_other_parties:
         edit:
           page_title: Other parties who should know about the application
@@ -1438,7 +1438,7 @@ en:
       hide_password: Hide password
     form_elements:
       dob: Date of birth
-      dob_hint: For example, 31 3 1980
+      dob_hint: For example, 31 3 1980. If you don’t know their date of birth, your application may take longer to process
       dob_child_hint: For example, 31 3 2010
       order_issue: What date was it made?
       order_issue_hint: For example, 31 3 2015

--- a/spec/presenters/summary/html_sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicants_details_spec.rb
@@ -64,7 +64,7 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(5)
+        expect(answers.count).to eq(6)
       end
 
       it 'has the correct rows in the right order' do
@@ -101,10 +101,15 @@ module Summary
           expect(details[3].question).to eq(:person_birthplace)
           expect(details[3].value).to eq('birthplace')
 
-        expect(answers[3]).to be_an_instance_of(AnswersGroup)
-        expect(answers[3].name).to eq(:person_contact_details)
-        expect(answers[3].change_path).to eq('/steps/applicant/address_details/uuid-123')
-        expect(answers[3].answers.count).to eq(6)
+          expect(answers[3]).to be_an_instance_of(AnswersGroup)
+          expect(answers[3].name).to eq(:person_address_details)
+          expect(answers[3].change_path).to eq('/steps/applicant/address_details/uuid-123')
+          expect(answers[3].answers.count).to eq(3)
+
+          # expect(answers[3]).to be_an_instance_of(AnswersGroup)
+          # expect(answers[3].name).to eq(:person_contact_details)
+          # expect(answers[3].change_path).to eq('/steps/applicant/contact_details/uuid-123')
+          # expect(answers[3].answers.count).to eq(3)
 
           # personal_details group answers ###
           details = answers[3].answers
@@ -121,23 +126,30 @@ module Summary
           expect(details[2].question).to eq(:person_residence_history)
           expect(details[2].value).to eq('history')
 
-          expect(details[3]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[3].question).to eq(:person_home_phone)
-          expect(details[3].value).to eq('home_phone')
+        expect(answers[4]).to be_an_instance_of(AnswersGroup)
+        expect(answers[4].name).to eq(:person_contact_details)
+        expect(answers[4].change_path).to eq('/steps/applicant/contact_details/uuid-123')
+        expect(answers[4].answers.count).to eq(3)
 
-          expect(details[4]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[4].question).to eq(:person_mobile_phone)
-          expect(details[4].value).to eq('mobile_phone')
+          details = answers[4].answers
 
-          expect(details[5]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[5].question).to eq(:person_email)
-          expect(details[5].value).to eq('email')
+          expect(details[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[0].question).to eq(:person_home_phone)
+          expect(details[0].value).to eq('home_phone')
 
-        expect(answers[4]).to be_an_instance_of(Answer)
-        expect(answers[4].question).to eq(:relationship_to_child)
-        expect(answers[4].change_path).to eq('/steps/applicant/relationship/uuid-123/child/uuid-555')
-        expect(answers[4].value).to eq('mother')
-        expect(answers[4].i18n_opts).to eq({child_name: 'Child Test'})
+          expect(details[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[1].question).to eq(:person_mobile_phone)
+          expect(details[1].value).to eq('mobile_phone')
+
+          expect(details[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[2].question).to eq(:person_email)
+          expect(details[2].value).to eq('email')
+
+        expect(answers[5]).to be_an_instance_of(Answer)
+        expect(answers[5].question).to eq(:relationship_to_child)
+        expect(answers[5].change_path).to eq('/steps/applicant/relationship/uuid-123/child/uuid-555')
+        expect(answers[5].value).to eq('mother')
+        expect(answers[5].i18n_opts).to eq({child_name: 'Child Test'})
       end
 
       context 'for existing previous name' do
@@ -145,7 +157,7 @@ module Summary
         let(:previous_name) { 'previous_name' }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(5)
+          expect(answers.count).to eq(6)
         end
 
         it 'renders the previous name' do
@@ -169,15 +181,15 @@ module Summary
         }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(5)
+          expect(answers.count).to eq(6)
         end
 
         it 'renders the correct relationship value' do
-          expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[4].question).to eq(:relationship_to_child)
-          expect(answers[4].change_path).to eq('/steps/applicant/relationship/uuid-123/child/uuid-555')
-          expect(answers[4].value).to eq('Aunt')
-          expect(answers[4].i18n_opts).to eq({child_name: 'Child Test'})
+          expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[5].question).to eq(:relationship_to_child)
+          expect(answers[5].change_path).to eq('/steps/applicant/relationship/uuid-123/child/uuid-555')
+          expect(answers[5].value).to eq('Aunt')
+          expect(answers[5].i18n_opts).to eq({child_name: 'Child Test'})
         end
       end
     end

--- a/spec/presenters/summary/html_sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/html_sections/other_parties_details_spec.rb
@@ -30,6 +30,10 @@ module Summary
       )
     }
 
+    before do
+      allow(subject).to receive(:contact_details_path).and_return(false)
+    end
+
     subject { described_class.new(c100_application) }
 
     let(:relationships) {
@@ -101,7 +105,7 @@ module Summary
           expect(details[2].value).to eq(Date.new(2018, 1, 20))
 
         expect(answers[4]).to be_an_instance_of(AnswersGroup)
-        expect(answers[4].name).to eq(:person_contact_details)
+        expect(answers[4].name).to eq(:person_address_details)
         expect(answers[4].change_path).to eq('/steps/other_parties/address_details/uuid-123')
         expect(answers[4].answers.count).to eq(1)
 

--- a/spec/presenters/summary/html_sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/html_sections/respondents_details_spec.rb
@@ -64,7 +64,7 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(5)
+        expect(answers.count).to eq(6)
       end
 
       it 'has the correct rows in the right order' do
@@ -102,9 +102,9 @@ module Summary
           expect(details[3].value).to eq('birthplace')
 
         expect(answers[3]).to be_an_instance_of(AnswersGroup)
-        expect(answers[3].name).to eq(:person_contact_details)
+        expect(answers[3].name).to eq(:person_address_details)
         expect(answers[3].change_path).to eq('/steps/respondent/address_details/uuid-123')
-        expect(answers[3].answers.count).to eq(6)
+        expect(answers[3].answers.count).to eq(3)
 
           # personal_details group answers ###
           details = answers[3].answers
@@ -121,23 +121,30 @@ module Summary
           expect(details[2].question).to eq(:person_residence_history)
           expect(details[2].value).to eq('history')
 
-          expect(details[3]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[3].question).to eq(:person_home_phone)
-          expect(details[3].value).to eq('home_phone')
+        expect(answers[4]).to be_an_instance_of(AnswersGroup)
+        expect(answers[4].name).to eq(:person_contact_details)
+        expect(answers[4].change_path).to eq('/steps/respondent/contact_details/uuid-123')
+        expect(answers[4].answers.count).to eq(3)
 
-          expect(details[4]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[4].question).to eq(:person_mobile_phone)
-          expect(details[4].value).to eq('mobile_phone')
+          details = answers[4].answers
 
-          expect(details[5]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[5].question).to eq(:person_email)
-          expect(details[5].value).to eq('email')
+          expect(details[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[0].question).to eq(:person_home_phone)
+          expect(details[0].value).to eq('home_phone')
 
-        expect(answers[4]).to be_an_instance_of(Answer)
-        expect(answers[4].question).to eq(:relationship_to_child)
-        expect(answers[4].change_path).to eq('/steps/respondent/relationship/uuid-123/child/uuid-555')
-        expect(answers[4].value).to eq('mother')
-        expect(answers[4].i18n_opts).to eq({child_name: 'Child Test'})
+          expect(details[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[1].question).to eq(:person_mobile_phone)
+          expect(details[1].value).to eq('mobile_phone')
+
+          expect(details[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[2].question).to eq(:person_email)
+          expect(details[2].value).to eq('email')
+
+        expect(answers[5]).to be_an_instance_of(Answer)
+        expect(answers[5].question).to eq(:relationship_to_child)
+        expect(answers[5].change_path).to eq('/steps/respondent/relationship/uuid-123/child/uuid-555')
+        expect(answers[5].value).to eq('mother')
+        expect(answers[5].i18n_opts).to eq({child_name: 'Child Test'})
       end
 
       context 'for existing previous name' do
@@ -145,7 +152,7 @@ module Summary
         let(:previous_name) { 'previous_name' }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(5)
+          expect(answers.count).to eq(6)
         end
 
         it 'renders the previous name' do
@@ -169,15 +176,15 @@ module Summary
         }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(5)
+          expect(answers.count).to eq(6)
         end
 
         it 'renders the correct relationship value' do
-          expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[4].question).to eq(:relationship_to_child)
-          expect(answers[4].change_path).to eq('/steps/respondent/relationship/uuid-123/child/uuid-555')
-          expect(answers[4].value).to eq('Aunt')
-          expect(answers[4].i18n_opts).to eq({child_name: 'Child Test'})
+          expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[5].question).to eq(:relationship_to_child)
+          expect(answers[5].change_path).to eq('/steps/respondent/relationship/uuid-123/child/uuid-555')
+          expect(answers[5].value).to eq('Aunt')
+          expect(answers[5].i18n_opts).to eq({child_name: 'Child Test'})
         end
       end
     end


### PR DESCRIPTION
## What
[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/15321247)

I have split contact details block in check your answers into two separate blocks (address details and  
contact details)

<img width="1019" alt="Screen Shot 2019-04-30 at 11 34 04" src="https://user-images.githubusercontent.com/22822829/56956397-f047f180-6b3b-11e9-81dc-9fe4396b132d.png">

Also made a few small text changes from this [ticket](https://mojdigital.teamwork.com/index.cfm#/tasks/15321257)
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
