### PR TITLE
Add split text boxes for address for applicant address details form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ end
 group :test do
   gem 'brakeman'
   gem 'capybara'
+  gem 'climate_control' # Allows environment variables to be modified within specs
   gem 'cucumber'
   gem 'cucumber-rails', require: false
   gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    climate_control (0.2.0)
     cliver (0.3.2)
     coderay (1.1.2)
     coercible (1.0.0)
@@ -403,6 +404,7 @@ DEPENDENCIES
   binding_of_caller
   brakeman
   capybara
+  climate_control
   combine_pdf (~> 1.0)
   cucumber
   cucumber-rails

--- a/app/assets/stylesheets/local/inputs.scss
+++ b/app/assets/stylesheets/local/inputs.scss
@@ -17,6 +17,13 @@ textarea.form-control-large {
   input[type=text].form-control.narrow {
     width: 50%;
   }
+  input[type=text].form-control[name*=town],
+  input[type=text].form-control[name*=country] {
+    width: 75%;
+  }
+  input[type=text].form-control[name*=postcode] {
+    width: 25%;
+  }
 }
 
 .block-label:last-child,

--- a/app/controllers/steps/applicant/address_details_controller.rb
+++ b/app/controllers/steps/applicant/address_details_controller.rb
@@ -2,8 +2,17 @@ module Steps
   module Applicant
     class AddressDetailsController < Steps::ApplicantStepController
       def edit
