### PR TITLE
Add voicemail consent for the applicant

### DIFF
--- a/app/forms/steps/applicant/contact_details_form.rb
+++ b/app/forms/steps/applicant/contact_details_form.rb
@@ -1,17 +1,20 @@
 module Steps
   module Applicant
     class ContactDetailsForm < BaseForm
+      attribute :email, StrippedString
       attribute :home_phone, StrippedString
       attribute :mobile_phone, StrippedString
-      attribute :email, StrippedString
+      attribute :voicemail_consent, YesNo
 
       # Note: we validate presence of these fields, but allow the applicant to enter
       # free text in case they do not want to disclose their phone or email address.
       # That is why we do not perform any further validation, other than presence
       # (do not validate the format of the phone or email, etc.)
       #
-      validates_presence_of :mobile_phone,
-                            :email
+      validates_presence_of :email,
+                            :mobile_phone
+
+      validates_inclusion_of :voicemail_consent, in: GenericYesNo.values
 
       private
 

--- a/app/forms/steps/respondent/contact_details_form.rb
+++ b/app/forms/steps/respondent/contact_details_form.rb
@@ -1,9 +1,9 @@
 module Steps
   module Respondent
     class ContactDetailsForm < BaseForm
+      attribute :email, NormalisedEmail
       attribute :home_phone, StrippedString
       attribute :mobile_phone, StrippedString
-      attribute :email, NormalisedEmail
 
       validates :email, email: true, allow_blank: true
 

--- a/app/presenters/summary/html_sections/people_details.rb
+++ b/app/presenters/summary/html_sections/people_details.rb
@@ -55,9 +55,10 @@ module Summary
 
       def contact_details_questions(person)
         [
+          FreeTextAnswer.new(:person_email, person.email),
           FreeTextAnswer.new(:person_home_phone, person.home_phone),
           FreeTextAnswer.new(:person_mobile_phone, person.mobile_phone),
-          FreeTextAnswer.new(:person_email, person.email),
+          Answer.new(:person_voicemail_consent, person.voicemail_consent), # This shows only if a value is present
         ]
       end
 

--- a/app/presenters/summary/sections/c1a_applicant_details.rb
+++ b/app/presenters/summary/sections/c1a_applicant_details.rb
@@ -19,9 +19,10 @@ module Summary
           Answer.new(:c1a_person_type, :applicant), # Always going to be `applicant` in our digital form
           Partial.row_blank_space,
           Separator.new(:contact_details),
+          FreeTextAnswer.new(:person_email, applicant.email),
           FreeTextAnswer.new(:person_home_phone, applicant.home_phone),
           FreeTextAnswer.new(:person_mobile_phone, applicant.mobile_phone),
-          FreeTextAnswer.new(:person_email, applicant.email),
+          Answer.new(:person_voicemail_consent, applicant.voicemail_consent),
           Partial.row_blank_space,
           Answer.new(:c1a_address_confidentiality, c100.address_confidentiality, default: GenericYesNo::NO),
         ].select(&:show?)

--- a/app/presenters/summary/sections/c8_applicants_details.rb
+++ b/app/presenters/summary/sections/c8_applicants_details.rb
@@ -24,9 +24,10 @@ module Summary
             FreeTextAnswer.new(:person_full_name, person.full_name),
             FreeTextAnswer.new(:person_address, person.full_address),
             FreeTextAnswer.new(:person_residence_history, person.residence_history),
+            FreeTextAnswer.new(:person_email, person.email),
             FreeTextAnswer.new(:person_home_phone, person.home_phone),
             FreeTextAnswer.new(:person_mobile_phone, person.mobile_phone),
-            FreeTextAnswer.new(:person_email, person.email),
+            Answer.new(:person_voicemail_consent, person.voicemail_consent),
             Partial.row_blank_space,
           ]
         end.flatten.select(&:show?)

