### PR TITLE
Add split text boxes for other parties address details form

### DIFF
--- a/app/controllers/steps/other_parties/address_details_controller.rb
+++ b/app/controllers/steps/other_parties/address_details_controller.rb
@@ -2,8 +2,16 @@ module Steps
   module OtherParties
     class AddressDetailsController < Steps::OtherPartiesStepController
       def edit
-        @form_object = AddressDetailsForm.build(
-          current_record, c100_application: current_c100_application
+        @form_object = AddressDetailsForm.new(
+          address: current_record.address,
+          address_unknown: current_record.address_unknown,
+          address_line_1: current_record.address_line_1,
+          address_line_2: current_record.address_line_2,
+          town: current_record.town,
+          country: current_record.country,
+          postcode: current_record.postcode,
+          c100_application: current_c100_application,
+          record: current_record
         )
       end
 

--- a/app/forms/steps/other_parties/address_details_form.rb
+++ b/app/forms/steps/other_parties/address_details_form.rb
@@ -1,11 +1,6 @@
 module Steps
   module OtherParties
-    class AddressDetailsForm < BaseForm
-      attribute :address, StrippedString
-      attribute :address_unknown, Boolean
-
-      validates_presence_of :address, unless: :address_unknown?
-
+    class AddressDetailsForm < AddressBaseForm
       private
 
       def persist!
@@ -13,7 +8,7 @@ module Steps
 
         party = c100_application.other_parties.find_or_initialize_by(id: record_id)
         party.update(
-          attributes_map
+          update_values
         )
       end
     end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,4 +1,2 @@
 class Applicant < Person
-  store_accessor :address_data, :address_line_1, :address_line_2,
-                 :town, :country, :postcode
 end

--- a/app/models/other_party.rb
+++ b/app/models/other_party.rb
@@ -1,5 +1,4 @@
 class OtherParty < Person
-  def full_address
-    address
-  end
+  store_accessor :address_data, :address_line_1, :address_line_2,
+                 :town, :country, :postcode
 end

--- a/app/models/other_party.rb
+++ b/app/models/other_party.rb
@@ -1,4 +1,2 @@
 class OtherParty < Person
-  store_accessor :address_data, :address_line_1, :address_line_2,
-                 :town, :country, :postcode
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,6 @@
 class Person < ApplicationRecord
+  store_accessor :address_data, :address_line_1, :address_line_2,
+                 :town, :country, :postcode
   belongs_to :c100_application
   has_many :relationships, source: :person, dependent: :destroy
 

--- a/app/models/respondent.rb
+++ b/app/models/respondent.rb
@@ -1,4 +1,2 @@
 class Respondent < Person
-  store_accessor :address_data, :address_line_1, :address_line_2,
-                 :town, :country, :postcode
 end

--- a/app/views/steps/other_parties/address_details/edit.html.erb
+++ b/app/views/steps/other_parties/address_details/edit.html.erb
@@ -7,7 +7,15 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
+      <% if f.object.split_address? %>
+          <%= f.text_field :address_line_1 %>
+          <%= f.text_field :address_line_2, label_options: { class: 'visually-hidden' } %>
+          <%= f.text_field :town %>
+          <%= f.text_field :country %>
+          <%= f.text_field :postcode %>
+      <% else %>
+        <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
+      <% end %>
       <%= f.single_check_box :address_unknown, class: 'dont-know' %>
 
       <%= f.continue_button %>

--- a/app/views/steps/other_parties/address_details/edit.html.erb
+++ b/app/views/steps/other_parties/address_details/edit.html.erb
@@ -8,11 +8,11 @@
 
     <%= step_form @form_object do |f| %>
       <% if f.object.split_address? %>
-          <%= f.text_field :address_line_1 %>
-          <%= f.text_field :address_line_2, label_options: { class: 'visually-hidden' } %>
-          <%= f.text_field :town %>
-          <%= f.text_field :country %>
-          <%= f.text_field :postcode %>
+        <%= f.text_field :address_line_1 %>
+        <%= f.text_field :address_line_2, label_options: { class: 'visually-hidden' } %>
+        <%= f.text_field :town %>
+        <%= f.text_field :country %>
+        <%= f.text_field :postcode %>
       <% else %>
         <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
       <% end %>

--- a/app/views/steps/respondent/address_details/edit.html.erb
+++ b/app/views/steps/respondent/address_details/edit.html.erb
@@ -12,11 +12,11 @@
 
     <%= step_form @form_object do |f| %>
       <% if f.object.split_address? %>
-          <%= f.text_field :address_line_1 %>
-          <%= f.text_field :address_line_2, label_options: { class: 'visually-hidden' } %>
-          <%= f.text_field :town %>
-          <%= f.text_field :country %>
-          <%= f.text_field :postcode %>
+        <%= f.text_field :address_line_1 %>
+        <%= f.text_field :address_line_2, label_options: { class: 'visually-hidden' } %>
+        <%= f.text_field :town %>
+        <%= f.text_field :country %>
+        <%= f.text_field :postcode %>
       <% else %>
         <%= f.text_area :address, size: '40x4', class: 'form-control-3-4' %>
       <% end %>

--- a/spec/forms/steps/other_parties/address_details_form_spec.rb
+++ b/spec/forms/steps/other_parties/address_details_form_spec.rb
@@ -102,9 +102,19 @@ RSpec.describe Steps::OtherParties::AddressDetailsForm do
         }
       end
 
