### PR TITLE
Improve the detection of undelivered emails

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -12,6 +12,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
     :reset_password_url,
     :applicant_name,
     :link_to_pdf,
+    :link_to_c8_pdf,
   ].freeze
 
   # Triggered automatically by Devise when the user resets its password.

--- a/app/services/reports/failed_emails_report.rb
+++ b/app/services/reports/failed_emails_report.rb
@@ -3,36 +3,65 @@ module Reports
   class FailedEmailsReport
     require 'csv'
 
-    def self.run
-      failures = []
+    class_attribute :failures
 
-      EmailSubmission.where(
-        created_at: Date.yesterday...Date.current
-      ).joins(:c100_application).find_each(batch_size: 25) do |record|
-        if record.sent_at.nil?
-          failures << report_line(record, 'court email')
+    class << self
+      def run
+        self.failures = []
+
+        EmailSubmission.where(
+          created_at: Date.yesterday...Date.current
+        ).joins(:c100_application).find_each(batch_size: 25) do |record|
+          reference_code = record.c100_application.reference_code
+
+          check_court_email(record, reference_code)
+
+          # Only if the applicant chose to receive a confirmation, otherwise
+          # these emails are not sent and there is no need to do any check.
+          check_user_email(record, reference_code) if record.c100_application.receipt_email?
         end
 
-        # Only if the applicant chose to receive a confirmation, otherwise
-        # this attribute will be genuinely `nil` on purpose.
-        if record.user_copy_sent_at.nil? && record.c100_application.receipt_email?
-          failures << report_line(record, 'applicant email')
+        return if failures.empty?
+
+        ReportsMailer.failed_emails_report(
+          failures.map(&:to_csv).join
+        ).deliver_now
+      end
+
+      def check_court_email(record, reference_code)
+        reference = ['court', reference_code].join(';').freeze
+
+        if record.sent_at.nil?
+          failures << report_line(record, reference, 'error')
+        elsif email_not_delivered?(reference)
+          failures << report_line(record, reference, 'undelivered')
         end
       end
 
-      return if failures.empty?
+      def check_user_email(record, reference_code)
+        reference = ['user', reference_code].join(';').freeze
 
-      ReportsMailer.failed_emails_report(
-        failures.map(&:to_csv).join
-      ).deliver_now
-    end
+        if record.user_copy_sent_at.nil?
+          failures << report_line(record, reference, 'error')
+        elsif email_not_delivered?(reference)
+          failures << report_line(record, reference, 'undelivered')
+        end
+      end
 
-    def self.report_line(record, email_type)
-      [
-        record.created_at,
-        record.c100_application.reference_code,
-        email_type,
-      ]
+      def email_not_delivered?(reference)
+        EmailSubmissionsAudit.unscoped.order(completed_at: :desc).find_by(
+          reference: reference,
+          status: 'delivered',
+        ).nil?
+      end
+
+      def report_line(record, reference, error_msg)
+        [
+          record.created_at,
+          reference,
+          error_msg,
+        ]
+      end
     end
   end
   # :nocov:

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe NotifyMailer, type: :mailer do
     it {
       expect(
         described_class::PERSONALISATION_ERROR_FILTER
-      ).to match_array([:reset_password_url, :applicant_name, :link_to_pdf])
+      ).to match_array([:reset_password_url, :applicant_name, :link_to_pdf, :link_to_c8_pdf])
     }
   end
 end


### PR DESCRIPTION
We already had a mechanism to detect unsent emails, caused by a failure in our service before the email even reached Notify (for example, errors when generating the PDF, or memory issues).

With this PR we extend the functionality to also detect emails that were correctly generated and sent to Notify, but for whatever reason Notify didn't process and delivered them (we use callbacks from Notify to update a table so we know the status of these emails).

Also, related to this, hide the `link_to_c8_pdf` value from any error sent to Sentry, as we already do with the `link_to_pdf`.

[Link to story](https://mojdigital.teamwork.com/#/tasks/16570206)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.