--- a/app/presenters/summary/sections/people_details.rb
+++ b/app/presenters/summary/sections/people_details.rb
@@ -31,9 +31,10 @@ module Summary
             FreeTextAnswer.new(:person_address, person.full_address, show: true),
             Answer.new(:person_residence_requirement_met, person.residence_requirement_met),
             FreeTextAnswer.new(:person_residence_history, person.residence_history),
+            FreeTextAnswer.new(:person_email, person.email),
             FreeTextAnswer.new(:person_home_phone, person.home_phone),
             FreeTextAnswer.new(:person_mobile_phone, person.mobile_phone),
-            FreeTextAnswer.new(:person_email, person.email),
+            Answer.new(:person_voicemail_consent, person.voicemail_consent), # This shows only if a value is present
             FreeTextAnswer.new(
               :person_relationship_to_children,
               RelationshipsPresenter.new(c100_application).relationship_to_children(

--- a/app/views/steps/applicant/contact_details/edit.html.erb
+++ b/app/views/steps/applicant/contact_details/edit.html.erb
@@ -7,9 +7,11 @@
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
 
     <%= step_form @form_object do |f| %>
+      <%= f.text_field :email, class: 'narrow' %>
       <%= f.text_field :home_phone %>
       <%= f.text_field :mobile_phone %>
-      <%= f.text_field :email, class: 'narrow' %>
+
+      <%= f.radio_button_fieldset :voicemail_consent, choices: GenericYesNo.values %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/respondent/contact_details/edit.html.erb
+++ b/app/views/steps/respondent/contact_details/edit.html.erb
@@ -11,9 +11,9 @@
     </div>
 
     <%= step_form @form_object do |f| %>
+      <%= f.email_field :email %>
       <%= f.text_field :home_phone %>
       <%= f.text_field :mobile_phone %>
-      <%= f.email_field :email %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -467,6 +467,11 @@ en:
       question: Mobile telephone number
     person_email:
       question: Email address
+    person_voicemail_consent:
+      question: Allow voicemail?
+      answers:
+        'yes': Yes, the court can leave a voicemail
+        'no': No, the court cannot leave a voicemail
 
     has_other_court_cases:
       question: Have any of the children in this application been involved in other family court proceedings?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1103,6 +1103,8 @@ en:
         gender: Sex
       steps_applicant_address_details_form:
         residence_requirement_met: Have you lived at your current address for more than 5 years?
+      steps_applicant_contact_details_form:
+        voicemail_consent: Can the court leave you a voicemail?
       steps_respondent_personal_details_form:
         has_previous_name: Have they changed their name?
         gender: Sex
@@ -1242,6 +1244,9 @@ en:
         previous_name: Enter your previous name
       steps_applicant_contact_details_form:
         <<: *PERSONAL_CONTACT_FIELDS
+        voicemail_consent:
+          'yes': Yes, the court can leave me a voicemail
+          'no': No, the court cannot leave me a voicemail
       steps_applicant_address_details_form:
         <<: *PERSONAL_ADDRESS_FIELDS
         residence_history: Provide details and dates of all previous addresses for the last 5 years
@@ -1385,6 +1390,8 @@ en:
         birthplace: *birthplace_hint
       steps_applicant_address_details_form:
         residence_history: Start with the most recent
+      steps_applicant_contact_details_form:
+        voicemail_consent: If the court calls you about your application and you cannot answer the phone, we need to know that it’s safe for them to leave a voicemail.
       steps_respondent_personal_details_form:
         has_previous_name: For example, through marriage or adoption or by deed poll. This includes first name, surname and any middle names
         previous_name: *previous_name_hint

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -370,6 +370,8 @@ en:
               blank: Enter a mobile number or tell us why the court cannot phone you
             email:
               blank: Enter an email address or tell us why the court cannot email you
+            voicemail_consent:
+              inclusion: Select yes if the court can leave you a voicemail
         steps/respondent/personal_details_form:
           attributes:
             <<: *PERSONAL_DETAILS_ERRORS

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -420,6 +420,11 @@ en:
       question: Mobile telephone number
     person_email:
       question: Email address
+    person_voicemail_consent:
+      question: Allow voicemail?
+      answers:
+        'yes': Yes, the court can leave a voicemail
+        'no': No, the court cannot leave a voicemail
     person_relationship_to_children:
       question: Relationship to children listed in this application
 

--- a/db/migrate/20191209103137_add_voicemail_consent_to_people.rb
+++ b/db/migrate/20191209103137_add_voicemail_consent_to_people.rb
@@ -1,0 +1,5 @@
+class AddVoicemailConsentToPeople < ActiveRecord::Migration[5.2]
+  def change
+    add_column :people, :voicemail_consent, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_02_153003) do
+ActiveRecord::Schema.define(version: 2019_12_09_103137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -278,6 +278,7 @@ ActiveRecord::Schema.define(version: 2019_12_02_153003) do
     t.text "residence_history"
     t.uuid "c100_application_id"
     t.json "address_data", default: {}
+    t.string "voicemail_consent"
     t.index ["c100_application_id"], name: "index_people_on_c100_application_id"
   end
 

--- a/spec/forms/steps/applicant/contact_details_form_spec.rb
+++ b/spec/forms/steps/applicant/contact_details_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
     home_phone: home_phone,
     mobile_phone: mobile_phone,
     email: email,
+    voicemail_consent: voicemail_consent,
   } }
 
   let(:c100_application) { instance_double(C100Application, applicants: applicants_collection) }
