### PR TITLE
Add lookup address results step

### DIFF
--- a/app/assets/stylesheets/local/utilities.scss
+++ b/app/assets/stylesheets/local/utilities.scss
@@ -34,6 +34,10 @@
   margin-bottom: 0px;
 }
 
+.util_ml-medium {
+  margin-left: 25px;
+}
+
 .sticky-wrapper {
   clear: both;
 }

--- a/app/attributes/split_address.rb
+++ b/app/attributes/split_address.rb
@@ -1,0 +1,16 @@
+class SplitAddress < Virtus::Attribute
+  TOKEN_SEPARATOR = '|'.freeze
+
+  def coerce(value)
+    tokens = value.to_s.split(TOKEN_SEPARATOR)
+    return nil if tokens.empty?
+
+    {
+      address_line_1: tokens[0],
+      address_line_2: tokens[1],
+      town: tokens[2],
+      country: tokens[3],
+      postcode: tokens[4],
+    }
+  end
+end

--- a/app/controllers/steps/address/results_controller.rb
+++ b/app/controllers/steps/address/results_controller.rb
@@ -1,0 +1,35 @@
+module Steps
+  module Address
+    class ResultsController < Steps::AddressStepController
+      before_action :retrieve_addresses
+
+      def edit
+        @form_object = ResultsForm.new(
+          c100_application: current_c100_application,
+          record: current_record,
+        )
+      end
+
+      def update
+        update_and_advance(
+          ResultsForm,
+          record: current_record,
+          as: :address_selection
+        )
+      end
+
+      private
+
+      def retrieve_addresses
+        @addresses = lookup_service.result
+        @successful_lookup = lookup_service.success?
+      end
+
+      def lookup_service
+        @_lookup_service ||= C100App::AddressLookupService.new(
+          current_record.postcode
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/steps/address_step_controller.rb
+++ b/app/controllers/steps/address_step_controller.rb
@@ -1,5 +1,7 @@
 module Steps
   class AddressStepController < CrudStepController
+    include PersonUrlHelper
+
     private
 
     def decision_tree_class

--- a/app/forms/steps/address/results_form.rb
+++ b/app/forms/steps/address/results_form.rb
@@ -1,0 +1,18 @@
+module Steps
+  module Address
+    class ResultsForm < BaseForm
+      attribute :selected_address, SplitAddress
+      validates_presence_of :selected_address
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record.update(
+          selected_address
+        )
+      end
+    end
+  end
+end

--- a/app/helpers/person_url_helper.rb
+++ b/app/helpers/person_url_helper.rb
@@ -1,0 +1,21 @@
+# TODO: this is a horrible, terrible workaround for the fact we were not careful
+# when we designed the URLs for people of kind `OtherParty` and we pluralised them,
+# against the convention, now making it very difficult to work with them.
+#
+# We must fix it soon but maintaining backwards-compatibility with saved applications.
+# Meanwhile, this helper will let us "hide" the horror.
+#
+module PersonUrlHelper
+  def person_url_for(record, step:)
+    if record.instance_of?(OtherParty)
+      # Will return:
+      #   /steps/other_parties/:step/:uuid
+      polymorphic_path([:steps, :other_parties, step], id: record)
+    else
+      # Will return:
+      #   /steps/applicant/:step/:uuid
+      #   /steps/respondent/:step/:uuid
+      polymorphic_path([:steps, record, step])
+    end
+  end
+end

--- a/app/services/c100_app/address_decision_tree.rb
+++ b/app/services/c100_app/address_decision_tree.rb
@@ -1,37 +1,18 @@
 module C100App
   class AddressDecisionTree < BaseDecisionTree
     include Rails.application.routes.url_helpers
+    include PersonUrlHelper
 
     def destination
       return next_step if next_step
 
       case step_name
       when :postcode_lookup
-        # TODO: introduce intermediate results step. For now we jump to the address fields
-        after_postcode_lookup
+        edit(:results, id: record)
+      when :address_selection
+        person_url_for(record, step: :address_details)
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
-      end
-    end
-
-    private
-
-    def after_postcode_lookup
-      # TODO: this is a horrible, terrible workaround for the fact we were not careful
-      # when we designed the URLs for people of kind `OtherParty` and we pluralised them,
-      # against the convention, now making it very difficult to work with them.
-      #
-      # We must fix it soon but maintaining backwards-compatibility with saved applications.
-      #
-      if record.instance_of?(OtherParty)
-        # Will return:
-        #   /steps/other_parties/address_details/:uuid
-        polymorphic_path([:steps, :other_parties, :address_details], id: record)
-      else
-        # Will return:
-        #   /steps/applicant/address_details/:uuid
-        #   /steps/respondent/address_details/:uuid
-        polymorphic_path([:steps, record, :address_details])
       end
     end
   end

--- a/app/services/c100_app/map_address_lookup_results.rb
+++ b/app/services/c100_app/map_address_lookup_results.rb
@@ -3,7 +3,16 @@ module C100App
     LINE_ONE_PARTS = %w[SUB_BUILDING_NAME BUILDING_NUMBER BUILDING_NAME].freeze
     LINE_TWO_PARTS = %w[DEPENDENT_THOROUGHFARE_NAME THOROUGHFARE_NAME].freeze
     COUNTRY_NAME = "United Kingdom".freeze
-    Address = Struct.new(:address_line_1, :address_line_2, :town, :country, :postcode)
+
+    Address = Struct.new(:address_line_1, :address_line_2, :town, :country, :postcode) do
+      def address_lines
+        [address_line_1, address_line_2].join(', ')
+      end
+
+      def tokenized_value
+        values.join('|')
+      end
+    end
 
     def self.call(results)
       results.map do |result|

--- a/app/views/steps/address/results/_no_results.en.html.erb
+++ b/app/views/steps/address/results/_no_results.en.html.erb
@@ -1,0 +1,28 @@
+<% if successful_lookup %>
+
+  <p class="lede">
+    Although the postcode you entered looks like it’s in the right format, no addresses were found. This can happen
+    sometimes if it’s a very new or old postcode.
+  </p>
+
+<% else %>
+
+  <p class="lede">
+    We’re having some trouble connecting to our postcode lookup at the moment - this could be a temporary problem, and
+    it might work if you try again.
+  </p>
+
+<% end %>
+
+<section id="what-to-do-now" class="moj-Section moj-Section--2" data-block-name="what-to-do-now">
+  <h2 class="gv-u-heading-xlarge">What to do now</h2>
+
+  <div class="Section__content govuk-govspeak gv-s-prose">
+    <p>You can go back and try again, change the postcode, or continue to enter the address manually.</p>
+  </div>
+</section>
+
+<div class="xform-group form-submit">
+  <%= link_to 'Continue', person_url_for(record, step: :address_details), class: 'button', role: 'button' %>
+  <%= link_to 'Go back and try again', edit_steps_address_lookup_path(record), class: 'button button-secondary', role: 'button' %>
+</div>

--- a/app/views/steps/address/results/edit.html.erb
+++ b/app/views/steps/address/results/edit.html.erb
@@ -1,0 +1,38 @@
+<% title t('.page_title') %>
+
+<% record = @form_object.record %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">
+      <%=t '.heading', name: record.full_name %>
+    </h1>
+
+    <p class="heading-small bold">
+      <%=t '.current_postcode' %>
+    </p>
+
+    <p>
+      <span class="bold-small"><%= record.postcode %></span>
+      <%= link_to t('.change_postcode'), edit_steps_address_lookup_path(record), class: 'util_ml-medium' %>
+    </p>
+
+    <% if @addresses.any? %>
+
+      <%= step_form @form_object do |f| %>
+        <%= f.collection_select :selected_address, @addresses, :tokenized_value, :address_lines, include_blank: true %>
+
+        <%= link_to t('.address_not_listed'), person_url_for(record, step: :address_details) %>
+
+        <%= f.continue_button %>
+      <% end %>
+
+    <% else %>
+      <%= render partial: 'steps/address/results/no_results', locals: {
+        successful_lookup: @successful_lookup, record: record
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,6 +282,13 @@ en:
           manual_address: I don’t know their postcode or they live outside the UK
         other_party:
           manual_address: I don’t know their postcode or they live outside the UK
+      results:
+        edit:
+          page_title: Select an address
+          heading: "Select address of %{name}"
+          current_postcode: Current postcode
+          change_postcode: Change
+          address_not_listed: I can’t find the address in the list
     solicitor:
       personal_details:
         edit:
@@ -1226,6 +1233,8 @@ en:
         <<: *NAMES_FORM_FIELDS
       steps_address_lookup_form:
         postcode: Current postcode
+      steps_address_results_form:
+        selected_address: Select an address
       steps_applicant_personal_details_form:
         <<: *PERSONAL_DETAILS_FIELDS
         previous_name: Enter your previous name

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -414,6 +414,10 @@ en:
             postcode:
               invalid: Enter a valid postcode
               blank: Enter the postcode
+        steps/address/results_form:
+          attributes:
+            selected_address:
+              blank: Select an address from the list
 
         steps/children/residence_form:
           attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,6 +189,7 @@ Rails.application.routes.draw do
     end
     namespace :address do
       crud_step :lookup, only: [:edit, :update]
+      crud_step :results, only: [:edit, :update]
     end
     namespace :children do
       crud_step :names

--- a/spec/attributes/split_address_spec.rb
+++ b/spec/attributes/split_address_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe SplitAddress do
+  subject { described_class.build(SplitAddress) }
+
+  let(:coerced_value) { subject.coerce(value) }
+
+  describe 'when value is `nil`' do
+    let(:value) { nil }
+    it { expect(coerced_value).to be_nil }
+  end
+
+  describe 'when value is an empty string' do
+    let(:value) { '' }
+    it { expect(coerced_value).to be_nil }
+  end
+
+  describe 'when value has all expected tokens' do
+    let(:value) { 'address_line_1|address_line_2|town|country|postcode' }
+    it {
+      expect(coerced_value).to eq({
+        address_line_1: 'address_line_1',
+        address_line_2: 'address_line_2',
+        town: 'town',
+        country: 'country',
+        postcode: 'postcode'
+      })
+    }
+  end
+
+  describe 'when value is missing some of the tokens' do
+    let(:value) { 'address_line_1|||country|postcode' }
+    it {
+      expect(coerced_value).to eq({
+        address_line_1: 'address_line_1',
+        address_line_2: '',
+        town: '',
+        country: 'country',
+        postcode: 'postcode'
+      })
+    }
+  end
+end

--- a/spec/controllers/steps/address/results_controller_spec.rb
+++ b/spec/controllers/steps/address/results_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Address::ResultsController, type: :controller do
+  let(:lookup_service) { spy(C100App::AddressLookupService) }
+
+  before do
+    allow(C100App::AddressLookupService).to receive(:new).and_return(lookup_service)
+  end
+
+  it_behaves_like 'an intermediate step controller', Steps::Address::ResultsForm, C100App::AddressDecisionTree
+
+  describe 'address results' do
+    let(:c100_application) { C100Application.new(status: :in_progress) }
+
+    before do
+      allow(controller).to receive(:current_c100_application).and_return(c100_application)
+
+      allow(lookup_service).to receive(:result).and_return(%w(address1 address2))
+      allow(lookup_service).to receive(:success?).and_return(true)
+    end
+
+    context 'on edit' do
+      it 'calls the lookup service to retrieve the addresses' do
+        get :edit, session: {c100_application_id: 'whatever'}
+
+        expect(assigns[:addresses]).to match_array(%w(address1 address2))
+        expect(assigns[:successful_lookup]).to eq(true)
+      end
+    end
+
+    context 'on update (needed for errors)' do
+      it 'calls the lookup service to retrieve the addresses' do
+        # provoke an error with wrong params
+        put :update, params: {whatever: ''}, session: {c100_application_id: 'whatever'}
+
+        expect(assigns[:addresses]).to match_array(%w(address1 address2))
+        expect(assigns[:successful_lookup]).to eq(true)
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/forms/steps/address/results_form_spec.rb
+++ b/spec/forms/steps/address/results_form_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Address::ResultsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    record: record,
+    selected_address: selected_address,
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:record) { nil }
+  let(:selected_address) { 'address_line_1|address_line_2|town|country|postcode' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'when the attribute is not given' do
+      let(:selected_address) { nil }
+
+      it 'adds a `blank` error on the attribute' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.added?(:selected_address, :blank)).to eq(true)
+      end
+    end
+
+    context 'when the attribute is an empty string' do
+      let(:selected_address) { '' }
+
+      it 'adds a `blank` error on the attribute' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.added?(:selected_address, :blank)).to eq(true)
+      end
+    end
+
+    context 'for valid details' do
+      let(:record) { spy(Applicant) }
+
+      it 'updates the record' do
+        expect(record).to receive(:update).with(
+          address_line_1: 'address_line_1',
+          address_line_2: 'address_line_2',
+          town: 'town',
+          country: 'country',
+          postcode: 'postcode'
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/address_decision_tree_spec.rb
+++ b/spec/services/c100_app/address_decision_tree_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe C100App::AddressDecisionTree do
 
   context 'when the step is `postcode_lookup`' do
     let(:step_params) { { 'postcode_lookup' => 'anything' } }
+    let(:record) { double('Applicant', id: 123) }
+
+    it 'goes to edit the address details of the record' do
+      expect(subject.destination).to eq(controller: :results, action: :edit, id: record)
+    end
+  end
+
+  context 'when the step is `address_selection`' do
+    let(:step_params) { { 'address_selection' => 'anything' } }
 
     context 'for a record of type `Applicant`' do
       let(:record) { Applicant.new(id: 'cb211915-6b89-42b8-ac50-24a0dfa73f53') }

--- a/spec/services/c100_app/map_address_lookup_results_spec.rb
+++ b/spec/services/c100_app/map_address_lookup_results_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe C100App::MapAddressLookupResults do
     context 'with results' do
       let(:parsed_body) { JSON.parse(file_fixture('address_lookups/success.json').read) }
       let(:results) { parsed_body['results'] }
+
       it 'retrieves the address return by api' do
         expect(subject.size).to eq(3)
 
@@ -16,6 +17,22 @@ RSpec.describe C100App::MapAddressLookupResults do
         expect(subject[0].town).to eq('LONDON')
         expect(subject[0].country).to eq('United Kingdom')
         expect(subject[0].postcode).to eq('E1 7AS')
+      end
+
+      context '`Address` struct convenience methods' do
+        let(:result) { subject[0] }
+
+        context '#address_lines' do
+          it 'returns only the address lines' do
+            expect(result.address_lines).to eq('APARTMENT 1001, 4, WIVERTON TOWER, NEW DRUM STREET')
+          end
+        end
+
+        context '#tokenized_value' do
+          it 'returns all address details in a tokenized string' do
+            expect(result.tokenized_value).to eq('APARTMENT 1001, 4, WIVERTON TOWER|NEW DRUM STREET|LONDON|United Kingdom|E1 7AS')
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/#/tasks/15628354)

Again, a few separated commits to organise the work.

This PR is a follow-up to previous PR #658 and introduces the results page, with a dropdown to select an address from the returned ones when calling the `AddressLookupService`.

There is also a placeholder (copy is provisional) error page for when there are no results or something failed in the request.

<img width="497" alt="Screen Shot 2019-05-17 at 09 35 11" src="https://user-images.githubusercontent.com/687910/57914708-16cd9280-7887-11e9-9863-b0de91f15fe8.png">

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.