### PR TITLE
Daily failed emails report (if any)

### DIFF
--- a/app/mailers/reports_mailer.rb
+++ b/app/mailers/reports_mailer.rb
@@ -1,0 +1,16 @@
+class ReportsMailer < NotifyMailer
+  #
+  # Internal reports to be sent by email. Triggered by `daily_tasks`.
+  #
+  def failed_emails_report(report_content)
+    set_template(:failed_emails_report)
+    set_personalisation(report_content: report_content)
+
+    # Unset the env variable to stop the emails (for example
+    # on staging we don't want these emails, only on production)
+    recipient = ENV['FAILED_EMAILS_REPORT_RECIPIENT']
+    return if recipient.nil?
+
+    mail to: recipient
+  end
+end

--- a/app/services/reports/failed_emails_report.rb
+++ b/app/services/reports/failed_emails_report.rb
@@ -1,0 +1,39 @@
+module Reports
+  # :nocov:
+  class FailedEmailsReport
+    require 'csv'
+
+    def self.run
+      failures = []
+
+      EmailSubmission.where(
+        created_at: Date.yesterday...Date.current
+      ).joins(:c100_application).find_each(batch_size: 25) do |record|
+        if record.sent_at.nil?
+          failures << report_line(record, 'court email')
+        end
+
+        # Only if the applicant chose to receive a confirmation, otherwise
+        # this attribute will be genuinely `nil` on purpose.
+        if record.user_copy_sent_at.nil? && record.c100_application.receipt_email?
+          failures << report_line(record, 'applicant email')
+        end
+      end
+
+      return if failures.empty?
+
+      ReportsMailer.failed_emails_report(
+        failures.map(&:to_csv).join
+      ).deliver_now
+    end
+
+    def self.report_line(record, email_type)
+      [
+        record.created_at,
+        record.c100_application.reference_code,
+        email_type,
+      ]
+    end
+  end
+  # :nocov:
+end

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -17,6 +17,7 @@ integration:
   submission_error: 'c99df4a0-5655-4ef8-aaf4-0a5b83397785'
   draft_first_reminder: 'fcd87b1c-a3a0-4a2a-9b4e-524857e3bf8c'
   draft_last_reminder: '8e622f55-4be8-49cc-8a94-0ab3fd868067'
+  failed_emails_report: 'aa4409f8-7232-4052-bdad-e99e26186a79'
 
 production:
   reset_password: '0f55e48a-ae27-464c-b30f-272fd3850296'
@@ -27,3 +28,4 @@ production:
   submission_error: '9ded5ada-9e33-4b7b-bdaf-daa85b6c7063'
   draft_first_reminder: 'bf271379-6158-407d-b09a-cc6d8b275f1e'
   draft_last_reminder: '30dedd21-e7da-4794-b66c-94729cfa3180'
+  failed_emails_report: 'ed7616f7-6d33-40b5-b6cc-95765c4e37e5'

--- a/lib/court_email_interceptor.rb
+++ b/lib/court_email_interceptor.rb
@@ -6,6 +6,7 @@ class CourtEmailInterceptor
   DELIVERY_WHITELIST = %w[
     NotifyMailer
     ReceiptMailer
+    ReportsMailer
   ].freeze
 
   class << self

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -11,6 +11,8 @@ task daily_tasks: :environment do
   Rake::Task['draft_reminders:first_email'].invoke
   Rake::Task['draft_reminders:last_email'].invoke
 
+  Rake::Task['reports:failed_emails'].invoke
+
   log "Users count: #{User.count} / Applications count: #{C100Application.count}"
   log 'Finished daily tasks'
 end
@@ -58,6 +60,13 @@ namespace :draft_reminders do
 
     log "#{task_name}  - Count: #{rule_set.count}"
     C100App::DraftReminders.new(rule_set: rule_set).run
+  end
+end
+
+namespace :reports do
+  task failed_emails: :environment do
+    log "Running failed emails report"
+    Reports::FailedEmailsReport.run
   end
 end
 

--- a/spec/lib/court_email_interceptor_spec.rb
+++ b/spec/lib/court_email_interceptor_spec.rb
@@ -14,7 +14,7 @@ describe CourtEmailInterceptor do
   end
 
   context 'whitelisted handlers' do
-    it { expect(described_class::DELIVERY_WHITELIST).to eq(%w[NotifyMailer ReceiptMailer]) }
+    it { expect(described_class::DELIVERY_WHITELIST).to eq(%w[NotifyMailer ReceiptMailer ReportsMailer]) }
   end
 
   context 'for a whitelisted delivery handler' do

--- a/spec/mailers/reports_mailer_spec.rb
+++ b/spec/mailers/reports_mailer_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe ReportsMailer, type: :mailer do
+  before do
+    allow(
+      Rails.configuration
+    ).to receive(:govuk_notify_templates).and_return(
+      failed_emails_report: 'failed_emails_report_template_id',
+    )
+  end
+
+  describe '#failed_emails_report' do
+    let(:mail) { described_class.failed_emails_report('report content') }
+    let(:reports_email) { 'reports@example.com' }
+
+    before do
+      allow(ENV).to receive(:[]).with('FAILED_EMAILS_REPORT_RECIPIENT').and_return(reports_email)
+    end
+
+    it_behaves_like 'a Notify mail', template_id: 'failed_emails_report_template_id'
+
+    it { expect(mail.to).to eq(['reports@example.com']) }
+
+    it 'has the right personalisation' do
+      expect(mail.govuk_notify_personalisation).to eq({
+        service_name: 'Apply to court about child arrangements',
+        report_content: 'report content',
+      })
+    end
+
+    context 'when the ENV variable is not set' do
+      let(:reports_email) { nil }
+      it { expect(mail.to).to eq(nil) }
+    end
+  end
+end


### PR DESCRIPTION
As part of the work to improve the monitoring around the submission jobs, a new daily report has been created to detect any submission where the emails (to court, or applicant copy if they chose so) were not sent.

This report will run daily together with the rest of maintenance task we have, and will check all online submissions from the day before (00:00:00 to 23:59:59).

If any issue is found, will send an alert email to the team, with a simple report, to analise further. See example of the report below.

[Link to story](https://mojdigital.teamwork.com/#/tasks/16039120)

<img width="603" alt="Screen Shot 2019-06-14 at 13 33 27" src="https://user-images.githubusercontent.com/687910/59509484-0cfc7680-8ea9-11e9-82d5-dd4cdf2a3faf.png">


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.