@@ -17,6 +18,7 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
   let(:home_phone) { nil }
   let(:mobile_phone) { '12345' }
   let(:email) { 'test@example.com' }
+  let(:voicemail_consent) { 'yes' }
 
   subject { described_class.new(arguments) }
 
@@ -47,12 +49,41 @@ RSpec.describe Steps::Applicant::ContactDetailsForm do
       end
     end
 
+    context 'voicemail consent validation' do
+      context 'when attribute is not given' do
+        let(:voicemail_consent) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:voicemail_consent]).to_not be_empty
+        end
+      end
+
+      context 'when attribute value is not valid' do
+        let(:voicemail_consent) {'INVALID VALUE'}
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:voicemail_consent]).to_not be_empty
+        end
+      end
+    end
+
     context 'for valid details' do
       let(:expected_attributes) {
         {
+          email: 'test@example.com',
           home_phone: '',
           mobile_phone: '12345',
-          email: 'test@example.com'
+          voicemail_consent: GenericYesNo::YES,
         }
       }
 

--- a/spec/forms/steps/respondent/contact_details_form_spec.rb
+++ b/spec/forms/steps/respondent/contact_details_form_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
     context 'for valid details' do
       let(:expected_attributes) {
         {
+          email: 'test@test.com',
           home_phone: '',
           mobile_phone: '',
-          email: 'test@test.com'
         }
       }
 

--- a/spec/presenters/summary/html_sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicants_details_spec.rb
@@ -24,6 +24,7 @@ module Summary
         home_phone: 'home_phone',
         mobile_phone: 'mobile_phone',
         email: 'email',
+        voicemail_consent: 'yes',
         relationships: [relationships],
       )
     }
@@ -132,21 +133,26 @@ module Summary
         expect(answers[4]).to be_an_instance_of(AnswersGroup)
         expect(answers[4].name).to eq(:person_contact_details)
         expect(answers[4].change_path).to eq('/steps/applicant/contact_details/uuid-123')
-        expect(answers[4].answers.count).to eq(3)
+        expect(answers[4].answers.count).to eq(4)
 
+          # contact details group answers ###
           details = answers[4].answers
 
           expect(details[0]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[0].question).to eq(:person_home_phone)
-          expect(details[0].value).to eq('home_phone')
+          expect(details[0].question).to eq(:person_email)
+          expect(details[0].value).to eq('email')
 
           expect(details[1]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[1].question).to eq(:person_mobile_phone)
-          expect(details[1].value).to eq('mobile_phone')
+          expect(details[1].question).to eq(:person_home_phone)
+          expect(details[1].value).to eq('home_phone')
 
           expect(details[2]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[2].question).to eq(:person_email)
