### PR TITLE
Improve the bypass functionality

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,9 @@ class ApplicationController < ActionController::Base
   def reset_c100_application_session
     session.delete(:c100_application_id)
     session.delete(:last_seen)
+
+    # ensure we don't have a memoized record anymore
+    @_current_c100_application = nil
   end
 
   def initialize_c100_application(attributes = {})

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -44,12 +44,17 @@ class SessionsController < ApplicationController
   def find_or_create_screener_answers
     ScreenerAnswers.find_or_initialize_by(c100_application_id: c100_application.id).tap do |screener|
       screener.update(
-        screener_answers_fixture
+        screener_answers_fixture(screener)
       ) unless screener.valid?(:completion)
     end
   end
 
-  def screener_answers_fixture
+  # If there are some answers already present, we maintain these previous
+  # answers (for example, it is possible to answer the postcode question
+  # in the screener, and then do a bypass, maintaining the court data
+  # returned from court tribunal finder).
+  #
+  def screener_answers_fixture(screener)
     {
       children_postcodes: 'MK9 2DT',
       parent: 'yes',
@@ -67,7 +72,9 @@ class SessionsController < ApplicationController
         "slug" => "milton-keynes-county-court-and-family-court",
         "email" => "family@miltonkeynes.countycourt.gsi.gov.uk",
       }
-    }
+    }.merge(screener.attributes.symbolize_keys) do |_key, old_value, new_value|
+      new_value || old_value
+    end
   end
   # :nocov:
 end

--- a/app/views/application/_developer_tools.html.erb
+++ b/app/views/application/_developer_tools.html.erb
@@ -6,6 +6,14 @@
       <% if current_c100_application %>
         <h4 class="heading-small">Current Application ID</h4>
         <p><%= current_c100_application.id %></p>
+
+        <% if current_c100_application.screener_answers_court %>
+          <h4 class="heading-small">Current court data</h4>
+          <p>
+            <%= current_c100_application.screener_answers_court.name %><br/>
+            <%= current_c100_application.screener_answers_court.email %>
+          </p>
+        <% end %>
       <% end %>
 
       <h4>Destroy session</h4>


### PR DESCRIPTION
It is now possible to answer one or more questions in the screener, and then do a bypass. These already answered questions will take precedence over the fixture data.

Also, now in the developer tools dropdown in the footer, the information about the court will appear, to quickly check where an application might be sent for a given postcode.

<img width="745" alt="Screen Shot 2019-09-23 at 16 36 36" src="https://user-images.githubusercontent.com/687910/65440231-50f40580-de20-11e9-940b-6dd2795b1b1f.png">

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
