### PR TITLE
Fix typo on accessibility statement

### DIFF
--- a/app/views/about/accessibility.en.html.erb
+++ b/app/views/about/accessibility.en.html.erb
@@ -24,9 +24,9 @@
 
     <h2 class="heading-large gv-u-heading-large">About the accessibility of this online service</h2>
 
-    <p>We’ve used components in the GOV.UK Design System to build this service. The
-      <a href="https://design-system.service.gov.uk/accessibility/" rel="external" target="_blank">Design System</a>
-      accessibility guide explains the current state of accessibility for these components.</p>
+    <p>We’ve used <a href="https://govuk-elements.herokuapp.com" rel="external" target="_blank">GOV.UK Elements</a> to
+      build this service. GOV.UK Elements has now been replaced by the GOV.UK Design System, but we will still carry out
+      major bug fixes and security patches.
 
     <p>Basic tests were performed on this online service on 9 October 2019. These tests were carried out by the Ministry
       of Justice.</p>
@@ -83,7 +83,7 @@
     <h2 class="heading-large gv-u-heading-large">PDF content</h2>
 
     <p>Some PDF content is essential to providing our services, but may not yet meet accessibility standards for screen
-      readers.The PDF content is designed to be used by the courts and is built to their specification, so any changes
+      readers. The PDF content is designed to be used by the courts and is built to their specification, so any changes
       will require their input. We plan to review this content by September 2020.</p>
 
     <h2 class="heading-large gv-u-heading-large">Third-party supplied service</h2>


### PR DESCRIPTION
It was missing a space after a full stop.

Also change the paragraph about the design system to actually talk about the GOV.UK Elements because this service is still using it.