### PR TITLE
Add a screener sanity check validation

### DIFF
--- a/app/controllers/concerns/savepoint_step.rb
+++ b/app/controllers/concerns/savepoint_step.rb
@@ -3,6 +3,8 @@ module SavepointStep
 
   included do
     skip_before_action :check_application_not_screening
+
+    before_action :screener_sanity_check
     before_action :mark_in_progress, only: [:update]
     before_action :save_application_for_later, if: :user_signed_in?, only: [:update]
   end
@@ -14,6 +16,11 @@ module SavepointStep
     # clicks the `back` link, they are not taken to start of the screener again.
     current_c100_application.navigation_stack = [entrypoint_v1_path]
     super
+  end
+
+  def screener_sanity_check
+    screener = current_c100_application.screener_answers
+    raise Errors::ApplicationScreening unless screener.present? && screener.valid?(:completion)
   end
 
   def mark_in_progress

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -44,22 +44,29 @@ class SessionsController < ApplicationController
   def find_or_create_screener_answers
     ScreenerAnswers.find_or_initialize_by(c100_application_id: c100_application.id).tap do |screener|
       screener.update(
-        children_postcodes: 'MK9 2DT',
-        local_court: local_court_fixture
-      ) unless screener.local_court?
+        screener_answers_fixture
+      ) unless screener.valid?(:completion)
     end
   end
 
-  def local_court_fixture
+  def screener_answers_fixture
     {
-      "address" => {
-        "address_lines" => ["351 Silbury Boulevard", "Witan Gate East"],
-        "town" => "Central Milton Keynes",
-        "postcode" => "MK9 2DT",
-      },
-      "name" => "Milton Keynes County Court and Family Court",
-      "slug" => "milton-keynes-county-court-and-family-court",
-      "email" => "family@miltonkeynes.countycourt.gsi.gov.uk",
+      children_postcodes: 'MK9 2DT',
+      parent: 'yes',
+      over18: 'yes',
+      legal_representation: 'no',
+      written_agreement: 'no',
+      email_consent: 'no',
+      local_court: {
+        "address" => {
+          "address_lines" => ["351 Silbury Boulevard", "Witan Gate East"],
+          "town" => "Central Milton Keynes",
+          "postcode" => "MK9 2DT",
+        },
+        "name" => "Milton Keynes County Court and Family Court",
+        "slug" => "milton-keynes-county-court-and-family-court",
+        "email" => "family@miltonkeynes.countycourt.gsi.gov.uk",
+      }
     }
   end
   # :nocov:

--- a/app/models/screener_answers.rb
+++ b/app/models/screener_answers.rb
@@ -1,6 +1,12 @@
 class ScreenerAnswers < ApplicationRecord
   belongs_to :c100_application
 
