### PR TITLE
Remove references to old dsd URL

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
   <![endif]-->
   <meta name="robots" content="noindex, nofollow"/>
   <meta name="msapplication-config" content="none"/>
-  <meta name="google-site-verification" content="lriduWRhNzjNWRLiG66idMmhQA9UaaOWS3_dFTQoips"/> <!-- dsd -->
   <meta name="google-site-verification" content="Ed6XKLFCCovwl_3gUpR5owg8AvgINOhiWWNGeJhHyio"/> <!-- service -->
 <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,8 +34,8 @@ class Application < Rails::Application
   # We are using our own url-shortener. These short urls redirect to surveymonkey,
   # and tracks visits, so we can see if they are being used.
   config.surveys = {
-    success: 'https://c100.dsd.io/survey',
-    kickout: 'https://c100.dsd.io/exit_survey',
+    success: 'https://c100.service.justice.gov.uk/survey',
+    kickout: 'https://c100.service.justice.gov.uk/exit_survey',
   }
 
   # This is the GDS-hosted homepage for our service, and the one with a `start` button

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,24 +30,10 @@ end
 # :nocov:
 
 Rails.application.routes.draw do
-  # TODO: once we migrate, there will be an S3/Route 53 redirection from `c100.dsd.io`
-  # to `c100.service.justice.gov.uk` and we can remove this constraint.
-  constraints host: 'c100.dsd.io' do
-    get '/(*path)' => redirect(
-      ShortUrlExpander.new('https://apply-to-court-about-child-arrangements.service.justice.gov.uk'), status: 302
-    )
-  end
-
-  # New short url in live-1 k8s cluster
   constraints host: 'c100.service.justice.gov.uk' do
     get '/(*path)' => redirect(
       ShortUrlExpander.new('https://apply-to-court-about-child-arrangements.service.justice.gov.uk'), status: 302
     )
-  end
-
-  # TODO: to be removed once we decommission our heroku environment
-  constraints host: 'c100-staging.herokuapp.com' do
-    get '/(*path)' => redirect('https://c100-application-staging.apps.live-1.cloud-platform.service.justice.gov.uk', status: 301)
   end
 
   devise_for :users,

--- a/lib/tasks/short_urls.rake
+++ b/lib/tasks/short_urls.rake
@@ -37,7 +37,7 @@ end
 private
 
 def default_host_domain
-  'https://c100.dsd.io'.freeze
+  'https://c100.service.justice.gov.uk'.freeze
 end
 
 def default_target_url


### PR DESCRIPTION
We are now using a new short URL under the `service.justice.gov.uk` domain.

The govuk Notify templates will be also updated to use the new short URL.

For the time being the (already) deployed application in Heroku will handle the old `dsd.io` URLs but eventually we will also decommission the app and use a simple s3 redirect or something like that so we don't have to maintain another app in Heroku.

[Link to story](https://mojdigital.teamwork.com/#/tasks/15821117)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.