### PR TITLE
Enable C8 split (remove feature flag)

### DIFF
--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -19,16 +19,7 @@ class NotifySubmissionMailer < NotifyMailer
   #
 
   def application_to_court(to_address:)
-    # TODO: This is a bit messy but neccessary to maintain current behaviour.
-    # Once we enable the split in production, we can leave only one template
-    # and get rid of the if-else.
-    #
-    if @documents[:c8_form]
-      set_template(:application_submitted_to_court_new_version)
-    else
-      set_template(:application_submitted_to_court)
-    end
-
+    set_template(:application_submitted_to_court)
     set_reference("court;#{@c100_application.reference_code}")
 
     set_personalisation(

--- a/app/services/base_online_submission.rb
+++ b/app/services/base_online_submission.rb
@@ -47,11 +47,4 @@ class BaseOnlineSubmission
       documents: documents,
     }
   end
-
-  # TODO: temporary feature-flag
-  # :nocov:
-  def enable_c8_split?
-    ENV['SPLIT_C8_FORM'].present? || ENV['DEV_TOOLS_ENABLED'].present?
-  end
-  # :nocov:
 end

--- a/app/services/c100_app/court_online_submission.rb
+++ b/app/services/c100_app/court_online_submission.rb
@@ -11,13 +11,8 @@ module C100App
     private
 
     def generate_documents
-      if enable_c8_split?
-        documents.store(:bundle, generate_pdf(:c100, :c1a))
-        documents.store(:c8_form, generate_pdf(:c8))
-      else
-        # Generates all 3 forms in a single bundle
-        documents.store(:bundle, generate_pdf)
-      end
+      documents.store(:bundle,  generate_pdf(:c100, :c1a))
+      documents.store(:c8_form, generate_pdf(:c8))
     end
 
     def deliver_email

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -13,7 +13,6 @@ integration:
   change_password: '97ea3c24-0b40-4b8e-8fc6-a54f7f1718e9'
   application_saved: '1252b250-541c-456a-b98b-c568aef05e5f'
   application_submitted_to_court: '0350031e-df36-42e1-8b97-510795dd9ac9'
-  application_submitted_to_court_new_version: '15f9af65-b9f7-4b0a-a604-6e5982f98009'
   application_submitted_to_user: 'e10806dd-55ae-47ad-a231-757dbb3c9a7e'
   submission_error: 'c99df4a0-5655-4ef8-aaf4-0a5b83397785'
   draft_first_reminder: 'fcd87b1c-a3a0-4a2a-9b4e-524857e3bf8c'

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -3,7 +3,7 @@ en:
     to_be_completed: &to_be_completed "To be completed by the court"
     not_applicable: &not_applicable "[Not applicable in this case]"
     not_required: &not_required "[Not required]"
-    c8_attached: &c8_attached "[See C8 attached at the end of this form]"
+    c8_attached: &c8_attached "[See C8]"
     none_selected: &none_selected "[None selected]"
     unknown: &unknown "Don't know"
     details: &details "Details:"
@@ -141,7 +141,7 @@ en:
     descriptions:
       risk_concerns: Are you alleging that the applicant(s) or the child(ren) named in Section 1 of this form have experienced, or are at risk of experiencing, harm from any of the following by any person who has had contact with the child(ren)?
       c1a_attached_html: <strong>C1A is attached at the end of this form</strong>
-      c8_attached_html: <strong>C8 is attached at the end of this form</strong>
+      c8_attached_html: <strong>C8 has been generated separately</strong>
     separators:
       c8_attached: *c8_attached
       not_applicable: *not_applicable

--- a/spec/presenters/c8_confidentiality_presenter_spec.rb
+++ b/spec/presenters/c8_confidentiality_presenter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe C8ConfidentialityPresenter do
   end
 
   describe '.replacement_answer' do
-    it { expect(described_class.replacement_answer).to eq('[See C8 attached at the end of this form]') }
+    it { expect(described_class.replacement_answer).to eq('[See C8]') }
   end
 
   it 'returns the original answer if it is blank/nil' do
@@ -31,11 +31,11 @@ RSpec.describe C8ConfidentialityPresenter do
   end
 
   it 'returns the replacement answer when confidentiality applies' do
-    expect(subject.address).to eq('[See C8 attached at the end of this form]')
+    expect(subject.address).to eq('[See C8]')
   end
 
   it 'returns the replacement answer when confidentiality applies' do
-    expect(subject.full_address).to eq('[See C8 attached at the end of this form]')
+    expect(subject.full_address).to eq('[See C8]')
   end
 
   it 'returns the original answer when confidentiality does not apply' do

--- a/spec/presenters/relationships_presenter_spec.rb
+++ b/spec/presenters/relationships_presenter_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe RelationshipsPresenter do
         let(:confidentiality_enabled) { true }
 
         it 'returns the C8 replacement string' do
-          expect(subject.relationship_to_children(person)).to eq('[See C8 attached at the end of this form]')
+          expect(subject.relationship_to_children(person)).to eq('[See C8]')
         end
 
         context 'but the bypass is activated' do

--- a/spec/presenters/summary/sections/c1a_applicant_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_applicant_details_spec.rb
@@ -109,15 +109,15 @@ module Summary
         it 'hides the contact details' do
           expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
           expect(answers[5].question).to eq(:person_home_phone)
-          expect(answers[5].value).to eq('[See C8 attached at the end of this form]')
+          expect(answers[5].value).to eq('[See C8]')
 
           expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
           expect(answers[6].question).to eq(:person_mobile_phone)
-          expect(answers[6].value).to eq('[See C8 attached at the end of this form]')
+          expect(answers[6].value).to eq('[See C8]')
 
           expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
           expect(answers[7].question).to eq(:person_email)
-          expect(answers[7].value).to eq('[See C8 attached at the end of this form]')
+          expect(answers[7].value).to eq('[See C8]')
 
           expect(answers[9]).to be_an_instance_of(Answer)
           expect(answers[9].question).to eq(:c1a_address_confidentiality)


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/#/tasks/15321243)

Remove/undo the temporary feature flag code in order to enable the C8 split in all environments.

Also, a few copy changes, due to the fact the C8 form will not be included in the bundle anymore, and we have to make the copy in the PDF consistent with this.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.