-          expect(details[2].value).to eq('email')
+          expect(details[2].question).to eq(:person_mobile_phone)
+          expect(details[2].value).to eq('mobile_phone')
+
+          expect(details[3]).to be_an_instance_of(Answer)
+          expect(details[3].question).to eq(:person_voicemail_consent)
+          expect(details[3].value).to eq('yes')
 
         expect(answers[5]).to be_an_instance_of(Answer)
         expect(answers[5].question).to eq(:relationship_to_child)

--- a/spec/presenters/summary/html_sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/html_sections/respondents_details_spec.rb
@@ -23,6 +23,7 @@ module Summary
         residence_history: 'history',
         home_phone: 'home_phone',
         mobile_phone: 'mobile_phone',
+        voicemail_consent: nil,
         email: 'email',
         relationships: [relationships],
       )
@@ -132,16 +133,16 @@ module Summary
           details = answers[4].answers
 
           expect(details[0]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[0].question).to eq(:person_home_phone)
-          expect(details[0].value).to eq('home_phone')
+          expect(details[0].question).to eq(:person_email)
+          expect(details[0].value).to eq('email')
 
           expect(details[1]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[1].question).to eq(:person_mobile_phone)
-          expect(details[1].value).to eq('mobile_phone')
+          expect(details[1].question).to eq(:person_home_phone)
+          expect(details[1].value).to eq('home_phone')
 
           expect(details[2]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[2].question).to eq(:person_email)
-          expect(details[2].value).to eq('email')
+          expect(details[2].question).to eq(:person_mobile_phone)
+          expect(details[2].value).to eq('mobile_phone')
 
         expect(answers[5]).to be_an_instance_of(Answer)
         expect(answers[5].question).to eq(:relationship_to_child)

--- a/spec/presenters/summary/sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/applicants_details_spec.rb
@@ -23,7 +23,8 @@ module Summary
         residence_history: 'history',
         home_phone: 'home_phone',
         mobile_phone: 'mobile_phone',
-        email: 'email'
+        email: 'email',
+        voicemail_consent: 'yes',
       )
     }
 
@@ -76,7 +77,7 @@ module Summary
       end
 
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(14)
+        expect(answers.count).to eq(15)
       end
 
       it 'has the correct rows in the right order' do
@@ -117,23 +118,27 @@ module Summary
         expect(answers[8].value).to eq('history')
 
         expect(answers[9]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[9].question).to eq(:person_home_phone)
-        expect(answers[9].value).to eq('home_phone')
+        expect(answers[9].question).to eq(:person_email)
+        expect(answers[9].value).to eq('email')
 
         expect(answers[10]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[10].question).to eq(:person_mobile_phone)
-        expect(answers[10].value).to eq('mobile_phone')
+        expect(answers[10].question).to eq(:person_home_phone)
+        expect(answers[10].value).to eq('home_phone')
 
         expect(answers[11]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[11].question).to eq(:person_email)
-        expect(answers[11].value).to eq('email')
+        expect(answers[11].question).to eq(:person_mobile_phone)
+        expect(answers[11].value).to eq('mobile_phone')
 
-        expect(answers[12]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[12].question).to eq(:person_relationship_to_children)
-        expect(answers[12].value).to eq('relationships')
+        expect(answers[12]).to be_an_instance_of(Answer)
+        expect(answers[12].question).to eq(:person_voicemail_consent)
+        expect(answers[12].value).to eq('yes')
 
-        expect(answers[13]).to be_an_instance_of(Partial)
-        expect(answers[13].name).to eq(:row_blank_space)
+        expect(answers[13]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[13].question).to eq(:person_relationship_to_children)
+        expect(answers[13].value).to eq('relationships')
+
+        expect(answers[14]).to be_an_instance_of(Partial)
+        expect(answers[14].name).to eq(:row_blank_space)
       end
 
       context 'for existing previous name' do
@@ -141,7 +146,7 @@ module Summary
         let(:previous_name) { 'previous_name' }
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(14)
+          expect(answers.count).to eq(15)
         end
 
         it 'renders the previous name' do