-      context 'validations on field presence unless `unknown`' do
-        it { should validate_presence_of(:address_line_1) }
-        it { should validate_presence_of(:postcode) }
+      # TODO: after the feature flag split_address has been removed this validation
+      # need to be changed to it { should validate_presence_unless_unknown_of(:address_line_1) }
+      context 'validations on field presence based on validate_split_address? value' do
+        context 'should validate on field presence when validate_split_address? is true ' do
+          it { should validate_presence_of(:address_line_1) }
+          it { should validate_presence_of(:postcode) }
+        end
+
+        context 'should not validate on field presence when validate_split_address? is false' do
+          let(:address_unknown) { true }
+          it { should_not validate_presence_of(:address_line_1) }
+          it { should_not validate_presence_of(:postcode) }
+        end
       end
 
       context 'address_line_1' do

--- a/spec/forms/steps/other_parties/address_details_form_spec.rb
+++ b/spec/forms/steps/other_parties/address_details_form_spec.rb
@@ -1,12 +1,19 @@
 require 'spec_helper'
 
 RSpec.describe Steps::OtherParties::AddressDetailsForm do
-  let(:arguments) { {
-    c100_application: c100_application,
-    record: record,
-    address: address,
-    address_unknown: address_unknown
-  } }
+  let(:arguments) do
+    {
+      c100_application: c100_application,
+      record: record,
+      address_line_1: address_line_1,
+      address_line_2: address_line_2,
+      town: town,
+      country: country,
+      postcode: postcode,
+      address: address,
+      address_unknown: address_unknown
+    }
+  end
 
   let(:c100_application) { instance_double(C100Application, other_parties: other_parties_collection) }
   let(:other_parties_collection) { double('other_parties_collection') }
@@ -15,6 +22,17 @@ RSpec.describe Steps::OtherParties::AddressDetailsForm do
   let(:record) { nil }
   let(:address) { 'address' }
   let(:address_unknown) { false }
+
+  let(:address_line_1) { nil }
+  let(:address_line_2) { nil }
+  let(:town) { nil }
+  let(:country) { nil }
+  let(:postcode) { nil }
+  let(:split_address_result) { false }
+
+  before do
+    allow(subject).to receive(:split_address?).and_return(split_address_result)
+  end
 
   subject { described_class.new(arguments) }
 
@@ -68,6 +86,90 @@ RSpec.describe Steps::OtherParties::AddressDetailsForm do
           ).and_return(true)
 
           expect(subject.save).to be(true)
+        end
+      end
+    end
+    context 'when split address' do
+      let(:split_address_result) { true }
+
+      let(:address_data) do
+        {
+          address_line_1: address_line_1,
+          address_line_2: address_line_2,
+          town: town,
+          country: country,
+          postcode: postcode
+        }
+      end
+
+      context 'validations on field presence unless `unknown`' do
+        it { should validate_presence_of(:address_line_1) }
+        it { should validate_presence_of(:postcode) }
+      end
+
+      context 'address_line_1' do
+        context 'when attribute is not given' do
+          let(:address_line_1) { nil }
+
+          it 'returns false' do
+            expect(subject.save).to be(false)
+          end
+
+          it 'has a validation error on the field' do
+            expect(subject).to_not be_valid
+            expect(subject.errors[:address_line_1]).to_not be_empty
+          end
+        end
+      end
+
+      context 'for valid details' do
+        let(:expected_attributes) {
+          {
+            address_data: address_data,
+            address_unknown: false,
+          }
+        }
+
+        context 'when record does not exist' do
+          let(:record) { nil }
+          let(:address_line_1) { 'address_line_1' }
+          let(:address_line_2) { 'address_line_2' }
+          let(:town) { 'town' }
+          let(:country) { 'c' }
+          let(:postcode) { 'postcode' }
+
+          it 'creates the record if it does not exist' do
+            expect(other_parties_collection).to receive(:find_or_initialize_by).with(
+              id: nil
+            ).and_return(party)
+
+            expect(party).to receive(:update).with(
+              expected_attributes
+            ).and_return(true)
+
+            expect(subject.save).to be(true)
+          end
+        end
+
+        context 'when record already exists' do
+          let(:record) { party }
+          let(:address_line_1) { 'address_line_1' }
+          let(:address_line_2) { 'address_line_2' }
+          let(:town) { 'town' }
+          let(:country) { 'c' }
+          let(:postcode) { 'postcode' }
+
+          it 'updates the record if it already exists' do
+            expect(other_parties_collection).to receive(:find_or_initialize_by).with(
+              id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6'
+            ).and_return(party)
+
+            expect(party).to receive(:update).with(
+              expected_attributes
+            ).and_return(true)
+
+            expect(subject.save).to be(true)
+          end
         end
       end
     end

