### PR TITLE
Add check and confirm interaction for receipt email

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -90,6 +90,37 @@ form.fmc-lookup-form {
   }
 }
 
+.link-button-secondary {
+  display: inline-block;
+  margin: 2rem 0 0;
+  padding: 0;
+  font-size: 1em;
+  line-height: 1.25;
+
+  @media (min-width: 641px) {
+    margin-top: 1rem;
+    margin-left: 6rem;
+  }
+}
+
+// State of the link remains as non-visited.
+// Used in cases where it is not helpful to distinguish between visited and non-visited links.
+//
+.no-visited-state {
+  &:link {
+    color: $link-colour;
+  }
+  &:visited {
+    color: $link-colour;
+  }
+  &:hover {
+    color: $link-hover-colour;
+  }
+  &:active {
+    color: $link-active-colour;
+  }
+}
+
 // This will hide the Sentry user-feedback attribution. There is a setting
 // to hide it but currently it is not working, so this is an alternative.
 div.sentry-error-embed-wrapper p.powered-by {

--- a/app/controllers/steps/application/receipt_email_check_controller.rb
+++ b/app/controllers/steps/application/receipt_email_check_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Application
+    class ReceiptEmailCheckController < Steps::ApplicationStepController
+      def show; end
+    end
+  end
+end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -34,7 +34,7 @@ module C100App
       when :payment
         edit(:submission)
       when :submission
-        edit(:check_your_answers)
+        after_submission_type
       when :declaration
         after_declaration
       else
@@ -74,6 +74,14 @@ module C100App
         edit(:litigation_capacity_details)
       else
         edit(:intermediary)
+      end
+    end
+
+    def after_submission_type
+      if c100_application.receipt_email.present?
+        show(:receipt_email_check)
+      else
+        edit(:check_your_answers)
       end
     end
 

--- a/app/views/steps/applicant/contact_details/edit.html.erb
+++ b/app/views/steps/applicant/contact_details/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.text_field :home_phone %>
       <%= f.text_field :mobile_phone %>
-      <%= f.text_field :email %>
+      <%= f.email_field :email %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/application/receipt_email_check/show.html.erb
+++ b/app/views/steps/application/receipt_email_check/show.html.erb
@@ -1,0 +1,24 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <div class="panel panel-border-narrow">
+      <p class="lede">
+        <strong><%= current_c100_application.receipt_email %></strong>
+      </p>
+    </div>
+
+    <p><%=t '.email_info' %></p>
+
+    <div class="xform-group form-submit">
+      <%= link_to t('.continue'), edit_steps_application_check_your_answers_path, class: 'button', role: 'button' %>
+      <%= link_to t('.go_back'), edit_steps_application_submission_path,
+                  class: 'link-button link-button-secondary no-visited-state ga-pageLink',
+                  data: { ga_category: 'receipt email address', ga_label: 'change email' } %>
+    </div>
+  </div>
+</div>

--- a/app/views/steps/application/submission/edit.html.erb
+++ b/app/views/steps/application/submission/edit.html.erb
@@ -14,7 +14,7 @@
           fieldset.radio_input(SubmissionType::ONLINE, panel_id: :receipt_email_panel)
           fieldset.radio_input(SubmissionType::PRINT_AND_POST)
           fieldset.revealing_panel(:receipt_email_panel) do |panel|
-            panel.text_field :receipt_email
+            panel.email_field :receipt_email
           end
         end
       %>

--- a/app/views/steps/respondent/contact_details/edit.html.erb
+++ b/app/views/steps/respondent/contact_details/edit.html.erb
@@ -11,10 +11,9 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-
       <%= f.text_field :home_phone %>
       <%= f.text_field :mobile_phone %>
-      <%= f.text_field :email %>
+      <%= f.email_field :email %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/email_consent/edit.html.erb
+++ b/app/views/steps/screener/email_consent/edit.html.erb
@@ -15,10 +15,10 @@
           fieldset.radio_input(GenericYesNo::YES, panel_id: :email_address_panel)
           fieldset.radio_input(GenericYesNo::NO)
           fieldset.revealing_panel(:email_address_panel) do |panel|
-            panel.text_field :email_address, type: :email
+            panel.email_field :email_address
           end
         end
-        %>
+    %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/solicitor/contact_details/edit.html.erb
+++ b/app/views/steps/solicitor/contact_details/edit.html.erb
@@ -14,7 +14,7 @@
       <%= f.text_field :dx_number, class: 'narrow' %>
       <%= f.text_field :phone_number, class: 'narrow' %>
       <%= f.text_field :fax_number, class: 'narrow' %>
-      <%= f.text_field :email %>
+      <%= f.email_field :email %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -745,6 +745,13 @@ en:
           page_title: How would you submit your application?
           heading: How would you like to submit your application to court?
           lead_text: Your completed application can be sent straight to the court electronically, or you can print it and send it by post if you prefer.
+      receipt_email_check:
+        show:
+          page_title: Check your email address
+          heading: Is this email address correct?
+          email_info: We’ll send a copy of your application to this email address. Please make sure it’s correct and that you can access the email account.
+          continue: Yes, continue
+          go_back: No, change it
       check_your_answers:
         edit:
           page_title: Check your answers
@@ -1359,7 +1366,7 @@ en:
       steps_application_payment_form:
         hwf_reference_number: 'This will be in the format: HWF-XXX-XXX'
       steps_application_submission_form:
-        receipt_email: We will send an copy of your application to this address
+        receipt_email: We’ll send a copy of your application to this email address
       steps_abduction_passport_details_form:
         passport_possesion: *select_all_that_apply
       steps_abduction_risk_details_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
       edit_step :intermediary
       edit_step :payment
       edit_step :submission
+      show_step :receipt_email_check
       edit_step :check_your_answers do
         get :resume, action: :resume
       end

--- a/spec/controllers/steps/application/receipt_email_check_controller_spec.rb
+++ b/spec/controllers/steps/application/receipt_email_check_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Application::ReceiptEmailCheckController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -122,7 +122,22 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
   context 'when the step is `submission`' do
     let(:step_params) { { submission: 'anything' } }
-    it { is_expected.to have_destination(:check_your_answers, :edit) }
+    let(:c100_application) { instance_double(C100Application, receipt_email: receipt_email) }
+
+    context 'and user chose to receive a confirmation email' do
+      let(:receipt_email) { 'test@example.com' }
+      it { is_expected.to have_destination(:receipt_email_check, :show) }
+    end
+
+    context 'and user left blank the confirmation email' do
+      let(:receipt_email) { '' }
+      it { is_expected.to have_destination(:check_your_answers, :edit) }
+    end
+
+    context 'and user do not want online submission' do
+      let(:receipt_email) { nil }
+      it { is_expected.to have_destination(:check_your_answers, :edit) }
+    end
   end
 
   context 'when the step is `declaration`' do


### PR DESCRIPTION
## What

In order to minimise emails with typos or incorrect, we are going to introduce a "check and confirm" interaction right after the applicant choose if they want to receive a copy of the submitted application.

This check and confirm follows the convention of Home Office (but we use our own styling to match the rest of the application):

https://home-office-digital-patterns.herokuapp.com/patterns/confirmation-loop

This check only appears when the user entered an email, as they can leave it blank, is not mandatory. Decision tree updated for this.

[Link to story](https://mojdigital.teamwork.com/#/tasks/17103551)

<img width="657" alt="Screen Shot 2019-08-29 at 09 35 05" src="https://user-images.githubusercontent.com/687910/63928649-d665df00-ca47-11e9-98d0-2e9f9e5f2c3c.png">

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.