### PR TITLE
Enable the address lookup in production

### DIFF
--- a/app/services/people_decision_tree.rb
+++ b/app/services/people_decision_tree.rb
@@ -60,7 +60,7 @@ class PeopleDecisionTree < BaseDecisionTree
   # Once all applications are in version >= 3, we can delete this code.
   # :nocov:
   def address_lookup_enabled?
-    c100_application.version > 2 && dev_tools_enabled?
+    c100_application.version > 2
   end
   # :nocov:
 end


### PR DESCRIPTION
We have the green light. Up until now this feature has been only visible on staging and local dev environments.

Still, we must ensure this is only enabled for `version >= 3` of the applications, so the condition will remain until all applications are in the new version, which can still take a couple weeks.

[Link to story](https://mojdigital.teamwork.com/#/tasks/15628354)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.