### PR TITLE
Add default false for address_unknown

### DIFF
--- a/app/forms/address_base_form.rb
+++ b/app/forms/address_base_form.rb
@@ -1,12 +1,12 @@
 class AddressBaseForm < BaseForm
   attribute :address, StrippedString
-  attribute :address_unknown, Boolean
+  attribute :address_unknown, Boolean, default: false
 
-  attribute :address_line_1, String
-  attribute :address_line_2, String
-  attribute :town, String
-  attribute :country, String
-  attribute :postcode, String
+  attribute :address_line_1, StrippedString
+  attribute :address_line_2, StrippedString
+  attribute :town, StrippedString
+  attribute :country, StrippedString
+  attribute :postcode, StrippedString
 
   validates_presence_of :address, unless: :validate_address?
 

--- a/spec/forms/steps/applicant/address_details_form_spec.rb
+++ b/spec/forms/steps/applicant/address_details_form_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Steps::Applicant::AddressDetailsForm do
       let(:expected_attributes) {
         {
           address: 'address',
-          address_unknown: nil,
+          address_unknown: false,
           residence_requirement_met: GenericYesNo::NO,
           residence_history: 'history'
         }
@@ -145,7 +145,7 @@ RSpec.describe Steps::Applicant::AddressDetailsForm do
       let(:expected_attributes) {
         {
           address_data: address_data,
-          address_unknown: nil,
+          address_unknown: false,
           residence_requirement_met: GenericYesNo::NO,
           residence_history: 'history'
         }


### PR DESCRIPTION
Add default to `address_unknown` because the following validation `validate_split_address?` is failing  when  `address_unknown` hasn't got a default value and is returning nil

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
