### PR TITLE
Initial version of backoffice resend emails page

### DIFF
--- a/app/controllers/backoffice/emails_controller.rb
+++ b/app/controllers/backoffice/emails_controller.rb
@@ -2,6 +2,17 @@ module Backoffice
   class EmailsController < Backoffice::ApplicationController
     include Auth0Secured
 
-    def index; end
+    def index
+      @report = Reports::FailedEmailsReport.list
+    end
+
+    def resend
+      email = EmailSubmission.find(params[:email_id])
+      email.resend!(type: params[:type])
+
+      redirect_to backoffice_emails_path, flash: {
+        alert: 'Email resend in progress. Please reload the page in a few seconds.'
+      }
+    end
   end
 end

--- a/app/models/email_submission.rb
+++ b/app/models/email_submission.rb
@@ -5,6 +5,9 @@ class EmailSubmission < ApplicationRecord
   # Do not rely on these methods other than to force manual submissions in
   # case of bounces or errors.
   #
+  # These methods are also used in the back-office. If possible, always use
+  # the back-office to performs these actions.
+  #
   # :nocov:
   def resend_court_email!
     CourtDeliveryJob.perform_later(c100_application)
@@ -12,6 +15,16 @@ class EmailSubmission < ApplicationRecord
 
   def resend_user_email!
     ApplicantDeliveryJob.perform_later(c100_application)
+  end
+
+  def resend!(type:)
+    if type == 'user'
+      resend_user_email!
+    elsif type == 'court'
+      resend_court_email!
+    else
+      raise 'Unknown email type'
+    end
   end
   # :nocov:
 end

--- a/app/presenters/backoffice/failed_email.rb
+++ b/app/presenters/backoffice/failed_email.rb
@@ -1,0 +1,40 @@
+module Backoffice
+  class FailedEmail < SimpleDelegator
+    COURT_TYPE = 'court'.freeze
+
+    def record
+      self[:record]
+    end
+
+    def type
+      self[:reference].split(';').first
+    end
+
+    def reference
+      self[:reference].split(';').last
+    end
+
+    def error
+      self[:error]
+    end
+
+    def address
+      court_email? ? record.to_address : record.email_copy_to
+    end
+
+    def sent_at
+      date = court_email? ? record.sent_at : record.user_copy_sent_at
+      format_date(date)
+    end
+
+    private
+
+    def court_email?
+      type == COURT_TYPE
+    end
+
+    def format_date(date)
+      date ? I18n.l(date, format: :short) : 'never'
+    end
+  end
+end

--- a/app/views/backoffice/emails/_failure.en.html.erb
+++ b/app/views/backoffice/emails/_failure.en.html.erb
@@ -1,0 +1,17 @@
+<tr>
+  <td valign="middle"><%= failure.sent_at %></td>
+  <td valign="middle"><%= failure.reference %></td>
+  <td valign="middle"><%= failure.type %></td>
+  <td valign="middle"><%= failure.error %></td>
+  <td valign="middle">
+    <%= button_to 'Resend email', backoffice_email_resend_path(failure.record, type: failure.type), method: :put, data: { confirm: 'Are you sure' }, class: 'button' %>
+  </td>
+</tr>
+
+<% if failure.address %>
+  <tr>
+    <td colspan="5">
+      <strong>Email:</strong> <%= failure.address %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/backoffice/emails/index.en.html.erb
+++ b/app/views/backoffice/emails/index.en.html.erb
@@ -5,7 +5,37 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge">Back office: emails</h1>
 
     <div class="govuk-govspeak gv-s-prose">
-      This is work in progress.
+      <p>
+        This is a report of any failed submission emails (court or applicant confirmation), in the last 7 days.
+      </p>
+
+      <p>
+        <strong>
+          After resending a failed email, wait a few seconds (usually less than 30) and reload this page. The failure
+          should be gone if the email was sent successfully, otherwise a new error will show.
+        </strong>
+      </p>
+
+      <p>
+        Please note some failures might be genuine, for instance, due to a typo in the applicant's email address. Do
+        not retry these emails as they will fail again.
+      </p>
     </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Sent at</th>
+          <th>Reference</th>
+          <th>Type</th>
+          <th>Error</th>
+          <th></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <%= render partial: 'failure', collection: @report, as: :failure %>
+      </tbody>
+    </table>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,9 @@ Rails.application.routes.draw do
 
     # Auth0-protected routes
     resources :dashboard, only: [:index]
-    resources :emails, only: [:index]
+    resources :emails, only: [:index] do
+      put :resend
+    end
   end
 
   devise_for :users,


### PR DESCRIPTION
This is a first version, subject to be changed, of the functionality to resend failed emails in the backoffice.

The idea behind this is to avoid havinf to SSH to trigger manual resend of emails that have failed due to Notify errors, connectivity issues, job failure when building the PDF, etc.

We will still receive an email notification when there is an email failure, and we will be able to trigger the resend (once some sanity check has been done in Notify) through this simple interface.

To be done / WIP:

* Some kind of audit record to know who triggered the resend (we can have this as the backoffice is behind Auth0 credentials).
* Some very basic tests. The backoffice is not tested at the moment, because it piggy-backs in existing functionality, but might be good to have some top level tests.
* Backoffice is not yet deploy to production, only staging.

[Link to story](https://mojdigital.teamwork.com/#/tasks/17415026)

<img width="585" alt="Screen Shot 2019-09-19 at 14 50 03" src="https://user-images.githubusercontent.com/687910/65250438-7bc31e80-daed-11e9-8292-d34141a80c11.png">

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.