### PR TITLE
Split C8 form to court (with feature flag)

### DIFF
--- a/app/services/base_online_submission.rb
+++ b/app/services/base_online_submission.rb
@@ -47,4 +47,11 @@ class BaseOnlineSubmission
       documents: documents,
     }
   end
+
+  # TODO: temporary feature-flag
+  # :nocov:
+  def enable_c8_split?
+    ENV['SPLIT_C8_FORM'].present? || ENV['DEV_TOOLS_ENABLED'].present?
+  end
+  # :nocov:
 end

--- a/app/services/c100_app/court_online_submission.rb
+++ b/app/services/c100_app/court_online_submission.rb
@@ -11,13 +11,13 @@ module C100App
     private
 
     def generate_documents
-      documents.store(
-        :bundle, generate_pdf(:c100, :c1a, :c8)
-      )
-      # TODO: in a follow-up PR we will split the C8 form
-      # documents.store(
-      #   :c8_form, generate_pdf(:c8)
-      # )
+      if enable_c8_split?
+        documents.store(:bundle, generate_pdf(:c100, :c1a))
+        documents.store(:c8_form, generate_pdf(:c8))
+      else
+        # Generates all 3 forms in a single bundle
+        documents.store(:bundle, generate_pdf)
+      end
     end
 
     def deliver_email

--- a/app/services/c100_app/pdf_generator.rb
+++ b/app/services/c100_app/pdf_generator.rb
@@ -1,7 +1,5 @@
 module C100App
   class PdfGenerator
-    delegate :to_pdf, to: :combiner
-
     def generate(presenter, copies:)
       main_doc = pdf_from_presenter(presenter)
       raw_file = presenter.raw_file_path
@@ -14,6 +12,11 @@ module C100App
 
     def has_forms_data?
       combiner.forms_data.present?
+    end
+
+    def to_pdf
+      return '' unless has_forms_data?
+      combiner.to_pdf
     end
 
     private

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -13,6 +13,7 @@ integration:
   change_password: '97ea3c24-0b40-4b8e-8fc6-a54f7f1718e9'
   application_saved: '1252b250-541c-456a-b98b-c568aef05e5f'
   application_submitted_to_court: '0350031e-df36-42e1-8b97-510795dd9ac9'
+  application_submitted_to_court_new_version: '15f9af65-b9f7-4b0a-a604-6e5982f98009'
   application_submitted_to_user: 'e10806dd-55ae-47ad-a231-757dbb3c9a7e'
   submission_error: 'c99df4a0-5655-4ef8-aaf4-0a5b83397785'
   draft_first_reminder: 'fcd87b1c-a3a0-4a2a-9b4e-524857e3bf8c'

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       created_at: Time.at(0),
       receipt_email: 'receipt@example.com',
       urgent_hearing: 'yes',
-      address_confidentiality: 'no',
+      address_confidentiality: address_confidentiality,
       payment_type: payment_type,
     )
   }
 
   let(:payment_type) { nil }
+  let(:address_confidentiality) { 'no' }
+
   let(:court) {
     double('Court',
       name: 'Test court',
@@ -26,6 +28,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       Rails.configuration
     ).to receive(:govuk_notify_templates).and_return(
       application_submitted_to_court: 'application_submitted_to_court_template_id',
+      application_submitted_to_court_new_version: 'application_submitted_to_court_new_template_id',
       application_submitted_to_user: 'application_submitted_to_user_template_id',
     )
 
@@ -59,8 +62,52 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         reference_code: '1970/01/4A362E1C',
         urgent: 'yes',
         c8_included: 'no',
+        link_to_c8_pdf: '',
         link_to_pdf: { file: 'YnVuZGxlIHBkZg==' },
       })
+    end
+
+    # TODO: temporary feature-flagged condition.
+    context 'when the C8 split is enabled' do
+      let(:documents) { { bundle: StringIO.new('bundle pdf'), c8_form: c8_form } }
+
+      context 'and applicant triggered the `address confidentiality`' do
+        let(:address_confidentiality) { 'yes' }
+        let(:c8_form) { StringIO.new('c8 form') }
+
+        it 'has the right template id' do
+          expect(mail.govuk_notify_template).to eq('application_submitted_to_court_new_template_id')
+        end
+
+        it 'has the right personalisation' do
+          expect(
+            mail.govuk_notify_personalisation
+          ).to match(hash_including(
+            c8_included: 'yes',
+            link_to_c8_pdf: { file: 'YzggZm9ybQ==' },
+            link_to_pdf: { file: 'YnVuZGxlIHBkZg==' },
+          ))
+        end
+      end
+
+      context 'and applicant did not trigger the `address confidentiality`' do
+        let(:address_confidentiality) { 'no' }
+        let(:c8_form) { StringIO.new('') }
+
+        it 'has the right template id' do
+          expect(mail.govuk_notify_template).to eq('application_submitted_to_court_new_template_id')
+        end
+
+        it 'has the right personalisation' do
+          expect(
+            mail.govuk_notify_personalisation
+          ).to match(hash_including(
+            c8_included: 'no',
+            link_to_c8_pdf: '',
+            link_to_pdf: { file: 'YnVuZGxlIHBkZg==' },
+          ))
+        end
+      end
     end
   end
 

--- a/spec/services/c100_app/pdf_generator_spec.rb
+++ b/spec/services/c100_app/pdf_generator_spec.rb
@@ -68,11 +68,24 @@ RSpec.describe C100App::PdfGenerator do
   end
 
   describe '#to_pdf' do
-    let(:combiner) { double.as_null_object }
+    let(:combiner) { double('Combiner', forms_data: forms_data) }
 
-    it 'delegates method to combiner' do
-      expect(combiner).to receive(:to_pdf)
-      subject.to_pdf
+    context 'there is data in the combiner' do
+      let(:forms_data) { {whatever: 'xyz'} }
+
+      it 'delegates to the combiner' do
+        expect(combiner).to receive(:to_pdf)
+        subject.to_pdf
+      end
+    end
+
+    context 'there is no data yet in the combiner' do
+      let(:forms_data) { nil }
+
+      it 'returns an empty string without calling the combiner' do
+        expect(combiner).not_to receive(:to_pdf)
+        expect(subject.to_pdf).to eq('')
+      end
     end
   end
 


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/#/tasks/15321243)

Follow up to PRs #638, #639 and #644.

Individual commits with more context and to be easier to review.

This is the final PR that completes the work necessary to split the C8 form (if generated) out of the main PDF bundle (C100 + C1A) in the email to court.

As we don't want this to be enabled just yet on production, there is a feature flag based on ENV variables so it can be easily tested on local, and enabled by default on staging, but not on production until we have the green light (May 13th).

Once we enable this on production, we will raise another PR to do the cleanup of the feature flag and other code no longer needed.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.