### PR TITLE
Postcode lookup fixes

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -19,7 +19,7 @@ class Person < ApplicationRecord
     # in a predictable order, matching the `store_accessor` declaration.
     address_data.symbolize_keys.values_at(
       *self.class.stored_attributes.fetch(:address_data)
-    ).reject(&:blank?).join(', ')
+    ).presence_join(', ')
   end
 
   # Until we've migrated all database records to the new address form

--- a/app/services/c100_app/address_lookup_service.rb
+++ b/app/services/c100_app/address_lookup_service.rb
@@ -24,7 +24,8 @@ module C100App
     def query_params
       {
         key: ENV.fetch('ORDNANCE_SURVEY_API_KEY'),
-        postcode: postcode
+        postcode: postcode,
+        lr: 'EN',
       }
     end
 

--- a/app/services/c100_app/map_address_lookup_results.rb
+++ b/app/services/c100_app/map_address_lookup_results.rb
@@ -7,7 +7,7 @@ module C100App
 
     Address = Struct.new(:address_line_1, :address_line_2, :town, :country, :postcode) do
       def address_lines
-        [address_line_1, address_line_2].join(', ')
+        [address_line_1, address_line_2].presence_join(', ')
       end
 
       def tokenized_value
@@ -36,13 +36,13 @@ module C100App
       result.fetch('POST_TOWN')
     end
 
-    def self.address_line(values)
-      values.reject(&:blank?).join(', ')
-    end
-
     def self.country_name(result)
       return result.fetch('POST_TOWN') if OTHER_COUNTRIES.include?(result.fetch('POST_TOWN'))
       DEFAULT_COUNTRY
+    end
+
+    def self.address_line(values)
+      values.presence_join(', ')
     end
   end
 end

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -1,4 +1,8 @@
-Dir[File.join(Rails.root, 'lib', 'extensions', '*.rb')].each { |file| require file }
+Dir[File.join(Rails.root, 'lib', 'extensions', '*.rb')].each(&method(:require))
+
+class Array
+  include ArrayExtension
+end
 
 class String
   include StringExtension

--- a/lib/extensions/array_extension.rb
+++ b/lib/extensions/array_extension.rb
@@ -1,0 +1,5 @@
+module ArrayExtension
+  def presence_join(separator = nil)
+    reject(&:blank?).join(separator)
+  end
+end

--- a/spec/lib/extensions/array_extension_spec.rb
+++ b/spec/lib/extensions/array_extension_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Array do
+  subject { described_class.new(values) }
+
+  context '#presence_join' do
+    let(:values) { ['a', nil, 'b', '', 'c', ' '] }
+
+    context 'for a specified separator' do
+      it 'returns the joined values, without blanks' do
+        expect(subject.presence_join(',')).to eq('a,b,c')
+      end
+    end
+
+    context 'for a nil separator' do
+      it 'returns the joined values, without blanks' do
+        expect(subject.presence_join).to eq('abc')
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/address_lookup_service_spec.rb
+++ b/spec/services/c100_app/address_lookup_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe C100App::AddressLookupService do
   let(:query_params) do
     {
       key: 'test-token',
-      postcode: postcode
+      postcode: postcode,
+      lr: 'EN',
     }
   end
 


### PR DESCRIPTION
We still have some little issues with the postcode lookup. This PR will fix a couple, and a follow-up PR will try to fix another one, related to Wales postcodes like LL61 5AB not returning the country properly.

In this PR (refer to the individual commits for more context):

* Fix duplicated addresses in Welsh.
* Fix extra trailing comma in addresses without `address_line_2`.

Before:
<img width="130" alt="Screen Shot 2019-05-31 at 16 20 28" src="https://user-images.githubusercontent.com/687910/58786890-7b575400-85e0-11e9-9fee-17371bdfe3ad.png">

After:
<img width="109" alt="Screen Shot 2019-06-03 at 08 42 49" src="https://user-images.githubusercontent.com/687910/58786895-7f837180-85e0-11e9-9edb-7757dbcd9c6a.png">

[Link to story](https://mojdigital.teamwork.com/#/tasks/15628354)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.