### PR TITLE
Ability to bypass Auth0 in localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,8 @@ GOVUK_NOTIFY_BEARER_TOKEN=notify-callback-token
 AUTH0_DOMAIN=c100-staging.eu.auth0.com
 AUTH0_CLIENT_ID=client-id
 AUTH0_CLIENT_SECRET=client-secret
+
+# If you just want to do a quick thing or "see" how the back office works, without
+# having to go all the trouble of getting Auth0 credentials, just uncomment this.
+#
+# AUTH0_BYPASS_LOCALHOST=1

--- a/app/controllers/backoffice/auth0_controller.rb
+++ b/app/controllers/backoffice/auth0_controller.rb
@@ -20,6 +20,13 @@ module Backoffice
       redirect_to backoffice_dashboard_index_path
     end
 
+    def local_auth
+      raise 'For development use only' unless helpers.auth0_bypass_in_local?
+
+      request.env['omniauth.auth'] = { info: { name: 'Test User' } }
+      callback
+    end
+
     def failure
       error = request.env['omniauth.error']
 

--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -7,6 +7,10 @@ module Auth0Helper
     session[:backoffice_userinfo].dig('info', 'name')
   end
 
+  def admin_auth_url
+    auth0_bypass_in_local? ? backoffice_auth0_local_auth_path : 'auth/auth0'
+  end
+
   def admin_logout_url
     params = {
       client_id: ENV['AUTH0_CLIENT_ID'],
@@ -18,5 +22,10 @@ module Auth0Helper
       path: '/v2/logout',
       query: params.to_query
     ).to_s
+  end
+
+  def auth0_bypass_in_local?
+    Rails.env.development? &&
+      ENV['AUTH0_BYPASS_LOCALHOST'].present?
   end
 end

--- a/app/views/backoffice/auth0/index.en.html.erb
+++ b/app/views/backoffice/auth0/index.en.html.erb
@@ -6,6 +6,6 @@
 
     <p class="lede">You need to authenticate in order to access the back office.</p>
 
-    <%= button_to 'Login', 'auth/auth0', method: :post, class: 'button', id: 'qsLoginBtn' %>
+    <%= button_to 'Login', admin_auth_url, method: :post, class: 'button', id: 'qsLoginBtn' %>
   </div>
 </div>

--- a/config/initializers/auth0.rb
+++ b/config/initializers/auth0.rb
@@ -11,4 +11,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   )
 end
 
+OmniAuth.config.allowed_request_methods = [:post]
 OmniAuth.config.on_failure = Backoffice::Auth0Controller.action(:failure)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
     namespace :auth0 do
       get :callback
       get :failure
+      post :local_auth
       delete :logout
     end
 


### PR DESCRIPTION
This will simplify and speed up the testing and development without having to worry about the Auth0 credentials.

It is only intended for local environments, but it is disabled by default as it is encouraged to always mimic production envs even when working on localhost.

To enable, just uncomment (or set if it does not exist) the env variable: `AUTH0_BYPASS_LOCALHOST`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
