### PR TITLE
Prepare for C8 form split in court email

### DIFF
--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -9,7 +9,7 @@ class NotifySubmissionMailer < NotifyMailer
 
   before_action do
     @c100_application = params[:c100_application]
-    @c100_pdf = params[:c100_pdf]
+    @documents = params[:documents]
   end
 
   #
@@ -54,7 +54,7 @@ class NotifySubmissionMailer < NotifyMailer
     {
       applicant_name: @c100_application.applicants.first&.full_name || '[name not entered]',
       reference_code: @c100_application.reference_code,
-      link_to_pdf: Notifications.prepare_upload(@c100_pdf),
+      link_to_pdf: Notifications.prepare_upload(@documents[:bundle]), # TODO: split for court and applicant
     }
   end
 

--- a/app/services/base_online_submission.rb
+++ b/app/services/base_online_submission.rb
@@ -1,0 +1,50 @@
+class BaseOnlineSubmission
+  attr_reader :c100_application
+  attr_reader :documents
+
+  def initialize(c100_application)
+    @c100_application = c100_application
+    @documents = {}
+  end
+
+  # :nocov:
+  def to_address
+    raise 'implement in subclasses'
+  end
+  # :nocov:
+
+  # Any exception in this method will bubble up to the Job classes
+  # :nocov:
+  def process
+    raise 'implement in subclasses'
+  end
+  # :nocov:
+
+  private
+
+  def generate_pdf(*args)
+    presenter = Summary::PdfPresenter.new(c100_application)
+    presenter.generate(*args)
+
+    StringIO.new(presenter.to_pdf)
+  end
+
+  # :nocov:
+  def generate_documents
+    raise 'implement in subclasses'
+  end
+  # :nocov:
+
+  # :nocov:
+  def deliver_email
+    raise 'implement in subclasses'
+  end
+  # :nocov:
+
+  def application_details
+    {
+      c100_application: c100_application,
+      documents: documents,
+    }
+  end
+end

--- a/app/services/c100_app/applicant_online_submission.rb
+++ b/app/services/c100_app/applicant_online_submission.rb
@@ -1,28 +1,19 @@
 module C100App
-  class ApplicantOnlineSubmission
-    attr_reader :c100_application
-    attr_reader :pdf_content
-
-    def initialize(c100_application)
-      @c100_application = c100_application
+  class ApplicantOnlineSubmission < BaseOnlineSubmission
+    def process
+      generate_documents && deliver_email && audit_data
     end
 
     def to_address
       c100_application.receipt_email
     end
 
-    # Any exception in this method will bubble up to the Job classes
-    def process
-      generate_pdf && deliver_email && audit_data
-    end
-
     private
 
-    def generate_pdf
-      presenter = Summary::PdfPresenter.new(c100_application)
-      presenter.generate
-
-      @pdf_content = StringIO.new(presenter.to_pdf)
+    def generate_documents
+      documents.store(
+        :bundle, generate_pdf
+      )
     end
 
     def deliver_email
@@ -35,13 +26,6 @@ module C100App
       c100_application.email_submission.update(
         email_copy_to: to_address, user_copy_sent_at: Time.current
       )
-    end
-
-    def application_details
-      {
-        c100_application: c100_application,
-        c100_pdf: pdf_content,
-      }
     end
   end
 end

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       payment_type: payment_type,
     )
   }
-  let(:c100_pdf) { Tempfile.new('test.pdf') }
 
   let(:payment_type) { nil }
   let(:court) {
@@ -30,17 +29,17 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       application_submitted_to_user: 'application_submitted_to_user_template_id',
     )
 
-    allow(c100_pdf).to receive(:read).and_return('file content')
-
     allow(I18n).to receive(:translate!).with('service.name').and_return(
       'Apply to court about child arrangements'
     )
   end
 
   describe '#application_to_court' do
+    let(:documents) { {bundle: StringIO.new('bundle pdf')} }
+
     let(:mail) {
       described_class.with(
-        c100_application: c100_application, c100_pdf: c100_pdf
+        c100_application: c100_application, documents: documents
       ).application_to_court(to_address: 'court@example.com')
     }
 
