### PR TITLE
Reduce number of email alerts

### DIFF
--- a/app/services/reports/failed_emails_report.rb
+++ b/app/services/reports/failed_emails_report.rb
@@ -67,6 +67,10 @@ module Reports
         if record.user_copy_sent_at.nil?
           failures << report_line(record, reference, 'error')
         elsif email_not_delivered?(reference)
+          # Ignore these failures when sending the report, as these are very
+          # frequently user typos, and nothing we can fix on our side.
+          return if report_type == :daily_tasks
+
           failures << report_line(record, reference, 'undelivered')
         end
       end


### PR DESCRIPTION
As the service take up increase, there is also an increase in the number of emails we receive alerting us of failures in the applicant receipt email.

These failures are usually typos in the email address and nothing we can fix on our side.

In order to minimise these alerts so we only receive them when the error is genuine (or looks genuine) we are going to ignore the notify failures for the user receipt.
We still get them in the backoffice.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