-        @form_object = AddressDetailsForm.build(
-          current_record, c100_application: current_c100_application
+        @form_object = AddressDetailsForm.new(
+          address: current_record.address,
+          address_line_1: current_record.address_line_1,
+          address_line_2: current_record.address_line_2,
+          town: current_record.town,
+          country: current_record.country,
+          postcode: current_record.postcode,
+          residence_requirement_met: current_record.residence_requirement_met,
+          residence_history: current_record.residence_history,
+          c100_application: current_c100_application,
+          record: current_record
         )
       end
 

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -60,6 +60,10 @@ class BaseForm
     true
   end
 
+  def split_address?
+    (c100_application.version > 2 || ENV.key?("SPLIT_ADDRESS")) || ENV.key?("DEV_TOOLS_ENABLED")
+  end
+
   private
 
   def record_id

--- a/app/forms/steps/applicant/address_details_form.rb
+++ b/app/forms/steps/applicant/address_details_form.rb
@@ -2,10 +2,20 @@ module Steps
   module Applicant
     class AddressDetailsForm < BaseForm
       attribute :address, StrippedString
+
+      attribute :address_line_1, String
+      attribute :address_line_2, String
+      attribute :town, String
+      attribute :country, String
+      attribute :postcode, String
+
       attribute :residence_requirement_met, YesNo
       attribute :residence_history, String
 
-      validates_presence_of :address
+      validates_presence_of :address, unless: :split_address?
+
+      validates_presence_of :address_line_1, if: :split_address?
+      validates_presence_of :postcode, if: :split_address?
 
       validates_inclusion_of :residence_requirement_met, in: GenericYesNo.values
       validates_presence_of  :residence_history, if: -> { residence_requirement_met&.no? }
@@ -17,8 +27,39 @@ module Steps
 
         applicant = c100_application.applicants.find_or_initialize_by(id: record_id)
         applicant.update(
-          attributes_map
+          update_values
         )
+      end
+
+      def update_values
+        return address_split_values if split_address?
+        address_values
+      end
+
+      def address_values
+        {
+          address: address,
+          residence_requirement_met: residence_requirement_met,
+          residence_history: residence_history
+        }
+      end
+
+      def address_split_values
+        {
+          address_data: address_hash,
+          residence_requirement_met: residence_requirement_met,
+          residence_history: residence_history
+        }
+      end
+
+      def address_hash
+        {
+          address_line_1: address_line_1,
+          address_line_2: address_line_2,
+          town: town,
+          country: country,
+          postcode: postcode
+        }
       end
     end
   end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,2 +1,4 @@
 class Applicant < Person
+  store_accessor :address_data, :address_line_1, :address_line_2,
+                 :town, :country, :postcode
 end

--- a/app/models/other_party.rb
+++ b/app/models/other_party.rb
@@ -1,2 +1,5 @@
 class OtherParty < Person
+  def full_address
+    address
+  end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -8,4 +8,17 @@ class Person < ApplicationRecord
   def full_name
     [first_name, last_name].compact.join(' ')
   end
+
+  def full_address
+    return address unless split_address?
+    address_data.values.reject(&:blank?).join(', ')
+  end
+
+  # Until we've migrated all database records to the new address form
+  # structure, we must maintain backward-compatibility. Only c100 records
+  # greater than this version will be eligible for the new split format.
+  #
+  def split_address?
+    (c100_application.version > 2 || ENV.key?("SPLIT_ADDRESS")) || ENV.key?("DEV_TOOLS_ENABLED")
+  end
 end

--- a/app/models/respondent.rb
+++ b/app/models/respondent.rb
@@ -1,2 +1,5 @@
 class Respondent < Person
+  def full_address
+    address
+  end
 end

--- a/app/presenters/summary/html_sections/people_details.rb
+++ b/app/presenters/summary/html_sections/people_details.rb
@@ -63,7 +63,7 @@ module Summary
 
       def address_details_questions(person)
         [
-          FreeTextAnswer.new(:person_address, person.address, show: true),
+          FreeTextAnswer.new(:person_address, person.full_address, show: true),
           Answer.new(:person_residence_requirement_met, person.residence_requirement_met),
           FreeTextAnswer.new(:person_residence_history, person.residence_history)
         ]

--- a/app/presenters/summary/sections/c8_applicants_details.rb
+++ b/app/presenters/summary/sections/c8_applicants_details.rb
@@ -22,7 +22,7 @@ module Summary
           [
             Separator.new("#{name}_index_title", index: index),
             FreeTextAnswer.new(:person_full_name, person.full_name),
-            FreeTextAnswer.new(:person_address, person.address),
+            FreeTextAnswer.new(:person_address, person.full_address),
             FreeTextAnswer.new(:person_residence_history, person.residence_history),
             FreeTextAnswer.new(:person_home_phone, person.home_phone),
             FreeTextAnswer.new(:person_mobile_phone, person.mobile_phone),

--- a/app/presenters/summary/sections/people_details.rb
+++ b/app/presenters/summary/sections/people_details.rb
@@ -28,7 +28,7 @@ module Summary
             DateAnswer.new(:person_dob, person.dob),
             FreeTextAnswer.new(:person_age_estimate, person.age_estimate), # This shows only if a value is present
             FreeTextAnswer.new(:person_birthplace, person.birthplace),
-            FreeTextAnswer.new(:person_address, person.address, show: true),
+            FreeTextAnswer.new(:person_address, person.full_address, show: true),
             Answer.new(:person_residence_requirement_met, person.residence_requirement_met),
             FreeTextAnswer.new(:person_residence_history, person.residence_history),
             FreeTextAnswer.new(:person_home_phone, person.home_phone),

--- a/app/views/steps/applicant/address_details/edit.html.erb
+++ b/app/views/steps/applicant/address_details/edit.html.erb
@@ -7,7 +7,15 @@
      <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
 
      <%= step_form @form_object do |f| %>
-        <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
+        <% if f.object.split_address? %>
+          <%= f.text_field :address_line_1 %>
+          <%= f.text_field :address_line_2, label_options: { class: 'visually-hidden' } %>
+          <%= f.text_field :town %>
+          <%= f.text_field :country %>
+          <%= f.text_field :postcode %>
+        <% else %>
+          <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
+        <% end %>
 
         <%=
           f.radio_button_fieldset :residence_requirement_met, inline: true do |fieldset|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,10 @@ en:
 
     PERSONAL_ADDRESS_FIELDS: &PERSONAL_ADDRESS_FIELDS
       address: Current Address
+      address_line_1: Building and street
+      town: Town or city
+      country: Country
+      postcode: Postal / zip code
       residence_requirement_met:
         <<: *YESNO
 

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -29,6 +29,10 @@ en:
         blank: Enter their place of birth
       address:
         blank: Enter the address
+      address_line_1:
+        blank: Enter first line of address
+      postcode:
+        blank: Enter a postcode
       residence_history:
         blank: Enter details and dates
       mobile_phone:

--- a/db/migrate/20190430132432_add_address_data_to_people.rb
+++ b/db/migrate/20190430132432_add_address_data_to_people.rb
@@ -1,0 +1,5 @@
+class AddAddressDataToPeople < ActiveRecord::Migration[5.1]
+  def change
+    add_column :people, :address_data, :json, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190123094339) do
+ActiveRecord::Schema.define(version: 20190430132432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -261,6 +261,7 @@ ActiveRecord::Schema.define(version: 20190123094339) do
     t.string "residence_requirement_met"
     t.text "residence_history"
     t.uuid "c100_application_id"
+    t.json "address_data", default: {}
     t.index ["c100_application_id"], name: "index_people_on_c100_application_id"
   end
 

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -35,6 +35,24 @@ RSpec.describe BaseForm do
     end
   end
 
+  describe 'split_address?' do
+    let(:version) { 2 }
+    let(:c100_application) { instance_double(C100Application, version: version) }
+
+    before do
+      subject.c100_application = c100_application
+    end
+
+    context 'return false' do
+      it { expect(subject.split_address?).to eq(false) }
+    end
+
+    context 'return true' do
+      let(:version) { 3 }
+      it { expect(subject.split_address?).to eq(true) }
+    end
+  end
+
   describe '[]' do
     let(:c100_application) { instance_double(C100Application) }
 

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Applicant, type: :model do
+  subject { applicant }
+
+  let(:applicant) do
+    Applicant.new(address_data: address_hash)
+  end
+
+  let(:address_hash) do
+    {
+      address_line_1: address_line_1,
+      address_line_2: address_line_2,
+      town: town,
+      country: country,
+      postcode: postcode
+    }
+  end
+
+  let(:address_line_1) { nil }
+  let(:address_line_2) { nil }
+  let(:town) { nil }
+  let(:country) { nil }
+  let(:postcode) { nil}
+
+  describe '#address_line_1' do
+    context 'for a applicant with address_line_1 attributes' do
+      let(:address_line_1) { 'address_line_1' }
+      it { expect(subject.address_line_1).to eq(address_line_1) }
+    end
+
+    context 'when address_line_1 attributes is not set' do
+      it { expect(subject.address_line_1).to eq(nil) }
+    end
+  end
+
+  describe '#address_line_1=' do
+    context 'for a applicant with address_line_1 attributes' do
+      let(:address_line_1) { 'address_line_1' }
+      it "provides the student's current address" do
+        expect(subject.address_line_1).to eq(address_line_1)
+        subject.address_line_1 = 'text'
+        expect(subject.address_line_1).to eq('text')
+      end
+    end
+  end
+end

--- a/spec/models/other_party_spec.rb
+++ b/spec/models/other_party_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe OtherParty, type: :model do
+  subject { other_party }
+
+ let(:address_string) { 'address' }
+
+
+  let(:other_party) do
+    OtherParty.new(address: address_string)
+  end
+
+  let(:address_string) { 'address' }
+  describe '#full_address' do
+    context 'return address' do
+      it { expect(subject.full_address).to eq(address_string) }
+    end
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,10 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe Person, type: :model do
-  subject { Person.new(first_name: first_name, last_name: last_name) }
+  subject { person }
+
+  let(:person) do
+    Person.new(first_name: first_name, last_name: last_name)
+  end
 
   let(:first_name) { nil }
   let(:last_name)  { nil }
+
+
+  let(:address_hash) do
+    {
+      address_line_1: 'address_line_1',
+      address_line_2: '',
+      town: 'town',
+      country: 'country',
+      postcode: 'postcode'
+    }
+  end
+
+  let(:full_address_string) { address_hash.values.reject(&:empty?).join(', ') }
+  let(:address_string) { 'address' }
+  let(:split_address_value) { false }
 
   describe '#full_name' do
     context 'for a person with first and last name attributes' do
@@ -21,6 +40,66 @@ RSpec.describe Person, type: :model do
     context 'for a person without a last_name attribute' do
       let(:last_name) { 'John Doe' }
       it { expect(subject.full_name).to eq('John Doe') }
+    end
+  end
+
+
+  describe '#full_address' do
+    let(:person) do
+      Person.new(first_name: first_name, last_name: last_name, address: address_string, address_data: address_hash)
+    end
+
+    before do
+      allow(subject).to receive(:split_address?).and_return(split_address_value)
+    end
+
+    context 'non split address' do
+      it { expect(subject.full_address).to eq(address_string) }
+    end
+
+    context 'split address' do
+      let(:split_address_value) { true }
+      it { expect(subject.full_address).to eq(full_address_string) }
+    end
+  end
+
+  describe '#split_address?' do
+    let(:version) { 2 }
+    let(:c100_application) { C100Application.new(version: version) }
+
+    let(:person) do
+      Person.new(first_name: first_name, last_name: last_name, address: address_string, address_data: address_hash, c100_application: c100_application)
+    end
+
+    context 'return false' do
+      it { expect(subject.split_address?).to eq(false) }
+    end
+
+    context 'return true' do
+      context 'when version > 2' do
+        context 'when version equal 3 'do
+          let(:version) { 3 }
+          it { expect(subject.split_address?).to eq(true) }
+        end
+      end
+
+      context 'when version < 3 and one of the  is set' do
+        it 'return true when SPLIT_ADDRESS set' do
+          with_modified_env SPLIT_ADDRESS: 'bar' do
+            expect(subject.split_address?).to eq(true)
+          end
+        end
+
+        it 'return true when DEV_TOOLS_ENABLED set' do
+          with_modified_env DEV_TOOLS_ENABLED: 'bar' do
+            expect(subject.split_address?).to eq(true)
+          end
+        end
+      end
+    end
+
+    def with_modified_env(options, &block)
+      ClimateControl.modify(options, &block)
     end
   end
 end

--- a/spec/models/respondent_spec.rb
+++ b/spec/models/respondent_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Respondent, type: :model do
+  subject { respondent }
+
+ let(:address_string) { 'address' }
+
+
+  let(:respondent) do
+    Respondent.new(address: address_string)
+  end
+
+  let(:address_string) { 'address' }
+  describe '#full_address' do
+    context 'return address' do
+      it { expect(subject.full_address).to eq(address_string) }
+    end
+  end
+end

--- a/spec/presenters/summary/html_sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicants_details_spec.rb
@@ -29,6 +29,11 @@ module Summary
       )
     }
 
