### PR TITLE
Protect from nil values

### DIFF
--- a/app/presenters/summary/sections/c1a_abduction_details.rb
+++ b/app/presenters/summary/sections/c1a_abduction_details.rb
@@ -13,7 +13,7 @@ module Summary
       def answers
         return [
           Answer.new(:c1a_abduction_risk, c100.risk_of_abduction)
-        ] unless c100.risk_of_abduction.eql?(GenericYesNo::YES.to_s)
+        ] unless abduction.present?
 
         [
           Answer.new(:c1a_abduction_risk, c100.risk_of_abduction),

--- a/app/presenters/summary/sections/other_court_cases.rb
+++ b/app/presenters/summary/sections/other_court_cases.rb
@@ -11,7 +11,7 @@ module Summary
 
       # rubocop:disable Metrics/AbcSize
       def answers
-        return [Separator.not_applicable] unless previous_proceedings?
+        return [Separator.not_applicable] unless court_proceeding.present?
 
         [
           FreeTextAnswer.new(:court_proceeding_children_names,   court_proceeding.children_names),
@@ -29,10 +29,6 @@ module Summary
 
       def court_proceeding
         @_court_proceeding ||= c100.court_proceeding
-      end
-
-      def previous_proceedings?
-        c100.children_previous_proceedings.eql?(GenericYesNo::YES.to_s)
       end
     end
   end

--- a/spec/presenters/summary/sections/c1a_abduction_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_abduction_details_spec.rb
@@ -92,6 +92,7 @@ module Summary
 
       context 'when there is no abduction risk' do
         let(:risk_of_abduction) { 'no' }
+        let(:abduction_detail) { nil }
 
         it 'has the correct rows' do
           expect(answers.count).to eq(1)
@@ -99,6 +100,19 @@ module Summary
           expect(answers[0]).to be_an_instance_of(Answer)
           expect(answers[0].question).to eq(:c1a_abduction_risk)
           expect(answers[0].value).to eq('no')
+        end
+      end
+
+      context 'when there are no abduction details' do
+        let(:risk_of_abduction) { 'yes' }
+        let(:abduction_detail) { nil }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(1)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:c1a_abduction_risk)
+          expect(answers[0].value).to eq('yes')
         end
       end
     end

--- a/spec/presenters/summary/sections/other_court_cases_spec.rb
+++ b/spec/presenters/summary/sections/other_court_cases_spec.rb
@@ -66,8 +66,8 @@ module Summary
         expect(answers[6].value).to eq('previous_details')
       end
 
-      context 'when there are no previous proceedings' do
-        let(:children_previous_proceedings) { 'no' }
+      context 'when there are no previous proceeding details' do
+        let(:court_proceeding) { nil }
 
         it 'has the correct rows' do
           expect(answers.count).to eq(1)


### PR DESCRIPTION
Under certain circunstances, an applicant might leave out some mandatory follow-up questions after changing their answer to the `abduction risk` or the `previous proceedings` questions.

The result of this would be an exception when trying to generate the PDF, due to missing data.

Although this has occurred only twice in the past so far, we better protect from this from happening again.

[Link to story](https://mojdigital.teamwork.com/#/tasks/15890246)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.