### PR TITLE
Ensure a predictable full address order

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,8 +1,9 @@
 class Person < ApplicationRecord
-  store_accessor :address_data, :address_line_1, :address_line_2,
-                 :town, :country, :postcode
   belongs_to :c100_application
   has_many :relationships, source: :person, dependent: :destroy
+
+  store_accessor :address_data,
+                 :address_line_1, :address_line_2, :town, :country, :postcode
 
   # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
   default_scope { order(created_at: :asc) }
@@ -13,7 +14,12 @@ class Person < ApplicationRecord
 
   def full_address
     return address unless split_address?
-    address_data.values.reject(&:blank?).join(', ')
+
+    # Ensure, no matter the order of the keys in the hash, we return the values
+    # in a predictable order, matching the `store_accessor` declaration.
+    address_data.symbolize_keys.values_at(
+      *self.class.stored_attributes.fetch(:address_data)
+    ).reject(&:blank?).join(', ')
   end
 
   # Until we've migrated all database records to the new address form

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -3,14 +3,6 @@ require 'rails_helper'
 RSpec.describe Person, type: :model do
   subject { person }
 
-  let(:person) do
-    Person.new(first_name: first_name, last_name: last_name)
-  end
-
-  let(:first_name) { nil }
-  let(:last_name)  { nil }
-
-
   let(:address_hash) do
     {
       address_line_1: 'address_line_1',
@@ -21,11 +13,17 @@ RSpec.describe Person, type: :model do
     }
   end
 
-  let(:full_address_string) { address_hash.values.reject(&:empty?).join(', ') }
   let(:address_string) { 'address' }
   let(:split_address_value) { false }
 
   describe '#full_name' do
+    let(:person) do
+      Person.new(first_name: first_name, last_name: last_name)
+    end
+
+    let(:first_name) { nil }
+    let(:last_name)  { nil }
+
     context 'for a person with first and last name attributes' do
       let(:first_name) { 'John' }
       let(:last_name) { 'Doe' }
@@ -43,10 +41,9 @@ RSpec.describe Person, type: :model do
     end
   end
 
-
   describe '#full_address' do
     let(:person) do
-      Person.new(first_name: first_name, last_name: last_name, address: address_string, address_data: address_hash)
+      Person.new(address: address_string, address_data: address_hash)
     end
 
     before do
@@ -59,7 +56,23 @@ RSpec.describe Person, type: :model do
 
     context 'split address' do
       let(:split_address_value) { true }
-      it { expect(subject.full_address).to eq(full_address_string) }
+
+      it { expect(subject.full_address).to eq('address_line_1, town, country, postcode') }
+
+      context 'when the hash keys are in a different order or missing' do
+        let(:address_hash) do
+          {
+            postcode: 'postcode',
+            country: 'country',
+            address_line_1: 'address_line_1',
+            town: 'town',
+          }
+        end
+
+        it 'returns the value in the expected order' do
+          expect(subject.full_address).to eq('address_line_1, town, country, postcode')
+        end
+      end
     end
   end
 
@@ -68,7 +81,7 @@ RSpec.describe Person, type: :model do
     let(:c100_application) { C100Application.new(version: version) }
 
     let(:person) do
-      Person.new(first_name: first_name, last_name: last_name, address: address_string, address_data: address_hash, c100_application: c100_application)
+      Person.new(address: address_string, address_data: address_hash, c100_application: c100_application)
     end
 
     context 'return false' do


### PR DESCRIPTION
The order in the `address_data` Hash (store) is not guaranteed, and in fact, some keys (postcode or country) are created before others (address lines).

This has the side effect of sometimes returning a funny `full_address` that does not maintain the order people are used to.

Make the `#full_address` method resilient to these scenarios and always return the attribute values in the same order they were declared, regardless of the order of the keys in the Hash.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