--- a/spec/forms/steps/respondent/address_details_form_spec.rb
+++ b/spec/forms/steps/respondent/address_details_form_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Steps::Respondent::AddressDetailsForm do
       town: town,
       country: country,
       postcode: postcode,
-      address: address,
       address_unknown: address_unknown,
       residence_requirement_met: residence_requirement_met,
       residence_history: residence_history

--- a/spec/forms/steps/respondent/address_details_form_spec.rb
+++ b/spec/forms/steps/respondent/address_details_form_spec.rb
@@ -146,9 +146,19 @@ RSpec.describe Steps::Respondent::AddressDetailsForm do
         }
       end
 
-      context 'validations on field presence unless `unknown`' do
-        it { should validate_presence_of(:address_line_1) }
-        it { should validate_presence_of(:postcode) }
+      # TODO: after the feature flag split_address has been removed this validation
+      # need to be changed to it { should validate_presence_unless_unknown_of(:address_line_1) }
+      context 'validations on field presence based on validate_split_address? value' do
+        context 'should validations on field presence when validate_split_address? is true ' do
+          it { should validate_presence_of(:address_line_1) }
+          it { should validate_presence_of(:postcode) }
+        end
+
+        context 'should not validations on field presence when validate_split_address? is false' do
+          let(:address_unknown) { true }
+          it { should_not validate_presence_of(:address_line_1) }
+          it { should_not validate_presence_of(:postcode) }
+        end
       end
 
       context 'address_line_1' do

--- a/spec/models/other_party_spec.rb
+++ b/spec/models/other_party_spec.rb
@@ -3,17 +3,45 @@ require 'rails_helper'
 RSpec.describe OtherParty, type: :model do
   subject { other_party }
 
- let(:address_string) { 'address' }
-
-
   let(:other_party) do
-    OtherParty.new(address: address_string)
+    OtherParty.new(address_data: address_hash)
   end
 
-  let(:address_string) { 'address' }
-  describe '#full_address' do
-    context 'return address' do
-      it { expect(subject.full_address).to eq(address_string) }
+  let(:address_hash) do
+    {
+      address_line_1: address_line_1,
+      address_line_2: address_line_2,
+      town: town,
+      country: country,
+      postcode: postcode
+    }
+  end
+
+  let(:address_line_1) { nil }
+  let(:address_line_2) { nil }
+  let(:town) { nil }
+  let(:country) { nil }
+  let(:postcode) { nil }
+
+  describe '#address_line_1' do
+    context 'for a applicant with address_line_1 attributes' do
+      let(:address_line_1) { 'address_line_1' }
+      it { expect(subject.address_line_1).to eq(address_line_1) }
+    end
+
+    context 'when address_line_1 attributes is not set' do
+      it { expect(subject.address_line_1).to eq(nil) }
+    end
+  end
+
+  describe '#address_line_1=' do
+    context 'for a applicant with address_line_1 attributes' do
+      let(:address_line_1) { 'address_line_1' }
+      it "provides the student's current address" do
+        expect(subject.address_line_1).to eq(address_line_1)
+        subject.address_line_1 = 'text'
+        expect(subject.address_line_1).to eq('text')
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/15152297)

Update other parties address form to separate address column into several text boxes and save in address_data form, when feature flag SPLIT_ADDRESS is enabled.  This is a follow on from [#646](https://github.com/ministryofjustice/c100-application/pull/646) [#647] and (https://github.com/ministryofjustice/c100-application/pull/647) PRs only for other parties.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