+  def self.attributes_to_validate
+    attribute_names - %w[id c100_application_id created_at updated_at email_address]
+  end.freeze
+
+  validates_presence_of attributes_to_validate, on: :completion
+
   def court
     Court.new(local_court) if local_court
   end

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -74,6 +74,7 @@ end
 def models
   %w(
     C100Application
+    ScreenerAnswers
     User
     Court
     Person

--- a/spec/controllers/steps/miam/child_protection_cases_controller_spec.rb
+++ b/spec/controllers/steps/miam/child_protection_cases_controller_spec.rb
@@ -2,9 +2,21 @@ require 'rails_helper'
 
 RSpec.describe Steps::Miam::ChildProtectionCasesController, type: :controller do
   it_behaves_like 'a savepoint step controller'
-  it_behaves_like 'an intermediate step controller', Steps::Miam::ChildProtectionCasesForm, C100App::MiamDecisionTree
+
+  # Following examples will stub the screener sanity check for simplicity,
+  # as the above `savepoint` examples already test the involved code.
+
+  it_behaves_like 'an intermediate step controller', Steps::Miam::ChildProtectionCasesForm, C100App::MiamDecisionTree do
+    before do
+      allow(controller).to receive(:screener_sanity_check).and_return(true)
+    end
+  end
 
   # The following shared specs can really be used in any other step controller.
   # The important thing is to be tested in at least one, as any other will behave the same.
-  it_behaves_like 'a step that can be drafted', Steps::Miam::ChildProtectionCasesForm
+  it_behaves_like 'a step that can be drafted', Steps::Miam::ChildProtectionCasesForm do
+    before do
+      allow(controller).to receive(:screener_sanity_check).and_return(true)
+    end
+  end
 end

--- a/spec/models/screener_answers_spec.rb
+++ b/spec/models/screener_answers_spec.rb
@@ -3,6 +3,37 @@ require 'rails_helper'
 RSpec.describe ScreenerAnswers, type: :model do
   subject { described_class.new(local_court: local_court) }
 
+  let(:local_court) { nil }
+
+  describe '.attributes_to_validate' do
+    it 'returns only the attributes that should be validated' do
+      expect(
+        described_class.attributes_to_validate
+      ).to match_array(%w(
+        children_postcodes
+        local_court
+        parent
+        over18
+        written_agreement
+        email_consent
+        legal_representation
+      ))
+    end
+  end
+
+  describe 'validations' do
+    # One example for an attribute is enough as we have already another test
+    # for all the attributes that will be run through the validator.
+    #
+    context 'when context is `completion`' do
+      it { should validate_presence_of(:parent, :blank).on_context(:completion) }
+    end
+
+    context 'when context is not `completion`' do
+      it { should_not validate_presence_of(:parent, :blank) }
+    end
+  end
+
   describe '#court' do
     context 'when there is a local_court' do
       let(:local_court) { { "name" => 'whatever' } }
@@ -14,8 +45,6 @@ RSpec.describe ScreenerAnswers, type: :model do
     end
 
     context 'when there is no local_court' do
-      let(:local_court) {nil}
-
       it 'returns nil' do
         expect(subject.court).to eq(nil)
       end

--- a/spec/support/matchers/validation_helpers.rb
+++ b/spec/support/matchers/validation_helpers.rb
@@ -2,7 +2,7 @@ module ValidationHelpers
   private
 
   def check_errors(object, attribute, error)
-    !object.valid?
+    !object.valid?(validation_context)
     object.errors.added?(attribute, error)
   end
 

--- a/spec/support/matchers/validation_matchers.rb
+++ b/spec/support/matchers/validation_matchers.rb
@@ -6,6 +6,8 @@ RSpec::Matchers.define :validate_presence_of do |attribute, error = :blank|
     check_errors(object, attribute, error)
   end
 
+  chain :on_context, :validation_context
+
   description do
     "validate_presence_of #{attribute}"
   end
@@ -26,6 +28,8 @@ RSpec::Matchers.define :validate_absence_of do |attribute, error = :present|
     object.send("#{attribute}=", 'xxx')
     check_errors(object, attribute, error)
   end
+
+  chain :on_context, :validation_context
 
   description do
     "validate_absence_of #{attribute}"
@@ -50,6 +54,8 @@ RSpec::Matchers.define :validate_presence_unless_unknown_of do |attribute, error
     object.valid?
   end
 
+  chain :on_context, :validation_context
+
   description do
     "validate_presence_unless_unknown_of #{attribute}"
   end
@@ -66,6 +72,8 @@ RSpec::Matchers.define :validate_email do |attribute, error = :invalid|
     object.send("#{attribute}=", 'x@x')
     check_errors(object, attribute, error)
   end
+
+  chain :on_context, :validation_context
 
   description do
     "validate_email #{attribute}"


### PR DESCRIPTION
There was an edge case where once you obtain a session (just visiting the postcode step, for example) and then jumping manually to the `child_protection_cases` step, would actually let you pass with a corrupt or missing 'screening', thus failing at submission time.

The validation has been improved.

Individual commits for more details and context.

[Link to story](https://mojdigital.teamwork.com/#/tasks/15910041)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.