### PR TITLE
Add application lookup functionality to back office

### DIFF
--- a/app/controllers/backoffice/dashboard_controller.rb
+++ b/app/controllers/backoffice/dashboard_controller.rb
@@ -5,5 +5,10 @@ module Backoffice
     def index
       @report = CompletedApplicationsAudit.unscoped.order(completed_at: :desc).limit(50)
     end
+
+    def lookup
+      @reference_code = params[:reference_code]
+      @report = CompletedApplicationsAudit.where(reference_code: @reference_code)
+    end
   end
 end

--- a/app/views/backoffice/dashboard/_lookup_form.en.html.erb
+++ b/app/views/backoffice/dashboard/_lookup_form.en.html.erb
@@ -1,0 +1,8 @@
+<p class="heading-medium">
+  Lookup an application by reference code
+</p>
+
+<%= form_with(url: lookup_backoffice_dashboard_index_path, local: true) do |f| %>
+  <%= f.text_field :reference_code, class: 'narrow', value: @reference_code %>
+  <%= f.submit 'Lookup application', class: 'button' %>
+<% end %>

--- a/app/views/backoffice/dashboard/_results_table.en.html.erb
+++ b/app/views/backoffice/dashboard/_results_table.en.html.erb
@@ -1,0 +1,22 @@
+<table class="backoffice-table">
+  <thead>
+    <tr>
+      <th>Completed at</th>
+      <th>Reference</th>
+      <th>Type</th>
+      <th>Payment</th>
+      <th>Postcode</th>
+      <th>Saved</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% if report.any? %>
+      <%= render partial: 'completion', collection: report, as: :completion %>
+    <% else %>
+      <tr>
+        <td colspan="6">No applications were found</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/backoffice/dashboard/lookup.en.html.erb
+++ b/app/views/backoffice/dashboard/lookup.en.html.erb
@@ -4,10 +4,10 @@
   <div class="column-full">
     <h1 class="heading-xlarge gv-u-heading-xxlarge">Back office: applications</h1>
 
-    <%= render partial: 'lookup_form' %>
+    <%= render partial: 'lookup_form', locals: { reference_code: @reference_code } %>
 
     <p class="heading-medium">
-      Last 50 completed applications
+      Results
     </p>
 
     <%= render partial: 'results_table', locals: { report: @report } %>

--- a/app/views/backoffice/shared/_menu.en.html.erb
+++ b/app/views/backoffice/shared/_menu.en.html.erb
@@ -1,7 +1,7 @@
 <nav id="proposition-menu">
   <ul id="proposition-links" aria-label="Top Level Navigation">
     <li>
-      <%= link_to_unless_current 'Dashboard', backoffice_dashboard_index_path %>
+      <%= link_to_unless_current 'Applications', backoffice_dashboard_index_path %>
     </li>
     <li>
       <%= link_to_unless_current 'Emails', backoffice_emails_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,10 @@ Rails.application.routes.draw do
     end
 
     # Auth0-protected routes
-    resources :dashboard, only: [:index]
+    resources :dashboard, only: [:index] do
+      post :lookup, on: :collection
+    end
+
     resources :emails, only: [:index] do
       put :resend
     end

--- a/features/screener.feature
+++ b/features/screener.feature
@@ -33,7 +33,7 @@ Feature: Screener
     Given I click the "Check eligibility" link
 
     Then I should see "Where do the children live?"
-    And I fill in "Postcode" with "TN17 4EA"
+    And I fill in "Postcode" with "ZE2 9TE"
     And I click the "Continue" button
 
     Then I should see "Sorry, you cannot apply online"


### PR DESCRIPTION
A simple way of searching a completed application, given its reference code.

Only exact matches will be returned (in essence only one result as reference codes are unique).

Refactor the views to DRY the markup and results table.

<img width="1008" alt="Screen Shot 2019-12-12 at 15 41 21" src="https://user-images.githubusercontent.com/687910/70726369-e30bfb80-1cf5-11ea-93b8-a3baa54ff7ff.png">
