### PR TITLE
Tweak email routing rules

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -28,14 +28,14 @@ class Court
 
   def best_enquiries_email
     # There's no consistency to how courts list their email address descriptions,
-    # so we try to find the most suitable email address, by looking at the `description`
-    # or the `explanation` for each of the emails, or the actual email address,
+    # so we try to find the most suitable email address, by looking at the `explanation`
+    # or the `description` for each of the emails, or the actual email address,
     # and if none is found, as a last resort we try to find an email address containing
     # the `enquiries` word and if still nothing is found, we pick the first entry.
     #
     emails = retrieve_emails_from_api
-    best = best_match_for(emails, 'description') ||
-           best_match_for(emails, 'explanation') ||
+    best = best_match_for(emails, 'explanation') ||
+           best_match_for(emails, 'description') ||
            best_match_for(emails, 'address') ||
            fallback_address(emails)
 
@@ -52,8 +52,8 @@ class Court
   private
 
   def best_match_for(emails, node)
-    emails.find { |e| e[node] =~ /children/i }           || \
-      emails.find { |e| e[node] =~ /\Aapplications\z/i } || \
+    emails.find { |e| e[node] =~ /children/i }       || \
+      emails.find { |e| e[node] =~ /applications/i } || \
       emails.find { |e| e[node] =~ /family/i }
   end
 

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -255,6 +255,46 @@ describe Court do
         end
       end
 
+      context 'containing an email with description matching "applications" and another with explanation matching "family"' do
+        let(:emails) {
+          [
+            {
+              'description' => 'Applications',
+              'address' => 'applications@email'
+            },
+            {
+              'description' => 'Anything',
+              'explanation' => 'Family',
+              'address' => 'email@example',
+            },
+          ]
+        }
+
+        it 'returns the email address of the matching explanation' do
+          expect(subject.best_enquiries_email).to eq('email@example')
+        end
+      end
+
+      context 'containing an email with description matching "applications"' do
+        let(:emails) {
+          [
+            {
+              'description' => 'Anything',
+              'explanation' => 'other queries',
+              'address' => 'email@example',
+            },
+            {
+              'description' => 'C100 applications',
+              'address' => 'c100@email'
+            }
+          ]
+        }
+
+        it 'returns the email address of the matching explanation' do
+          expect(subject.best_enquiries_email).to eq('c100@email')
+        end
+      end
+
       context 'containing an email with explanation matching "family" but also enquiries' do
         let(:emails){
           [


### PR DESCRIPTION
We raise the priority of the explanation over the description, and remove the strict regex for the "applications" word so it can be matched anywhere.

This will fix the issue with Derby court emails being sent to an incorrect address, without introducing any change for the rest of courts.