### PR TITLE
Fix issues with country name / post town for postcode lookup service

### DIFF
--- a/app/services/c100_app/map_address_lookup_results.rb
+++ b/app/services/c100_app/map_address_lookup_results.rb
@@ -1,8 +1,9 @@
 module C100App
   class MapAddressLookupResults
-    LINE_ONE_PARTS = %w[SUB_BUILDING_NAME BUILDING_NUMBER BUILDING_NAME].freeze
+    LINE_ONE_PARTS = %w[SUB_BUILDING_NAME BUILDING_NUMBER BUILDING_NAME DEPARTMENT_NAME ORGANISATION_NAME].freeze
     LINE_TWO_PARTS = %w[DEPENDENT_THOROUGHFARE_NAME THOROUGHFARE_NAME].freeze
     DEFAULT_COUNTRY = 'UNITED KINGDOM'.freeze
+    OTHER_COUNTRIES = ['ISLE OF MAN', 'JERSEY', 'GUERNSEY'].freeze
 
     Address = Struct.new(:address_line_1, :address_line_2, :town, :country, :postcode) do
       def address_lines
@@ -24,14 +25,24 @@ module C100App
       Address.new(
         address_line(result.slice(*LINE_ONE_PARTS).values),
         address_line(result.slice(*LINE_TWO_PARTS).values),
-        result.fetch('POST_TOWN'),
-        DEFAULT_COUNTRY,
+        postal_town(result),
+        country_name(result),
         result.fetch('POSTCODE')
       )
     end
 
+    def self.postal_town(result)
+      return result.fetch('DEPENDENT_LOCALITY') if OTHER_COUNTRIES.include?(result.fetch('POST_TOWN'))
+      result.fetch('POST_TOWN')
+    end
+
     def self.address_line(values)
       values.reject(&:blank?).join(', ')
+    end
+
+    def self.country_name(result)
+      return result.fetch('POST_TOWN') if OTHER_COUNTRIES.include?(result.fetch('POST_TOWN'))
+      DEFAULT_COUNTRY
     end
   end
 end

--- a/spec/fixtures/files/address_lookups/guernsey.json
+++ b/spec/fixtures/files/address_lookups/guernsey.json
@@ -1,0 +1,35 @@
+{
+    "header": {
+        "uri": "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?postcode=GY10%201PB",
+        "query": "postcode=GY10 1PB",
+        "offset": 0,
+        "totalresults": 1,
+        "format": "JSON",
+        "dataset": "DPA",
+        "lr": "EN,CY",
+        "maxresults": 100,
+        "epoch": "66",
+        "output_srs": "EPSG:27700"
+    },
+    "results": [
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "10406258",
+                "ADDRESS": "SARK POST OFFICE, SARK, GUERNSEY, GY10 1PB",
+                "ORGANISATION_NAME": "SARK POST OFFICE",
+                "DEPENDENT_LOCALITY": "SARK",
+                "POST_TOWN": "GUERNSEY",
+                "POSTCODE": "GY10 1PB",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        }
+    ]
+}

