### PR TITLE
Use new design system visually-hidden class

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -127,6 +127,22 @@ div.sentry-error-embed-wrapper p.powered-by {
   display: none;
 }
 
+// Bring over the visually hidden class from the new design system as it seems
+// to be more compliant with screen readers in some browsers.
+.govuk-visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  border: 0 !important;
+  white-space: nowrap !important
+}
+
 @import 'app/flash_card';
 @import 'app/pros_cons';
 @import 'app/sidebar';

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -57,7 +57,7 @@ en:
       undertaking: Undertaking in place of an order
 
   check_answers_html:
-    change_link_html: Change <span class="visuallyhidden">your answer to, %{a11y_question}</span>
+    change_link_html: Change <span class="govuk-visually-hidden">your answer to, %{a11y_question}</span>
     sections:
       child_protection_cases: Emergency protection, care or supervision proceedings
       miam_requirement: MIAM requirement


### PR DESCRIPTION
There seems to be some weird issue with the CYA and some screen readers in some browsers.

In order to make sure we are using the most up to date CSS definition that might include bug fixes, we are going to use the same definition as in the new design system, only in the CYA, for now.

We might backport this to other places where we use the "old" `visually-hidden` class.