### PR TITLE
Enable address lookup on dev/staging

### DIFF
--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -86,25 +86,8 @@ RSpec.describe C100App::ApplicantDecisionTree do
     context 'when all child relationships have been edited' do
       let(:child) { double('Child', id: 3) }
 
-      context 'and the address lookup is enabled' do
-        before do
-          allow(c100_application).to receive(:version).and_return(3)
-          allow(ENV).to receive(:key?).with('ADDRESS_LOOKUP_ENABLED').and_return('yes')
-        end
-
-        it 'goes to the address lookup of the current applicant' do
-          expect(subject.destination).to eq(controller: '/steps/address/lookup', action: :edit, id: applicant)
-        end
-      end
-
-      context 'and the address lookup is disabled' do
-        before do
-          allow(c100_application).to receive(:version).and_return(2)
-        end
-
-        it 'goes to edit the address details of the current applicant' do
-          expect(subject.destination).to eq(controller: :address_details, action: :edit, id: applicant)
-        end
+      include_examples 'address lookup decision tree' do
+        let(:person) { applicant }
       end
     end
   end

--- a/spec/services/c100_app/other_parties_decision_tree_spec.rb
+++ b/spec/services/c100_app/other_parties_decision_tree_spec.rb
@@ -65,25 +65,8 @@ RSpec.describe C100App::OtherPartiesDecisionTree do
     context 'when all child relationships have been edited' do
       let(:child) { double('Child', id: 3) }
 
-      context 'and the address lookup is enabled' do
-        before do
-          allow(c100_application).to receive(:version).and_return(3)
-          allow(ENV).to receive(:key?).with('ADDRESS_LOOKUP_ENABLED').and_return('yes')
-        end
-
-        it 'goes to the address lookup of the current party' do
-          expect(subject.destination).to eq(controller: '/steps/address/lookup', action: :edit, id: other_party)
-        end
-      end
-
-      context 'and the address lookup is disabled' do
-        before do
-          allow(c100_application).to receive(:version).and_return(2)
-        end
-
-        it 'goes to edit the address details of the current party' do
-          expect(subject.destination).to eq(controller: :address_details, action: :edit, id: other_party)
-        end
+      include_examples 'address lookup decision tree' do
+        let(:person) { other_party }
       end
     end
   end

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -102,29 +102,11 @@ RSpec.describe C100App::RespondentDecisionTree do
     context 'when all child relationships have been edited' do
       let(:child) { double('Child', id: 3) }
 
-      context 'and the address lookup is enabled' do
-        before do
-          allow(c100_application).to receive(:version).and_return(3)
-          allow(ENV).to receive(:key?).with('ADDRESS_LOOKUP_ENABLED').and_return('yes')
-        end
-
-        it 'goes to the address lookup of the current respondent' do
-          expect(subject.destination).to eq(controller: '/steps/address/lookup', action: :edit, id: respondent)
-        end
-      end
-
-      context 'and the address lookup is disabled' do
-        before do
-          allow(c100_application).to receive(:version).and_return(2)
-        end
-
-        it 'goes to edit the address details of the current respondent' do
-          expect(subject.destination).to eq(controller: :address_details, action: :edit, id: respondent)
-        end
+      include_examples 'address lookup decision tree' do
+        let(:person) { respondent }
       end
     end
   end
-
 
   context 'when the step is `address_details`' do
     let(:step_params) {{'address_details' => 'anything'}}

--- a/spec/support/decision_tree_shared_examples.rb
+++ b/spec/support/decision_tree_shared_examples.rb
@@ -36,3 +36,51 @@ RSpec.shared_examples 'a decision tree' do
     end
   end
 end
+
+RSpec.shared_examples 'address lookup decision tree' do
+  before do
+    allow(subject).to receive(:address_lookup_enabled?).and_return(address_lookup_enabled)
+  end
+
+  context 'and the address lookup is enabled' do
+    let(:address_lookup_enabled) { true }
+
+    before do
+      allow(person).to receive(:address_unknown?).and_return(address_unknown)
+      allow(person).to receive(:address_line_1).and_return(address_line_1)
+    end
+
+    let(:address_line_1) { nil }
+    let(:address_unknown) { false }
+
+    context 'and the person has yet to enter an address' do
+      it 'goes to the address lookup of the current person' do
+        expect(subject.destination).to eq(controller: '/steps/address/lookup', action: :edit, id: person)
+      end
+    end
+
+    context 'and the person has already entered an address' do
+      let(:address_line_1) { 'address line 1' }
+
+      it 'goes to edit the address details of the current person' do
+        expect(subject.destination).to eq(controller: :address_details, action: :edit, id: person)
+      end
+    end
+
+    context 'and the person does not know the address' do
+      let(:address_unknown) { true }
+
+      it 'goes to edit the address details of the current person' do
+        expect(subject.destination).to eq(controller: :address_details, action: :edit, id: person)
+      end
+    end
+  end
+
+  context 'and the address lookup is disabled' do
+    let(:address_lookup_enabled) { false }
+
+    it 'goes to edit the address details of the current person' do
+      expect(subject.destination).to eq(controller: :address_details, action: :edit, id: person)
+    end
+  end
+end


### PR DESCRIPTION
And bypass the lookup if the person has already entered address details, or their address is `unknown`.

This is a continuation to PR #664.

[Link to story](https://mojdigital.teamwork.com/#/tasks/15628354)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.