### PR TITLE
Add case number field to court orders step

### DIFF
--- a/app/forms/steps/court_orders/details_form.rb
+++ b/app/forms/steps/court_orders/details_form.rb
@@ -8,6 +8,7 @@ module Steps
 
       NON_MOLESTATION_ATTRIBUTES = {
         non_molestation: YesNo,
+        non_molestation_case_number: String,
         non_molestation_issue_date: Date,
         non_molestation_length: String,
         non_molestation_is_current: YesNo,
@@ -16,6 +17,7 @@ module Steps
 
       OCCUPATION_ATTRIBUTES = {
         occupation: YesNo,
+        occupation_case_number: String,
         occupation_issue_date: Date,
         occupation_length: String,
         occupation_is_current: YesNo,
@@ -24,6 +26,7 @@ module Steps
 
       FORCED_MARRIAGE_PROTECTION_ATTRIBUTES = {
         forced_marriage_protection: YesNo,
+        forced_marriage_protection_case_number: String,
         forced_marriage_protection_issue_date: Date,
         forced_marriage_protection_length: String,
         forced_marriage_protection_is_current: YesNo,
@@ -32,6 +35,7 @@ module Steps
 
       RESTRAINING_ATTRIBUTES = {
         restraining: YesNo,
+        restraining_case_number: String,
         restraining_issue_date: Date,
         restraining_length: String,
         restraining_is_current: YesNo,
@@ -40,6 +44,7 @@ module Steps
 
       INJUNCTIVE_ATTRIBUTES = {
         injunctive: YesNo,
+        injunctive_case_number: String,
         injunctive_issue_date: Date,
         injunctive_length: String,
         injunctive_is_current: YesNo,
@@ -48,6 +53,7 @@ module Steps
 
       UNDERTAKING_ATTRIBUTES = {
         undertaking: YesNo,
+        undertaking_case_number: String,
         undertaking_issue_date: Date,
         undertaking_length: String,
         undertaking_is_current: YesNo,

--- a/app/presenters/summary/html_sections/court_orders.rb
+++ b/app/presenters/summary/html_sections/court_orders.rb
@@ -37,6 +37,7 @@ module Summary
         orders_made.map do |name|
           [
             Answer.new(:order_name, name),
+            FreeTextAnswer.new(:order_case_number, answer_for(name, :case_number)),
             DateAnswer.new(:order_issue_date, answer_for(name, :issue_date)),
             FreeTextAnswer.new(:order_length, answer_for(name, :length)),
             Answer.new(:order_is_current, answer_for(name, :is_current)),

--- a/app/presenters/summary/sections/c1a_court_orders.rb
+++ b/app/presenters/summary/sections/c1a_court_orders.rb
@@ -13,6 +13,7 @@ module Summary
         orders_made.map do |name|
           [
             Answer.new(:c1a_order_name, name),
+            FreeTextAnswer.new(:c1a_order_case_number, answer_for(name, :case_number)),
             DateAnswer.new(:c1a_order_issue_date, answer_for(name, :issue_date)),
             FreeTextAnswer.new(:c1a_order_length, answer_for(name, :length)),
             Answer.new(:c1a_order_is_current, answer_for(name, :is_current)),

--- a/app/views/steps/court_orders/details/edit.html.erb
+++ b/app/views/steps/court_orders/details/edit.html.erb
@@ -15,8 +15,9 @@
             fieldset.radio_input(GenericYesNo::YES, panel_id: "#{order_name}_panel")
             fieldset.radio_input(GenericYesNo::NO)
             fieldset.revealing_panel("#{order_name}_panel") do |panel|
+              panel.text_field :"#{order_name}_case_number", class: 'narrow'
               panel.gov_uk_date_field :"#{order_name}_issue_date", placeholders: true, legend_text: t('shared.form_elements.order_issue'), form_hint_text: t('shared.form_elements.order_issue_hint')
-              panel.text_field :"#{order_name}_length"
+              panel.text_field :"#{order_name}_length", class: 'narrow'
               panel.radio_button_fieldset :"#{order_name}_is_current", inline: true, choices: GenericYesNo.values
               panel.text_field :"#{order_name}_court_name"
             end

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -376,6 +376,8 @@ en:
       question: Order
       answers:
         <<: *COURT_ORDER_TYPES
+    order_case_number:
+      question: Case number
     order_issue_date:
       question: Date issued
     order_length:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,8 @@ en:
     order_current: &order_current "Is the order current?"
     order_length: &order_length "How long was the order for?"
     order_court_name: &order_court_name "Which court issued the order?"
+    order_case_number: &order_case_number "Case number"
+    order_case_number_hint: &order_case_number_hint "For example, BS19F99999"
     provide_details: &provide_details "Provide details"
     select_all_that_apply: &select_all_that_apply "Select all that apply"
     select_all_that_apply_or_none: &select_all_that_apply_or_none "Select all that apply or ‘None of these’"
@@ -1299,16 +1301,22 @@ en:
         has_court_orders:
           <<: *YESNO
       steps_court_orders_details_form:
+        non_molestation_case_number: *order_case_number
         non_molestation_length: *order_length
         non_molestation_court_name: *order_court_name
+        occupation_case_number: *order_case_number
         occupation_length: *order_length
         occupation_court_name: *order_court_name
+        forced_marriage_protection_case_number: *order_case_number
         forced_marriage_protection_length: *order_length
         forced_marriage_protection_court_name: *order_court_name
+        restraining_case_number: *order_case_number
         restraining_length: *order_length
         restraining_court_name: *order_court_name
+        injunctive_case_number: *order_case_number
         injunctive_length: *order_length
         injunctive_court_name: *order_court_name
+        undertaking_case_number: *order_case_number
         undertaking_length: *order_length
         undertaking_court_name: *order_court_name
       steps_international_jurisdiction_form:
@@ -1421,6 +1429,12 @@ en:
         concerns_contact_other: For example, by phone, text or email
       steps_court_orders_details_form:
         restraining: Under the Protection from Harassment Act 1997
+        non_molestation_case_number: *order_case_number_hint
+        occupation_case_number: *order_case_number_hint
+        forced_marriage_protection_case_number: *order_case_number_hint
+        restraining_case_number: *order_case_number_hint
+        injunctive_case_number: *order_case_number_hint
+        undertaking_case_number: *order_case_number_hint
       steps_miam_exemptions_domestic_form:
         domestic_exemptions: *select_all_that_apply_or_none
       steps_miam_exemptions_protection_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -217,6 +217,8 @@ en:
             # non-molestation order
             non_molestation:
               inclusion: Select yes if you have a non-molestation order
+            non_molestation_case_number:
+              blank: Enter the case number of the non-molestation order
             non_molestation_issue_date:
               blank: Enter the date the non-molestation order was made
             non_molestation_length:
@@ -228,6 +230,8 @@ en:
             # occupation order
             occupation:
               inclusion: Select yes if you have an occupation order
+            occupation_case_number:
+              blank: Enter the case number of the occupation order
             occupation_issue_date:
               blank: Enter the date the occupation order was made
             occupation_length:
@@ -239,6 +243,8 @@ en:
             # forced marriage protection order
             forced_marriage_protection:
               inclusion: Select yes if you have a forced marriage protection order
+            forced_marriage_protection_case_number:
+              blank: Enter the case number of the forced marriage protection order
             forced_marriage_protection_issue_date:
               blank: Enter the date the forced marriage protection order was made
             forced_marriage_protection_length:
@@ -250,6 +256,8 @@ en:
             # restraining order
             restraining:
               inclusion: Select yes if you have a restraining order
+            restraining_case_number:
+              blank: Enter the case number of the restraining order
             restraining_issue_date:
               blank: Enter the date the restraining order was made
             restraining_length:
@@ -261,6 +269,8 @@ en:
             # another injunctive order
             injunctive:
               inclusion: Select yes if you have another injunctive order
+            injunctive_case_number:
+              blank: Enter the case number of the injunctive order
             injunctive_issue_date:
               blank: Enter the date the injunctive order was made
             injunctive_length:
@@ -272,6 +282,8 @@ en:
             # undertaking in place of an order
             undertaking:
               inclusion: Select yes if you have an undertaking in place of an order
+            undertaking_case_number:
+              blank: Enter the case number of the undertaking in place of an order
             undertaking_issue_date:
               blank: Enter the date the undertaking in place of an order was made
             undertaking_length:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -598,8 +598,10 @@ en:
       question: Order
       answers:
         <<: *COURT_ORDER_TYPES
+    c1a_order_case_number:
+      question: Case number
     c1a_order_issue_date:
-      question: Date issued (DD MM YYY)
+      question: Date issued
     c1a_order_length:
       question: Length of order
     c1a_order_is_current:

--- a/db/migrate/20191128124833_add_case_number_to_court_orders.rb
+++ b/db/migrate/20191128124833_add_case_number_to_court_orders.rb
@@ -1,0 +1,10 @@
+class AddCaseNumberToCourtOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :court_orders, :non_molestation_case_number, :string
+    add_column :court_orders, :occupation_case_number, :string
+    add_column :court_orders, :forced_marriage_protection_case_number, :string
+    add_column :court_orders, :restraining_case_number, :string
+    add_column :court_orders, :injunctive_case_number, :string
+    add_column :court_orders, :undertaking_case_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191114093418) do
+ActiveRecord::Schema.define(version: 20191128124833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,6 +201,12 @@ ActiveRecord::Schema.define(version: 20191114093418) do
     t.string "undertaking_is_current"
     t.string "undertaking_court_name"
     t.uuid "c100_application_id"
+    t.string "non_molestation_case_number"
+    t.string "occupation_case_number"
+    t.string "forced_marriage_protection_case_number"
+    t.string "restraining_case_number"
+    t.string "injunctive_case_number"
+    t.string "undertaking_case_number"
     t.index ["c100_application_id"], name: "index_court_orders_on_c100_application_id"
   end
 

--- a/spec/forms/steps/court_orders/details_form_spec.rb
+++ b/spec/forms/steps/court_orders/details_form_spec.rb
@@ -5,36 +5,42 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
     c100_application: c100_application,
 
     non_molestation: non_molestation,
+    non_molestation_case_number: non_molestation_case_number,
     non_molestation_issue_date: non_molestation_issue_date,
     non_molestation_length: non_molestation_length,
     non_molestation_is_current: non_molestation_is_current,
     non_molestation_court_name: non_molestation_court_name,
 
     occupation: occupation,
+    occupation_case_number: occupation_case_number,
     occupation_issue_date: occupation_issue_date,
     occupation_length: occupation_length,
     occupation_is_current: occupation_is_current,
     occupation_court_name: occupation_court_name,
 
     forced_marriage_protection: forced_marriage_protection,
+    forced_marriage_protection_case_number: forced_marriage_protection_case_number,
     forced_marriage_protection_issue_date: forced_marriage_protection_issue_date,
     forced_marriage_protection_length: forced_marriage_protection_length,
     forced_marriage_protection_is_current: forced_marriage_protection_is_current,
     forced_marriage_protection_court_name: forced_marriage_protection_court_name,
 
     restraining: restraining,
+    restraining_case_number: restraining_case_number,
     restraining_issue_date: restraining_issue_date,
     restraining_length: restraining_length,
     restraining_is_current: restraining_is_current,
     restraining_court_name: restraining_court_name,
 
     injunctive: injunctive,
+    injunctive_case_number: injunctive_case_number,
     injunctive_issue_date: injunctive_issue_date,
     injunctive_length: injunctive_length,
     injunctive_is_current: injunctive_is_current,
     injunctive_court_name: injunctive_court_name,
 
     undertaking: undertaking,
+    undertaking_case_number: undertaking_case_number,
     undertaking_issue_date: undertaking_issue_date,
     undertaking_length: undertaking_length,
     undertaking_is_current: undertaking_is_current,
@@ -45,36 +51,42 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
   let(:court_order) { double('court_order') }
 
   let(:non_molestation) { 'no' }
+  let(:non_molestation_case_number) { nil }
   let(:non_molestation_issue_date) { nil }
   let(:non_molestation_length) { nil }
   let(:non_molestation_is_current) { nil }
   let(:non_molestation_court_name) { nil }
 
   let(:occupation) { 'no' }
+  let(:occupation_case_number) { nil }
   let(:occupation_issue_date) { nil }
   let(:occupation_length) { nil }
   let(:occupation_is_current) { nil }
   let(:occupation_court_name) { nil }
 
   let(:forced_marriage_protection) { 'no' }
+  let(:forced_marriage_protection_case_number) { nil }
   let(:forced_marriage_protection_issue_date) { nil }
   let(:forced_marriage_protection_length) { nil }
   let(:forced_marriage_protection_is_current) { nil }
   let(:forced_marriage_protection_court_name) { nil }
 
   let(:restraining) { 'no' }
+  let(:restraining_case_number) { nil }
   let(:restraining_issue_date) { nil }
   let(:restraining_length) { nil }
   let(:restraining_is_current) { nil }
   let(:restraining_court_name) { nil }
 
   let(:injunctive) { 'no' }
+  let(:injunctive_case_number) { nil }
   let(:injunctive_issue_date) { nil }
   let(:injunctive_length) { nil }
   let(:injunctive_is_current) { nil }
   let(:injunctive_court_name) { nil }
 
   let(:undertaking) { 'no' }
+  let(:undertaking_case_number) { nil }
   let(:undertaking_issue_date) { nil }
   let(:undertaking_length) { nil }
   let(:undertaking_is_current) { nil }
@@ -104,6 +116,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `yes`' do
         let(:non_molestation) { 'yes' }
 
+        it { should validate_presence_of(:non_molestation_case_number) }
         it { should validate_presence_of(:non_molestation_issue_date) }
         it { should validate_presence_of(:non_molestation_length) }
         it { should validate_presence_of(:non_molestation_is_current, :inclusion) }
@@ -113,6 +126,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `no`' do
         let(:non_molestation) { 'no' }
 
+        it { should_not validate_presence_of(:non_molestation_case_number) }
         it { should_not validate_presence_of(:non_molestation_issue_date) }
         it { should_not validate_presence_of(:non_molestation_length) }
         it { should_not validate_presence_of(:non_molestation_is_current) }
@@ -124,6 +138,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `yes`' do
         let(:occupation) { 'yes' }
 
+        it { should validate_presence_of(:occupation_case_number) }
         it { should validate_presence_of(:occupation_issue_date) }
         it { should validate_presence_of(:occupation_length) }
         it { should validate_presence_of(:occupation_is_current, :inclusion) }
@@ -133,6 +148,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `no`' do
         let(:occupation) { 'no' }
 
+        it { should_not validate_presence_of(:occupation_case_number) }
         it { should_not validate_presence_of(:occupation_issue_date) }
         it { should_not validate_presence_of(:occupation_length) }
         it { should_not validate_presence_of(:occupation_is_current) }
@@ -144,6 +160,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `yes`' do
         let(:forced_marriage_protection) { 'yes' }
 
+        it { should validate_presence_of(:forced_marriage_protection_case_number) }
         it { should validate_presence_of(:forced_marriage_protection_issue_date) }
         it { should validate_presence_of(:forced_marriage_protection_length) }
         it { should validate_presence_of(:forced_marriage_protection_is_current, :inclusion) }
@@ -153,6 +170,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `no`' do
         let(:forced_marriage_protection) { 'no' }
 
+        it { should_not validate_presence_of(:forced_marriage_protection_case_number) }
         it { should_not validate_presence_of(:forced_marriage_protection_issue_date) }
         it { should_not validate_presence_of(:forced_marriage_protection_length) }
         it { should_not validate_presence_of(:forced_marriage_protection_is_current) }
@@ -164,6 +182,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `yes`' do
         let(:restraining) { 'yes' }
 
+        it { should validate_presence_of(:restraining_case_number) }
         it { should validate_presence_of(:restraining_issue_date) }
         it { should validate_presence_of(:restraining_length) }
         it { should validate_presence_of(:restraining_is_current, :inclusion) }
@@ -173,6 +192,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `no`' do
         let(:restraining) { 'no' }
 
+        it { should_not validate_presence_of(:restraining_case_number) }
         it { should_not validate_presence_of(:restraining_issue_date) }
         it { should_not validate_presence_of(:restraining_length) }
         it { should_not validate_presence_of(:restraining_is_current) }
@@ -184,6 +204,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `yes`' do
         let(:injunctive) { 'yes' }
 
+        it { should validate_presence_of(:injunctive_case_number) }
         it { should validate_presence_of(:injunctive_issue_date) }
         it { should validate_presence_of(:injunctive_length) }
         it { should validate_presence_of(:injunctive_is_current, :inclusion) }
@@ -193,6 +214,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `no`' do
         let(:injunctive) { 'no' }
 
+        it { should_not validate_presence_of(:injunctive_case_number) }
         it { should_not validate_presence_of(:injunctive_issue_date) }
         it { should_not validate_presence_of(:injunctive_length) }
         it { should_not validate_presence_of(:injunctive_is_current) }
@@ -204,6 +226,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `yes`' do
         let(:undertaking) { 'yes' }
 
+        it { should validate_presence_of(:undertaking_case_number) }
         it { should validate_presence_of(:undertaking_issue_date) }
         it { should validate_presence_of(:undertaking_length) }
         it { should validate_presence_of(:undertaking_is_current, :inclusion) }
@@ -213,6 +236,7 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
       context 'when order value is `no`' do
         let(:undertaking) { 'no' }
 
+        it { should_not validate_presence_of(:undertaking_case_number) }
         it { should_not validate_presence_of(:undertaking_issue_date) }
         it { should_not validate_presence_of(:undertaking_length) }
         it { should_not validate_presence_of(:undertaking_is_current) }
@@ -225,36 +249,42 @@ RSpec.describe Steps::CourtOrders::DetailsForm do
                       association_name: :court_order,
                       expected_attributes: {
                         non_molestation: GenericYesNo::NO,
+                        non_molestation_case_number: nil,
                         non_molestation_issue_date: nil,
                         non_molestation_length: nil,
                         non_molestation_is_current: nil,
                         non_molestation_court_name: nil,
 
                         occupation: GenericYesNo::NO,
+                        occupation_case_number: nil,
                         occupation_issue_date: nil,
                         occupation_length: nil,
                         occupation_is_current: nil,
                         occupation_court_name: nil,
 
                         forced_marriage_protection: GenericYesNo::NO,
+                        forced_marriage_protection_case_number: nil,
                         forced_marriage_protection_issue_date: nil,
                         forced_marriage_protection_length: nil,
                         forced_marriage_protection_is_current: nil,
                         forced_marriage_protection_court_name: nil,
 
                         restraining: GenericYesNo::NO,
+                        restraining_case_number: nil,
                         restraining_issue_date: nil,
                         restraining_length: nil,
                         restraining_is_current: nil,
                         restraining_court_name: nil,
 
                         injunctive: GenericYesNo::NO,
+                        injunctive_case_number: nil,
                         injunctive_issue_date: nil,
                         injunctive_length: nil,
                         injunctive_is_current: nil,
                         injunctive_court_name: nil,
 
                         undertaking: GenericYesNo::NO,
+                        undertaking_case_number: nil,
                         undertaking_issue_date: nil,
                         undertaking_length: nil,
                         undertaking_is_current: nil,

--- a/spec/presenters/summary/html_sections/court_orders_spec.rb
+++ b/spec/presenters/summary/html_sections/court_orders_spec.rb
@@ -15,6 +15,7 @@ module Summary
     let(:court_order) {
       CourtOrder.new(
         restraining: 'yes',
+        restraining_case_number: '12345678',
         restraining_issue_date: Date.new(2018, 1, 20),
         restraining_length: '1 year',
         restraining_is_current: 'yes',
@@ -54,7 +55,7 @@ module Summary
         expect(answers[1]).to be_an_instance_of(AnswersGroup)
         expect(answers[1].name).to eq(:court_orders_details)
         expect(answers[1].change_path).to eq('/steps/court_orders/details')
-        expect(answers[1].answers.count).to eq(5)
+        expect(answers[1].answers.count).to eq(6)
 
           ## court_orders details group answers ###
           details = answers[1].answers
@@ -63,21 +64,25 @@ module Summary
           expect(details[0].question).to eq(:order_name)
           expect(details[0].value).to eq('restraining')
 
-          expect(details[1]).to be_an_instance_of(DateAnswer)
-          expect(details[1].question).to eq(:order_issue_date)
-          expect(details[1].value).to eq(Date.new(2018, 1, 20))
+          expect(details[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[1].question).to eq(:order_case_number)
+          expect(details[1].value).to eq('12345678')
 
-          expect(details[2]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[2].question).to eq(:order_length)
-          expect(details[2].value).to eq('1 year')
+          expect(details[2]).to be_an_instance_of(DateAnswer)
+          expect(details[2].question).to eq(:order_issue_date)
+          expect(details[2].value).to eq(Date.new(2018, 1, 20))
 
-          expect(details[3]).to be_an_instance_of(Answer)
-          expect(details[3].question).to eq(:order_is_current)
-          expect(details[3].value).to eq('yes')
+          expect(details[3]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[3].question).to eq(:order_length)
+          expect(details[3].value).to eq('1 year')
 
-          expect(details[4]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[4].question).to eq(:order_court_name)
-          expect(details[4].value).to eq('court name')
+          expect(details[4]).to be_an_instance_of(Answer)
+          expect(details[4].question).to eq(:order_is_current)
+          expect(details[4].value).to eq('yes')
+
+          expect(details[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[5].question).to eq(:order_court_name)
+          expect(details[5].value).to eq('court name')
       end
 
       context 'when no court orders were made' do

--- a/spec/presenters/summary/sections/c1a_court_orders_spec.rb
+++ b/spec/presenters/summary/sections/c1a_court_orders_spec.rb
@@ -10,6 +10,7 @@ module Summary
     let(:court_order) {
       CourtOrder.new(
         restraining: GenericYesNo::YES,
+        restraining_case_number: '12345678',
         restraining_issue_date: Date.new(2018, 1, 20),
         restraining_length: '1 year',
         restraining_is_current: GenericYesNo::YES,
@@ -39,30 +40,34 @@ module Summary
       end
 
       it 'has the correct rows' do
-        expect(answers.count).to eq(6)
+        expect(answers.count).to eq(7)
 
         expect(answers[0]).to be_an_instance_of(Answer)
         expect(answers[0].question).to eq(:c1a_order_name)
         expect(answers[0].value).to eq('restraining')
 
-        expect(answers[1]).to be_an_instance_of(DateAnswer)
-        expect(answers[1].question).to eq(:c1a_order_issue_date)
-        expect(answers[1].value).to eq(Date.new(2018, 1, 20))
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:c1a_order_case_number)
+        expect(answers[1].value).to eq('12345678')
 
-        expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[2].question).to eq(:c1a_order_length)
-        expect(answers[2].value).to eq('1 year')
+        expect(answers[2]).to be_an_instance_of(DateAnswer)
+        expect(answers[2].question).to eq(:c1a_order_issue_date)
+        expect(answers[2].value).to eq(Date.new(2018, 1, 20))
 
-        expect(answers[3]).to be_an_instance_of(Answer)
-        expect(answers[3].question).to eq(:c1a_order_is_current)
-        expect(answers[3].value).to eq('yes')
+        expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[3].question).to eq(:c1a_order_length)
+        expect(answers[3].value).to eq('1 year')
 
-        expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[4].question).to eq(:c1a_order_court_name)
-        expect(answers[4].value).to eq('court name')
+        expect(answers[4]).to be_an_instance_of(Answer)
+        expect(answers[4].question).to eq(:c1a_order_is_current)
+        expect(answers[4].value).to eq('yes')
 
-        expect(answers[5]).to be_an_instance_of(Partial)
-        expect(answers[5].name).to eq(:row_blank_space)
+        expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[5].question).to eq(:c1a_order_court_name)
+        expect(answers[5].value).to eq('court name')
+
+        expect(answers[6]).to be_an_instance_of(Partial)
+        expect(answers[6].name).to eq(:row_blank_space)
       end
 
       context 'when no court orders were made' do


### PR DESCRIPTION
Based on feedback from court staff and legal advisers, we've added
a field for the case number in the section which asks about
protective orders.

Court staff will be able to locate copies of protective orders more
quickly.

This field is mandatory and do not have any format validation as each
court and even each order will have their own format.

Updated step view, form object, CYA and PDF generation.

<img width="465" alt="Screen Shot 2019-11-29 at 11 39 58" src="https://user-images.githubusercontent.com/687910/69962147-47180e00-1505-11ea-9038-67f5eacaf7a9.png">
