### PR TITLE
Fix accessibility issue with password link

### DIFF
--- a/app/assets/javascripts/modules/password-toggle.js
+++ b/app/assets/javascripts/modules/password-toggle.js
@@ -21,7 +21,7 @@ moj.Modules.passwordToggle = {
       var $el = $(e.target),
           tag = $el.prop('tagName').toLowerCase();
 
-      if(tag === 'span') {
+      if(tag === 'a') {
         $el = $el.closest('p');
       }
       e.preventDefault();
@@ -33,7 +33,7 @@ moj.Modules.passwordToggle = {
   injectLinks: function($els) {
     var self = this;
 
-    $els.after('<p class="' + self.link_class + '"><span class="show toggle">' + moj.Modules.showPasswordText + '</span><span class="hide toggle js-hidden">' + moj.Modules.hidePasswordText + '</span></p>');
+    $els.after('<p class="' + self.link_class + '"><a href="#" class="show toggle">' + moj.Modules.showPasswordText + '</a><a href="#" class="hide toggle js-hidden">' + moj.Modules.hidePasswordText + '</a></p>');
   },
 
   togglePassword: function($link) {

--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -114,6 +114,7 @@ address {
   color: $link-colour;
   text-decoration: underline;
   margin-bottom: 0;
+  width: 200px;
 }
 
 .govuk-box-highlight {


### PR DESCRIPTION
This show/hide functionality was relying on a `span` element, which will not get the focus when navigating with a screen reader.

Changing this `span` to a proper link `a` fix the issue.

Also, without stylesheets, will look like a proper link.