### PR TITLE
Add new welsh courts

### DIFF
--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -57,6 +57,18 @@ module C100App
       hertford-county-court-and-family-court
       chester-civil-and-family-justice-centre
       crewe-county-court-and-family-court
+      caernarfon-justice-centre
+      wrexham-county-and-family-court
+      welshpool-magistrates-court
+      prestatyn-justice-centre
+      blackwood-civil-and-family-court
+      pontypridd-county-court-and-family-court
+      port-talbot-justice-centre
+      merthyr-tydfil-combined-court-centre
+      aberystwyth-justice-centre
+      carmarthen-county-court-and-family-court
+      haverfordwest-county-court-and-family-court
+      carmarthen-county-court-and-family-court
     ].freeze
 
     # Separate multiple postcodes/postcode areas by "\n"

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe C100App::CourtPostcodeChecker do
   describe 'COURT_SLUGS_USING_THIS_APP' do
     it 'returns the expected number of court slugs taking part in the trial' do
-      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(53)
+      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(65)
     end
   end
 


### PR DESCRIPTION
## What

[Link to story](https://mojdigital.teamwork.com/index.cfm#/tasks/17432754)

New welsh courts which will go live near the end of October.

Caernarfon = https://courttribunalfinder.service.gov.uk/courts/caernarfon-justice-centre
Wrexham = https://courttribunalfinder.service.gov.uk/courts/wrexham-county-and-family-court
Welshpool = https://courttribunalfinder.service.gov.uk/courts/welshpool-magistrates-court
Prestatyn = https://courttribunalfinder.service.gov.uk/courts/prestatyn-justice-centre
Blackwood = https://courttribunalfinder.service.gov.uk/courts/blackwood-civil-and-family-court   > missing family email address
Pontypridd = https://courttribunalfinder.service.gov.uk/courts/pontypridd-county-court-and-family-court
Port Talbot = https://courttribunalfinder.service.gov.uk/courts/port-talbot-justice-centre
Merthyr Tydfil= https://courttribunalfinder.service.gov.uk/courts/merthyr-tydfil-combined-court-centre  > missing family email address
Aberystwyth = https://courttribunalfinder.service.gov.uk/courts/aberystwyth-justice-centre  > missing family email address
Carmarthen = https://courttribunalfinder.service.gov.uk/courts/carmarthen-county-court-and-family-court  > missing family email address

HaverfordWest = https://courttribunalfinder.service.gov.uk/courts/haverfordwest-county-court-and-family-court   > missing family email address

Llanelli = https://courttribunalfinder.service.gov.uk/courts/carmarthen-county-court-and-family-court  > missing family email address