### PR TITLE
Enable postgres `verify-full` SSL mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,12 @@ ENV APP_BUILD_TAG ${APP_BUILD_TAG}
 ARG APP_GIT_COMMIT
 ENV APP_GIT_COMMIT ${APP_GIT_COMMIT}
 
+# Download RDS certificates bundle -- needed for SSL verification
+#
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem \
+    /usr/src/app/config/rds-combined-ca-bundle.pem
+RUN chmod +r /usr/src/app/config/rds-combined-ca-bundle.pem
+
 # Run the application as user `moj` (created in the base image)
 # uid=1000(moj) gid=1000(moj) groups=1000(moj)
 # Some directories/files need to be chowned otherwise we get Errno::EACCES

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,8 @@
-# This file is only present to fix a Jenkins
-# build error that started to occur after
-# adding devise, but which we could not
-# reproduce on our local machines
+# Note: in production we are forcing SSL and certificate verification.
+# The RDS certificates bundle is downloaded in the Dockerfile.
+#
+# Refer to https://www.postgresql.org/docs/current/libpq-ssl.html for more information.
+#
 default: &default
   adapter: postgresql
 
@@ -11,3 +12,5 @@ test:
   <<: *default
 production:
   <<: *default
+  sslmode: <%= ENV.fetch('DATABASE_SSLMODE', 'verify-full') %>
+  sslrootcert: <%= Rails.root.join('config', 'rds-combined-ca-bundle.pem') %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,8 +47,8 @@ Rails.application.configure do
   # get the constantized attribute name itself, in form labels.
   config.action_view.raise_on_missing_translations = false
 
-  # Enforce SSL-only (but allow disabling it, in case of running locally via Docker)
-  config.force_ssl = ENV.key?('DISABLE_SSL') ? false : true
+  # Force HTTPS (but allow disabling it, when running locally via docker-compose)
+  config.force_ssl = ENV.key?('DISABLE_HTTPS') ? false : true
 
   # Prevent host header poisoning by enforcing absolute redirects
   if ENV['EXTERNAL_URL'].present?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - DATABASE_URL=postgresql://postgres@db/c100-application
       - EXTERNAL_URL=http://localhost:3000
       - RAILS_SERVE_STATIC_FILES=1
-      - DISABLE_SSL=1
+      - DATABASE_SSLMODE=disable
+      - DISABLE_HTTPS=1
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
For production environments we are going to force the `verify-full` SSL mode in all connections to the database.

It will be overriden (`DATABASE_SSLMODE=disable`) when using docker-compose so we are still able to run and test the application locally.

This follows best practices and guidance from Cloud Platforms here:

https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#ssl-connections-with-rds

To avoid potential confusion with the introduction of this new ENV var, I'm renaming `DISABLE_SSL` to `DISABLE_HTTPS` so it is more clear this other env variable is for https connections and nothing to do with the database.

[Link to story](https://mojdigital.teamwork.com/#/tasks/16091694)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.