### PR TITLE
Revert "Force garbage collection on delivery jobs"

### DIFF
--- a/app/jobs/applicant_delivery_job.rb
+++ b/app/jobs/applicant_delivery_job.rb
@@ -3,7 +3,5 @@ class ApplicantDeliveryJob < ApplicationJob
 
   def perform(c100_application)
     C100App::ApplicantOnlineSubmission.new(c100_application).process
-  ensure
-    GC.start # force garbage collection
   end
 end

--- a/app/jobs/court_delivery_job.rb
+++ b/app/jobs/court_delivery_job.rb
@@ -10,8 +10,6 @@ class CourtDeliveryJob < ApplicationJob
 
   def perform(c100_application)
     C100App::CourtOnlineSubmission.new(c100_application).process
-  ensure
-    GC.start # force garbage collection
   end
 
   private

--- a/spec/jobs/applicant_delivery_job_spec.rb
+++ b/spec/jobs/applicant_delivery_job_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe ApplicantDeliveryJob, type: :job do
       ).and_return(queue)
 
       expect(queue).to receive(:process)
-      expect(GC).to receive(:start)
 
       ApplicantDeliveryJob.perform_now(c100_application)
     end

--- a/spec/jobs/court_delivery_job_spec.rb
+++ b/spec/jobs/court_delivery_job_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe CourtDeliveryJob, type: :job do
       ).and_return(queue)
 
       expect(queue).to receive(:process)
-      expect(GC).to receive(:start)
 
       CourtDeliveryJob.perform_now(c100_application)
     end
@@ -26,8 +25,6 @@ RSpec.describe CourtDeliveryJob, type: :job do
       it 'captures the error' do
         expect(Raven).to receive(:extra_context).with({ c100_application_id: '123-456' })
         expect(Raven).to receive(:capture_exception).with(NoMethodError)
-
-        expect(GC).to receive(:start)
 
         CourtDeliveryJob.perform_now(c100_application)
       end


### PR DESCRIPTION
Reverts ministryofjustice/c100-application#676

This turned out to not have any meaningful effect, so we are going to get rid of it.

Also, hopefully we should not need to worry about memory anymore, after the recent bump in resources in the kubernetes container.