### PR TITLE
bump c100 application version to 3 to display split address address f…

### DIFF
--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -61,7 +61,7 @@ class BaseForm
   end
 
   def split_address?
-    (c100_application.version > 2 || ENV.key?("SPLIT_ADDRESS")) || ENV.key?("DEV_TOOLS_ENABLED")
+    c100_application.version > 2
   end
 
   private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -21,6 +21,6 @@ class Person < ApplicationRecord
   # greater than this version will be eligible for the new split format.
   #
   def split_address?
-    (c100_application.version > 2 || ENV.key?("SPLIT_ADDRESS")) || ENV.key?("DEV_TOOLS_ENABLED")
+    c100_application.version > 2
   end
 end

--- a/db/migrate/20190516095303_bump_c100_application_version_for_split_address.rb
+++ b/db/migrate/20190516095303_bump_c100_application_version_for_split_address.rb
@@ -1,0 +1,7 @@
+class BumpC100ApplicationVersionForSplitAddress < ActiveRecord::Migration[5.1]
+  def change
+    # Version 3 introduces split address fields form
+    # New records will be created with version=3
+    change_column_default :c100_applications, :version, from: 2, to: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190430132432) do
+ActiveRecord::Schema.define(version: 20190516095303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,7 +132,7 @@ ActiveRecord::Schema.define(version: 20190430132432) do
     t.string "urgent_hearing_short_notice"
     t.text "urgent_hearing_short_notice_details"
     t.string "has_solicitor"
-    t.integer "version", default: 2
+    t.integer "version", default: 3
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -82,29 +82,6 @@ RSpec.describe Person, type: :model do
           it { expect(subject.split_address?).to eq(true) }
         end
       end
-
-      context 'when version < 3 and one of the  is set' do
-        context 'SPLIT_ADDRESS is set' do
-          before do
-            allow(ENV).to receive(:key?).with('SPLIT_ADDRESS').and_return(true)
-          end
-
-          it 'return true when SPLIT_ADDRESS set' do
-            expect(subject.split_address?).to eq(true)
-          end
-        end
-
-        context 'DEV_TOOLS_ENABLED is set' do
-          before do
-            allow(ENV).to receive(:key?).with('SPLIT_ADDRESS').and_return(false)
-            allow(ENV).to receive(:key?).with('DEV_TOOLS_ENABLED').and_return(true)
-          end
-
-          it 'return true when DEV_TOOLS_ENABLED set' do
-            expect(subject.split_address?).to eq(true)
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Bump version of the c100_application records

All existing `c100_application` records are in version 2, and with this change new ones will be created with version 3.

This allow us to introduce the splitting of the address fields for new application and old applications will continue with the old format.