--- a/spec/presenters/summary/sections/c1a_applicant_details_spec.rb
+++ b/spec/presenters/summary/sections/c1a_applicant_details_spec.rb
@@ -16,7 +16,8 @@ module Summary
         gender: 'female',
         home_phone: 'home_phone',
         mobile_phone: 'mobile_phone',
-        email: 'email'
+        email: 'email',
+        voicemail_consent: 'yes',
       )
     }
 
@@ -45,7 +46,7 @@ module Summary
       end
 
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(10)
+        expect(answers.count).to eq(11)
       end
 
       it 'has the correct rows in the right order' do
@@ -68,23 +69,27 @@ module Summary
         expect(answers[4].title).to eq(:contact_details)
 
         expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[5].question).to eq(:person_home_phone)
-        expect(answers[5].value).to eq('home_phone')
+        expect(answers[5].question).to eq(:person_email)
+        expect(answers[5].value).to eq('email')
 
         expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[6].question).to eq(:person_mobile_phone)
-        expect(answers[6].value).to eq('mobile_phone')
+        expect(answers[6].question).to eq(:person_home_phone)
+        expect(answers[6].value).to eq('home_phone')
 
         expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[7].question).to eq(:person_email)
-        expect(answers[7].value).to eq('email')
+        expect(answers[7].question).to eq(:person_mobile_phone)
+        expect(answers[7].value).to eq('mobile_phone')
 
-        expect(answers[8]).to be_an_instance_of(Partial)
-        expect(answers[8].name).to eq(:row_blank_space)
+        expect(answers[8]).to be_an_instance_of(Answer)
+        expect(answers[8].question).to eq(:person_voicemail_consent)
+        expect(answers[8].value).to eq('yes')
 
-        expect(answers[9]).to be_an_instance_of(Answer)
-        expect(answers[9].question).to eq(:c1a_address_confidentiality)
-        expect(answers[9].value).to eq(GenericYesNo::NO)
+        expect(answers[9]).to be_an_instance_of(Partial)
+        expect(answers[9].name).to eq(:row_blank_space)
+
+        expect(answers[10]).to be_an_instance_of(Answer)
+        expect(answers[10].question).to eq(:c1a_address_confidentiality)
+        expect(answers[10].value).to eq(GenericYesNo::NO)
       end
 
       context 'when no applicant present' do
@@ -103,25 +108,29 @@ module Summary
         end
 
         it 'has the correct number of rows' do
-          expect(answers.count).to eq(10)
+          expect(answers.count).to eq(11)
         end
 
         it 'hides the contact details' do
           expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[5].question).to eq(:person_home_phone)
+          expect(answers[5].question).to eq(:person_email)
           expect(answers[5].value).to eq('[See C8]')
 
           expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[6].question).to eq(:person_mobile_phone)
+          expect(answers[6].question).to eq(:person_home_phone)
           expect(answers[6].value).to eq('[See C8]')
 
           expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[7].question).to eq(:person_email)
+          expect(answers[7].question).to eq(:person_mobile_phone)
           expect(answers[7].value).to eq('[See C8]')
 
-          expect(answers[9]).to be_an_instance_of(Answer)
-          expect(answers[9].question).to eq(:c1a_address_confidentiality)
-          expect(answers[9].value).to eq('yes')
+          expect(answers[8]).to be_an_instance_of(Answer)
+          expect(answers[8].question).to eq(:person_voicemail_consent)
+          expect(answers[8].value).to eq('yes')
+
+          expect(answers[10]).to be_an_instance_of(Answer)
+          expect(answers[10].question).to eq(:c1a_address_confidentiality)
+          expect(answers[10].value).to eq('yes')
         end
       end
     end

--- a/spec/presenters/summary/sections/c8_applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/c8_applicants_details_spec.rb
@@ -15,7 +15,8 @@ module Summary
         residence_history: 'history',
         home_phone: 'home_phone',
         mobile_phone: 'mobile_phone',
