### PR TITLE
Add one time task to fix some rows in audit table

### DIFF
--- a/audit_courts.csv
+++ b/audit_courts.csv
@@ -1,0 +1,1045 @@
+2018-05-14 09:09:23.311169,Milton Keynes County Court and Family Court,0001
+2018-05-14 09:53:43.435677,Watford County Court and Family Court,0002
+2018-05-14 17:23:48.909355,Milton Keynes County Court and Family Court,0003
+2018-05-15 10:37:16.151034,Watford County Court and Family Court,0004
+2018-05-16 09:16:47.185167,Guildford County Court and Family Court,0005
+2018-05-17 17:10:05.234964,Watford County Court and Family Court,0006
+2018-06-06 18:41:07.382047,Slough County Court and Family Court,0007
+2018-05-29 14:26:24.434972,Milton Keynes County Court and Family Court,0008
+2018-06-01 13:49:15.694401,Milton Keynes County Court and Family Court,0009
+2018-06-06 09:56:41.444763,Watford County Court and Family Court,0010
+2018-06-07 16:27:11.521827,Reading County Court and Family Court,0011
+2018-06-07 16:10:00.660222,Milton Keynes County Court and Family Court,0012
+2018-06-09 10:08:22.582512,Reading County Court and Family Court,0013
+2018-06-09 14:26:37.051777,Milton Keynes County Court and Family Court,0014
+2018-06-10 16:35:36.017188,Reading County Court and Family Court,0015
+2018-06-10 23:13:18.630578,Watford County Court and Family Court,0016
+2018-06-11 12:35:06.475981,Watford County Court and Family Court,0017
+2018-06-11 19:50:07.239226,Slough County Court and Family Court,0018
+2018-06-13 14:16:40.826231,Guildford County Court and Family Court,0019
+2018-06-14 17:01:38.455507,Reading County Court and Family Court,0020
+2018-06-14 21:59:27.383275,Watford County Court and Family Court,0021
+2018-06-16 21:46:19.156793,Watford County Court and Family Court,0022
+2018-06-19 14:13:54.055549,Milton Keynes County Court and Family Court,0023
+2018-06-27 11:34:25.797794,Reading County Court and Family Court,0024
+2018-06-26 13:18:39.875757,Watford County Court and Family Court,0025
+2018-06-20 22:40:11.12437,Milton Keynes County Court and Family Court,0026
+2018-06-22 10:50:32.987391,Watford County Court and Family Court,0027
+2018-06-23 10:54:09.762051,Reading County Court and Family Court,0028
+2018-07-02 16:10:26.48722,Milton Keynes County Court and Family Court,0029
+2018-06-25 23:40:52.788392,Milton Keynes County Court and Family Court,0030
+2018-07-21 04:08:26.243829,Milton Keynes County Court and Family Court,0031
+2018-06-27 20:17:15.796791,Kingston-upon-Hull Combined Court Centre,0032
+2018-06-28 10:10:44.849376,Bristol Civil and Family Justice Centre,0033
+2018-06-29 09:01:01.726449,Milton Keynes County Court and Family Court,0034
+2018-06-29 09:23:50.774108,Bristol Civil and Family Justice Centre,0035
+2018-06-29 11:37:52.898909,Milton Keynes County Court and Family Court,0036
+2018-07-04 00:43:08.962852,Milton Keynes County Court and Family Court,0037
+2018-07-01 19:44:33.268214,Watford County Court and Family Court,0038
+2018-07-04 08:17:23.993243,Oxford Combined Court Centre,0039
+2018-07-02 18:36:17.139945,Kingston-upon-Hull Combined Court Centre,0040
+2018-07-03 12:32:16.524059,Bristol Civil and Family Justice Centre,0041
+2018-07-03 23:51:23.491825,Reading County Court and Family Court,0042
+2018-07-04 10:51:45.797661,Bristol Civil and Family Justice Centre,0043
+2018-07-04 11:21:41.103254,Reading County Court and Family Court,0044
+2018-07-04 10:11:11.558543,Watford County Court and Family Court,0045
+2018-07-04 15:33:57.010806,Watford County Court and Family Court,0046
+2018-08-01 14:26:26.693196,Bristol Civil and Family Justice Centre,0047
+2018-07-05 10:24:53.382886,Bristol Civil and Family Justice Centre,0048
+2018-07-05 12:33:44.804039,Oxford Combined Court Centre,0049
+2018-07-05 19:23:32.642386,Kingston-upon-Hull Combined Court Centre,0050
+2018-07-08 23:44:22.573947,Slough County Court and Family Court,0051
+2018-07-09 07:05:25.424506,Watford County Court and Family Court,0052
+2018-08-02 08:03:34.430625,Bristol Civil and Family Justice Centre,0053
+2018-07-09 11:47:25.002615,Bristol Civil and Family Justice Centre,0054
+2018-07-10 21:31:28.18529,Oxford Combined Court Centre,0055
+2018-07-10 21:35:18.224722,Reading County Court and Family Court,0056
+2018-07-11 10:04:40.937935,Nottingham County Court and Family Court,0057
+2018-07-11 10:26:42.806559,Bristol Civil and Family Justice Centre,0058
+2018-07-11 15:41:36.600537,Newcastle upon Tyne Combined Court Centre,0059
+2018-07-11 19:06:02.076421,Nottingham County Court and Family Court,0060
+2018-07-12 09:50:53.396449,Leeds Combined Court Centre,0061
+2018-08-09 07:06:27.772494,Watford County Court and Family Court,0062
+2018-07-12 17:39:43.2967,Bristol Civil and Family Justice Centre,0063
+2018-07-14 10:48:56.741604,Newcastle upon Tyne Combined Court Centre,0064
+2018-07-12 21:20:35.56266,West London Family Court,0065
+2018-07-13 11:01:59.051164,Bristol Civil and Family Justice Centre,0066
+2018-07-13 10:00:21.451318,Bristol Civil and Family Justice Centre,0067
+2018-07-13 17:10:03.848849,West London Family Court,0068
+2018-07-15 14:35:01.074148,Reading County Court and Family Court,0069
+2018-07-18 09:51:57.552658,Leeds Combined Court Centre,0070
+2018-07-15 22:01:50.69169,Leeds Combined Court Centre,0071
+2018-07-16 10:30:49.385537,Bristol Civil and Family Justice Centre,0072
+2018-07-16 19:17:26.216969,Preston Crown Court and Family Court (Sessions House),0073
+2018-07-18 09:51:21.803373,Oxford Combined Court Centre,0074
+2018-07-17 11:02:00.834783,Bristol Civil and Family Justice Centre,0075
+2018-07-22 16:51:17.279373,Bristol Civil and Family Justice Centre,0076
+2018-07-17 13:15:47.239315,Milton Keynes County Court and Family Court,0077
+2018-07-17 13:14:18.358569,West London Family Court,0078
+2018-07-17 17:34:38.048236,Newcastle upon Tyne Combined Court Centre,0079
+2018-07-18 07:34:29.542536,Cardiff Civil and Family Justice Centre,0080
+2018-07-18 11:07:58.49451,Bristol Civil and Family Justice Centre,0081
+2018-07-18 10:17:56.080201,Leeds Combined Court Centre,0082
+2018-07-18 17:17:19.375854,Oxford Combined Court Centre,0083
+2018-07-19 09:22:03.339845,Bristol Civil and Family Justice Centre,0084
+2018-07-19 15:17:04.070063,Cardiff Civil and Family Justice Centre,0085
+2018-07-19 15:18:24.311943,Bristol Civil and Family Justice Centre,0086
+2018-07-19 15:16:57.863401,Preston Crown Court and Family Court (Sessions House),0087
+2018-07-19 21:40:45.380988,Preston Crown Court and Family Court (Sessions House),0088
+2018-07-20 18:39:36.538635,Preston Crown Court and Family Court (Sessions House),0089
+2018-07-20 20:18:32.753001,Leeds Combined Court Centre,0090
+2018-07-20 21:35:36.25789,Bristol Civil and Family Justice Centre,0091
+2018-07-21 23:22:22.375506,Milton Keynes County Court and Family Court,0092
+2018-07-21 19:44:47.300368,Leeds Combined Court Centre,0093
+2018-07-21 18:36:17.798598,Newcastle upon Tyne Combined Court Centre,0094
+2018-07-22 08:28:19.950678,Newcastle upon Tyne Combined Court Centre,0095
+2018-07-22 09:19:28.197941,Preston Crown Court and Family Court (Sessions House),0096
+2018-07-22 19:24:15.639295,Guildford County Court and Family Court,0097
+2018-07-23 16:36:19.395276,West London Family Court,0098
+2018-07-28 12:54:36.976849,Bristol Civil and Family Justice Centre,0099
+2018-07-24 14:13:02.181339,Bristol Civil and Family Justice Centre,0100
+2018-07-23 15:56:35.514284,Oxford Combined Court Centre,0101
+2018-08-01 15:55:27.600834,Guildford County Court and Family Court,0102
+2018-07-23 17:43:45.483258,Milton Keynes County Court and Family Court,0103
+2018-07-23 19:02:32.762995,Nottingham County Court and Family Court,0104
+2018-07-24 11:28:23.67039,Leeds Combined Court Centre,0105
+2018-07-24 12:52:00.063169,Bristol Civil and Family Justice Centre,0106
+2018-07-24 14:01:26.067309,West London Family Court,0107
+2018-07-24 14:35:14.218463,Leeds Combined Court Centre,0108
+2018-07-24 17:56:02.434254,Watford County Court and Family Court,0109
+2018-07-24 21:20:04.07808,Bristol Civil and Family Justice Centre,0110
+2018-07-25 02:21:03.842943,Reading County Court and Family Court,0111
+2018-07-25 22:21:56.231366,West London Family Court,0112
+2018-07-27 13:14:30.801881,Bristol Civil and Family Justice Centre,0113
+2018-07-25 19:26:12.386168,Reading County Court and Family Court,0114
+2018-07-25 20:22:47.686451,Nottingham County Court and Family Court,0115
+2018-07-26 11:59:54.742997,Leeds Combined Court Centre,0116
+2018-08-02 13:20:58.010642,West London Family Court,0117
+2018-07-29 18:09:20.709459,West London Family Court,0118
+2018-07-26 23:12:30.078912,Slough County Court and Family Court,0119
+2018-07-27 13:39:48.019489,Bristol Civil and Family Justice Centre,0120
+2018-07-27 19:18:30.107218,Oxford Combined Court Centre,0121
+2018-07-31 13:10:21.126713,Preston Crown Court and Family Court (Sessions House),0122
+2018-07-28 15:11:48.520474,Newcastle upon Tyne Combined Court Centre,0123
+2018-07-29 00:20:55.9156,Leeds Combined Court Centre,0124
+2018-08-04 16:30:10.172969,Leeds Combined Court Centre,0125
+2018-07-29 18:50:39.29174,Milton Keynes County Court and Family Court,0126
+2018-07-29 20:32:00.946283,Leeds Combined Court Centre,0127
+2018-08-01 22:42:27.649262,West London Family Court,0128
+2018-07-30 09:48:59.152036,Nottingham County Court and Family Court,0129
+2018-07-30 11:18:09.718009,Bristol Civil and Family Justice Centre,0130
+2018-07-30 13:14:51.585899,Nottingham County Court and Family Court,0131
+2018-07-30 19:54:44.8893,Newcastle upon Tyne Combined Court Centre,0132
+2018-07-31 08:30:56.227456,West London Family Court,0133
+2018-07-31 10:42:00.852121,West London Family Court,0134
+2018-07-31 10:38:31.745846,Leeds Combined Court Centre,0135
+2018-07-31 12:12:34.775278,Bristol Civil and Family Justice Centre,0136
+2018-07-31 16:51:48.645103,Cardiff Civil and Family Justice Centre,0137
+2018-07-31 19:15:55.710243,Milton Keynes County Court and Family Court,0138
+2018-07-31 19:59:20.797758,Nottingham County Court and Family Court,0139
+2018-07-31 20:47:41.274959,West London Family Court,0140
+2018-07-31 22:24:32.196831,Leeds Combined Court Centre,0141
+2018-07-31 23:53:17.723451,Nottingham County Court and Family Court,0142
+2018-08-01 12:12:30.063224,Reading County Court and Family Court,0143
+2018-08-01 15:56:16.590206,Newcastle upon Tyne Combined Court Centre,0144
+2018-08-01 17:04:18.80167,Watford County Court and Family Court,0145
+2018-08-01 18:17:14.136241,Preston Crown Court and Family Court (Sessions House),0146
+2018-08-02 11:32:19.502916,Nottingham County Court and Family Court,0147
+2018-08-02 13:12:20.518269,Preston Crown Court and Family Court (Sessions House),0148
+2018-08-02 14:22:31.892109,Nottingham County Court and Family Court,0149
+2018-08-02 15:05:24.827298,Bristol Civil and Family Justice Centre,0150
+2018-08-02 15:05:03.337162,Cardiff Civil and Family Justice Centre,0151
+2018-08-02 14:11:35.323118,Leeds Combined Court Centre,0152
+2018-08-02 20:34:27.245871,Cardiff Civil and Family Justice Centre,0153
+2018-08-02 20:56:17.004956,Watford County Court and Family Court,0154
+2018-08-03 12:24:09.712887,Bristol Civil and Family Justice Centre,0155
+2018-08-03 11:13:41.921776,Reading County Court and Family Court,0156
+2018-08-03 14:17:54.544314,Preston Crown Court and Family Court (Sessions House),0157
+2018-08-03 14:48:21.070014,West London Family Court,0158
+2018-08-04 13:44:02.492261,Preston Crown Court and Family Court (Sessions House),0159
+2018-08-05 01:30:46.732985,West London Family Court,0160
+2018-08-04 23:28:17.998196,Preston Crown Court and Family Court (Sessions House),0161
+2018-08-06 08:31:10.990548,Leeds Combined Court Centre,0162
+2018-08-05 21:28:20.494288,West London Family Court,0163
+2018-08-06 12:27:57.011977,West London Family Court,0164
+2018-08-06 11:05:30.779623,Newcastle upon Tyne Combined Court Centre,0165
+2018-08-06 23:52:54.769052,Leeds Combined Court Centre,0166
+2018-08-07 10:49:02.022999,Bristol Civil and Family Justice Centre,0167
+2018-08-07 13:20:29.865625,Nottingham County Court and Family Court,0168
+2018-08-07 11:00:20.355337,Nottingham County Court and Family Court,0169
+2018-08-08 09:39:50.501317,Leeds Combined Court Centre,0170
+2018-08-07 11:46:04.074927,West London Family Court,0171
+2018-08-07 11:45:04.226955,Preston Crown Court and Family Court (Sessions House),0172
+2018-08-07 12:16:29.267096,West London Family Court,0173
+2018-08-07 15:07:16.753154,Preston Crown Court and Family Court (Sessions House),0174
+2018-08-07 15:21:52.147032,West London Family Court,0175
+2018-08-08 10:45:21.349459,Guildford County Court and Family Court,0176
+2018-08-14 17:33:17.364259,Slough County Court and Family Court,0177
+2018-08-08 18:45:58.849133,Preston Crown Court and Family Court (Sessions House),0178
+2018-08-09 19:00:58.100695,Preston Crown Court and Family Court (Sessions House),0179
+2018-08-10 13:16:25.416036,Bristol Civil and Family Justice Centre,0180
+2018-08-10 15:12:41.021061,Bristol Civil and Family Justice Centre,0181
+2018-08-11 21:08:27.001588,Cardiff Civil and Family Justice Centre,0182
+2018-08-10 16:15:29.396383,West London Family Court,0183
+2018-08-11 20:44:53.995097,Oxford Combined Court Centre,0184
+2018-08-11 16:35:57.61672,Oxford Combined Court Centre,0185
+2018-08-12 23:42:29.037078,Kingston-upon-Hull Combined Court Centre,0186
+2018-08-14 14:51:27.027646,Nottingham County Court and Family Court,0187
+2018-08-13 14:03:00.723787,Reading County Court and Family Court,0188
+2018-08-13 20:30:37.309669,Newcastle upon Tyne Combined Court Centre,0189
+2018-08-13 22:49:25.473608,Preston Crown Court and Family Court (Sessions House),0190
+2018-08-14 05:58:00.830072,Leeds Combined Court Centre,0191
+2018-08-14 11:05:18.887242,Nottingham County Court and Family Court,0192
+2018-08-15 10:51:23.354575,Guildford County Court and Family Court,0193
+2018-08-14 21:24:40.980278,Oxford Combined Court Centre,0194
+2018-08-15 03:09:00.236257,Newcastle upon Tyne Combined Court Centre,0195
+2018-08-15 10:06:30.887929,Nottingham County Court and Family Court,0196
+2018-08-15 10:28:45.106639,Bristol Civil and Family Justice Centre,0197
+2018-08-15 13:05:50.547471,West London Family Court,0198
+2018-08-15 14:13:04.332132,Leeds Combined Court Centre,0199
+2018-09-10 18:42:42.136929,Reading County Court and Family Court,0200
+2018-08-15 18:33:37.758772,Nottingham County Court and Family Court,0201
+2018-08-15 19:30:33.948908,Leeds Combined Court Centre,0202
+2018-08-31 13:07:26.294543,Oxford Combined Court Centre,0203
+2018-08-16 08:03:09.355467,Cardiff Civil and Family Justice Centre,0204
+2018-08-16 13:50:12.073271,Preston Crown Court and Family Court (Sessions House),0205
+2018-08-16 13:55:59.283016,Cardiff Civil and Family Justice Centre,0206
+2018-08-16 15:29:19.551934,Preston Crown Court and Family Court (Sessions House),0207
+2018-08-16 17:42:05.735692,West London Family Court,0208
+2018-08-18 11:07:06.107035,West London Family Court,0209
+2018-08-17 11:42:21.155807,West London Family Court,0210
+2018-08-17 13:04:04.149822,Watford County Court and Family Court,0211
+2018-08-17 13:29:05.579517,Watford County Court and Family Court,0212
+2018-08-17 12:36:26.825547,Preston Crown Court and Family Court (Sessions House),0213
+2018-08-17 16:23:19.07364,Preston Crown Court and Family Court (Sessions House),0214
+2018-08-17 19:22:05.639246,Cardiff Civil and Family Justice Centre,0215
+2018-08-17 21:51:30.675945,West London Family Court,0216
+2018-08-18 14:40:52.110834,Milton Keynes County Court and Family Court,0217
+2018-08-18 21:21:00.723427,Preston Crown Court and Family Court (Sessions House),0218
+2018-08-26 13:23:06.53594,Guildford County Court and Family Court,0219
+2018-08-19 21:19:24.301067,Oxford Combined Court Centre,0220
+2018-08-20 10:20:56.833362,Milton Keynes County Court and Family Court,0221
+2018-08-20 14:34:19.982039,Preston Crown Court and Family Court (Sessions House),0222
+2018-08-20 16:34:54.045802,Bristol Civil and Family Justice Centre,0223
+2018-08-20 18:44:53.142876,Milton Keynes County Court and Family Court,0224
+2018-08-20 19:40:35.685503,Bristol Civil and Family Justice Centre,0225
+2018-08-21 13:38:17.770043,Bristol Civil and Family Justice Centre,0226
+2018-08-21 16:32:53.976208,Nottingham County Court and Family Court,0227
+2018-08-21 22:02:08.240691,Bristol Civil and Family Justice Centre,0228
+2018-08-22 14:57:34.398808,Newcastle upon Tyne Combined Court Centre,0229
+2018-08-26 14:31:10.30923,Newcastle upon Tyne Combined Court Centre,0230
+2018-08-23 10:53:11.289966,Leeds Combined Court Centre,0231
+2018-08-23 13:17:03.533781,Reading County Court and Family Court,0232
+2018-08-24 09:16:56.725284,Kingston-upon-Hull Combined Court Centre,0233
+2018-08-24 14:52:03.243866,Nottingham County Court and Family Court,0234
+2018-09-02 21:01:06.344462,Kingston-upon-Hull Combined Court Centre,0235
+2018-09-04 11:17:22.458886,Preston Crown Court and Family Court (Sessions House),0236
+2018-08-24 14:53:33.59768,Guildford County Court and Family Court,0237
+2018-08-24 17:14:43.836646,West London Family Court,0238
+2018-08-25 09:44:53.839542,Watford County Court and Family Court,0239
+2018-09-06 20:34:14.804933,Leeds Combined Court Centre,0240
+2018-09-02 12:15:06.141113,Bristol Civil and Family Justice Centre,0241
+2018-08-27 13:59:41.116504,West London Family Court,0242
+2018-08-27 18:22:15.204298,West London Family Court,0243
+2018-08-27 20:36:46.625305,Preston Crown Court and Family Court (Sessions House),0244
+2018-08-27 23:55:41.938966,Leeds Combined Court Centre,0245
+2018-08-28 12:04:52.364108,Bristol Civil and Family Justice Centre,0246
+2018-08-28 14:12:53.294021,Cardiff Civil and Family Justice Centre,0247
+2018-08-28 13:16:18.871012,Slough County Court and Family Court,0248
+2018-08-28 16:29:02.459824,Bristol Civil and Family Justice Centre,0249
+2018-09-10 16:50:53.422479,Nottingham County Court and Family Court,0250
+2018-09-12 20:01:53.574868,Kingston-upon-Hull Combined Court Centre,0251
+2018-09-16 17:33:40.157104,Guildford County Court and Family Court,0252
+2018-08-29 18:35:41.800194,Preston Crown Court and Family Court (Sessions House),0253
+2018-08-29 21:16:50.401722,Nottingham County Court and Family Court,0254
+2018-08-30 21:21:51.410059,Oxford Combined Court Centre,0255
+2018-08-30 14:43:19.9895,Nottingham County Court and Family Court,0256
+2018-08-31 10:06:19.813788,West London Family Court,0257
+2018-08-30 18:05:54.255327,Kingston-upon-Hull Combined Court Centre,0258
+2018-08-30 18:04:41.512191,Oxford Combined Court Centre,0259
+2018-08-30 21:07:36.582073,Kingston-upon-Hull Combined Court Centre,0260
+2018-08-31 09:26:24.890018,Reading County Court and Family Court,0261
+2018-08-31 10:11:58.530446,Bristol Civil and Family Justice Centre,0262
+2018-08-31 14:10:54.822222,Kingston-upon-Hull Combined Court Centre,0263
+2018-08-31 12:51:57.493369,Watford County Court and Family Court,0264
+2018-08-31 13:14:52.597894,Reading County Court and Family Court,0265
+2018-09-06 22:41:49.108964,Nottingham County Court and Family Court,0266
+2018-09-01 10:05:13.508976,Slough County Court and Family Court,0267
+2018-08-31 17:36:37.848204,Preston Crown Court and Family Court (Sessions House),0268
+2018-08-31 17:58:13.102603,Cardiff Civil and Family Justice Centre,0269
+2018-08-31 18:43:20.490255,Cardiff Civil and Family Justice Centre,0270
+2018-08-31 19:37:26.918125,Milton Keynes County Court and Family Court,0271
+2018-09-03 05:15:07.006781,Leeds Combined Court Centre,0272
+2018-09-01 20:44:58.898742,Preston Crown Court and Family Court (Sessions House),0273
+2018-09-01 10:37:20.335628,Preston Crown Court and Family Court (Sessions House),0274
+2018-09-01 10:54:21.475253,Guildford County Court and Family Court,0275
+2018-09-01 14:52:51.190727,West London Family Court,0276
+2018-09-01 13:11:07.27627,Kingston-upon-Hull Combined Court Centre,0277
+2018-09-02 01:54:16.262142,West London Family Court,0278
+2018-09-02 10:37:20.730128,Milton Keynes County Court and Family Court,0279
+2018-09-02 14:55:00.365023,Kingston-upon-Hull Combined Court Centre,0280
+2018-09-30 21:25:44.432114,Leeds Combined Court Centre,0281
+2018-09-04 09:24:12.610338,Milton Keynes County Court and Family Court,0282
+2018-09-03 10:02:08.19783,Cardiff Civil and Family Justice Centre,0283
+2018-09-03 10:50:32.594681,Cardiff Civil and Family Justice Centre,0284
+2018-09-03 11:50:52.947365,Preston Crown Court and Family Court (Sessions House),0285
+2018-09-03 10:58:25.528497,Cardiff Civil and Family Justice Centre,0286
+2018-09-03 13:54:47.711912,Cardiff Civil and Family Justice Centre,0287
+2018-09-03 13:42:37.837972,Watford County Court and Family Court,0288
+2018-09-03 14:34:01.478191,Oxford Combined Court Centre,0289
+2018-09-10 13:39:52.277653,Leeds Combined Court Centre,0290
+2018-09-04 09:32:42.081886,Newcastle upon Tyne Combined Court Centre,0291
+2018-09-03 19:43:23.445924,Cardiff Civil and Family Justice Centre,0292
+2018-09-05 20:36:43.808703,Nottingham County Court and Family Court,0293
+2018-09-03 20:29:37.259379,Nottingham County Court and Family Court,0294
+2018-09-03 22:09:32.731902,Preston Crown Court and Family Court (Sessions House),0295
+2018-09-14 14:58:55.216379,Nottingham County Court and Family Court,0296
+2018-09-09 08:09:25.386833,Reading County Court and Family Court,0297
+2018-09-04 13:35:32.269844,Nottingham County Court and Family Court,0298
+2018-09-04 13:03:21.226658,Nottingham County Court and Family Court,0299
+2018-09-04 13:18:00.427466,West London Family Court,0300
+2018-09-04 14:17:43.43387,Bristol Civil and Family Justice Centre,0301
+2018-09-04 15:40:39.335013,Kingston-upon-Hull Combined Court Centre,0302
+2018-09-10 14:09:03.052349,Preston Crown Court and Family Court (Sessions House),0303
+2018-09-04 14:38:38.960768,Bristol Civil and Family Justice Centre,0304
+2018-09-04 16:34:46.753635,Leeds Combined Court Centre,0305
+2018-09-04 14:45:59.230928,Cardiff Civil and Family Justice Centre,0306
+2018-09-07 15:52:02.406345,West London Family Court,0307
+2018-09-04 17:05:37.066552,Oxford Combined Court Centre,0308
+2018-09-06 19:45:11.638429,West London Family Court,0309
+2018-09-05 07:28:29.839106,Cardiff Civil and Family Justice Centre,0310
+2018-09-07 23:30:51.749813,West London Family Court,0311
+2018-09-05 11:41:41.668822,West London Family Court,0312
+2018-09-05 13:43:34.2497,Preston Crown Court and Family Court (Sessions House),0313
+2018-09-05 14:41:09.027851,Leeds Combined Court Centre,0314
+2018-09-05 16:06:45.69587,Preston Crown Court and Family Court (Sessions House),0315
+2018-09-05 16:54:32.551072,Leeds Combined Court Centre,0316
+2018-09-20 06:39:35.823802,Bristol Civil and Family Justice Centre,0317
+2018-09-06 10:54:13.031503,Nottingham County Court and Family Court,0318
+2018-09-06 11:33:01.951152,Bristol Civil and Family Justice Centre,0319
+2018-09-06 18:16:37.742694,Cardiff Civil and Family Justice Centre,0320
+2018-09-06 22:00:32.448794,Bristol Civil and Family Justice Centre,0321
+2018-09-07 06:02:58.791752,Nottingham County Court and Family Court,0322
+2018-09-07 07:37:10.019531,Guildford County Court and Family Court,0323
+2018-09-07 08:16:32.171129,Guildford County Court and Family Court,0324
+2018-09-07 09:06:53.411565,Cardiff Civil and Family Justice Centre,0325
+2018-09-08 09:26:32.169075,Preston Crown Court and Family Court (Sessions House),0326
+2018-09-07 09:55:59.985393,Reading County Court and Family Court,0327
+2018-09-07 12:19:37.815855,Bristol Civil and Family Justice Centre,0328
+2018-09-07 12:47:12.258939,Newcastle upon Tyne Combined Court Centre,0329
+2018-09-07 14:29:05.404234,Nottingham County Court and Family Court,0330
+2018-09-07 16:05:43.204347,Nottingham County Court and Family Court,0331
+2018-09-07 16:01:09.772361,Guildford County Court and Family Court,0332
+2018-09-21 20:30:35.466111,Preston Crown Court and Family Court (Sessions House),0333
+2018-09-26 13:03:01.501759,Nottingham County Court and Family Court,0334
+2018-09-08 09:23:54.151982,Leeds Combined Court Centre,0335
+2018-09-08 12:21:50.063695,Preston Crown Court and Family Court (Sessions House),0336
+2018-09-08 14:06:28.46554,Oxford Combined Court Centre,0337
+2018-09-08 15:30:54.769344,Reading County Court and Family Court,0338
+2018-09-09 08:40:45.732582,Cardiff Civil and Family Justice Centre,0339
+2018-09-09 10:06:30.793216,West London Family Court,0340
+2018-09-09 14:04:16.868352,Kingston-upon-Hull Combined Court Centre,0341
+2018-09-09 17:01:30.063224,Newcastle upon Tyne Combined Court Centre,0342
+2018-09-10 10:13:08.578808,Bristol Civil and Family Justice Centre,0343
+2018-09-12 10:00:20.943898,Oxford Combined Court Centre,0344
+2018-09-10 11:43:38.28193,West London Family Court,0345
+2018-09-10 10:17:02.849944,West London Family Court,0346
+2018-09-12 08:50:17.883094,Reading County Court and Family Court,0347
+2018-09-12 08:44:33.479927,Watford County Court and Family Court,0348
+2018-09-15 12:02:39.913783,Nottingham County Court and Family Court,0349
+2018-09-10 15:02:43.115971,Bristol Civil and Family Justice Centre,0350
+2018-09-10 12:38:27.572246,Bristol Civil and Family Justice Centre,0351
+2018-09-10 13:31:21.792689,Guildford County Court and Family Court,0352
+2018-10-08 08:50:00.36896,Nottingham County Court and Family Court,0353
+2018-09-10 19:41:30.08907,Leeds Combined Court Centre,0354
+2018-09-11 16:15:22.976283,Preston Crown Court and Family Court (Sessions House),0355
+2018-09-10 18:21:02.245655,Bristol Civil and Family Justice Centre,0356
+2018-10-05 09:22:53.333308,Leeds Combined Court Centre,0357
+2018-09-10 22:24:40.04859,Leeds Combined Court Centre,0358
+2018-09-15 10:29:11.700309,Guildford County Court and Family Court,0359
+2018-09-11 08:15:24.701187,Oxford Combined Court Centre,0360
+2018-09-25 08:41:18.777449,Leeds Combined Court Centre,0361
+2018-09-11 09:15:29.786937,Watford County Court and Family Court,0362
+2018-09-11 13:57:02.036959,Bristol Civil and Family Justice Centre,0363
+2018-09-11 15:13:54.821227,Preston Crown Court and Family Court (Sessions House),0364
+2018-09-11 16:33:23.005815,West London Family Court,0365
+2018-09-11 22:01:09.37085,Milton Keynes County Court and Family Court,0366
+2018-09-11 21:49:35.980274,Reading County Court and Family Court,0367
+2018-09-27 16:58:35.779528,Bristol Civil and Family Justice Centre,0368
+2018-09-18 12:01:09.866213,Leeds Combined Court Centre,0369
+2018-09-12 10:31:46.318688,Preston Crown Court and Family Court (Sessions House),0370
+2018-09-12 12:09:51.497601,Nottingham County Court and Family Court,0371
+2018-09-12 13:39:09.168112,Cardiff Civil and Family Justice Centre,0372
+2018-09-12 12:48:35.638808,Nottingham County Court and Family Court,0373
+2018-09-12 15:30:58.773528,Cardiff Civil and Family Justice Centre,0374
+2018-09-12 16:00:07.886094,Leeds Combined Court Centre,0375
+2018-09-13 15:37:28.567562,West London Family Court,0376
+2018-09-12 17:21:21.635118,West London Family Court,0377
+2018-09-12 18:39:10.687248,Watford County Court and Family Court,0378
+2018-09-12 18:38:43.636518,Nottingham County Court and Family Court,0379
+2018-09-12 19:39:51.43436,Preston Crown Court and Family Court (Sessions House),0380
+2018-09-12 20:03:27.134108,Oxford Combined Court Centre,0381
+2018-09-25 16:37:42.517015,West London Family Court,0382
+2018-09-13 13:00:26.062162,Bristol Civil and Family Justice Centre,0383
+2018-09-20 20:43:45.446324,Oxford Combined Court Centre,0384
+2018-09-13 14:22:34.72631,Kingston-upon-Hull Combined Court Centre,0385
+2018-09-14 12:13:09.017425,Leeds Combined Court Centre,0386
+2018-09-15 17:16:51.285029,West London Family Court,0387
+2018-09-23 15:35:18.739242,Preston Crown Court and Family Court (Sessions House),0388
+2018-09-14 10:08:12.231524,West London Family Court,0389
+2018-09-28 15:26:16.970034,West London Family Court,0390
+2018-09-14 13:32:34.596956,Preston Crown Court and Family Court (Sessions House),0391
+2018-09-19 08:37:30.052376,West London Family Court,0392
+2018-09-18 10:27:56.472244,West London Family Court,0393
+2018-09-14 13:06:52.256956,Leeds Combined Court Centre,0394
+2018-09-14 13:52:43.530806,Leeds Combined Court Centre,0395
+2018-09-14 16:43:53.830388,Watford County Court and Family Court,0396
+2018-09-14 17:48:09.345947,Bristol Civil and Family Justice Centre,0397
+2018-09-14 18:39:34.650545,Leeds Combined Court Centre,0398
+2018-09-14 22:43:42.201983,Leeds Combined Court Centre,0399
+2018-09-15 12:31:39.772858,Leeds Combined Court Centre,0400
+2018-09-15 13:58:49.0601,Newcastle upon Tyne Combined Court Centre,0401
+2018-09-15 18:27:24.478109,Nottingham County Court and Family Court,0402
+2018-09-15 22:55:32.159663,Cardiff Civil and Family Justice Centre,0403
+2018-09-16 11:26:54.541929,West London Family Court,0404
+2018-09-16 11:09:11.702005,Preston Crown Court and Family Court (Sessions House),0405
+2018-09-16 14:00:11.265572,Slough County Court and Family Court,0406
+2018-09-16 14:36:53.57372,Preston Crown Court and Family Court (Sessions House),0407
+2018-09-16 16:23:43.777312,Kingston-upon-Hull Combined Court Centre,0408
+2018-09-16 20:46:19.032071,Oxford Combined Court Centre,0409
+2018-09-16 21:53:39.84047,Leeds Combined Court Centre,0410
+2018-09-17 11:54:20.003902,Newcastle upon Tyne Combined Court Centre,0411
+2018-09-17 12:44:43.298469,Newcastle upon Tyne Combined Court Centre,0412
+2018-10-01 10:46:58.76958,Guildford County Court and Family Court,0413
+2018-09-17 15:31:17.744663,Nottingham County Court and Family Court,0414
+2018-09-28 11:56:24.05645,West London Family Court,0415
+2018-09-17 16:14:04.958474,Cardiff Civil and Family Justice Centre,0416
+2018-09-17 18:02:09.051072,Nottingham County Court and Family Court,0417
+2018-09-17 18:46:58.845458,Newcastle upon Tyne Combined Court Centre,0418
+2018-09-17 19:37:59.170121,Bristol Civil and Family Justice Centre,0419
+2018-09-17 20:27:45.166365,Bristol Civil and Family Justice Centre,0420
+2018-09-17 19:44:46.518429,Bristol Civil and Family Justice Centre,0421
+2018-09-18 11:09:12.499088,Bristol Civil and Family Justice Centre,0422
+2018-09-18 11:33:50.279843,Preston Crown Court and Family Court (Sessions House),0423
+2018-09-18 11:53:16.125103,Nottingham County Court and Family Court,0424
+2018-09-18 13:26:22.704306,Guildford County Court and Family Court,0425
+2018-09-18 15:06:48.150311,Bristol Civil and Family Justice Centre,0426
+2018-09-18 20:22:30.212306,Watford County Court and Family Court,0427
+2018-09-26 17:03:01.909808,Bristol Civil and Family Justice Centre,0428
+2018-09-18 22:10:31.708119,Leeds Combined Court Centre,0429
+2018-09-19 13:04:15.447714,Leeds Combined Court Centre,0430
+2018-09-19 09:51:04.191675,Watford County Court and Family Court,0431
+2018-10-17 10:19:13.291066,Bristol Civil and Family Justice Centre,0432
+2018-09-19 22:28:14.287788,Watford County Court and Family Court,0433
+2018-09-20 08:21:11.900607,Leeds Combined Court Centre,0434
+2018-09-20 11:20:41.993372,Cardiff Civil and Family Justice Centre,0435
+2018-09-20 12:37:18.954372,Preston Crown Court and Family Court (Sessions House),0436
+2018-09-20 13:09:49.843129,Nottingham County Court and Family Court,0437
+2018-09-26 10:47:53.760819,Preston Crown Court and Family Court (Sessions House),0438
+2018-10-07 16:15:19.375874,Preston Crown Court and Family Court (Sessions House),0439
+2018-09-20 17:21:48.536721,Bristol Civil and Family Justice Centre,0440
+2018-09-22 17:30:15.202456,Cardiff Civil and Family Justice Centre,0441
+2018-09-21 09:00:39.78257,Bristol Civil and Family Justice Centre,0442
+2018-09-21 11:14:47.534885,Watford County Court and Family Court,0443
+2018-09-21 12:14:53.733537,Guildford County Court and Family Court,0444
+2018-09-21 13:51:25.469276,Newcastle upon Tyne Combined Court Centre,0445
+2018-09-21 20:05:18.46082,Kingston-upon-Hull Combined Court Centre,0446
+2018-09-22 00:17:01.118249,Nottingham County Court and Family Court,0447
+2018-09-22 04:43:36.36754,Preston Crown Court and Family Court (Sessions House),0448
+2018-09-22 10:18:37.845682,Newcastle upon Tyne Combined Court Centre,0449
+2018-09-25 12:24:56.983653,Leeds Combined Court Centre,0450
+2018-09-23 01:53:50.314781,Oxford Combined Court Centre,0451
+2018-09-23 11:11:42.34989,Watford County Court and Family Court,0452
+2018-09-23 18:57:32.444349,West London Family Court,0453
+2018-09-27 12:41:16.097523,Nottingham County Court and Family Court,0454
+2018-09-23 17:27:18.41974,Watford County Court and Family Court,0455
+2018-09-23 17:52:19.273055,Bristol Civil and Family Justice Centre,0456
+2018-09-23 18:01:13.17387,Leeds Combined Court Centre,0457
+2018-09-23 19:17:56.550049,Leeds Combined Court Centre,0458
+2018-09-23 21:59:23.121431,Newcastle upon Tyne Combined Court Centre,0459
+2018-09-23 22:51:04.390095,Preston Crown Court and Family Court (Sessions House),0460
+2018-09-24 05:09:45.348951,Nottingham County Court and Family Court,0461
+2018-09-26 18:43:52.139061,Leeds Combined Court Centre,0462
+2018-09-24 12:14:35.040386,Leeds Combined Court Centre,0463
+2018-09-24 15:39:22.998823,Kingston-upon-Hull Combined Court Centre,0464
+2018-09-24 17:01:47.445445,Watford County Court and Family Court,0465
+2018-09-24 18:04:47.963088,Nottingham County Court and Family Court,0466
+2018-09-24 19:26:26.265305,West London Family Court,0467
+2018-09-25 12:31:24.764292,Cardiff Civil and Family Justice Centre,0468
+2018-09-25 13:46:33.455885,Reading County Court and Family Court,0469
+2018-09-25 13:06:32.920253,Cardiff Civil and Family Justice Centre,0470
+2018-09-25 15:17:46.09976,Preston Crown Court and Family Court (Sessions House),0471
+2018-09-25 15:28:59.837093,West London Family Court,0472
+2018-09-25 17:13:42.002081,Bristol Civil and Family Justice Centre,0473
+2018-09-25 19:22:19.905197,Watford County Court and Family Court,0474
+2018-09-25 20:25:17.741234,Newcastle upon Tyne Combined Court Centre,0475
+2018-09-25 20:39:30.131061,Preston Crown Court and Family Court (Sessions House),0476
+2018-09-26 08:49:36.287882,Preston Crown Court and Family Court (Sessions House),0477
+2018-10-03 09:18:09.885447,Reading County Court and Family Court,0478
+2018-09-26 15:58:16.928118,Cardiff Civil and Family Justice Centre,0479
+2018-09-26 18:54:24.726955,Bristol Civil and Family Justice Centre,0480
+2018-09-26 19:24:50.230132,Bristol Civil and Family Justice Centre,0481
+2018-09-26 20:13:38.457342,Preston Crown Court and Family Court (Sessions House),0482
+2018-09-26 23:14:26.191861,Preston Crown Court and Family Court (Sessions House),0483
+2018-09-27 02:34:31.298856,West London Family Court,0484
+2018-09-27 12:05:08.470806,Bristol Civil and Family Justice Centre,0485
+2018-09-27 12:43:58.053842,Oxford Combined Court Centre,0486
+2018-09-28 09:09:22.79105,Bristol Civil and Family Justice Centre,0487
+2018-09-28 11:35:32.504977,Preston Crown Court and Family Court (Sessions House),0488
+2018-09-28 11:47:25.487083,Guildford County Court and Family Court,0489
+2018-09-28 15:27:34.375945,Oxford Combined Court Centre,0490
+2018-09-28 18:05:21.03052,West London Family Court,0491
+2018-09-28 21:37:42.20775,Newcastle upon Tyne Combined Court Centre,0492
+2018-09-29 00:43:32.369074,Watford County Court and Family Court,0493
+2018-09-29 22:31:36.73285,Preston Crown Court and Family Court (Sessions House),0494
+2018-09-30 09:28:17.173067,West London Family Court,0495
+2018-10-21 09:55:48.029809,West London Family Court,0496
+2018-09-30 12:49:05.399418,West London Family Court,0497
+2018-10-27 17:49:34.420295,Bristol Civil and Family Justice Centre,0498
+2018-10-08 16:01:28.777796,Guildford County Court and Family Court,0499
+2018-10-01 09:09:21.436846,Guildford County Court and Family Court,0500
+2018-10-05 13:38:33.431901,West London Family Court,0501
+2018-10-01 09:36:17.060063,Slough County Court and Family Court,0502
+2018-10-02 12:58:38.491415,Cardiff Civil and Family Justice Centre,0503
+2018-10-01 19:19:01.708262,Oxford Combined Court Centre,0504
+2018-10-01 15:59:37.226745,Leeds Combined Court Centre,0505
+2018-10-01 16:36:31.526123,Newcastle upon Tyne Combined Court Centre,0506
+2018-10-01 15:08:27.697424,Preston Crown Court and Family Court (Sessions House),0507
+2018-10-02 16:28:15.939591,Watford County Court and Family Court,0508
+2018-10-07 14:33:42.198639,Newcastle upon Tyne Combined Court Centre,0509
+2018-10-01 19:50:17.148098,Reading County Court and Family Court,0510
+2018-10-01 20:32:36.693911,Reading County Court and Family Court,0511
+2018-10-01 22:23:37.481344,West London Family Court,0512
+2018-10-01 22:42:24.205306,West London Family Court,0513
+2018-10-01 23:35:12.594637,West London Family Court,0514
+2018-10-02 07:56:10.680822,Reading County Court and Family Court,0515
+2018-10-02 09:59:02.33115,Watford County Court and Family Court,0516
+2018-10-02 12:43:42.859434,Kingston-upon-Hull Combined Court Centre,0517
+2018-10-02 20:55:17.13426,Leeds Combined Court Centre,0518
+2018-10-03 18:02:45.576417,Preston Crown Court and Family Court (Sessions House),0519
+2018-10-03 08:49:04.894385,Preston Crown Court and Family Court (Sessions House),0520
+2018-10-03 08:44:39.434459,West London Family Court,0521
+2018-10-03 10:08:33.102064,Kingston-upon-Hull Combined Court Centre,0522
+2018-10-30 21:50:31.177751,West London Family Court,0523
+2018-10-03 11:21:12.336534,Slough County Court and Family Court,0524
+2018-10-03 13:16:25.704956,West London Family Court,0525
+2018-10-27 10:11:20.223066,West London Family Court,0526
+2018-10-03 16:29:36.791267,Reading County Court and Family Court,0527
+2018-10-03 18:24:33.970147,Watford County Court and Family Court,0528
+2018-10-03 18:52:58.480926,Preston Crown Court and Family Court (Sessions House),0529
+2018-10-03 18:05:57.391637,Preston Crown Court and Family Court (Sessions House),0530
+2018-10-03 19:14:36.809717,West London Family Court,0531
+2018-10-07 16:55:51.15031,Nottingham County Court and Family Court,0532
+2018-10-04 08:35:17.502415,Cardiff Civil and Family Justice Centre,0533
+2018-10-04 13:32:45.667452,Newcastle upon Tyne Combined Court Centre,0534
+2018-10-04 13:37:26.873582,Leicester County Court and Family Court,0535
+2018-10-04 19:49:57.878319,Nottingham County Court and Family Court,0536
+2018-10-05 15:26:08.052041,Nottingham County Court and Family Court,0537
+2018-10-05 09:45:20.154961,Milton Keynes County Court and Family Court,0538
+2018-10-05 10:26:52.363066,Preston Crown Court and Family Court (Sessions House),0539
+2018-10-10 15:54:36.294246,Bristol Civil and Family Justice Centre,0540
+2018-10-06 14:14:30.335625,Newcastle upon Tyne Combined Court Centre,0541
+2018-10-05 15:04:36.8099,Reading County Court and Family Court,0542
+2018-10-05 15:17:39.535552,Kingston-upon-Hull Combined Court Centre,0543
+2018-10-05 15:52:01.984046,Cardiff Civil and Family Justice Centre,0544
+2018-10-05 16:06:50.123799,Cardiff Civil and Family Justice Centre,0545
+2018-10-05 18:42:59.134394,West London Family Court,0546
+2018-10-05 19:00:42.228121,Preston Crown Court and Family Court (Sessions House),0547
+2018-10-17 12:40:38.098416,Watford County Court and Family Court,0548
+2018-10-05 20:31:39.314811,Kingston-upon-Hull Combined Court Centre,0549
+2018-10-06 05:34:53.946421,Preston Crown Court and Family Court (Sessions House),0550
+2018-10-14 10:33:20.926088,Milton Keynes County Court and Family Court,0551
+2018-10-06 09:14:23.948426,Kingston-upon-Hull Combined Court Centre,0552
+2018-10-06 13:36:13.505987,Nottingham County Court and Family Court,0553
+2018-10-06 14:18:25.208757,Kingston-upon-Hull Combined Court Centre,0554
+2018-10-06 19:54:37.727262,Kingston-upon-Hull Combined Court Centre,0555
+2018-10-06 21:46:10.558244,West London Family Court,0556
+2018-10-07 10:45:05.754939,Leeds Combined Court Centre,0557
+2018-10-07 18:02:49.00198,Leeds Combined Court Centre,0558
+2018-10-07 22:01:27.950398,Preston Crown Court and Family Court (Sessions House),0559
+2018-10-07 21:07:34.602316,Preston Crown Court and Family Court (Sessions House),0560
+2018-10-07 20:57:52.173436,Preston Crown Court and Family Court (Sessions House),0561
+2018-10-07 21:01:58.199125,Oxford Combined Court Centre,0562
+2018-10-07 21:21:25.104682,Watford County Court and Family Court,0563
+2018-10-07 23:34:16.774259,Preston Crown Court and Family Court (Sessions House),0564
+2018-10-08 06:12:02.978229,Nottingham County Court and Family Court,0565
+2018-10-08 09:33:38.510233,Preston Crown Court and Family Court (Sessions House),0566
+2018-10-08 13:28:28.774256,West London Family Court,0567
+2018-10-08 11:50:12.882703,Oxford Combined Court Centre,0568
+2018-10-08 11:58:54.559771,Preston Crown Court and Family Court (Sessions House),0569
+2018-10-08 12:23:50.491637,Nottingham County Court and Family Court,0570
+2018-10-08 11:58:46.594535,Leeds Combined Court Centre,0571
+2018-10-08 17:14:29.403436,Watford County Court and Family Court,0572
+2018-10-08 14:41:43.729105,Reading County Court and Family Court,0573
+2018-10-08 13:25:36.88717,Nottingham County Court and Family Court,0574
+2018-10-15 13:03:49.21404,West London Family Court,0575
+2018-10-08 15:57:06.312136,West London Family Court,0576
+2018-10-08 16:16:42.660547,Kingston-upon-Hull Combined Court Centre,0577
+2018-10-30 20:29:14.185859,Cardiff Civil and Family Justice Centre,0578
+2018-10-08 19:04:27.451693,Preston Crown Court and Family Court (Sessions House),0579
+2018-10-08 19:42:51.805536,Cardiff Civil and Family Justice Centre,0580
+2018-10-09 01:11:33.566056,Preston Crown Court and Family Court (Sessions House),0581
+2018-10-09 01:02:33.657328,Watford County Court and Family Court,0582
+2018-10-09 06:35:52.882502,Guildford County Court and Family Court,0583
+2018-10-09 09:59:01.36855,Leicester County Court and Family Court,0584
+2018-10-09 11:05:04.076534,Preston Crown Court and Family Court (Sessions House),0585
+2018-10-09 13:04:03.190494,Newcastle upon Tyne Combined Court Centre,0586
+2018-10-09 10:25:17.366426,Oxford Combined Court Centre,0587
+2018-10-09 13:33:38.788302,Bristol Civil and Family Justice Centre,0588
+2018-10-09 12:59:57.751172,Watford County Court and Family Court,0589
+2018-10-09 14:26:48.487751,Bristol Civil and Family Justice Centre,0590
+2018-10-09 15:57:27.732748,West London Family Court,0591
+2018-10-09 15:58:08.677054,Bristol Civil and Family Justice Centre,0592
+2018-10-09 19:16:38.300605,Watford County Court and Family Court,0593
+2018-10-09 18:45:41.672042,Leicester County Court and Family Court,0594
+2018-10-14 15:11:47.299783,West London Family Court,0595
+2018-10-09 23:56:33.249613,Oxford Combined Court Centre,0596
+2018-10-14 16:58:29.301049,West London Family Court,0597
+2018-10-10 13:04:19.272877,Preston Crown Court and Family Court (Sessions House),0598
+2018-10-16 13:45:23.666675,West London Family Court,0599
+2018-10-10 13:13:26.631582,Watford County Court and Family Court,0600
+2018-10-10 12:59:22.716381,Preston Crown Court and Family Court (Sessions House),0601
+2018-10-10 14:01:51.954802,Leeds Combined Court Centre,0602
+2018-10-10 14:25:39.237164,Preston Crown Court and Family Court (Sessions House),0603
+2018-10-10 14:46:47.298566,Leeds Combined Court Centre,0604
+2018-10-10 18:44:23.261372,Watford County Court and Family Court,0605
+2018-10-10 20:50:10.702766,West London Family Court,0606
+2018-10-10 21:47:07.954901,Kingston-upon-Hull Combined Court Centre,0607
+2018-10-11 00:17:45.389401,Milton Keynes County Court and Family Court,0608
+2018-10-11 09:33:50.79496,Leeds Combined Court Centre,0609
+2018-10-11 09:26:39.470189,Nottingham County Court and Family Court,0610
+2018-11-08 21:48:48.330351,West London Family Court,0611
+2018-10-11 15:34:08.399525,Watford County Court and Family Court,0612
+2018-10-29 16:05:49.53629,West London Family Court,0613
+2018-10-11 15:50:15.73077,Kingston-upon-Hull Combined Court Centre,0614
+2018-10-11 18:57:35.892839,Cardiff Civil and Family Justice Centre,0615
+2018-10-11 22:47:05.909062,East London Family Court,0616
+2018-10-11 21:24:42.729369,East London Family Court,0617
+2018-10-11 21:55:23.818779,Milton Keynes County Court and Family Court,0618
+2018-10-12 15:10:52.605827,West London Family Court,0619
+2018-10-11 23:08:40.023798,Leeds Combined Court Centre,0620
+2018-10-14 17:55:23.932265,East London Family Court,0621
+2018-10-12 07:44:55.288999,West London Family Court,0622
+2018-10-12 11:10:04.32595,West London Family Court,0623
+2018-10-12 12:21:33.187619,Leeds Combined Court Centre,0624
+2018-10-12 12:24:13.279504,Leicester County Court and Family Court,0625
+2018-10-12 12:54:13.748442,Leicester County Court and Family Court,0626
+2018-10-12 12:35:02.960813,Cardiff Civil and Family Justice Centre,0627
+2018-10-12 13:18:34.750381,Nottingham County Court and Family Court,0628
+2018-10-14 21:44:02.56985,Bristol Civil and Family Justice Centre,0629
+2018-10-12 18:22:02.675826,Slough County Court and Family Court,0630
+2018-10-12 20:05:34.101531,Leicester County Court and Family Court,0631
+2018-10-13 12:41:27.393029,Guildford County Court and Family Court,0632
+2018-11-09 21:49:30.806309,Reading County Court and Family Court,0633
+2018-10-13 16:09:45.267819,West London Family Court,0634
+2018-10-13 20:08:38.169483,Watford County Court and Family Court,0635
+2018-10-14 12:20:35.064509,Guildford County Court and Family Court,0636
+2018-10-14 14:44:23.927191,Guildford County Court and Family Court,0637
+2018-10-14 16:48:27.560016,West London Family Court,0638
+2018-10-14 18:54:47.256733,Newcastle upon Tyne Combined Court Centre,0639
+2018-10-14 20:24:31.856775,Preston Crown Court and Family Court (Sessions House),0640
+2018-10-21 22:18:51.373113,Nottingham County Court and Family Court,0641
+2018-10-15 09:51:21.450645,Guildford County Court and Family Court,0642
+2018-10-15 10:35:33.503801,Watford County Court and Family Court,0643
+2018-10-15 11:55:02.873054,Preston Crown Court and Family Court (Sessions House),0644
+2018-10-15 12:27:38.923809,Watford County Court and Family Court,0645
+2018-10-15 12:28:32.649479,Leeds Combined Court Centre,0646
+2018-10-15 12:57:48.264084,Reading County Court and Family Court,0647
+2018-10-15 13:01:35.637145,Leeds Combined Court Centre,0648
+2018-10-15 14:13:22.086723,Leeds Combined Court Centre,0649
+2018-10-15 17:14:50.664044,West London Family Court,0650
+2018-10-15 15:41:31.647901,Watford County Court and Family Court,0651
+2018-10-19 10:39:41.140962,Preston Crown Court and Family Court (Sessions House),0652
+2018-10-15 18:45:33.757921,Nottingham County Court and Family Court,0653
+2018-10-15 19:29:06.506353,Kingston-upon-Hull Combined Court Centre,0654
+2018-10-15 19:59:39.699835,Leeds Combined Court Centre,0655
+2018-10-15 23:22:56.245317,Newcastle upon Tyne Combined Court Centre,0656
+2018-10-16 10:32:10.469056,Reading County Court and Family Court,0657
+2018-10-16 11:01:03.02369,East London Family Court,0658
+2018-10-16 15:02:50.787778,Preston Crown Court and Family Court (Sessions House),0659
+2018-10-16 16:39:58.773598,Milton Keynes County Court and Family Court,0660
+2018-10-16 19:40:41.696028,Guildford County Court and Family Court,0661
+2018-10-16 21:19:25.61656,Oxford Combined Court Centre,0662
+2018-10-17 02:21:15.426035,Nottingham County Court and Family Court,0663
+2018-10-17 04:54:08.426731,Leeds Combined Court Centre,0664
+2018-10-17 10:25:24.51479,West London Family Court,0665
+2018-10-17 11:43:00.062423,Oxford Combined Court Centre,0666
+2018-10-17 11:34:58.197588,Preston Crown Court and Family Court (Sessions House),0667
+2018-10-19 11:38:08.501377,Watford County Court and Family Court,0668
+2018-10-17 14:01:57.024472,West London Family Court,0669
+2018-10-17 12:56:05.639966,Preston Crown Court and Family Court (Sessions House),0670
+2018-10-17 13:46:20.519678,West London Family Court,0671
+2018-10-17 14:55:25.912674,Southampton Combined Court Centre,0672
+2018-10-17 16:07:44.441587,Newcastle upon Tyne Combined Court Centre,0673
+2018-10-17 17:01:48.217241,Nottingham County Court and Family Court,0674
+2018-10-17 18:46:50.566275,Reading County Court and Family Court,0675
+2018-10-17 18:59:23.884751,Preston Crown Court and Family Court (Sessions House),0676
+2018-10-17 20:51:08.171838,Oxford Combined Court Centre,0677
+2018-10-17 21:48:53.234697,Southampton Combined Court Centre,0678
+2018-10-18 10:50:43.700023,Bristol Civil and Family Justice Centre,0679
+2018-10-25 19:29:17.643637,West London Family Court,0680
+2018-10-18 11:00:41.859903,Oxford Combined Court Centre,0681
+2018-10-18 11:59:55.007506,West London Family Court,0682
+2018-10-18 13:51:01.022399,Leicester County Court and Family Court,0683
+2018-10-18 14:12:04.900107,Watford County Court and Family Court,0684
+2018-10-18 14:03:52.174092,Oxford Combined Court Centre,0685
+2018-10-18 17:29:01.630139,Slough County Court and Family Court,0686
+2018-10-22 14:21:47.293318,East London Family Court,0687
+2018-10-18 20:58:08.276797,Nottingham County Court and Family Court,0688
+2018-10-18 21:26:12.183059,Milton Keynes County Court and Family Court,0689
+2018-10-19 01:45:37.848226,West London Family Court,0690
+2018-10-19 09:13:17.608159,Slough County Court and Family Court,0691
+2018-10-19 10:02:28.79217,Nottingham County Court and Family Court,0692
+2018-10-19 12:13:43.629638,Bristol Civil and Family Justice Centre,0693
+2018-10-19 12:31:33.865678,East London Family Court,0694
+2018-10-19 13:09:19.427594,West London Family Court,0695
+2018-10-19 12:47:21.961342,East London Family Court,0696
+2018-10-19 16:07:53.783925,Leeds Combined Court Centre,0697
+2018-10-29 12:38:23.158717,Oxford Combined Court Centre,0698
+2018-10-19 16:29:49.4908,Leeds Combined Court Centre,0699
+2018-10-22 18:10:26.711382,West London Family Court,0700
+2018-10-19 20:17:28.543562,Leicester County Court and Family Court,0701
+2018-10-19 19:52:10.892581,Nottingham County Court and Family Court,0702
+2018-10-20 10:15:17.717308,Bristol Civil and Family Justice Centre,0703
+2018-10-20 11:28:44.45859,East London Family Court,0704
+2018-10-20 13:36:33.648099,Kingston-upon-Hull Combined Court Centre,0705
+2018-10-20 17:05:45.98585,Cardiff Civil and Family Justice Centre,0706
+2018-10-20 22:11:42.189282,Preston Crown Court and Family Court (Sessions House),0707
+2018-10-21 16:48:26.105981,Preston Crown Court and Family Court (Sessions House),0708
+2018-10-21 19:18:04.07305,Preston Crown Court and Family Court (Sessions House),0709
+2018-10-24 18:03:26.746986,Newcastle upon Tyne Combined Court Centre,0710
+2018-10-21 20:47:06.327304,West London Family Court,0711
+2018-10-23 15:50:40.50088,Preston Crown Court and Family Court (Sessions House),0712
+2018-10-21 23:09:06.548544,West London Family Court,0713
+2018-10-22 00:20:17.651392,Newcastle upon Tyne Combined Court Centre,0714
+2018-10-22 00:39:34.532965,Southampton Combined Court Centre,0715
+2018-10-22 07:53:16.859363,West London Family Court,0716
+2018-10-22 13:48:59.307535,Southampton Combined Court Centre,0717
+2018-10-22 19:16:33.22984,Milton Keynes County Court and Family Court,0718
+2018-10-22 12:54:20.77109,Leeds Combined Court Centre,0719
+2018-10-22 13:43:58.223151,Milton Keynes County Court and Family Court,0720
+2018-10-22 15:45:32.090132,Watford County Court and Family Court,0721
+2018-10-22 17:08:21.46112,Bristol Civil and Family Justice Centre,0722
+2018-10-22 18:11:09.253467,West London Family Court,0723
+2018-10-28 17:07:36.436491,Kingston-upon-Hull Combined Court Centre,0724
+2018-10-22 18:27:21.002576,Swansea Civil Justice Centre,0725
+2018-10-22 17:52:12.747338,Leicester County Court and Family Court,0726
+2018-11-02 13:43:27.770801,Watford County Court and Family Court,0727
+2018-10-22 21:20:56.457442,West London Family Court,0728
+2018-10-22 19:45:56.186933,West London Family Court,0729
+2018-10-22 19:38:54.250931,Leeds Combined Court Centre,0730
+2018-10-22 21:29:04.891471,Swansea Civil Justice Centre,0731
+2018-10-23 04:00:28.422185,Preston Crown Court and Family Court (Sessions House),0732
+2018-10-23 08:24:08.952971,Leicester County Court and Family Court,0733
+2018-10-23 08:33:28.523397,Newcastle upon Tyne Combined Court Centre,0734
+2018-10-31 02:12:47.229951,Nottingham County Court and Family Court,0735
+2018-10-23 10:54:23.405057,Reading County Court and Family Court,0736
+2018-10-23 12:32:43.318356,Cardiff Civil and Family Justice Centre,0737
+2018-10-23 12:49:40.605653,Watford County Court and Family Court,0738
+2018-10-23 12:30:24.601173,West London Family Court,0739
+2018-10-23 13:21:13.912258,East London Family Court,0740
+2018-10-23 13:19:15.594431,Cardiff Civil and Family Justice Centre,0741
+2018-10-23 14:11:04.421507,Watford County Court and Family Court,0742
+2018-10-23 13:58:03.978957,Reading County Court and Family Court,0743
+2018-10-23 15:16:32.987434,Watford County Court and Family Court,0744
+2018-10-23 16:48:55.856901,Bristol Civil and Family Justice Centre,0745
+2018-10-24 10:05:43.775329,Southampton Combined Court Centre,0746
+2018-10-23 19:56:31.983005,Preston Crown Court and Family Court (Sessions House),0747
+2018-10-23 20:30:59.714521,West London Family Court,0748
+2018-10-25 08:59:17.902796,Southampton Combined Court Centre,0749
+2018-10-24 09:51:30.602658,Slough County Court and Family Court,0750
+2018-10-25 21:01:38.758609,Oxford Combined Court Centre,0751
+2018-10-24 13:48:55.816147,Nottingham County Court and Family Court,0752
+2018-10-24 10:50:38.30504,Watford County Court and Family Court,0753
+2018-10-24 20:51:34.666268,Preston Crown Court and Family Court (Sessions House),0754
+2018-10-24 12:33:55.084781,Slough County Court and Family Court,0755
+2018-10-24 15:15:56.250307,Leeds Combined Court Centre,0756
+2018-11-05 08:40:27.797175,Leicester County Court and Family Court,0757
+2018-10-29 14:31:40.037166,Nottingham County Court and Family Court,0758
+2018-10-28 12:14:05.762203,West London Family Court,0759
+2018-10-24 20:46:38.215684,Leeds Combined Court Centre,0760
+2018-10-25 08:02:06.946009,Oxford Combined Court Centre,0761
+2018-10-25 13:18:09.753117,Leeds Combined Court Centre,0762
+2018-10-30 12:22:37.863841,Preston Crown Court and Family Court (Sessions House),0763
+2018-10-25 15:19:33.987501,West London Family Court,0764
+2018-10-25 15:18:39.147271,Watford County Court and Family Court,0765
+2018-10-25 21:05:53.936798,East London Family Court,0766
+2018-10-26 08:55:13.591562,Newcastle upon Tyne Combined Court Centre,0767
+2018-10-26 12:59:59.992289,Cardiff Civil and Family Justice Centre,0768
+2018-10-26 09:58:24.786976,Newport (South Wales) County Court and Family Court,0769
+2018-10-26 10:48:18.204835,Preston Crown Court and Family Court (Sessions House),0770
+2018-10-26 11:58:40.127555,West London Family Court,0771
+2018-10-26 12:48:43.438233,Guildford County Court and Family Court,0772
+2018-10-26 12:46:14.20354,Oxford Combined Court Centre,0773
+2018-10-26 15:51:06.800203,Southampton Combined Court Centre,0774
+2018-11-14 00:28:07.468185,Leeds Combined Court Centre,0775
+2018-10-26 14:54:29.446954,Leeds Combined Court Centre,0776
+2018-10-26 15:47:28.962168,Reading County Court and Family Court,0777
+2018-10-27 22:20:20.623548,Slough County Court and Family Court,0778
+2018-10-29 18:21:27.908793,Watford County Court and Family Court,0779
+2018-10-27 12:06:21.26167,Kingston-upon-Hull Combined Court Centre,0780
+2018-10-27 16:55:01.950766,Cardiff Civil and Family Justice Centre,0781
+2018-10-28 10:25:09.77196,Preston Crown Court and Family Court (Sessions House),0782
+2018-10-28 12:23:29.180602,West London Family Court,0783
+2018-10-30 12:32:50.400731,West London Family Court,0784
+2018-11-01 11:22:57.080809,Guildford County Court and Family Court,0785
+2018-10-31 14:11:02.583577,West London Family Court,0786
+2018-10-28 18:27:28.806535,Cardiff Civil and Family Justice Centre,0787
+2018-10-28 19:00:52.984376,Nottingham County Court and Family Court,0788
+2018-10-28 19:16:16.93182,Kingston-upon-Hull Combined Court Centre,0789
+2018-10-29 11:15:29.552944,Leicester County Court and Family Court,0790
+2018-10-29 12:34:47.740881,East London Family Court,0791
+2018-11-03 17:24:45.165714,Leeds Combined Court Centre,0792
+2018-11-09 08:36:29.523867,Southampton Combined Court Centre,0793
+2018-10-29 15:12:26.15979,Leicester County Court and Family Court,0794
+2018-11-02 10:34:23.344209,Guildford County Court and Family Court,0795
+2018-10-29 15:14:21.902481,Leeds Combined Court Centre,0796
+2018-10-29 17:24:50.568393,Newport (South Wales) County Court and Family Court,0797
+2018-10-29 22:57:39.417224,Reading County Court and Family Court,0798
+2018-10-29 18:15:25.029986,Leeds Combined Court Centre,0799
+2018-10-29 18:31:12.214665,Nottingham County Court and Family Court,0800
+2018-10-30 12:42:57.426887,Swansea Civil Justice Centre,0801
+2018-10-29 19:32:13.061713,Bristol Civil and Family Justice Centre,0802
+2018-10-29 19:52:00.966965,Kingston-upon-Hull Combined Court Centre,0803
+2018-11-05 01:42:37.574832,East London Family Court,0804
+2018-10-30 16:55:02.237842,Leicester County Court and Family Court,0805
+2018-10-31 21:27:34.928977,Newcastle upon Tyne Combined Court Centre,0806
+2018-10-30 11:11:33.185664,Cardiff Civil and Family Justice Centre,0807
+2018-10-31 16:33:50.286188,Oxford Combined Court Centre,0808
+2018-10-30 13:18:47.724851,Liverpool Civil and Family Court,0809
+2018-10-30 13:50:27.883741,Milton Keynes County Court and Family Court,0810
+2018-10-30 14:16:31.505939,Milton Keynes County Court and Family Court,0811
+2018-10-30 23:15:39.433666,Milton Keynes County Court and Family Court,0812
+2018-10-30 18:52:40.881895,Southampton Combined Court Centre,0813
+2018-10-30 20:50:36.95398,Watford County Court and Family Court,0814
+2018-10-30 20:59:18.138243,Southampton Combined Court Centre,0815
+2018-10-30 20:57:28.750611,Medway County Court and Family Court,0816
+2018-10-30 22:48:57.856492,Kingston-upon-Hull Combined Court Centre,0817
+2018-10-31 00:26:08.201891,Milton Keynes County Court and Family Court,0818
+2018-11-01 12:12:00.111831,Kingston-upon-Hull Combined Court Centre,0819
+2018-10-31 09:36:38.972167,Newcastle upon Tyne Combined Court Centre,0820
+2018-10-31 12:21:41.721554,Plymouth Combined Court,0821
+2018-10-31 13:01:55.424937,Southampton Combined Court Centre,0822
+2018-11-01 17:08:02.323822,East London Family Court,0823
+2018-10-31 14:06:22.514825,Preston Crown Court and Family Court (Sessions House),0824
+2018-10-31 21:02:41.7489,Preston Crown Court and Family Court (Sessions House),0825
+2018-10-31 14:42:55.886589,Preston Crown Court and Family Court (Sessions House),0826
+2018-10-31 16:09:23.450079,Preston Crown Court and Family Court (Sessions House),0827
+2018-10-31 16:31:52.434459,Leicester County Court and Family Court,0828
+2018-10-31 18:30:59.833028,Watford County Court and Family Court,0829
+2018-11-05 02:23:51.130744,Bristol Civil and Family Justice Centre,0830
+2018-10-31 19:36:01.0255,Preston Crown Court and Family Court (Sessions House),0831
+2018-10-31 20:02:20.734255,Kingston-upon-Hull Combined Court Centre,0832
+2018-11-01 09:52:04.721595,Preston Crown Court and Family Court (Sessions House),0833
+2018-11-01 10:35:41.982102,Newcastle upon Tyne Combined Court Centre,0834
+2018-11-01 14:42:17.399062,Swansea Civil Justice Centre,0835
+2018-11-01 12:52:45.186098,West London Family Court,0836
+2018-11-01 18:35:17.998539,West London Family Court,0837
+2018-11-06 10:45:48.718768,Leicester County Court and Family Court,0838
+2018-11-01 15:19:56.77831,Oxford Combined Court Centre,0839
+2018-11-01 15:20:18.290679,Nottingham County Court and Family Court,0840
+2018-11-01 15:18:07.967568,Kingston-upon-Hull Combined Court Centre,0841
+2018-11-08 12:23:45.932293,Liverpool Civil and Family Court,0842
+2018-11-01 15:26:06.294445,Swansea Civil Justice Centre,0843
+2018-11-02 15:56:24.307705,West London Family Court,0844
+2018-11-01 16:35:11.817356,Bristol Civil and Family Justice Centre,0845
+2018-11-01 17:21:36.518131,Guildford County Court and Family Court,0846
+2018-11-06 14:30:45.064976,Peterborough Combined Court Centre,0847
+2018-11-01 22:09:43.091188,Swansea Civil Justice Centre,0848
+2018-11-01 21:56:34.038435,Kingston-upon-Hull Combined Court Centre,0849
+2018-11-01 21:48:31.25994,Milton Keynes County Court and Family Court,0850
+2018-11-02 03:09:24.570275,Liverpool Civil and Family Court,0851
+2018-11-02 10:11:36.633118,Preston Crown Court and Family Court (Sessions House),0852
+2018-11-02 12:03:04.807235,Preston Crown Court and Family Court (Sessions House),0853
+2018-11-02 10:56:00.373583,Bristol Civil and Family Justice Centre,0854
+2018-11-02 10:27:22.559034,East London Family Court,0855
+2018-11-02 11:00:14.678273,Watford County Court and Family Court,0856
+2018-11-02 11:08:56.905232,Kingston-upon-Hull Combined Court Centre,0857
+2018-11-02 15:02:12.259552,Southampton Combined Court Centre,0858
+2018-11-02 15:43:54.060707,Liverpool Civil and Family Court,0859
+2018-11-02 13:16:41.731458,Medway County Court and Family Court,0860
+2018-11-02 14:49:36.983954,Guildford County Court and Family Court,0861
+2018-11-04 13:25:28.190041,Oxford Combined Court Centre,0862
+2018-11-02 15:59:07.645019,Bristol Civil and Family Justice Centre,0863
+2018-11-02 15:15:22.915351,Liverpool Civil and Family Court,0864
+2018-11-02 15:54:20.085912,East London Family Court,0865
+2018-11-02 16:36:52.257812,Southampton Combined Court Centre,0866
+2018-11-02 17:28:34.700399,Southampton Combined Court Centre,0867
+2018-11-02 21:02:00.478059,Cardiff Civil and Family Justice Centre,0868
+2018-11-14 12:02:36.334203,West London Family Court,0869
+2018-11-03 08:35:03.887793,Watford County Court and Family Court,0870
+2018-11-03 09:33:36.752846,West London Family Court,0871
+2018-11-03 09:52:30.03722,Reading County Court and Family Court,0872
+2018-11-03 11:23:51.299191,Cardiff Civil and Family Justice Centre,0873
+2018-11-03 12:01:26.933282,Preston Crown Court and Family Court (Sessions House),0874
+2018-11-03 16:55:08.218387,Leeds Combined Court Centre,0875
+2018-11-03 19:57:46.514143,Bristol Civil and Family Justice Centre,0876
+2018-11-03 18:15:14.309172,Cardiff Civil and Family Justice Centre,0877
+2018-11-05 21:32:17.25264,Reading County Court and Family Court,0878
+2018-11-03 20:08:11.983557,Slough County Court and Family Court,0879
+2018-11-04 19:05:57.926719,Milton Keynes County Court and Family Court,0880
+2018-11-05 09:46:46.806148,West London Family Court,0881
+2018-11-08 22:25:53.035029,Leeds Combined Court Centre,0882
+2018-11-04 17:44:22.477404,West London Family Court,0883
+2018-11-04 16:51:17.432435,Liverpool Civil and Family Court,0884
+2018-11-04 17:03:55.461146,Peterborough Combined Court Centre,0885
+2018-11-04 18:34:03.651519,Medway County Court and Family Court,0886
+2018-11-04 20:35:26.589605,Oxford Combined Court Centre,0887
+2018-11-04 21:19:47.246753,Swansea Civil Justice Centre,0888
+2018-11-04 21:36:42.983067,Leeds Combined Court Centre,0889
+2018-11-05 14:27:05.882434,Leicester County Court and Family Court,0890
+2018-11-04 23:31:40.634655,Milton Keynes County Court and Family Court,0891
+2018-11-05 03:27:11.893813,Liverpool Civil and Family Court,0892
+2018-11-05 15:16:04.860211,Leeds Combined Court Centre,0893
+2018-11-05 11:15:09.967008,Preston Crown Court and Family Court (Sessions House),0894
+2018-11-05 12:06:55.129339,Reading County Court and Family Court,0895
+2018-11-12 09:09:04.493536,Medway County Court and Family Court,0896
+2018-11-05 12:31:01.493633,Medway County Court and Family Court,0897
+2018-11-05 14:26:38.338281,Milton Keynes County Court and Family Court,0898
+2018-11-05 14:18:02.12731,Kingston-upon-Hull Combined Court Centre,0899
+2018-11-06 15:45:43.535232,West London Family Court,0900
+2018-11-05 13:30:11.578074,Exeter Combined Court Centre,0901
+2018-11-06 11:01:45.519103,Leeds Combined Court Centre,0902
+2018-11-05 14:25:06.287408,Leicester County Court and Family Court,0903
+2018-11-05 15:43:49.487455,Southampton Combined Court Centre,0904
+2018-11-05 14:46:50.871096,Southampton Combined Court Centre,0905
+2018-11-05 16:05:01.64262,Leicester County Court and Family Court,0906
+2018-11-05 17:05:23.85192,Leicester County Court and Family Court,0907
+2018-11-05 16:52:28.810712,East London Family Court,0908
+2018-11-13 17:26:57.467961,Watford County Court and Family Court,0909
+2018-11-05 20:09:23.772297,East London Family Court,0910
+2018-11-05 22:23:47.770683,Oxford Combined Court Centre,0911
+2018-11-05 21:19:46.643265,Swansea Civil Justice Centre,0912
+2018-11-05 23:14:31.075074,Leeds Combined Court Centre,0913
+2018-11-05 22:23:03.452915,Southampton Combined Court Centre,0914
+2018-11-06 01:36:43.375268,West London Family Court,0915
+2018-11-06 19:20:42.942696,West London Family Court,0916
+2018-11-06 11:02:17.710872,Medway County Court and Family Court,0917
+2018-11-06 11:00:53.977265,West London Family Court,0918
+2018-11-06 14:01:05.999499,Plymouth Combined Court,0919
+2018-11-06 11:01:26.122034,Leicester County Court and Family Court,0920
+2018-11-06 11:55:46.478225,Liverpool Civil and Family Court,0921
+2018-11-06 12:06:33.824823,Leeds Combined Court Centre,0922
+2018-11-06 12:37:11.242912,Leicester County Court and Family Court,0923
+2018-11-06 13:18:46.497844,Leeds Combined Court Centre,0924
+2018-11-06 12:56:41.356916,Kingston-upon-Hull Combined Court Centre,0925
+2018-11-06 18:32:00.553226,Newcastle upon Tyne Combined Court Centre,0926
+2018-11-06 18:29:06.480963,Medway County Court and Family Court,0927
+2018-11-06 14:46:42.536901,Bristol Civil and Family Justice Centre,0928
+2018-11-08 13:32:36.136212,Milton Keynes County Court and Family Court,0929
+2018-11-13 10:03:19.919336,Bristol Civil and Family Justice Centre,0930
+2018-11-06 15:56:47.803901,Nottingham County Court and Family Court,0931
+2018-11-06 17:52:13.636973,Leeds Combined Court Centre,0932
+2018-11-06 19:01:01.987741,Southampton Combined Court Centre,0933
+2018-11-12 13:06:40.699354,Bristol Civil and Family Justice Centre,0934
+2018-11-06 22:39:38.005746,Reading County Court and Family Court,0935
+2018-11-07 13:47:19.241375,Medway County Court and Family Court,0936
+2018-11-06 20:29:49.652345,Nottingham County Court and Family Court,0937
+2018-11-06 22:03:21.136078,Preston Crown Court and Family Court (Sessions House),0938
+2018-11-06 22:10:59.144954,Bristol Civil and Family Justice Centre,0939
+2018-11-13 12:50:56.73136,West London Family Court,0940
+2018-11-07 19:38:52.741664,Watford County Court and Family Court,0941
+2018-11-07 01:18:07.42095,West London Family Court,0942
+2018-11-07 08:35:11.554381,Newcastle upon Tyne Combined Court Centre,0943
+2018-11-07 12:00:14.897807,East London Family Court,0944
+2018-11-07 10:11:21.155024,Medway County Court and Family Court,0945
+2018-11-07 11:42:08.859712,West London Family Court,0946
+2018-11-07 12:41:36.976306,East London Family Court,0947
+2018-11-07 13:05:07.714049,Oxford Combined Court Centre,0948
+2018-11-07 15:14:53.476982,Medway County Court and Family Court,0949
+2018-11-07 12:51:26.675143,Cardiff Civil and Family Justice Centre,0950
+2018-11-07 14:23:36.515136,Leicester County Court and Family Court,0951
+2018-11-07 13:51:08.852933,Kingston-upon-Hull Combined Court Centre,0952
+2018-11-07 15:25:43.288344,Liverpool Civil and Family Court,0953
+2018-11-07 17:32:10.034997,Oxford Combined Court Centre,0954
+2018-11-07 17:09:00.215278,Bristol Civil and Family Justice Centre,0955
+2018-11-07 17:44:23.005608,Bristol Civil and Family Justice Centre,0956
+2018-11-07 21:30:48.067512,Nottingham County Court and Family Court,0957
+2018-11-07 21:02:07.715234,Kingston-upon-Hull Combined Court Centre,0958
+2018-11-08 09:44:18.488755,Leicester County Court and Family Court,0959
+2018-11-08 10:23:08.012497,Milton Keynes County Court and Family Court,0960
+2018-11-08 10:19:54.318092,Kingston-upon-Hull Combined Court Centre,0961
+2018-11-11 17:50:56.324048,East London Family Court,0962
+2018-11-08 12:20:04.814142,West London Family Court,0963
+2018-11-08 12:54:50.883816,Swansea Civil Justice Centre,0964
+2018-11-08 12:13:48.130777,Swansea Civil Justice Centre,0965
+2018-11-08 15:09:05.420266,West London Family Court,0966
+2018-11-08 17:26:06.176888,Liverpool Civil and Family Court,0967
+2018-11-08 17:05:47.392749,Oxford Combined Court Centre,0968
+2018-11-08 18:32:02.127453,Cardiff Civil and Family Justice Centre,0969
+2018-11-08 20:13:05.881398,Peterborough Combined Court Centre,0970
+2018-11-08 20:00:33.223536,Cardiff Civil and Family Justice Centre,0971
+2018-11-08 21:59:36.798691,Watford County Court and Family Court,0972
+2018-11-08 23:00:18.906535,Leeds Combined Court Centre,0973
+2018-11-09 21:16:44.412142,Leeds Combined Court Centre,0974
+2018-11-09 10:41:57.42025,Southampton Combined Court Centre,0975
+2018-11-09 15:43:15.658275,Plymouth Combined Court,0976
+2018-11-13 08:21:31.725414,West London Family Court,0977
+2018-11-09 17:46:19.950599,Cardiff Civil and Family Justice Centre,0978
+2018-11-09 17:48:35.12155,Kingston-upon-Hull Combined Court Centre,0979
+2018-11-09 18:30:25.934763,Nottingham County Court and Family Court,0980
+2018-11-09 18:59:16.460147,West London Family Court,0981
+2018-11-09 20:27:11.927524,Bristol Civil and Family Justice Centre,0982
+2018-11-12 22:08:08.406899,Liverpool Civil and Family Court,0983
+2018-11-09 21:26:57.654756,Preston Crown Court and Family Court (Sessions House),0984
+2018-11-10 00:32:03.223278,Peterborough Combined Court Centre,0985
+2018-11-10 05:43:00.599579,Plymouth Combined Court,0986
+2018-11-10 08:23:44.355808,Leicester County Court and Family Court,0987
+2018-11-10 11:08:55.208735,Swansea Civil Justice Centre,0988
+2018-11-10 12:25:38.695284,Liverpool Civil and Family Court,0989
+2018-11-10 16:13:30.01339,Medway County Court and Family Court,0990
+2018-11-10 21:54:26.108998,Leeds Combined Court Centre,0991
+2018-11-11 10:15:34.34059,Preston Crown Court and Family Court (Sessions House),0992
+2018-11-11 12:11:58.346646,West London Family Court,0993
+2018-11-11 15:33:33.933936,Oxford Combined Court Centre,0994
+2018-11-11 16:46:35.951546,Southampton Combined Court Centre,0995
+2018-11-11 22:16:04.716672,Newcastle upon Tyne Combined Court Centre,0996
+2018-11-13 11:15:33.64628,Peterborough Combined Court Centre,0997
+2018-11-11 23:38:08.380264,West London Family Court,0998
+2018-11-11 22:20:16.029514,Medway County Court and Family Court,0999
+2018-11-11 22:12:06.090798,Newcastle upon Tyne Combined Court Centre,1000
+2018-11-12 05:48:03.944149,West London Family Court,1001
+2018-11-12 10:26:41.948308,Southampton Combined Court Centre,1002
+2018-11-12 10:53:00.495517,Milton Keynes County Court and Family Court,1003
+2018-11-12 13:11:38.627343,West London Family Court,1004
+2018-11-12 12:59:46.284619,West London Family Court,1005
+2018-11-12 13:23:48.469901,Leicester County Court and Family Court,1006
+2018-11-12 17:07:13.926758,West London Family Court,1007
+2018-11-12 13:48:41.539041,Leicester County Court and Family Court,1008
+2018-11-12 12:40:59.293713,Liverpool Civil and Family Court,1009
+2018-11-12 15:31:16.05115,Bristol Civil and Family Justice Centre,1010
+2018-11-12 18:28:03.859269,Bristol Civil and Family Justice Centre,1011
+2018-11-12 18:39:15.170916,East London Family Court,1012
+2018-11-13 00:15:32.0509,Swansea Civil Justice Centre,1013
+2018-11-13 10:41:00.274038,Leeds Combined Court Centre,1014
+2018-11-13 11:51:21.81145,Liverpool Civil and Family Court,1015
+2018-11-13 13:20:18.066003,Bristol Civil and Family Justice Centre,1016
+2018-11-13 13:22:57.399778,Southampton Combined Court Centre,1017
+2018-11-13 12:28:43.304042,Medway County Court and Family Court,1018
+2018-11-13 14:34:07.041449,Swansea Civil Justice Centre,1019
+2018-11-13 17:38:51.208837,Newcastle upon Tyne Combined Court Centre,1020
+2018-11-14 12:01:57.448801,Guildford County Court and Family Court,1021
+2018-11-13 21:28:30.065141,Milton Keynes County Court and Family Court,1022
+2018-11-13 19:12:35.173414,Newcastle upon Tyne Combined Court Centre,1023
+2018-11-14 19:59:00.087554,Liverpool Civil and Family Court,1024
+2018-11-14 02:50:51.053374,Milton Keynes County Court and Family Court,1025
+2018-11-13 23:55:47.727446,Peterborough Combined Court Centre,1026
+2018-11-14 08:31:27.76113,Nottingham County Court and Family Court,1027
+2018-11-14 09:46:30.612761,Oxford Combined Court Centre,1028
+2018-11-14 09:44:54.282553,Southampton Combined Court Centre,1029
+2018-11-14 09:31:30.275073,Bristol Civil and Family Justice Centre,1030
+2018-11-14 11:26:11.784809,Preston Crown Court and Family Court (Sessions House),1031
+2018-11-14 12:21:28.010964,Liverpool Civil and Family Court,1032
+2018-11-14 12:31:18.322972,Kingston-upon-Hull Combined Court Centre,1033
+2018-11-14 14:36:26.761203,Nottingham County Court and Family Court,1034
+2018-11-14 13:09:03.20398,Cardiff Civil and Family Justice Centre,1035
+2018-11-14 13:28:56.076798,Plymouth Combined Court,1036
+2018-11-14 12:43:20.873147,Preston Crown Court and Family Court (Sessions House),1037
+2018-11-14 15:03:24.9008,East London Family Court,1038
+2018-11-14 17:32:42.805802,Nottingham County Court and Family Court,1039
+2018-11-14 17:51:22.890377,Liverpool Civil and Family Court,1040
+2018-11-14 19:49:53.548004,Newcastle upon Tyne Combined Court Centre,1041
+2018-11-14 20:28:27.504582,Medway County Court and Family Court,1042
+2018-11-14 21:42:11.759732,Watford County Court and Family Court,1043
+2018-11-14 21:28:07.642318,Medway County Court and Family Court,1044
+2018-11-14 22:52:51.877668,East London Family Court,1045

