### PR TITLE
Update split address validations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ end
 group :test do
   gem 'brakeman'
   gem 'capybara'
-  gem 'climate_control' # Allows environment variables to be modified within specs
   gem 'cucumber'
   gem 'cucumber-rails', require: false
   gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
-    climate_control (0.2.0)
     cliver (0.3.2)
     coderay (1.1.2)
     coercible (1.0.0)
@@ -404,7 +403,6 @@ DEPENDENCIES
   binding_of_caller
   brakeman
   capybara
-  climate_control
   combine_pdf (~> 1.0)
   cucumber
   cucumber-rails

--- a/app/forms/address_base_form.rb
+++ b/app/forms/address_base_form.rb
@@ -10,9 +10,8 @@ class AddressBaseForm < BaseForm
 
   validates_presence_of :address, unless: :validate_address?
 
-  # TODO: To confirm the if we want any validation on a split address
   validates_presence_of :address_line_1, if: :validate_split_address?
-  validates_presence_of :postcode, if: :validate_split_address?
+  validates_presence_of :town, if: :validate_split_address?
 
   def validate_address?
     [address_unknown?, split_address?].any?

--- a/app/forms/steps/applicant/address_details_form.rb
+++ b/app/forms/steps/applicant/address_details_form.rb
@@ -7,6 +7,8 @@ module Steps
       validates_inclusion_of :residence_requirement_met, in: GenericYesNo.values
       validates_presence_of :residence_history, if: -> { residence_requirement_met&.no? }
 
+      validates_presence_of :country, if: :validate_split_address?
+
       private
 
       def persist!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,7 +89,7 @@ en:
       address_line_2: Building and street line 2
       town: Town or city
       country: Country
-      postcode: Postal / zip code
+      postcode: Postcode
       address_unknown: I don’t know where they currently live
       residence_requirement_met:
         <<: *YESNO

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -30,11 +30,13 @@ en:
       address:
         blank: Enter the address
       address_line_1:
-        blank: Enter first line of address
-      postcode:
-        blank: Enter a postcode
+        blank: Enter the first line of the address
+      town:
+        blank: Enter the town or city
+      country:
+        blank: Enter the country
       residence_history:
-        blank: Enter details and dates
+        blank: Enter details and dates of previous addresses
       mobile_phone:
         blank: Enter the mobile phone
 
@@ -367,7 +369,11 @@ en:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
             residence_requirement_met:
-              inclusion: Select yes if they’ve lived at the address for more than 5 years
+              inclusion: Select if they’ve lived at the address for more than 5 years
+            address_line_1:
+              blank: Enter the first line of the address or select if you don’t know where they live
+            town:
+              blank: Enter the town or city or select if you don’t know where they live
         steps/children/personal_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
@@ -380,6 +386,10 @@ en:
         steps/other_parties/address_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
+            address_line_1:
+              blank: Enter the first line of the address or select if you don’t know where they live
+            town:
+              blank: Enter the town or city or select if you don’t know where they live
         steps/solicitor/contact_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS

--- a/spec/forms/steps/applicant/address_details_form_spec.rb
+++ b/spec/forms/steps/applicant/address_details_form_spec.rb
@@ -151,6 +151,23 @@ RSpec.describe Steps::Applicant::AddressDetailsForm do
         }
       }
 
+      # TODO: after the feature flag split_address has been removed this validation
+      # need to be changed to it { should validate_presence_unless_unknown_of(:address_line_1) }
+      context 'validations on field presence based on validate_split_address? value' do
+        context 'should validate on field presence when validate_split_address? is true ' do
+          it { should validate_presence_of(:address_line_1) }
+          it { should validate_presence_of(:town) }
+          it { should validate_presence_of(:country) }
+        end
+
+        context 'should not validate on field presence when validate_split_address? is false' do
+          let(:split_address_result) { false }
+          it { should_not validate_presence_of(:address_line_1) }
+          it { should_not validate_presence_of(:town) }
+          it { should_not validate_presence_of(:country) }
+        end
+      end
+
       context 'when record does not exist' do
         let(:record) { nil }
 