@@ -60,7 +59,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         reference_code: '1970/01/4A362E1C',
         urgent: 'yes',
         c8_included: 'no',
-        link_to_pdf: { file: 'ZmlsZSBjb250ZW50' },
+        link_to_pdf: { file: 'YnVuZGxlIHBkZg==' },
       })
     end
   end
@@ -74,9 +73,11 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       ).and_return('payment instructions from locales')
     end
 
+    let(:documents) { {bundle: StringIO.new('bundle pdf')} }
+
     let(:mail) {
       described_class.with(
-        c100_application: c100_application, c100_pdf: c100_pdf
+        c100_application: c100_application, documents: documents
       ).application_to_user(to_address: 'user@example.com')
     }
 
@@ -98,7 +99,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         court_email: 'court@example.com',
         court_url: 'https://courttribunalfinder.service.gov.uk/courts/test-court',
         payment_instructions: 'payment instructions from locales',
-        link_to_pdf: { file: 'ZmlsZSBjb250ZW50' },
+        link_to_pdf: { file: 'YnVuZGxlIHBkZg==' },
       })
     end
 

--- a/spec/services/c100_app/applicant_online_submission_spec.rb
+++ b/spec/services/c100_app/applicant_online_submission_spec.rb
@@ -17,16 +17,16 @@ RSpec.describe C100App::ApplicantOnlineSubmission do
       allow(Summary::PdfPresenter).to receive(:new).with(c100_application).and_return(pdf_presenter)
     end
 
-    context '#generate_pdf' do
+    context '#generate_documents' do
       before do
         allow(subject).to receive(:deliver_email) # do not care here about the email
       end
 
       it 'generates the PDF' do
-        expect(pdf_presenter).to receive(:generate)
+        expect(pdf_presenter).to receive(:generate).with(no_args)
         subject.process
-        expect(subject.pdf_content).to be_a(StringIO)
-        expect(subject.pdf_content.read).to eq('pdf content')
+
+        expect(subject.documents.size).to eq(1)
       end
     end
 
@@ -35,7 +35,7 @@ RSpec.describe C100App::ApplicantOnlineSubmission do
 
       before do
         allow(NotifySubmissionMailer).to receive(:with).with(
-          c100_application: c100_application, c100_pdf: kind_of(StringIO)
+          c100_application: c100_application, documents: { bundle: kind_of(StringIO) }
         ).and_return(mailer)
       end
 

--- a/spec/services/c100_app/court_online_submission_spec.rb
+++ b/spec/services/c100_app/court_online_submission_spec.rb
@@ -18,16 +18,16 @@ RSpec.describe C100App::CourtOnlineSubmission do
       allow(Summary::PdfPresenter).to receive(:new).with(c100_application).and_return(pdf_presenter)
     end
 
-    context '#generate_pdf' do
+    context '#generate_documents' do
       before do
         allow(subject).to receive(:deliver_email) # do not care here about the email
       end
 
       it 'generates the PDF' do
-        expect(pdf_presenter).to receive(:generate)
+        expect(pdf_presenter).to receive(:generate).with(:c100, :c1a, :c8).ordered
         subject.process
-        expect(subject.pdf_content).to be_a(StringIO)
-        expect(subject.pdf_content.read).to eq('pdf content')
+
+        expect(subject.documents.size).to eq(1)
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe C100App::CourtOnlineSubmission do
 
       before do
         allow(NotifySubmissionMailer).to receive(:with).with(
-          c100_application: c100_application, c100_pdf: kind_of(StringIO)
+          c100_application: c100_application, documents: { bundle: kind_of(StringIO) }
         ).and_return(mailer)
       end
 


### PR DESCRIPTION
Follow-up to #638 and #639.

No breaking changes or new behaviour. Everything still the same, just refactoring and preparing the path for the next PR.

- Allows to send emails that contain more than one document.
- DRY some duplicated code to a superclass `BaseOnlineSubmission`.

As we can't deploy just yet the split of the C8 (target is May 13th), in the next PR we will need to introduce a feature-flag so the split only happens on staging, but not on production environments.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.