### PR TITLE
Small copy change to previous abduction

### DIFF
--- a/app/views/steps/abduction/previous_attempt_details/edit.html.erb
+++ b/app/views/steps/abduction/previous_attempt_details/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-      <%= f.text_area :previous_attempt_details, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.text_area :previous_attempt_details, size: '40x4', class: 'form-control-3-4', label_options: { class: 'visually-hidden' } %>
 
       <%=
         f.radio_button_fieldset :previous_attempt_agency_involved, inline: true do |fieldset|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -647,7 +647,7 @@ en:
           page_title: Previous abduction details
           section: Safety concerns
           heading: Provide details of the previous abductions
-          lead_text: Include any previous attempts or threats to abduct them
+          lead_text: Include any previous attempts or threats to abduct them.
       risk_details:
         edit:
           page_title: Abduction risk details
@@ -1210,7 +1210,7 @@ en:
         passport_possession_other: Other
         passport_possession_other_details: Provide more details
       steps_abduction_previous_attempt_details_form:
-        previous_attempt_details: Give a short description
+        previous_attempt_details: Give a short description of the previous abductions
         previous_attempt_agency_details: Provide more details
       steps_abduction_risk_details_form:
         risk_details: Briefly explain your concerns about abduction


### PR DESCRIPTION
This is to make this text area consistent with the one in the abduction risk details step.

We make the label visually hidden, but change the copy so screen readers know what this text area is about.

<img width="678" alt="Screen Shot 2019-12-11 at 10 15 23" src="https://user-images.githubusercontent.com/687910/70612630-2d5e8100-1bff-11ea-918b-dfbcb8d7a781.png">
