### PR TITLE
Improve accessibility in CYA page

### DIFF
--- a/app/presenters/summary/answers_group.rb
+++ b/app/presenters/summary/answers_group.rb
@@ -1,12 +1,11 @@
 module Summary
   class AnswersGroup
-    attr_reader :name, :change_path, :name_args
+    attr_reader :name, :change_path
 
     def initialize(name, answers, params = {})
       @name = name
       @answers = answers
       @change_path = params[:change_path]
-      @name_args = params[:name_args]
     end
 
     def answers

--- a/app/views/steps/completion/shared/_answers_group.html.erb
+++ b/app/views/steps/completion/shared/_answers_group.html.erb
@@ -1,6 +1,6 @@
 <dl class="answers-group" id="<%= answers_group.name %>">
   <dt class="question">
-    <%=t "check_answers_html.groups.#{answers_group.name}", answers_group.name_args || {} %>
+    <%=t "check_answers_html.groups.#{answers_group.name}" %>
   </dt>
   <dd class="answer">
     <dl class="answers-group-inner">

--- a/app/views/steps/completion/shared/_change_link.html.erb
+++ b/app/views/steps/completion/shared/_change_link.html.erb
@@ -1,6 +1,14 @@
 <% if question.show_change_link? %>
-  <%= link_to t('check_answers_html.change_link'),
-              question.change_path,
-              class: 'ga-pageLink',
-              data: {ga_category: 'check your answers', ga_label: 'change link'} %>
+  <%
+    a11y_question = if question.is_a?(Summary::AnswersGroup)
+                      t("check_answers_html.groups.#{question.name}")
+                    else
+                      t("check_answers_html.#{question.question}.question_a11y",
+                        default: t("check_answers_html.#{question.question}.question", question.i18n_opts || {}))
+                    end
+  %>
+
+  <%= link_to question.change_path, class: 'ga-pageLink', data: { ga_category: 'check your answers', ga_label: 'change link' } do %>
+    <%= t('check_answers_html.change_link_html', a11y_question: a11y_question) %>
+  <% end %>
 <% end %>

--- a/app/views/steps/completion/shared/_change_link.html.erb
+++ b/app/views/steps/completion/shared/_change_link.html.erb
@@ -3,8 +3,13 @@
     a11y_question = if question.is_a?(Summary::AnswersGroup)
                       t("check_answers_html.groups.#{question.name}")
                     else
-                      t("check_answers_html.#{question.question}.question_a11y",
-                        default: t("check_answers_html.#{question.question}.question", question.i18n_opts || {}))
+                      i18n_opts = question.i18n_opts || {}
+
+                      t(
+                        "check_answers_html.#{question.question}.question_a11y", {
+                          default: t("check_answers_html.#{question.question}.question", i18n_opts)
+                        }.merge(i18n_opts)
+                      )
                     end
   %>
 

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -57,7 +57,7 @@ en:
       undertaking: Undertaking in place of an order
 
   check_answers_html:
-    change_link: Change
+    change_link_html: Change <span class="visuallyhidden">answer to %{a11y_question}</span>
     sections:
       child_protection_cases: Emergency protection, care or supervision proceedings
       miam_requirement: MIAM requirement

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -57,7 +57,7 @@ en:
       undertaking: Undertaking in place of an order
 
   check_answers_html:
-    change_link_html: Change <span class="visuallyhidden">answer to %{a11y_question}</span>
+    change_link_html: Change <span class="visuallyhidden">your answer to, %{a11y_question}</span>
     sections:
       child_protection_cases: Emergency protection, care or supervision proceedings
       miam_requirement: MIAM requirement
@@ -93,7 +93,7 @@ en:
       abduction_passport_possession: Details of the children’s passports
       abduction_previous_attempt: Details of the previous abductions
       abduction_risk_details: Why do you think the children may be abducted or kept outside the UK without your consent?
-      abuse_details: Details
+      abuse_details: Details of the abuse
       court_orders_details: What orders have been made?
       protection_orders: Is there anything else you are asking the court to decide, specifically to protect the safety of you or the children?
       person_personal_details: Personal details
@@ -182,6 +182,7 @@ en:
         <<: *YESNO
     child_residence:
       question: '%{child_name}'
+      question_a11y: Who %{child_name} lives with
 
     miam_exemptions_domestic:
       question: Evidence of domestic abuse and violence
@@ -385,8 +386,6 @@ en:
         <<: *YESNO
     order_court_name:
       question: Name of court
-    protection_orders:
-      question: Is there anything else you are asking the court to decide, specifically to protect the safety of you or the children?
     concerns_contact_type:
       question: Do you agree to the children spending time with the other people in this application?
       answers:
@@ -400,18 +399,22 @@ en:
 
     child_arrangements_orders:
       question: 'You would like the court to:'
+      question_a11y: What you’re asking the court to decide about living arrangements
       answers:
         <<: *ARRANGEMENT_ORDERS
     specific_issues_orders:
       question: 'You would like the court to resolve an issue about:'
+      question_a11y: What you’re asking the court to decide about other issues
       answers:
         <<: *SPECIFIC_ISSUE_ORDERS
     prohibited_steps_orders:
       question: 'You would like the court to stop the other person:'
+      question_a11y: What you’re asking the court to stop the other person from doing
       answers:
         <<: *PROHIBITED_STEPS_ORDERS
     other_issue_details:
       question: 'You told us that you need help with this dispute:'
+      question_a11y: You need help with this dispute
     protection_orders:
       question: ''
       answers:


### PR DESCRIPTION
Append a visually hidden sentence to each of the `Change` links so it is more accessible to screen readers.

We might still need to tweak some of the visually hidden copy in some `Change` links to make it better.