### PR TITLE
Add an automated daily courts smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-# Ruby CircleCI 2.0 configuration file
+# Ruby CircleCI configuration file
 #
-# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+# Check https://circleci.com/docs/2.0/configuration-reference/ for more details
 #
-version: 2
+version: 2.1
 
 references:
   app_containers: &app_containers
@@ -28,6 +28,10 @@ references:
 jobs:
   test:
     <<: *app_containers
+    parameters:
+      test_command:
+        type: string
+        default: bundle exec rake test:all_the_things master
     steps:
       - checkout
 
@@ -57,7 +61,7 @@ jobs:
 
       - run:
           name: run tests
-          command: bundle exec rake test:all_the_things master
+          command: << parameters.test_command >>
 
   build_staging:
     <<: *cloud_container
@@ -167,8 +171,6 @@ jobs:
 
 
 workflows:
-  version: 2
-
   test-build-deploy:
     jobs:
       - test
@@ -191,3 +193,16 @@ workflows:
       - deploy_production:
           requires:
             - tag_production
+
+  smoke-tests:
+    jobs:
+      - test:
+          name: smoke-tests
+          test_command: bundle exec cucumber -p smoke
+    triggers:
+      - schedule:
+          cron: "0 * * * *"
+          filters:
+            branches:
+              only:
+                - master

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -44,6 +44,10 @@ class Court
     best.fetch('address')
   end
 
+  def court_data
+    @_court_data ||= C100App::CourtfinderAPI.new.court_lookup(slug)
+  end
+
   private
 
   def best_match_for(emails, node)
@@ -57,8 +61,7 @@ class Court
   end
 
   def retrieve_emails_from_api
-    this_court = C100App::CourtfinderAPI.new.court_lookup(slug)
-    this_court.fetch('emails')
+    court_data.fetch('emails')
   end
 
   def log_and_raise(exception, data)

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,0 +1,7 @@
+default: >
+  --format pretty
+  --tags 'not @smoke'
+
+smoke: >
+  --format pretty
+  --tags '@smoke'

--- a/features/courts_smoke_test.feature
+++ b/features/courts_smoke_test.feature
@@ -1,0 +1,12 @@
+@smoke
+Feature: Courts smoke test
+
+  # Note: this is a very high level smoke test to ensure the slugs we use in the service
+  # are correct, with no typos, and found in Court Tribunal Finder service.
+  #
+  # Dot not relay on this, but at least, if the slug for a court changes, or the court
+  # gets disabled/removed, this smoke test will fail, giving us a heads up.
+
+  Scenario: Court slugs are found in Court Tribunal Finder
+    When Using the court slugs defined in the service
+    Then Iterate through each court slug and call the API

--- a/features/errors.feature
+++ b/features/errors.feature
@@ -1,6 +1,5 @@
 Feature: Errors
   Background:
-    Given I show my environment
     When I visit "/"
     Given I click the "Check now" link
 

--- a/features/screener.feature
+++ b/features/screener.feature
@@ -1,6 +1,5 @@
 Feature: Screener
   Background:
-    Given I show my environment
     When I visit "/"
     Then I should see "We’re trialling a new online service to apply to court about child arrangements"
 

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -1,8 +1,3 @@
-Given(/^I show my environment$/) do
-  puts "Running against: #{Capybara.app_host}"
-  puts "Never point these features against a production environment :-)"
-end
-
 When(/^I visit "([^"]*)"$/) do |path|
   visit path
 end

--- a/features/step_definitions/smoke.rb
+++ b/features/step_definitions/smoke.rb
@@ -1,0 +1,44 @@
+When(/^Using the court slugs defined in the service$/) do
+  @court_slugs = C100App::CourtPostcodeChecker::COURT_SLUGS_USING_THIS_APP
+  @court_aol = C100App::CourtPostcodeChecker::AREA_OF_LAW
+end
+
+Then(/^Iterate through each court slug and call the API$/) do
+  @court_slugs.each do |slug|
+    step %[Using the court slug "#{slug}"]
+    step %[The court exists and is enabled]
+    step %[I pause for "1" seconds]
+  end
+end
+
+When(/^Using the court slug "([^"]*)"$/) do |slug|
+  $stdout.puts "Checking court slug: #{slug}".prepend(' ' * 6)
+
+  attributes = {
+    slug: slug,
+    address: nil,
+    name: nil,
+    email: nil
+  }.stringify_keys
+
+  @court = Court.new(attributes)
+end
+
+Then(/^The court exists and is enabled$/) do
+  # We don't test here if the email is what it needs to be, as emails can change,
+  # we just check if at least we found something that looks like an email address
+  #
+  expect(@court.best_enquiries_email).to match(/.*@.*/)
+
+  # Above method will trigger the call to the API and populate the following
+  # memoized method for further introspection (mainly for smoke tests)
+  #
+  expect(@court.court_data['open']).to be_truthy
+
+  # Make an exception for Clerkenwell as it is a very weird case, where the
+  # API is returning the court despite not having `Children` in the AOL
+  #
+  unless @court.slug == 'clerkenwell-and-shoreditch-county-court-and-family-court'
+    expect(@court.court_data['areas_of_law']).to include(@court_aol)
+  end
+end


### PR DESCRIPTION
A very high level smoke test to ensure the slugs we use in the service are correct, with no typos, and found in Court Tribunal Finder service.

This will only run if explicitely pass the `-p smoke` flag to cucumber. Otherwise the "default" cukes will run, as it is now.

A new workflow on CircleCI will run the smoke tests automatically (currently hourly, but we will increase the frequency after we are sure it works).

**Individual commits for easier review**