### PR TITLE
Specify version of gem to avoid surprises

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.6.2'
 
 gem 'devise', '~> 4.7.1'
 gem 'email_validator'
-gem 'govuk_elements_form_builder', git: "https://github.com/ministryofjustice/govuk_elements_form_builder.git"
+gem 'govuk_elements_form_builder', '~> 1.3.1'
 gem 'govuk_elements_rails', '~> 3.0'
 gem 'govuk_frontend_toolkit', '< 8.0.0'
 gem 'govuk_notify_rails', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
-  revision: 3049c945f46e61a1a2264346f3ce5f7b60a7c8f4
-  specs:
-    govuk_elements_form_builder (1.3.0)
-      govuk_elements_rails (>= 3.0.0)
-      govuk_frontend_toolkit (>= 6.0.0)
-      rails (>= 4.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -146,6 +137,10 @@ GEM
       activesupport (>= 4.2.0)
     gov_uk_date_fields (3.1.0)
       rails (>= 5.0)
+    govuk_elements_form_builder (1.3.1)
+      govuk_elements_rails (>= 3.0.0)
+      govuk_frontend_toolkit (< 9.0.0)
+      rails (>= 4.2)
     govuk_elements_rails (3.1.3)
       govuk_frontend_toolkit (>= 6.0.2)
       rails (>= 4.1.0)
@@ -425,7 +420,7 @@ DEPENDENCIES
   dotenv-rails
   email_validator
   gov_uk_date_fields (~> 3.1.0)
-  govuk_elements_form_builder!
+  govuk_elements_form_builder (~> 1.3.1)
   govuk_elements_rails (~> 3.0)
   govuk_frontend_toolkit (< 8.0.0)
   govuk_notify_rails (~> 2.1.0)


### PR DESCRIPTION
We had `govuk_elements_form_builder` pointing to master branch of the repo while awaiting a release of a new version.

The release is now done (https://github.com/ministryofjustice/govuk_elements_form_builder/pull/106) so we can change this to avoid nasty surprises in the future.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
