### PR TITLE
Force garbage collection on delivery jobs

### DIFF
--- a/app/jobs/applicant_delivery_job.rb
+++ b/app/jobs/applicant_delivery_job.rb
@@ -3,5 +3,7 @@ class ApplicantDeliveryJob < ApplicationJob
 
   def perform(c100_application)
     C100App::ApplicantOnlineSubmission.new(c100_application).process
+  ensure
+    GC.start # force garbage collection
   end
 end

--- a/app/jobs/court_delivery_job.rb
+++ b/app/jobs/court_delivery_job.rb
@@ -10,6 +10,8 @@ class CourtDeliveryJob < ApplicationJob
 
   def perform(c100_application)
     C100App::CourtOnlineSubmission.new(c100_application).process
+  ensure
+    GC.start # force garbage collection
   end
 
   private

--- a/spec/jobs/applicant_delivery_job_spec.rb
+++ b/spec/jobs/applicant_delivery_job_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ApplicantDeliveryJob, type: :job do
       ).and_return(queue)
 
       expect(queue).to receive(:process)
+      expect(GC).to receive(:start)
 
       ApplicantDeliveryJob.perform_now(c100_application)
     end

--- a/spec/jobs/court_delivery_job_spec.rb
+++ b/spec/jobs/court_delivery_job_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CourtDeliveryJob, type: :job do
       ).and_return(queue)
 
       expect(queue).to receive(:process)
+      expect(GC).to receive(:start)
 
       CourtDeliveryJob.perform_now(c100_application)
     end
@@ -25,6 +26,8 @@ RSpec.describe CourtDeliveryJob, type: :job do
       it 'captures the error' do
         expect(Raven).to receive(:extra_context).with({ c100_application_id: '123-456' })
         expect(Raven).to receive(:capture_exception).with(NoMethodError)
+
+        expect(GC).to receive(:start)
 
         CourtDeliveryJob.perform_now(c100_application)
       end


### PR DESCRIPTION
We continue to have memory peaks after each submission. This is mostly a consequence of the PDF generation, and the tools used to combine multiple files into one.

Let's experiment for a few days by having an explicit garbage collection after the jobs complete, and see if this  improves in any way the situation.

As these are async jobs, there is no penalty to the user (that otherwise would be if this was part of the request lifecycle).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
