### PR TITLE
Increase date range in DB lookup

### DIFF
--- a/app/models/concerns/application_reference.rb
+++ b/app/models/concerns/application_reference.rb
@@ -14,7 +14,7 @@ module ApplicationReference
 
     def date_range(year, month)
       date = Date.new(year.to_i, month.to_i)
-      [date.beginning_of_month..date.end_of_month]
+      [date.beginning_of_month.beginning_of_day..date.end_of_month.end_of_day]
     end
   end
 

--- a/spec/models/concerns/application_reference_spec.rb
+++ b/spec/models/concerns/application_reference_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ApplicationReference do
 
     it 'has the correct date filter criteria' do
       expect(test_class).to receive(:where).with(
-        created_at: [Date.new(2018, 5, 1)..Date.new(2018, 5, 31)]
+        created_at: [Date.new(2018, 5, 1).beginning_of_day..Date.new(2018, 5, 31).end_of_day]
       ).and_return(date_finder_double)
 
       test_class.find_by_reference_code('2018/05/DB2ED4FD')


### PR DESCRIPTION
There was an edge case where applications created in the last day of the month were not found when using the utility method `#find_by_reference_code`.

To ensure these applications are also included, we will force the end of the day, so the where clause is (take May as an example):

`WHERE (created_at BETWEEN '2019-05-01 00:00:00' AND '2019-05-31 23:59:59.999999')`

This is an internal method for debug purposes and is not used anywhere, so no harm done, but to avoid confusion in the future better to change it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.