### PR TITLE
Update swansea slug

### DIFF
--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -22,7 +22,7 @@ module C100App
       east-london-family-court
       newport-south-wales-county-court-and-family-court
       southampton-combined-court-centre
-      swansea-civil-and-family-justice-centre
+      swansea-civil-justice-centre
       exeter-combined-court-centre
       medway-county-court-and-family-court
       liverpool-civil-and-family-court


### PR DESCRIPTION
The slug for the swansea court changed from  `swansea-civil-and-family-justice-centre` to [swansea-civil-justice-centre](https://courttribunalfinder.service.gov.uk/courts/swansea-civil-justice-centre).