--- a/lib/tasks/tools.rake
+++ b/lib/tasks/tools.rake
@@ -1,0 +1,19 @@
+namespace :tools do
+  task fix_audit: :environment do
+    rows = File.readlines(
+      File.join(Rails.root, 'audit_courts.csv')
+    )
+
+    puts "fixing #{rows.size} rows..."
+
+    rows.each do |data|
+      completed_at, court, reference_code = data.chomp.split(',')
+
+      ActiveRecord::Base.connection.execute(
+        "UPDATE completed_applications_audit SET reference_code = '#{reference_code}', court = '#{court}' WHERE completed_at = '#{completed_at}'"
+      )
+    end
+
+    puts 'done'
+  end
+end


### PR DESCRIPTION
The `completed_applications_audit` table was created a few months after the release of the service.

Although we tried to backtrack as many applications as possible from the early days, the consequence was for some (1045) applications we couldn't reliably assign their reference code, leaving this field as `nil` in these rows.

This is not a very smart decision as the `reference_code` is the primary key and any mass update is done using this PK, which means if we want to update a bunch of records without reference code, we must use the exact timestamp which is not ideal.

Also, some of these old rows have been mistakenly re-assigned a different court, meaning the analytics are incorrect.

This one-time task will, based on an old backup, re-assign the proper court to these 1045 records, and at the same time assign also a `reference_code` so they are no longer `nil` (even if this code means nothing).