### PR TITLE
Ensure index uniqueness in two DB tables

### DIFF
--- a/db/migrate/20191031094024_change_abduction_details_index_to_unique.rb
+++ b/db/migrate/20191031094024_change_abduction_details_index_to_unique.rb
@@ -1,0 +1,6 @@
+class ChangeAbductionDetailsIndexToUnique < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :abduction_details, :c100_application_id
+    add_index    :abduction_details, :c100_application_id, unique: true
+  end
+end

--- a/db/migrate/20191031094243_change_miam_exemption_index_to_unique.rb
+++ b/db/migrate/20191031094243_change_miam_exemption_index_to_unique.rb
@@ -1,0 +1,6 @@
+class ChangeMiamExemptionIndexToUnique < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :miam_exemptions, :c100_application_id
+    add_index    :miam_exemptions, :c100_application_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190905111838) do
+ActiveRecord::Schema.define(version: 20191031094243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 20190905111838) do
     t.text "risk_details"
     t.uuid "c100_application_id"
     t.text "current_location"
-    t.index ["c100_application_id"], name: "index_abduction_details_on_c100_application_id"
+    t.index ["c100_application_id"], name: "index_abduction_details_on_c100_application_id", unique: true
   end
 
   create_table "abuse_concerns", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -244,7 +244,7 @@ ActiveRecord::Schema.define(version: 20190905111838) do
     t.string "adr", default: [], array: true
     t.string "misc", default: [], array: true
     t.uuid "c100_application_id"
-    t.index ["c100_application_id"], name: "index_miam_exemptions_on_c100_application_id"
+    t.index ["c100_application_id"], name: "index_miam_exemptions_on_c100_application_id", unique: true
   end
 
   create_table "people", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|


### PR DESCRIPTION
These tables can only contain unique references to `C100Application`. There can't be duplicates.

There have been a rare occurrence where a duplicate entry was inserted (probably by submitting twice the form quickly, or some kind of race-condition difficult to replicate).

In order to avoid this from happening again, and as we do with other tables already, we are going to enforce the uniqueness of the index `c100_application_id` column.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
