### PR TITLE
Make the applicant contact email mandatory

### DIFF
--- a/app/forms/steps/applicant/contact_details_form.rb
+++ b/app/forms/steps/applicant/contact_details_form.rb
@@ -3,10 +3,15 @@ module Steps
     class ContactDetailsForm < BaseForm
       attribute :home_phone, StrippedString
       attribute :mobile_phone, StrippedString
-      attribute :email, NormalisedEmail
+      attribute :email, StrippedString
 
-      validates_presence_of :mobile_phone
-      validates :email, email: true, allow_blank: true
+      # Note: we validate presence of these fields, but allow the applicant to enter
+      # free text in case they do not want to disclose their phone or email address.
+      # That is why we do not perform any further validation, other than presence
+      # (do not validate the format of the phone or email, etc.)
+      #
+      validates_presence_of :mobile_phone,
+                            :email
 
       private
 

--- a/app/views/steps/applicant/contact_details/edit.html.erb
+++ b/app/views/steps/applicant/contact_details/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object do |f| %>
       <%= f.text_field :home_phone %>
       <%= f.text_field :mobile_phone %>
-      <%= f.email_field :email %>
+      <%= f.text_field :email, class: 'narrow' %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -37,8 +37,6 @@ en:
         blank: Enter the country
       residence_history:
         blank: Enter details and dates of previous addresses
-      mobile_phone:
-        blank: Enter a mobile number or tell us why the court cannot phone you
 
   errors:
     format: "%{message}"
@@ -359,6 +357,10 @@ en:
         steps/applicant/contact_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS
+            mobile_phone:
+              blank: Enter a mobile number or tell us why the court cannot phone you
+            email:
+              blank: Enter an email address or tell us why the court cannot email you
         steps/respondent/personal_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS

--- a/spec/forms/steps/applicant/contact_details_form_spec.rb
+++ b/spec/forms/steps/applicant/contact_details_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
   let(:record) { nil }
   let(:home_phone) { nil }
   let(:mobile_phone) { '12345' }
-  let(:email) { nil }
+  let(:email) { 'test@example.com' }
 
   subject { described_class.new(arguments) }
 
@@ -39,17 +39,11 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
     end
 
     context 'email validation' do
-      context 'email is not validated if not present' do
-        let(:email) { nil }
-        it { expect(subject).to be_valid }
-      end
+      let(:email) { nil }
 
-      context 'email is validated if present' do
-        let(:email) { 'xxx' }
-        it {
-          expect(subject).not_to be_valid
-          expect(subject.errors.added?(:email, :invalid)).to eq(true)
-        }
+      it 'has a validation error on the field if not present' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.added?(:email, :blank)).to eq(true)
       end
     end
 
@@ -58,7 +52,7 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
         {
           home_phone: '',
           mobile_phone: '12345',
-          email: ''
+          email: 'test@example.com'
         }
       }
 


### PR DESCRIPTION
But allow to enter free text as a reason in case they don't feel like disclosing this information, due to safety reasons or similar.

Basically we do the same we did in the past with the mobile number. The error message follows the same format.

<img width="706" alt="Screen Shot 2019-11-26 at 11 44 40" src="https://user-images.githubusercontent.com/687910/69633496-3d476400-1048-11ea-9e22-62ea0756b01d.png">
