### PR TITLE
Add address lookup analytics

### DIFF
--- a/app/views/steps/address/lookup/_applicant.html.erb
+++ b/app/views/steps/address/lookup/_applicant.html.erb
@@ -3,7 +3,7 @@
 
   <%= link_to t('.manual_address'), {
       controller: '/steps/applicant/address_details', action: :edit, id: form_object.record
-  } %>
+  }, class: 'ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'applicant manual entry' } %>
 
   <%= f.continue_button %>
 <% end %>

--- a/app/views/steps/address/lookup/_other_party.html.erb
+++ b/app/views/steps/address/lookup/_other_party.html.erb
@@ -3,7 +3,7 @@
 
   <%= link_to t('.manual_address'), {
       controller: '/steps/other_parties/address_details', action: :edit, id: form_object.record
-  } %>
+  }, class: 'ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'other party manual entry' } %>
 
   <%= f.continue_button %>
 <% end %>

--- a/app/views/steps/address/lookup/_respondent.html.erb
+++ b/app/views/steps/address/lookup/_respondent.html.erb
@@ -3,7 +3,7 @@
 
   <%= link_to t('.manual_address'), {
       controller: '/steps/respondent/address_details', action: :edit, id: form_object.record
-  } %>
+  }, class: 'ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'respondent manual entry' } %>
 
   <%= f.continue_button %>
 <% end %>

--- a/app/views/steps/address/results/_no_results.en.html.erb
+++ b/app/views/steps/address/results/_no_results.en.html.erb
@@ -23,6 +23,6 @@
 </section>
 
 <div class="xform-group form-submit">
-  <%= link_to 'Continue', person_url_for(record, step: :address_details), class: 'button', role: 'button' %>
-  <%= link_to 'Go back and try again', edit_steps_address_lookup_path(record), class: 'button button-secondary', role: 'button' %>
+  <%= link_to 'Continue', person_url_for(record, step: :address_details), class: 'button ga-pageLink', role: 'button', data: { ga_category: 'address lookup', ga_label: 'no results continue' } %>
+  <%= link_to 'Go back and try again', edit_steps_address_lookup_path(record), class: 'button button-secondary ga-pageLink', role: 'button', data: { ga_category: 'address lookup', ga_label: 'no results retry' } %>
 </div>


### PR DESCRIPTION
In order to have a better understanding of how users are using the address lookup, as we do in other places in the application, and diagnose issues when addresses are not found, we are going to track the use of `manual entry` links and `no results` links.

[Link to story](https://mojdigital.teamwork.com/#/tasks/15628354)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.