### PR TITLE
Set `RDS_COMBINED_CA_BUNDLE` in the ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,11 @@ ARG APP_GIT_COMMIT
 ENV APP_GIT_COMMIT ${APP_GIT_COMMIT}
 
 # Download RDS certificates bundle -- needed for SSL verification
+# We set the path to the bundle in the ENV, and use it in `/config/database.yml`
 #
-ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem \
-    /usr/src/app/config/rds-combined-ca-bundle.pem
-RUN chmod +r /usr/src/app/config/rds-combined-ca-bundle.pem
+ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/rds-combined-ca-bundle.pem
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem $RDS_COMBINED_CA_BUNDLE
+RUN chmod +r $RDS_COMBINED_CA_BUNDLE
 
 # Run the application as user `moj` (created in the base image)
 # uid=1000(moj) gid=1000(moj) groups=1000(moj)

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,4 +13,4 @@ test:
 production:
   <<: *default
   sslmode: <%= ENV.fetch('DATABASE_SSLMODE', 'verify-full') %>
-  sslrootcert: <%= Rails.root.join('config', 'rds-combined-ca-bundle.pem') %>
+  sslrootcert: <%= ENV['RDS_COMBINED_CA_BUNDLE'] %>


### PR DESCRIPTION
Instead of having paths in two places, let's give the control of the path to Dockerfile which is actually the one downloading the RDS bundle.

So we expose the bundle in the ENV and can be used in `/config/database.yml` without having to deal with paths and if this ever changes, there is only one place to touch.

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.