--- a/spec/fixtures/files/address_lookups/isle_of_man.json
+++ b/spec/fixtures/files/address_lookups/isle_of_man.json
@@ -1,0 +1,82 @@
+{
+    "header": {
+        "uri": "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?postcode=IM11BE",
+        "query": "postcode=IM11BE",
+        "offset": 0,
+        "totalresults": 29,
+        "format": "JSON",
+        "dataset": "DPA",
+        "lr": "EN,CY",
+        "maxresults": 100,
+        "epoch": "66",
+        "output_srs": "EPSG:27700"
+    },
+    "results": [
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "11453891",
+                "ADDRESS": "FLAT 1, FAIRFIELD MANSIONS, 2, FAIRFIELD TERRACE, DOUGLAS, ISLE OF MAN, IM1 1BE",
+                "SUB_BUILDING_NAME": "FLAT 1",
+                "BUILDING_NAME": "FAIRFIELD MANSIONS",
+                "BUILDING_NUMBER": "2",
+                "THOROUGHFARE_NAME": "FAIRFIELD TERRACE",
+                "DEPENDENT_LOCALITY": "DOUGLAS",
+                "POST_TOWN": "ISLE OF MAN",
+                "POSTCODE": "IM1 1BE",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        },
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "11453893",
+                "ADDRESS": "FLAT 2, FAIRFIELD MANSIONS, 2, FAIRFIELD TERRACE, DOUGLAS, ISLE OF MAN, IM1 1BE",
+                "SUB_BUILDING_NAME": "FLAT 2",
+                "BUILDING_NAME": "FAIRFIELD MANSIONS",
+                "BUILDING_NUMBER": "2",
+                "THOROUGHFARE_NAME": "FAIRFIELD TERRACE",
+                "DEPENDENT_LOCALITY": "DOUGLAS",
+                "POST_TOWN": "ISLE OF MAN",
+                "POSTCODE": "IM1 1BE",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        },
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "11453896",
+                "ADDRESS": "FLAT 3, FAIRFIELD MANSIONS, 2, FAIRFIELD TERRACE, DOUGLAS, ISLE OF MAN, IM1 1BE",
+                "SUB_BUILDING_NAME": "FLAT 3",
+                "BUILDING_NAME": "FAIRFIELD MANSIONS",
+                "BUILDING_NUMBER": "2",
+                "THOROUGHFARE_NAME": "FAIRFIELD TERRACE",
+                "DEPENDENT_LOCALITY": "DOUGLAS",
+                "POST_TOWN": "ISLE OF MAN",
+                "POSTCODE": "IM1 1BE",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        }
+    ]
+}

--- a/spec/fixtures/files/address_lookups/jersey.json
+++ b/spec/fixtures/files/address_lookups/jersey.json
@@ -1,0 +1,143 @@
+{
+    "header": {
+        "uri": "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?postcode=je2%203qa",
+        "query": "postcode=je2 3qa",
+        "offset": 0,
+        "totalresults": 47,
+        "format": "JSON",
+        "dataset": "DPA",
+        "lr": "EN,CY",
+        "maxresults": 100,
+        "epoch": "66",
+        "output_srs": "EPSG:27700"
+    },
+    "results": [
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "55544644",
+                "ADDRESS": "INVESTEC, 1, ESPLANADE, ST. HELIER, JERSEY, JE2 3QA",
+                "ORGANISATION_NAME": "INVESTEC",
+                "BUILDING_NUMBER": "1",
+                "THOROUGHFARE_NAME": "ESPLANADE",
+                "DEPENDENT_LOCALITY": "ST. HELIER",
+                "POST_TOWN": "JERSEY",
+                "POSTCODE": "JE2 3QA",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        },
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "53095898",
+                "ADDRESS": "VOISIN HUNTER, 1, ESPLANADE, ST. HELIER, JERSEY, JE2 3QA",
+                "ORGANISATION_NAME": "VOISIN HUNTER",
+                "BUILDING_NUMBER": "1",
+                "THOROUGHFARE_NAME": "ESPLANADE",
+                "DEPENDENT_LOCALITY": "ST. HELIER",
+                "POST_TOWN": "JERSEY",
+                "POSTCODE": "JE2 3QA",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        },
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "11861881",
+                "ADDRESS": "FERRY CENTRE, 5, ESPLANADE, ST. HELIER, JERSEY, JE2 3QA",
+                "ORGANISATION_NAME": "FERRY CENTRE",
+                "BUILDING_NUMBER": "5",
+                "THOROUGHFARE_NAME": "ESPLANADE",
+                "DEPENDENT_LOCALITY": "ST. HELIER",
+                "POST_TOWN": "JERSEY",
+                "POSTCODE": "JE2 3QA",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        },
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "11861886",
+                "ADDRESS": "PLATINUM NIGHT CLUB, 6, ESPLANADE, ST. HELIER, JERSEY, JE2 3QA",
+                "ORGANISATION_NAME": "PLATINUM NIGHT CLUB",
+                "BUILDING_NUMBER": "6",
+                "THOROUGHFARE_NAME": "ESPLANADE",
+                "DEPENDENT_LOCALITY": "ST. HELIER",
+                "POST_TOWN": "JERSEY",
+                "POSTCODE": "JE2 3QA",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        },
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "55539525",
+                "ADDRESS": "A C P I INVESTMENT MANAGERS, 3RD FLOOR, 7, ESPLANADE, ST. HELIER, JERSEY, JE2 3QA",
+                "ORGANISATION_NAME": "A C P I INVESTMENT MANAGERS",
+                "SUB_BUILDING_NAME": "3RD FLOOR",
+                "BUILDING_NUMBER": "7",
+                "THOROUGHFARE_NAME": "ESPLANADE",
+                "DEPENDENT_LOCALITY": "ST. HELIER",
+                "POST_TOWN": "JERSEY",
+                "POSTCODE": "JE2 3QA",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        },
+        {
+            "DPA": {
+                "UPRN": "",
+                "UDPRN": "11861882",
+                "ADDRESS": "FLATS, 8, ESPLANADE, ST. HELIER, JERSEY, JE2 3QA",
+                "SUB_BUILDING_NAME": "FLATS",
+                "BUILDING_NUMBER": "8",
+                "THOROUGHFARE_NAME": "ESPLANADE",
+                "DEPENDENT_LOCALITY": "ST. HELIER",
+                "POST_TOWN": "JERSEY",
+                "POSTCODE": "JE2 3QA",
+                "RPC": "0",
+                "X_COORDINATE": 0,
+                "Y_COORDINATE": 0,
+                "STATUS": "",
+                "BLPU_STATE_CODE_DESCRIPTION": "Unknown/Not applicable",
+                "LANGUAGE": "EN",
+                "MATCH": 1,
+                "MATCH_DESCRIPTION": "EXACT"
+            }
+        }
+    ]
+}