+    before do
+      allow(applicant).to receive(:split_address?).and_return(false)
+       allow(applicant).to receive(:full_address).and_return(applicant.address)
+    end
+
     subject { described_class.new(c100_application) }
 
     let(:has_previous_name) { 'no' }

--- a/spec/presenters/summary/html_sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/html_sections/other_parties_details_spec.rb
@@ -32,6 +32,8 @@ module Summary
 
     before do
       allow(subject).to receive(:contact_details_path).and_return(false)
+      allow(other_party).to receive(:split_address?).and_return(false)
+      allow(other_party).to receive(:full_address).and_return(other_party.address)
     end
 
     subject { described_class.new(c100_application) }

--- a/spec/presenters/summary/html_sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/html_sections/respondents_details_spec.rb
@@ -29,6 +29,11 @@ module Summary
       )
     }
 
+    before do
+      allow(respondent).to receive(:split_address?).and_return(false)
+      allow(respondent).to receive(:full_address).and_return(respondent.address)
+    end
+
     subject { described_class.new(c100_application) }
 
     let(:has_previous_name) { 'no' }

--- a/spec/presenters/summary/sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/applicants_details_spec.rb
@@ -28,6 +28,11 @@ module Summary
       )
     }
 
+    before do
+      allow(applicant).to receive(:split_address?).and_return(false)
+      allow(applicant).to receive(:full_address).and_return(applicant.address)
+    end
+
     subject { described_class.new(c100_application) }
 
     let(:has_previous_name) { 'no' }

