### PR TITLE
Add new courts

### DIFF
--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -39,12 +39,14 @@ module C100App
       harrogate-magistrates-court-and-family-court
       scarborough-justice-centre
       skipton-county-court-and-family-court
+      central-family-court
       clerkenwell-and-shoreditch-county-court-and-family-court
       bury-st-edmunds-county-court-and-family-court
       southend-magistrates-court-and-family-court
       taunton-crown-county-and-family-court
       yeovil-county-family-and-magistrates-court
       norwich-combined-court-centre
+      kings-lynn-magistrates-court-and-family-court
       luton-county-court-and-family-court
       bedford-county-court-and-family-court
       chelmsford-county-and-family-court

--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -43,6 +43,7 @@ module C100App
       bury-st-edmunds-county-court-and-family-court
       southend-magistrates-court-and-family-court
       taunton-crown-county-and-family-court
+      yeovil-county-family-and-magistrates-court
       norwich-combined-court-centre
       luton-county-court-and-family-court
       bedford-county-court-and-family-court

--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -29,6 +29,31 @@ module C100App
       plymouth-combined-court
       peterborough-combined-court-centre
       barnstaple-magistrates-county-and-family-court
+      portsmouth-combined-court-centre
+      isle-of-wight-combined-court
+      sheffield-combined-court-centre
+      doncaster-magistrates-court-and-family-court
+      barnsley-law-courts
+      lincoln-county-court-and-family-court
+      york-county-court-and-family-court
+      harrogate-magistrates-court-and-family-court
+      scarborough-justice-centre
+      skipton-county-court-and-family-court
+      clerkenwell-and-shoreditch-county-court-and-family-court
+      bury-st-edmunds-county-court-and-family-court
+      southend-magistrates-court-and-family-court
+      taunton-crown-county-and-family-court
+      norwich-combined-court-centre
+      luton-county-court-and-family-court
+      bedford-county-court-and-family-court
+      chelmsford-county-and-family-court
+      southend-magistrates-court-and-family-court
+      canterbury-combined-court-centre
+      dartford-county-court-and-family-court
+      maidstone-combined-court-centre
+      hertford-county-court-and-family-court
+      chester-civil-and-family-justice-centre
+      crewe-county-court-and-family-court
     ].freeze
 
     # Separate multiple postcodes/postcode areas by "\n"

--- a/features/screener.feature
+++ b/features/screener.feature
@@ -34,7 +34,7 @@ Feature: Screener
     Given I click the "Check now" link
 
     Then I should see "Where do the children live?"
-    And I fill in "Postcode" with "E1 8QS"
+    And I fill in "Postcode" with "M60 9DJ"
     And I click the "Continue" button
 
     Then I should see "Sorry, you're not eligible to apply online"

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe C100App::CourtPostcodeChecker do
   describe 'COURT_SLUGS_USING_THIS_APP' do
     it 'returns the expected number of court slugs taking part in the trial' do
-      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(25)
+      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(50)
     end
   end
 

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe C100App::CourtPostcodeChecker do
   describe 'COURT_SLUGS_USING_THIS_APP' do
     it 'returns the expected number of court slugs taking part in the trial' do
-      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(51)
+      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(53)
     end
   end
 

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe C100App::CourtPostcodeChecker do
   describe 'COURT_SLUGS_USING_THIS_APP' do
     it 'returns the expected number of court slugs taking part in the trial' do
-      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(50)
+      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(51)
     end
   end
 


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/17296619)


The courts which will go live on 24/25 September are as follows.

Portsmouth = https://courttribunalfinder.service.gov.uk/courts/portsmouth-combined-court-centre
Isle of Wight = https://courttribunalfinder.service.gov.uk/courts/isle-of-wight-combined-court
 
Sheffield =  https://courttribunalfinder.service.gov.uk/courts/sheffield-combined-court-centre
Doncaster = https://courttribunalfinder.service.gov.uk/courts/doncaster-magistrates-court-and-family-court > missing family email address
Barnsley  = https://courttribunalfinder.service.gov.uk/courts/barnsley-law-courts
 
Lincoln =  https://courttribunalfinder.service.gov.uk/courts/lincoln-county-court-and-family-court
Boston = no results
 
York = https://courttribunalfinder.service.gov.uk/courts/york-county-court-and-family-court 
Harrogate = https://courttribunalfinder.service.gov.uk/courts/harrogate-magistrates-court-and-family-court > missing family email address
Scarborough = https://courttribunalfinder.service.gov.uk/courts/scarborough-justice-centre
Skipton  =  https://courttribunalfinder.service.gov.uk/courts/skipton-county-court-and-family-court

Central Family Court = https://courttribunalfinder.service.gov.uk/courts/central-family-court
Clerkenwell and Shoreditch = https://courttribunalfinder.service.gov.uk/courts/clerkenwell-and-shoreditch-county-court-and-family-court
 
Taunton  = https://courttribunalfinder.service.gov.uk/courts/taunton-crown-county-and-family-court
Yeovil = https://courttribunalfinder.service.gov.uk/courts/yeovil-county-family-and-magistrates-court 
 
Norwich = https://courttribunalfinder.service.gov.uk/courts/norwich-combined-court-centre
Kings Lynn = https://courttribunalfinder.service.gov.uk/courts/kings-lynn-magistrates-court-and-family-court
Great Yarmouth = https://courttribunalfinder.service.gov.uk/courts/great-yarmouth-magistrates-court-and-family-court  > missing family email address
 
Luton = https://courttribunalfinder.service.gov.uk/courts/luton-county-court-and-family-court
Bedford = https://courttribunalfinder.service.gov.uk/courts/bedford-county-court-and-family-court
 
Chelmsford  = https://courttribunalfinder.service.gov.uk/courts/chelmsford-county-and-family-court
Ipswich = no family courts
Bury St Edmunds = https://courttribunalfinder.service.gov.uk/courts/bury-st-edmunds-county-court-and-family-court
Southend = https://courttribunalfinder.service.gov.uk/courts/southend-magistrates-court-and-family-court
 
Canterbury = https://courttribunalfinder.service.gov.uk/courts/canterbury-combined-court-centre
Dartford  = https://courttribunalfinder.service.gov.uk/courts/dartford-county-court-and-family-court
Maidstone = https://courttribunalfinder.service.gov.uk/courts/maidstone-combined-court-centre

Hertford = https://courttribunalfinder.service.gov.uk/courts/hertford-county-court-and-family-court > missing family email address

Chester = https://courttribunalfinder.service.gov.uk/courts/chester-civil-and-family-justice-centre
Crewe = https://courttribunalfinder.service.gov.uk/courts/crewe-county-court-and-family-court