### PR TITLE
Create basic back office scaffolding

### DIFF
--- a/app/controllers/backoffice/application_controller.rb
+++ b/app/controllers/backoffice/application_controller.rb
@@ -1,0 +1,25 @@
+module Backoffice
+  class ApplicationController < ActionController::Base
+    layout 'backoffice'
+
+    protect_from_forgery with: :exception, prepend: true
+
+    rescue_from Exception do |exception|
+      raise if Rails.application.config.consider_all_requests_local
+
+      Raven.capture_exception(exception)
+      redirect_to unhandled_backoffice_errors_path
+    end
+
+    private
+
+    # This is required to get request attributes in to the production logs.
+    # See the various lograge configurations in `production.rb`.
+    def append_info_to_payload(payload)
+      super
+      payload[:referrer] = request&.referrer
+      payload[:session_id] = request&.session&.id
+      payload[:user_agent] = request&.user_agent
+    end
+  end
+end

--- a/app/controllers/backoffice/dashboard_controller.rb
+++ b/app/controllers/backoffice/dashboard_controller.rb
@@ -1,0 +1,5 @@
+module Backoffice
+  class DashboardController < Backoffice::ApplicationController
+    def index; end
+  end
+end

--- a/app/controllers/backoffice/emails_controller.rb
+++ b/app/controllers/backoffice/emails_controller.rb
@@ -1,0 +1,5 @@
+module Backoffice
+  class EmailsController < Backoffice::ApplicationController
+    def index; end
+  end
+end

--- a/app/controllers/backoffice/errors_controller.rb
+++ b/app/controllers/backoffice/errors_controller.rb
@@ -1,0 +1,18 @@
+module Backoffice
+  class ErrorsController < Backoffice::ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    def unhandled
+      respond_with_status(:internal_server_error)
+    end
+
+    private
+
+    def respond_with_status(status)
+      respond_to do |format|
+        format.html
+        format.all { head status }
+      end
+    end
+  end
+end

--- a/app/views/backoffice/dashboard/index.en.html.erb
+++ b/app/views/backoffice/dashboard/index.en.html.erb
@@ -1,0 +1,11 @@
+<% title 'Back office: dashboard' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Back office: dashboard</h1>
+
+    <div class="govuk-govspeak gv-s-prose">
+      This is work in progress.
+    </div>
+  </div>
+</div>

--- a/app/views/backoffice/emails/index.en.html.erb
+++ b/app/views/backoffice/emails/index.en.html.erb
@@ -1,0 +1,11 @@
+<% title 'Back office: emails' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Back office: emails</h1>
+
+    <div class="govuk-govspeak gv-s-prose">
+      This is work in progress.
+    </div>
+  </div>
+</div>

--- a/app/views/backoffice/errors/unhandled.en.html.erb
+++ b/app/views/backoffice/errors/unhandled.en.html.erb
@@ -1,0 +1,9 @@
+<% title 'Back office unhandled error' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Sorry, something went wrong</h1>
+
+    <p class="lede">You can try again, or contact a service developer.</p>
+  </div>
+</div>

--- a/app/views/backoffice/shared/_menu.en.html.erb
+++ b/app/views/backoffice/shared/_menu.en.html.erb
@@ -1,0 +1,13 @@
+<a role="button" href="#proposition-links" class="js-header-toggle menu"
+   aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</a>
+
+<nav id="proposition-menu">
+  <ul id="proposition-links" aria-label="Top Level Navigation">
+    <li>
+      <%= link_to_unless_current 'Dashboard', backoffice_dashboard_index_path %>
+    </li>
+    <li>
+      <%= link_to_unless_current 'Emails', backoffice_emails_path %>
+    </li>
+  </ul>
+</nav>

--- a/app/views/layouts/backoffice.html.erb
+++ b/app/views/layouts/backoffice.html.erb
@@ -8,7 +8,6 @@
   <![endif]-->
   <meta name="robots" content="noindex, nofollow"/>
   <meta name="msapplication-config" content="none"/>
-  <meta name="google-site-verification" content="Ed6XKLFCCovwl_3gUpR5owg8AvgINOhiWWNGeJhHyio"/> <!-- service -->
 <% end %>
 
 <% content_for(:header_class) do %>with-proposition<% end %>
@@ -16,25 +15,14 @@
 <% content_for(:proposition_header) do %>
   <div class="header-proposition">
     <div class="content">
-      <% if user_signed_in? %>
-        <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
-      <% end %>
-      <nav id="proposition-menu">
-        <%= link_to service_name, Rails.configuration.gds_service_homepage_url, id: 'proposition-name', class: 'ga-pageLink', data: {ga_category: 'header', ga_label: 'service name'} %>
-        <%= render partial: 'layouts/current_user_menu' if user_signed_in? %>
-      </nav>
+      <%= link_to service_name, Rails.configuration.gds_service_homepage_url, id: 'proposition-name' %>
+      <%= render partial: 'backoffice/shared/menu' %>
     </div>
   </div>
 <% end %>
 
-<% content_for(:body_start) do %>
-  <%= render partial: 'layouts/analytics' if analytics_tracking_id.present? %>
-<% end %>
-
 <% content_for(:content) do %>
   <main id="content" role="main">
-    <%= render partial: 'layouts/phase_banner' %>
-
     <% if flash[:alert] %>
       <div class="error-summary">
         <%= flash[:alert] %>
@@ -46,10 +34,6 @@
 <% end %>
 
 <% content_for(:body_end) do %>
-  <% if current_c100_application %>
-    <%= render partial: 'layouts/timeout_modal' %>
-  <% end %>
-
   <!--[if lte IE 8]>
   <script>
     document.body.className = document.body.className.replace("js-enabled","")
@@ -61,10 +45,6 @@
 
 <% content_for(:footer_support_links) do %>
   <%= render partial: 'layouts/footer_links' %>
-<% end %>
-
-<% if dev_tools_enabled? %>
-  <%= render partial: 'developer_tools' %>
 <% end %>
 
 <%= render template: "layouts/govuk_template" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,15 @@ Rails.application.routes.draw do
     )
   end
 
+  # Back office
+  namespace :backoffice do
+    resources :dashboard, only: [:index]
+    resources :emails, only: [:index]
+    resource :errors, only: [] do
+      get :unhandled
+    end
+  end
+
   devise_for :users,
              controllers: {
                registrations: 'users/registrations',


### PR DESCRIPTION
Very simple (and very useless, right now, without any functionality at all) back office scaffolding, in preparation for implementing Auth0.

The back office will reside in the `/backoffice` namespace, and will provide very basic functionality to remove as much as possible the need for a developer to do some admin stuff.

All copy is placeholder.

A more streamlined layout (named `layouts/backoffice.html.erb`) has been created, based off the existing `application` layout but removing things we don't need in the backoffice.

As part of this new layout I found out some old, unused IE9 detection code. This has been removed for both layouts.

[Link to story](https://mojdigital.teamwork.com/#/tasks/17169364)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.