### PR TITLE
Add court enquiries email as fallback

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -30,13 +30,14 @@ class Court
     # There's no consistency to how courts list their email address descriptions,
     # so we try to find the most suitable email address, by looking at the `description`
     # or the `explanation` for each of the emails, or the actual email address,
-    # and if none is found, use the first entry.
-
+    # and if none is found, as a last resort we try to find an email address containing
+    # the `enquiries` word and if still nothing is found, we pick the first entry.
+    #
     emails = retrieve_emails_from_api
     best = best_match_for(emails, 'description') ||
            best_match_for(emails, 'explanation') ||
            best_match_for(emails, 'address') ||
-           emails.first
+           fallback_address(emails)
 
     # We want this to raise a `KeyError` exception when no email is found
     best ||= {}
@@ -49,6 +50,10 @@ class Court
     emails.find { |e| e[node] =~ /children/i }           || \
       emails.find { |e| e[node] =~ /\Aapplications\z/i } || \
       emails.find { |e| e[node] =~ /family/i }
+  end
+
+  def fallback_address(emails)
+    emails.find { |e| e['address'] =~ /enquiries/i } || emails.first
   end
 
   def retrieve_emails_from_api

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -148,7 +148,7 @@ describe Court do
           [
             {
               'description' => 'Enquiries',
-              'address' => 'my@email',
+              'address' => 'enquiries@email',
             },
             {
               'description' => 'All Children Enquiries',
@@ -197,21 +197,21 @@ describe Court do
           end
         end
 
-        context 'and containing an email with description matching "enquiries"' do
+        context 'and containing an email matching "enquiries"' do
           let(:emails){
             [
+              {
+                'description' => 'Enquiries',
+                'address' => 'enquiries@email',
+              },
               {
                 'description' => 'All children things',
                 'address' => 'children@email'
               },
-              {
-                'description' => 'Enquiries',
-                'address' => 'my@email',
-              },
             ]
           }
 
-          it 'returns the email address of the description matching children' do
+          it 'returns the email address matching children' do
             expect(subject.best_enquiries_email).to eq('children@email')
           end
         end
@@ -222,7 +222,7 @@ describe Court do
           [
             {
               'description' => 'Enquiries',
-              'address' => 'my@email',
+              'address' => 'enquiries@email',
             },
             {
               'description' => 'All Family Enquiries',
@@ -240,7 +240,7 @@ describe Court do
             [
               {
                 'description' => 'Enquiries',
-                'address' => 'my@email',
+                'address' => 'enquiries@email',
               },
               {
                 'description' => 'All family things',
@@ -255,23 +255,23 @@ describe Court do
         end
       end
 
-      context 'containing an email with explanation matching "family"' do
+      context 'containing an email with explanation matching "family" but also enquiries' do
         let(:emails){
           [
             {
-              'description' => 'All other things',
-              'address' => 'other@email'
+              'description' => 'Other enquiries',
+              'address' => 'other.enquiries@email'
             },
             {
               'description' => '',
               'explanation' => 'Family enquiries',
-              'address' => 'my@email',
+              'address' => 'enquiries@email',
             },
           ]
         }
 
-        it 'returns the email address of the matching description' do
-          expect(subject.best_enquiries_email).to eq('my@email')
+        it 'returns the email address of the matching explanation' do
+          expect(subject.best_enquiries_email).to eq('enquiries@email')
         end
       end
 
@@ -292,6 +292,27 @@ describe Court do
 
         it 'returns the matching email address based on priority' do
           expect(subject.best_enquiries_email).to eq('Children@email')
+        end
+      end
+
+      context 'nothing matches except the enquiries email address' do
+        let(:emails){
+          [
+            {
+              'description' => 'Should not match anything',
+              'address' => 'my@email',
+            },
+            {
+              'description' => 'No address',
+            },
+            {
+              'description' => 'Any description',
+              'address' => 'Enquiries@email',
+            },
+          ]
+        }
+        it 'returns the `enquiries` email' do
+          expect(subject.best_enquiries_email).to eq('Enquiries@email')
         end
       end
 


### PR DESCRIPTION
We had this in the past, but was removed.

We want to reintroduce this as some new courts don't have the appropriate email addresses in place just yet, and it is better to pick the enquiries email (if any) instead of the first address of the list.

Only seek the `enquiries` word in the email address itself, not in the description or explanation.

Still if no email is found, first in the list will be picked.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