-        email: 'email'
+        email: 'email',
+        voicemail_consent: 'yes',
       )
     }
 
@@ -48,7 +49,7 @@ module Summary
 
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(8)
+        expect(answers.count).to eq(9)
       end
 
       it 'has the correct rows in the right order' do
@@ -69,19 +70,23 @@ module Summary
         expect(answers[3].value).to eq('history')
 
         expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[4].question).to eq(:person_home_phone)
-        expect(answers[4].value).to eq('home_phone')
+        expect(answers[4].question).to eq(:person_email)
+        expect(answers[4].value).to eq('email')
 
         expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[5].question).to eq(:person_mobile_phone)
-        expect(answers[5].value).to eq('mobile_phone')
+        expect(answers[5].question).to eq(:person_home_phone)
+        expect(answers[5].value).to eq('home_phone')
 
         expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[6].question).to eq(:person_email)
-        expect(answers[6].value).to eq('email')
+        expect(answers[6].question).to eq(:person_mobile_phone)
+        expect(answers[6].value).to eq('mobile_phone')
 
-        expect(answers[7]).to be_an_instance_of(Partial)
-        expect(answers[7].name).to eq(:row_blank_space)
+        expect(answers[7]).to be_an_instance_of(Answer)
+        expect(answers[7].question).to eq(:person_voicemail_consent)
+        expect(answers[7].value).to eq('yes')
+
+        expect(answers[8]).to be_an_instance_of(Partial)
+        expect(answers[8].name).to eq(:row_blank_space)
       end
     end
   end

--- a/spec/presenters/summary/sections/c8_other_parties_details_spec.rb
+++ b/spec/presenters/summary/sections/c8_other_parties_details_spec.rb
@@ -23,6 +23,7 @@ module Summary
         home_phone: nil,
         mobile_phone: nil,
         email: nil,
+        voicemail_consent: nil,
       )
     }
 

--- a/spec/presenters/summary/sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/sections/other_parties_details_spec.rb
@@ -26,6 +26,7 @@ module Summary
         home_phone: nil,
         mobile_phone: nil,
         email: nil,
+        voicemail_consent: nil,
       )
     }
 

--- a/spec/presenters/summary/sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/sections/respondents_details_spec.rb
@@ -17,7 +17,8 @@ module Summary
         residence_history: 'history',
         home_phone: 'home_phone',
         mobile_phone: 'mobile_phone',
-        email: 'email'
+        email: 'email',
+        voicemail_consent: nil,
       )
     }
 
@@ -114,16 +115,16 @@ module Summary
         expect(answers[8].value).to eq('history')
 
         expect(answers[9]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[9].question).to eq(:person_home_phone)
-        expect(answers[9].value).to eq('home_phone')
+        expect(answers[9].question).to eq(:person_email)
+        expect(answers[9].value).to eq('email')
 
         expect(answers[10]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[10].question).to eq(:person_mobile_phone)
-        expect(answers[10].value).to eq('mobile_phone')
+        expect(answers[10].question).to eq(:person_home_phone)
+        expect(answers[10].value).to eq('home_phone')
 
         expect(answers[11]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[11].question).to eq(:person_email)
-        expect(answers[11].value).to eq('email')
+        expect(answers[11].question).to eq(:person_mobile_phone)
+        expect(answers[11].value).to eq('mobile_phone')
 
         expect(answers[12]).to be_an_instance_of(FreeTextAnswer)
         expect(answers[12].question).to eq(:person_relationship_to_children)


### PR DESCRIPTION
Individual commits for more details.

In the applicant contact details, we are going to ask a new question, whether they consent the court to leave a voicemail. This is a Yes/No question.

Updated the view to add this radio, as well as reorder the fields in both, applicant and respondent, moving the email field to the top.
Also updated the CYA page and the different PDFs.

<img width="634" alt="275a49f2e101d9110beab8e4bc057584" src="https://user-images.githubusercontent.com/687910/70606703-f7b49a80-1bf4-11ea-88f6-b4f2e19ab280.png">
