### PR TITLE
Add a basic in-memory cache for court slugs

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -44,8 +44,9 @@ class Court
     best.fetch('address')
   end
 
+  # No need to memoize, we are using a basic ActiveSupport cache
   def court_data
-    @_court_data ||= C100App::CourtfinderAPI.new.court_lookup(slug)
+    C100App::CourtfinderAPI.new.court_lookup(slug)
   end
 
   private

--- a/features/step_definitions/smoke.rb
+++ b/features/step_definitions/smoke.rb
@@ -32,7 +32,7 @@ Then(/^The court exists and is enabled$/) do
   # We don't test here if the email is what it needs to be, as emails can change,
   # we just check if at least we found something that looks like an email address
   #
-  expect(@court.best_enquiries_email).to match(/.*@.*/)
+  expect(@court.best_enquiries_email).to match(/.+@.+/)
 
   # Above method will trigger the call to the API and populate the following
   # memoized method for further introspection (mainly for smoke tests)


### PR DESCRIPTION
Instead of using memoization of the `court_data`, we replace it with a very basic `ActiveSupport::Cache::MemoryStore` which in essence does the same but allow us to set an expiration per-key and also it is easier to test.

Also in the near future, this should be replace with a `RedisCacheStore` as otherwise it is suboptimal, having more than one instance, or loosing the cache on deploys.