### PR TITLE
Heroku to MOJ Cloud Platforms data migration

### DIFF
--- a/heroku-migration/Dockerfile
+++ b/heroku-migration/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:alpine
+
+ENV WORKDIR /usr/src/app
+WORKDIR $WORKDIR
+
+COPY scripts scripts/
+
+RUN apk add --no-cache bash curl postgresql-client
+RUN curl https://cli-assets.heroku.com/install.sh | sh
+
+# uid=1000(node) gid=1000(node) groups=1000(node),1000(node)
+ENV USERID 1000
+
+RUN chown -R $USERID:$USERID $WORKDIR
+
+USER $USERID
+
+WORKDIR $WORKDIR/scripts
+ENTRYPOINT ["./run.sh"]

--- a/heroku-migration/scripts/backup.sh
+++ b/heroku-migration/scripts/backup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+HEROKU_APP=$1
+DRY_RUN=$2
+
+if [[ -z "$HEROKU_APP" ]]; then
+  echo "Usage: ${0} [HEROKU_APP]"
+  exit 1
+fi
+
+if [[ -z "$HEROKU_API_KEY" ]]; then
+  echo "HEROKU_API_KEY not found in the environment"
+  exit 1
+fi
+
+if [[ -z "$DRY_RUN" ]]; then
+  heroku maintenance:on -a ${HEROKU_APP}
+fi
+
+echo -e "Current status of database in ${HEROKU_APP} ...\n"
+heroku pg:psql -a ${HEROKU_APP} -f tables_info.sql
+
+heroku pg:backups:capture -a ${HEROKU_APP}
+heroku pg:backups:download -a ${HEROKU_APP}
+
+if [[ -z "$DRY_RUN" ]]; then
+  heroku maintenance:off -a ${HEROKU_APP}
+fi
+
+echo "--- Backup completed ---"

--- a/heroku-migration/scripts/restore.sh
+++ b/heroku-migration/scripts/restore.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+DATABASE_URL=$1
+DRY_RUN=$2
+
+if [[ -z "$DATABASE_URL" ]]; then
+  echo "Usage: ${0} [DATABASE_URL]"
+  exit 1
+fi
+
+echo -e "Status of database BEFORE the restore ...\n"
+psql -d ${DATABASE_URL} -f tables_info.sql
+
+
+if [[ -z "$DRY_RUN" ]]; then
+
+  echo -e "Restoring latest.dump ...\n"
+  pg_restore --verbose --clean --no-acl --no-owner -d ${DATABASE_URL} latest.dump
+
+  echo -e "Status of database AFTER the restore ...\n"
+  psql -d ${DATABASE_URL} -f tables_info.sql
+
+else
+
+  echo -e "DRY-RUN detected. Checking integrity if dump, without restoring ...\n"
+  pg_restore latest.dump > /dev/null
+
+fi
+
+echo "--- Restore completed ---"

--- a/heroku-migration/scripts/run.sh
+++ b/heroku-migration/scripts/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+DRY_RUN="${DRY_RUN}"
+HEROKU_APP="${HEROKU_APP}"
+HEROKU_API_KEY="${HEROKU_API_KEY}"
+DATABASE_URL="${DATABASE_URL}"
+
+./backup.sh ${HEROKU_APP} ${DRY_RUN} && ./restore.sh ${DATABASE_URL} ${DRY_RUN}

--- a/heroku-migration/scripts/tables_info.sql
+++ b/heroku-migration/scripts/tables_info.sql
@@ -1,0 +1,8 @@
+VACUUM (FULL); -- so stats are accurate, removing dead rows
+
+SELECT nspname AS schemaname, relname, reltuples
+FROM pg_class C
+         LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
+WHERE nspname NOT IN ('pg_catalog', 'information_schema')
+  AND relkind = 'r'
+ORDER BY reltuples DESC;


### PR DESCRIPTION
Minimal docker image (base image `node:alpine`) where we install Heroku CLI and postgres client in order to run a series of scripts.

The plan is to create a one-off Job or Pod in the corresponding namespace (staging or production) and use this docker image with access to the necessary env variables.

* backup.sh -- will place the app in maintenance mode and take a database dump of a Heroku application (`HEROKU_APP`)

* restore.sh -- will restore the previous db dump to another database, with connection string `DATABASE_URL`.

If `DRY_RUN` env variable is defined, will skip destructive commands.

A `HEROKU_API_KEY` env variable is needed, with access to the heroku app.