### PR TITLE
Reset address lookup dependent attributes

### DIFF
--- a/app/forms/steps/address/lookup_form.rb
+++ b/app/forms/steps/address/lookup_form.rb
@@ -10,12 +10,30 @@ module Steps
 
       private
 
+      def changed?
+        !record.postcode.eql?(postcode)
+      end
+
       def persist!
         raise C100ApplicationNotFound unless c100_application
+        return true unless changed?
 
         record.update(
           postcode: postcode,
+          country: lookup_default_country,
+          # The following are dependent attributes that need to be reset
+          address_line_1: nil,
+          address_line_2: nil,
+          town: nil,
         )
+      end
+
+      # We can pre-populate the country attribute so, in case the user
+      # can't find the address in the list or the lookup fails, they have
+      # one less input to enter (but they can change it if they need to).
+      #
+      def lookup_default_country
+        C100App::MapAddressLookupResults::DEFAULT_COUNTRY
       end
     end
   end

--- a/app/services/c100_app/map_address_lookup_results.rb
+++ b/app/services/c100_app/map_address_lookup_results.rb
@@ -2,7 +2,7 @@ module C100App
   class MapAddressLookupResults
     LINE_ONE_PARTS = %w[SUB_BUILDING_NAME BUILDING_NUMBER BUILDING_NAME].freeze
     LINE_TWO_PARTS = %w[DEPENDENT_THOROUGHFARE_NAME THOROUGHFARE_NAME].freeze
-    COUNTRY_NAME = "United Kingdom".freeze
+    DEFAULT_COUNTRY = 'UNITED KINGDOM'.freeze
 
     Address = Struct.new(:address_line_1, :address_line_2, :town, :country, :postcode) do
       def address_lines
@@ -25,7 +25,7 @@ module C100App
         address_line(result.slice(*LINE_ONE_PARTS).values),
         address_line(result.slice(*LINE_TWO_PARTS).values),
         result.fetch('POST_TOWN'),
-        COUNTRY_NAME,
+        DEFAULT_COUNTRY,
         result.fetch('POSTCODE')
       )
     end

--- a/spec/forms/steps/address/lookup_form_spec.rb
+++ b/spec/forms/steps/address/lookup_form_spec.rb
@@ -61,14 +61,36 @@ RSpec.describe Steps::Address::LookupForm do
     end
 
     context 'for valid details' do
-      let(:record) { spy(Applicant) }
+      before do
+        allow(postcode).to receive(:eql?).and_call_original
+      end
 
-      it 'updates the record' do
-        expect(record).to receive(:update).with(
-          postcode: 'SW1H 9AJ'
-        ).and_return(true)
+      context 'when the postcode has changed' do
+        let(:record) { spy(Applicant, postcode: nil) }
 
-        expect(subject.save).to be(true)
+        it 'updates the record' do
+          expect(record).to receive(:update).with(
+            postcode: 'SW1H 9AJ',
+            country: 'UNITED KINGDOM',
+            address_line_1: nil,
+            address_line_2: nil,
+            town: nil,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when the postcode is the same as in the persisted record' do
+        let(:record) { spy(Applicant, postcode: postcode) }
+
+        it 'does not save the record but returns true' do
+          expect(record).not_to receive(:update)
+          expect(subject.save).to be(true)
+
+          # mutant kill
+          expect(postcode).to have_received(:eql?).with('SW1H 9AJ')
+        end
       end
     end
   end

--- a/spec/services/c100_app/address_decision_tree_spec.rb
+++ b/spec/services/c100_app/address_decision_tree_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe C100App::AddressDecisionTree do
     let(:step_params) { { 'postcode_lookup' => 'anything' } }
     let(:record) { double('Applicant', id: 123) }
 
-    it 'goes to edit the address details of the record' do
+    it 'goes to the address results page' do
       expect(subject.destination).to eq(controller: :results, action: :edit, id: record)
     end
   end

--- a/spec/services/c100_app/map_address_lookup_results_spec.rb
+++ b/spec/services/c100_app/map_address_lookup_results_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe C100App::MapAddressLookupResults do
         expect(subject[0].address_line_1).to eq('APARTMENT 1001, 4, WIVERTON TOWER')
         expect(subject[0].address_line_2).to eq('NEW DRUM STREET')
         expect(subject[0].town).to eq('LONDON')
-        expect(subject[0].country).to eq('United Kingdom')
+        expect(subject[0].country).to eq('UNITED KINGDOM')
         expect(subject[0].postcode).to eq('E1 7AS')
       end
 
@@ -30,7 +30,7 @@ RSpec.describe C100App::MapAddressLookupResults do
 
         context '#tokenized_value' do
           it 'returns all address details in a tokenized string' do
-            expect(result.tokenized_value).to eq('APARTMENT 1001, 4, WIVERTON TOWER|NEW DRUM STREET|LONDON|United Kingdom|E1 7AS')
+            expect(result.tokenized_value).to eq('APARTMENT 1001, 4, WIVERTON TOWER|NEW DRUM STREET|LONDON|UNITED KINGDOM|E1 7AS')
           end
         end
       end


### PR DESCRIPTION
This is a kind of edge case but... if the user search for a postcode and select an address from the list, but then they go back (for whatever reason) and search another postcode, and, without selecting a new address (could happen the lookup didn't return results) go to the address edit page, then the old address is still pre-populated, which is confusing for the user.

We avoid this by checking if the postcode has changed or not, to reset dependent attributes.

Also, we pre-populate the country as we know 99% of users will be in United Kingdom if using the postcode lookup, although for the cases where not (Isle of Man or Channel Islands) they can always change it.
This was a suggestion by Simon to improve the UX for users that couldn't find their address in the list.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