--- a/spec/forms/steps/other_parties/address_details_form_spec.rb
+++ b/spec/forms/steps/other_parties/address_details_form_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe Steps::OtherParties::AddressDetailsForm do
       context 'validations on field presence based on validate_split_address? value' do
         context 'should validate on field presence when validate_split_address? is true ' do
           it { should validate_presence_of(:address_line_1) }
-          it { should validate_presence_of(:postcode) }
+          it { should validate_presence_of(:town) }
         end
 
         context 'should not validate on field presence when validate_split_address? is false' do
           let(:address_unknown) { true }
           it { should_not validate_presence_of(:address_line_1) }
-          it { should_not validate_presence_of(:postcode) }
+          it { should_not validate_presence_of(:town) }
         end
       end
 

--- a/spec/forms/steps/respondent/address_details_form_spec.rb
+++ b/spec/forms/steps/respondent/address_details_form_spec.rb
@@ -150,13 +150,13 @@ RSpec.describe Steps::Respondent::AddressDetailsForm do
       context 'validations on field presence based on validate_split_address? value' do
         context 'should validations on field presence when validate_split_address? is true ' do
           it { should validate_presence_of(:address_line_1) }
-          it { should validate_presence_of(:postcode) }
+          it { should validate_presence_of(:town) }
         end
 
         context 'should not validations on field presence when validate_split_address? is false' do
           let(:address_unknown) { true }
           it { should_not validate_presence_of(:address_line_1) }
-          it { should_not validate_presence_of(:postcode) }
+          it { should_not validate_presence_of(:town) }
         end
       end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -84,22 +84,27 @@ RSpec.describe Person, type: :model do
       end
 
       context 'when version < 3 and one of the  is set' do
-        it 'return true when SPLIT_ADDRESS set' do
-          with_modified_env SPLIT_ADDRESS: 'bar' do
+        context 'SPLIT_ADDRESS is set' do
+          before do
+            allow(ENV).to receive(:key?).with('SPLIT_ADDRESS').and_return(true)
+          end
+
+          it 'return true when SPLIT_ADDRESS set' do
             expect(subject.split_address?).to eq(true)
           end
         end
 
-        it 'return true when DEV_TOOLS_ENABLED set' do
-          with_modified_env DEV_TOOLS_ENABLED: 'bar' do
+        context 'DEV_TOOLS_ENABLED is set' do
+          before do
+            allow(ENV).to receive(:key?).with('SPLIT_ADDRESS').and_return(false)
+            allow(ENV).to receive(:key?).with('DEV_TOOLS_ENABLED').and_return(true)
+          end
+
+          it 'return true when DEV_TOOLS_ENABLED set' do
             expect(subject.split_address?).to eq(true)
           end
         end
       end
-    end
-
-    def with_modified_env(options, &block)
-      ClimateControl.modify(options, &block)
     end
   end
 end

--- a/spec/support/address_form_shared_examples.rb
+++ b/spec/support/address_form_shared_examples.rb
@@ -11,7 +11,6 @@ RSpec.shared_examples 'a address CRUD form' do |form_class, |
       town: town,
       country: country,
       postcode: postcode,
-      address: address,
       address_unknown: address_unknown,
       residence_requirement_met: residence_requirement_met,
       residence_history: residence_history


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/15321247)

Update the following
 - To change ‘postal/zip code’ to ‘postcode’
-  To make the following fields mandatory for the applicant address: first line, town/city, country
-  To make the following fields mandatory for the respondent and other parties’ addresses: first line, town/city. If the applicant is unable to fill in these fields they will be directed to check the box ‘I don’t know their address’
- update split address validation messages

applicant address form
<img width="921" alt="Screen Shot 2019-05-16 at 10 27 04" src="https://user-images.githubusercontent.com/22822829/57842866-42884400-77c5-11e9-905f-4fedbfc2e77a.png">


respondent address form 
<img width="809" alt="Screen Shot 2019-05-16 at 10 29 44" src="https://user-images.githubusercontent.com/22822829/57843085-92670b00-77c5-11e9-8523-d1dc002f5b4d.png">

Other parties form
<img width="758" alt="Screen Shot 2019-05-16 at 10 31 41" src="https://user-images.githubusercontent.com/22822829/57843256-d5c17980-77c5-11e9-904a-3e6e56f07b4d.png">

- remove climate_control gem 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