--- a/spec/presenters/summary/sections/c8_applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/c8_applicants_details_spec.rb
@@ -20,6 +20,11 @@ module Summary
       )
     }
 
+    before do
+      allow(applicant).to receive(:split_address?).and_return(false)
+      allow(applicant).to receive(:full_address).and_return(applicant.address)
+    end
+
     subject { described_class.new(c100_application) }
 
     let(:answers) { subject.answers }

--- a/spec/presenters/summary/sections/c8_other_parties_details_spec.rb
+++ b/spec/presenters/summary/sections/c8_other_parties_details_spec.rb
@@ -27,6 +27,12 @@ module Summary
       )
     }
 
+
+    before do
+      allow(other_party).to receive(:split_address?).and_return(false)
+      allow(other_party).to receive(:full_address).and_return(other_party.address)
+    end
+
     subject { described_class.new(c100_application) }
 
     let(:has_previous_name) { 'no' }

--- a/spec/presenters/summary/sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/sections/other_parties_details_spec.rb
@@ -30,6 +30,11 @@ module Summary
       )
     }
 
+    before do
+      allow(other_party).to receive(:split_address?).and_return(false)
+      allow(other_party).to receive(:full_address).and_return(other_party.address)
+    end
+
     subject { described_class.new(c100_application) }
 
     let(:has_previous_name) { 'no' }

--- a/spec/presenters/summary/sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/sections/respondents_details_spec.rb
@@ -22,6 +22,12 @@ module Summary
       )
     }
 
+    before do
+      allow(respondent).to receive(:split_address?).and_return(false)
+      allow(respondent).to receive(:full_address).and_return(respondent.address)
+    end
+
+
     subject { described_class.new(c100_application) }
 
     let(:has_previous_name) { 'no' }


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/15152297)

- Add address_data JSON column to the Person model.
- Add feature flag SPLIT_ADDRESS
- Update applicant address form to separate address column into several text boxes and save in address_data form, when feature flag SPLIT_ADDRESS is enabled.

New applicant  address details form look like the screenshot below:

<img width="709" alt="Screen Shot 2019-05-02 at 12 23 55" src="https://user-images.githubusercontent.com/22822829/57072462-aa269580-6cd5-11e9-8461-26785ba7e890.png">

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
