### PR TITLE
Update pdf layout for children’s relationship with parents section

### DIFF
--- a/app/presenters/relationships_presenter.rb
+++ b/app/presenters/relationships_presenter.rb
@@ -1,6 +1,4 @@
 class RelationshipsPresenter
-  PEOPLE_SEPARATOR = '; '.freeze
-
   attr_reader :c100_application
 
   def initialize(c100_application)
@@ -14,7 +12,7 @@ class RelationshipsPresenter
 
     relationships.where(minor: minors, person: person_or_people).map do |relationship|
       show_person_name ? present_relation_with_person(relationship) : present_relation_without_person(relationship)
-    end.join(PEOPLE_SEPARATOR)
+    end.join
   end
 
   private
@@ -39,7 +37,7 @@ class RelationshipsPresenter
 
   def present_relation_with_person(relationship)
     I18n.translate!(
-      'shared.relationship_to_child.show_person',
+      'shared.relationship_to_child.show_person_html',
       person_name: relationship.person.full_name,
       child_name: relationship.minor.full_name,
       relation: i18n_relation(relationship)
@@ -48,7 +46,7 @@ class RelationshipsPresenter
 
   def present_relation_without_person(relationship)
     I18n.translate!(
-      'shared.relationship_to_child.hide_person',
+      'shared.relationship_to_child.hide_person_html',
       child_name: relationship.minor.full_name,
       relation: i18n_relation(relationship)
     )

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -74,8 +74,8 @@ en:
     statement_of_truth: "%{applicant_name} believes that the facts stated in this application are true."
     statement_of_truth_hmcts_instructions: Statement of truth has been completed online - no signature required
     relationship_to_child:
-      show_person: "%{person_name} - %{relation} to %{child_name}"
-      hide_person: "%{relation} to %{child_name}"
+      show_person_html: "<div>%{person_name} - %{relation} to %{child_name}</div>"
+      hide_person_html: "<div>%{relation} to %{child_name}</div>"
 
   check_answers:
     headers:

--- a/spec/presenters/relationships_presenter_spec.rb
+++ b/spec/presenters/relationships_presenter_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe RelationshipsPresenter do
 
     context 'showing the person name' do
       it 'returns a string describing the relationships' do
-        expect(subject.relationship_to_children(person, show_person_name: true)).to eq('Person name - Father to Child name')
+        expect(subject.relationship_to_children(person, show_person_name: true)).to eq('<div>Person name - Father to Child name</div>')
       end
     end
 
     context 'hiding the person name' do
       it 'returns a string describing the relationships' do
-        expect(subject.relationship_to_children(person, show_person_name: false)).to eq('Father to Child name')
+        expect(subject.relationship_to_children(person, show_person_name: false)).to eq('<div>Father to Child name</div>')
       end
     end
 
@@ -49,13 +49,13 @@ RSpec.describe RelationshipsPresenter do
 
       context 'showing the person name' do
         it 'returns a string describing the relationships' do
-          expect(subject.relationship_to_children(person, show_person_name: true)).to eq('Person name - A friend to Child name')
+          expect(subject.relationship_to_children(person, show_person_name: true)).to eq('<div>Person name - A friend to Child name</div>')
         end
       end
 
       context 'hiding the person name' do
         it 'returns a string describing the relationships' do
-          expect(subject.relationship_to_children(person, show_person_name: false)).to eq('A friend to Child name')
+          expect(subject.relationship_to_children(person, show_person_name: false)).to eq('<div>A friend to Child name</div>')
         end
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe RelationshipsPresenter do
 
         context 'but the bypass is activated' do
           it 'returns the relationship details' do
-            expect(subject.relationship_to_children(person, bypass_c8: true)).to eq('Person name - Father to Child name')
+            expect(subject.relationship_to_children(person, bypass_c8: true)).to eq('<div>Person name - Father to Child name</div>')
           end
         end
       end
@@ -81,7 +81,7 @@ RSpec.describe RelationshipsPresenter do
         let(:confidentiality_enabled) { false }
 
         it 'returns the relationship details' do
-          expect(subject.relationship_to_children(person)).to eq('Person name - Father to Child name')
+          expect(subject.relationship_to_children(person)).to eq('<div>Person name - Father to Child name</div>')
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/17280033)

Describe what you did and why.

Add a new line between each child in the children’s relationship with parents section of the c100 pdf

It look like this currently:

<img width="740" alt="Screen Shot 2019-10-09 at 15 14 21" src="https://user-images.githubusercontent.com/22822829/66489427-8434c680-eaa7-11e9-944b-b2aadc79d332.png">

has been updated to look like this:

![Screen Shot 2019-10-09 at 15 05 22](https://user-images.githubusercontent.com/22822829/66488830-85b1bf00-eaa6-11e9-8c25-ec3c4733a6e1.png)


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
