### PR TITLE
Prepare short url for live-1 cluster

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,13 +30,22 @@ end
 # :nocov:
 
 Rails.application.routes.draw do
+  # TODO: once we migrate, there will be an S3/Route 53 redirection from `c100.dsd.io`
+  # to `c100.service.justice.gov.uk` and we can remove this constraint.
   constraints host: 'c100.dsd.io' do
     get '/(*path)' => redirect(
       ShortUrlExpander.new('https://apply-to-court-about-child-arrangements.service.justice.gov.uk'), status: 302
     )
   end
 
-  # Maintain this for some time until all our traffic is coming directly from `k8s` domain
+  # New short url in live-1 k8s cluster
+  constraints host: 'c100.service.justice.gov.uk' do
+    get '/(*path)' => redirect(
+      ShortUrlExpander.new('https://apply-to-court-about-child-arrangements.service.justice.gov.uk'), status: 302
+    )
+  end
+
+  # TODO: to be removed once we decommission our heroku environment
   constraints host: 'c100-staging.herokuapp.com' do
     get '/(*path)' => redirect('https://c100-application-staging.apps.live-1.cloud-platform.service.justice.gov.uk', status: 301)
   end


### PR DESCRIPTION
For some time we will also need to maintain the `dsd.io` one but we can probably handle the redirect at s3/route53 level.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