--- a/spec/services/c100_app/map_address_lookup_results_spec.rb
+++ b/spec/services/c100_app/map_address_lookup_results_spec.rb
@@ -42,6 +42,52 @@ RSpec.describe C100App::MapAddressLookupResults do
         expect(subject).to eq([])
       end
     end
+
+    context 'jeresy results' do
+      let(:parsed_body) { JSON.parse(file_fixture('address_lookups/jersey.json').read) }
+      let(:results) { parsed_body['results'] }
+
+      it 'retrieves the address return by api' do
+
+        expect(subject.size).to eq(6)
+
+        expect(subject[0].address_line_1).to eq('1, INVESTEC')
+        expect(subject[0].address_line_2).to eq('ESPLANADE')
+        expect(subject[0].town).to eq('ST. HELIER')
+        expect(subject[0].country).to eq('JERSEY')
+        expect(subject[0].postcode).to eq('JE2 3QA')
+      end
+    end
+
+    context 'guernsey results' do
+      let(:parsed_body) { JSON.parse(file_fixture('address_lookups/guernsey.json').read) }
+      let(:results) { parsed_body['results'] }
+
+      it 'retrieves the address return by api' do
+        expect(subject.size).to eq(1)
+
+        expect(subject[0].address_line_1).to eq('SARK POST OFFICE')
+        expect(subject[0].address_line_2).to eq('')
+        expect(subject[0].town).to eq('SARK')
+        expect(subject[0].country).to eq('GUERNSEY')
+        expect(subject[0].postcode).to eq('GY10 1PB')
+      end
+    end
+
+    context 'isle of man results' do
+      let(:parsed_body) { JSON.parse(file_fixture('address_lookups/isle_of_man.json').read) }
+      let(:results) { parsed_body['results'] }
+
+      it 'retrieves the address return by api' do
+        expect(subject.size).to eq(3)
+
+        expect(subject[0].address_line_1).to eq('FLAT 1, 2, FAIRFIELD MANSIONS')
+        expect(subject[0].address_line_2).to eq('FAIRFIELD TERRACE')
+        expect(subject[0].town).to eq('DOUGLAS')
+        expect(subject[0].country).to eq('ISLE OF MAN')
+        expect(subject[0].postcode).to eq('IM1 1BE')
+      end
+    end
   end
 
   context '#address_line' do


### PR DESCRIPTION
Currently we default country names to UNITED KINGDOM.  This is incorrect for ISLE OF MAN,JERSEY  and GUERNSEY.  For postcodes from the above countries, the service returns the country name in  POST_TOWN and the town/city name in DEPENDENT_LOCALITY field.   