### PR TITLE
Ensure index uniqueness in screener_answers

### DIFF
--- a/db/migrate/20191114093418_add_unique_index_to_screener_answers.rb
+++ b/db/migrate/20191114093418_add_unique_index_to_screener_answers.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToScreenerAnswers < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :screener_answers, :c100_application_id
+    add_index    :screener_answers, :c100_application_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191113151710) do
+ActiveRecord::Schema.define(version: 20191114093418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -297,7 +297,7 @@ ActiveRecord::Schema.define(version: 20191113151710) do
     t.string "email_consent"
     t.string "email_address"
     t.string "legal_representation"
-    t.index ["c100_application_id"], name: "index_screener_answers_on_c100_application_id"
+    t.index ["c100_application_id"], name: "index_screener_answers_on_c100_application_id", unique: true
     t.index ["email_address"], name: "index_screener_answers_on_email_address"
     t.index ["email_consent"], name: "index_screener_answers_on_email_consent"
   end


### PR DESCRIPTION
This table can only contain unique references to C100Application. There can't be duplicates.

There have been a rare occurrence where a duplicate entry was inserted (probably some kind of race-condition difficult to replicate).

In order to avoid this from happening again, and as we did with other tables already, we are going to enforce the uniqueness of the index `c100_application_id`.