### PR TITLE
Backoffice styling improvements

### DIFF
--- a/app/assets/stylesheets/local/app/backoffice.scss
+++ b/app/assets/stylesheets/local/app/backoffice.scss
@@ -2,4 +2,7 @@ table.backoffice-table {
   td {
     font-size: 85%;
   }
+  td.no-border {
+    border: 0;
+  }
 }

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -1,14 +1,16 @@
 <tr>
   <td valign="middle" width="200"><%= completion.completed_at %></td>
-  <td valign="middle"><%= completion.submission_type || SubmissionType::PRINT_AND_POST.value %></td>
   <td valign="middle"><%= completion.reference_code %></td>
-  <td valign="middle"><%= completion.court %></td>
+  <td valign="middle"><%= completion.submission_type || 'N/A' %></td>
+  <td valign="middle"><%= completion.metadata['payment_type'] || 'N/A' %></td>
+  <td valign="middle"><%= completion.metadata['postcode'] %></td>
+  <td valign="middle"><%= completion.metadata['saved_for_later'] %></td>
 </tr>
 <tr>
-  <td valign="middle" colspan="4">
-    <strong>Postcode:</strong> <%= completion.metadata['postcode'] %> |
-    <strong>Urgent:</strong> <%= completion.metadata['urgent_hearing'] %> |
-    <strong>Payment:</strong> <%= completion.metadata['payment_type'] %> |
-    <strong>Saved:</strong> <%= completion.metadata['saved_for_later'] %>
+  <td valign="middle" colspan="6" class="no-border">
+    <%= completion.court %>
   </td>
+</tr>
+<tr>
+  <td valign="middle" colspan="6" class="no-border"></td>
 </tr>

--- a/app/views/backoffice/dashboard/index.en.html.erb
+++ b/app/views/backoffice/dashboard/index.en.html.erb
@@ -14,9 +14,11 @@
       <thead>
         <tr>
           <th>Completed at</th>
-          <th>Type</th>
           <th>Reference</th>
-          <th>Court</th>
+          <th>Type</th>
+          <th>Payment</th>
+          <th>Postcode</th>
+          <th>Saved</th>
         </tr>
       </thead>
 

--- a/app/views/backoffice/emails/_failure.en.html.erb
+++ b/app/views/backoffice/emails/_failure.en.html.erb
@@ -10,8 +10,12 @@
 
 <% if failure.address %>
   <tr>
-    <td colspan="5">
+    <td colspan="5" class="no-border">
       <strong>Recipient:</strong> <%= failure.address %>
     </td>
   </tr>
 <% end %>
+
+<tr>
+  <td valign="middle" colspan="5" class="no-border"></td>
+</tr>


### PR DESCRIPTION
The table of completed applications was too crowded and a bit confusing.

Re-arranged the columns and added some space, removing not needed borders.

<img width="1048" alt="Screen Shot 2019-09-25 at 09 53 00" src="https://user-images.githubusercontent.com/687910/65585456-6715d900-df7a-11e9-8098-df7b0c8c4ca6.png">

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
