### PR TITLE
Some validations/error messages tweaks

### DIFF
--- a/app/forms/steps/applicant/contact_details_form.rb
+++ b/app/forms/steps/applicant/contact_details_form.rb
@@ -5,6 +5,7 @@ module Steps
       attribute :mobile_phone, StrippedString
       attribute :email, NormalisedEmail
 
+      validates_presence_of :mobile_phone
       validates :email, email: true, allow_blank: true
 
       private

--- a/app/forms/steps/respondent/address_details_form.rb
+++ b/app/forms/steps/respondent/address_details_form.rb
@@ -5,7 +5,6 @@ module Steps
       attribute :residence_history, String
 
       validates_inclusion_of :residence_requirement_met, in: GenericYesNoUnknown.values
-      validates_presence_of :residence_history, if: -> { residence_requirement_met&.no? }
 
       private
 

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -1,6 +1,6 @@
 en:
   dictionary:
-    invalid_email_error: &invalid_email_error "Enter a valid email address"
+    invalid_email_error: &invalid_email_error "Enter an email address in the correct format, like name@example.com"
     blank_email_error: &blank_email_error "Enter an email address"
     yes_no_error: &yes_no_error "Select yes or no"
     blank_details_error: &blank_details_error "Enter details"
@@ -38,7 +38,7 @@ en:
       residence_history:
         blank: Enter details and dates of previous addresses
       mobile_phone:
-        blank: Enter the mobile phone
+        blank: Enter a mobile number or tell us why the court cannot phone you
 
   errors:
     format: "%{message}"

--- a/spec/forms/steps/applicant/contact_details_form_spec.rb
+++ b/spec/forms/steps/applicant/contact_details_form_spec.rb
@@ -4,12 +4,9 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
   let(:arguments) { {
     c100_application: c100_application,
     record: record,
-    address: address,
     home_phone: home_phone,
     mobile_phone: mobile_phone,
     email: email,
-    residence_requirement_met: residence_requirement_met,
-    residence_history: residence_history
   } }
 
   let(:c100_application) { instance_double(C100Application, applicants: applicants_collection) }
@@ -17,12 +14,9 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
   let(:applicant) { double('Applicant', id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6') }
 
   let(:record) { nil }
-  let(:address) { 'address' }
   let(:home_phone) { nil }
-  let(:mobile_phone) { nil }
-  let(:email) { 'test@test.com' }
-  let(:residence_requirement_met) { 'no' }
-  let(:residence_history) { 'history' }
+  let(:mobile_phone) { '12345' }
+  let(:email) { nil }
 
   subject { described_class.new(arguments) }
 
@@ -32,6 +26,15 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
 
       it 'raises an error' do
         expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'mobile phone validation' do
+      let(:mobile_phone) { nil }
+
+      it 'has a validation error on the field if not present' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.added?(:mobile_phone, :blank)).to eq(true)
       end
     end
 
@@ -45,7 +48,7 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
         let(:email) { 'xxx' }
         it {
           expect(subject).not_to be_valid
-          expect(subject.errors[:email]).to_not be_empty
+          expect(subject.errors.added?(:email, :invalid)).to eq(true)
         }
       end
     end
@@ -54,8 +57,8 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
       let(:expected_attributes) {
         {
           home_phone: '',
-          mobile_phone: '',
-          email: 'test@test.com'
+          mobile_phone: '12345',
+          email: ''
         }
       }
 

--- a/spec/forms/steps/respondent/address_details_form_spec.rb
+++ b/spec/forms/steps/respondent/address_details_form_spec.rb
@@ -65,18 +65,8 @@ RSpec.describe Steps::Respondent::AddressDetailsForm do
         end
       end
 
-      context 'when attribute is given and requires residency history' do
+      context 'when attribute is `no`, does not require residency history' do
         let(:residence_requirement_met) { 'no' }
-        let(:residence_history) { nil }
-
-        it 'has a validation error on the `residence_history` field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:residence_history]).to_not be_empty
-        end
-      end
-
-      context 'when attribute is given and does not requires residency history' do
-        let(:residence_requirement_met) { 'yes' }
         let(:residence_history) { nil }
 
         it 'has no validation errors' do


### PR DESCRIPTION
As per this ticket:

https://mojdigital.teamwork.com/#/tasks/15321247

We've made mandatory the mobile number for the applicant, and remove the validation on the address history for respondent.

Some copy changes to the error messages.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
