### PR TITLE
Replace MemoryStore with RedisCacheStore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ SESSION_WARNING_WHEN_REMAINING=5
 GOVUK_NOTIFY_API_KEY=notify-api-key
 GOVUK_NOTIFY_BEARER_TOKEN=notify-callback-token
 
+# By default, if this env variable is not set, we use MemoryStore
+# URI format: redis://[:password@]host[:port][/database]
+#
+# REDIS_URL=redis://localhost:6379
+
 # Following env variables are not required unless you are working in a feature
 # involving the back office, or want to test the Auth0 integration.
 # If required, ask another developer in the team to give you access to Auth0.

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem 'uglifier'
 gem 'uk_postcode'
 gem 'virtus'
 
+# Caching. Jobs processing (Sidekiq?) might be next
+gem 'redis'
+
 # PDF generation
 gem 'combine_pdf', '~> 1.0'
 gem 'wicked_pdf', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redis (4.1.3)
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -449,6 +450,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.2.4)
   rails-controller-testing
+  redis
   responders
   rspec-rails
   rspec_junit_formatter

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,19 +4,7 @@ Rails.application.configure do
   config.eager_load = false
 
   config.consider_all_requests_local = true
-
-  if Rails.root.join('tmp/caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
-
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=172800'
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  config.action_controller.perform_caching = false
 
   # save mails to tmp/mails
   config.action_mailer.delivery_method = :file

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -1,0 +1,16 @@
+if ENV.key?('REDIS_URL')
+  Rails.application.config.cache_store = :redis_cache_store, {
+    connect_timeout: 2,
+    read_timeout: 0.3,
+    write_timeout: 0.3,
+
+    error_handler: -> (method:, returning:, exception:) {
+      Raven.capture_exception(exception, level: 'warning', tags: { method: method, returning: returning })
+    }
+  }
+else
+  Rails.application.config.cache_store = :memory_store
+end
+
+# http://stackoverflow.com/a/38619281/2066546
+Rails.cache = ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,13 @@ version: '3'
 services:
   db:
     image: postgres
+  cache:
+    image: redis
   web:
     build: .
     environment:
       - DATABASE_URL=postgresql://postgres@db/c100-application
+      - REDIS_URL=redis://cache:6379
       - EXTERNAL_URL=http://localhost:3000
       - RAILS_SERVE_STATIC_FILES=1
       - DATABASE_SSLMODE=disable
@@ -20,3 +23,4 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - cache

--- a/spec/services/c100_app/courtfinder_api_spec.rb
+++ b/spec/services/c100_app/courtfinder_api_spec.rb
@@ -166,6 +166,10 @@ describe C100App::CourtfinderAPI do
       allow(subject).to receive(:open).with('my court url').and_return(mock_io_stream)
     end
 
+    it 'uses the memory store on envs that does not declare the `REDIS_URL` variable' do
+      expect(subject.cache).to be_kind_of(ActiveSupport::Cache::MemoryStore)
+    end
+
     context 'without cache' do
       before do
         subject.cache.clear
@@ -188,7 +192,10 @@ describe C100App::CourtfinderAPI do
 
     context 'with cache' do
       it 'tries to fetch the key from the cache' do
-        expect(subject.cache).to receive(:fetch).with('my-slug', skip_nil: true, expires_in: 72.hours).and_call_original
+        expect(subject.cache).to receive(:fetch).with(
+          'my-slug', skip_nil: true, compress: false, expires_in: 72.hours, namespace: 'courtfinder'
+        ).and_call_original
+
         subject.court_lookup('my-slug')
       end
 


### PR DESCRIPTION
CourtfinderAPI was using `MemoryStore` for a very basic cache of slugs JSON response, saving a few API requests, but, as stated in the original PR #726, it was suboptimal because we have more than one application instance (each instance having its own memory, not shared) and also, any deploys would wipe the cache.

As we've bumped the Rails version to the 5.2.x branch (PR #728) now it is very easy to just replace the `MemoryStore` with a `RedisCacheStore` which will work out much better in a multiple instances deployment like ours.

Kubernetes already provides to us an elasticache (redis) database and, in production environments, the `REDIS_URL` is exposed, so we use this, instead of the `MemoryStore` that we will continue using on dev/test envs.

Once we test this works well, we could use the cache in a few other places to optimise the application.