### PR TITLE
Ensure index uniqueness in two DB tables

### DIFF
--- a/db/migrate/20190809082945_change_child_orders_index_to_unique.rb
+++ b/db/migrate/20190809082945_change_child_orders_index_to_unique.rb
@@ -1,0 +1,6 @@
+class ChangeChildOrdersIndexToUnique < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :child_orders, :child_id
+    add_index    :child_orders, :child_id, unique: true
+  end
+end

--- a/db/migrate/20190809083025_change_child_residences_index_to_unique.rb
+++ b/db/migrate/20190809083025_change_child_residences_index_to_unique.rb
@@ -1,0 +1,6 @@
+class ChangeChildResidencesIndexToUnique < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :child_residences, :child_id
+    add_index    :child_residences, :child_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190516095303) do
+ActiveRecord::Schema.define(version: 20190809083025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "uuid-ossp"
   enable_extension "pgcrypto"
+  enable_extension "uuid-ossp"
 
   create_table "abduction_details", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "children_have_passport"
@@ -140,13 +140,13 @@ ActiveRecord::Schema.define(version: 20190516095303) do
   create_table "child_orders", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid "child_id"
     t.string "orders", default: [], array: true
-    t.index ["child_id"], name: "index_child_orders_on_child_id"
+    t.index ["child_id"], name: "index_child_orders_on_child_id", unique: true
   end
 
   create_table "child_residences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "child_id"
     t.string "person_ids", default: [], array: true
-    t.index ["child_id"], name: "index_child_residences_on_child_id"
+    t.index ["child_id"], name: "index_child_residences_on_child_id", unique: true
   end
 
   create_table "completed_applications_audit", id: false, force: :cascade do |t|


### PR DESCRIPTION
These tables can only contain unique children. There can't be duplicates.

There have been a rare occurrence where a duplicate child was inserted (probably by submitting twice the form quickly, or some kind of race-condition).

In order to avoid this from happening again, and as we do with other tables already, we are going to enforce the uniqueness of the index `child_id` column.


## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
