### PR TITLE
Add sent emails lookup functionality to back office

### DIFF
--- a/app/controllers/backoffice/emails_controller.rb
+++ b/app/controllers/backoffice/emails_controller.rb
@@ -6,6 +6,13 @@ module Backoffice
       @report = Reports::FailedEmailsReport.list
     end
 
+    def lookup
+      @reference_code = params[:reference_code]
+      @email_address  = params[:email_address]
+
+      @report = EmailSubmissionsAudit.find_records(@reference_code, @email_address)
+    end
+
     def resend
       email = EmailSubmission.find(params[:email_id])
       email.resend!(type: params[:type])

--- a/app/models/email_submissions_audit.rb
+++ b/app/models/email_submissions_audit.rb
@@ -20,7 +20,7 @@ class EmailSubmissionsAudit < ApplicationRecord
     #
     # :nocov:
     def find_records(reference, email = nil)
-      EmailSubmissionsAudit.where(reference: reference).select do |record|
+      EmailSubmissionsAudit.where(reference: %W[user;#{reference} court;#{reference}]).select do |record|
         email.blank? || BCrypt::Password.new(record.to) == email
       end
     end

--- a/app/views/backoffice/emails/_lookup_form.en.html.erb
+++ b/app/views/backoffice/emails/_lookup_form.en.html.erb
@@ -1,0 +1,16 @@
+<p class="heading-medium">
+  Lookup sent emails (last 90 days)
+</p>
+
+<div class="govuk-govspeak gv-s-prose">
+  <p>
+    The reference code is mandatory. Email is optional and can be the email of the applicant, if they chose to receive a
+    copy of the application, or the email of the court where the application was sent.
+  </p>
+</div>
+
+<%= form_with(url: lookup_backoffice_emails_path, local: true) do |f| %>
+  <%= f.text_field :reference_code, class: 'narrow', value: @reference_code %>
+  <%= f.text_field :email_address, class: 'narrow', value: @email_address %>
+  <%= f.submit 'Lookup emails', class: 'button' %>
+<% end %>

--- a/app/views/backoffice/emails/_results_table.en.html.erb
+++ b/app/views/backoffice/emails/_results_table.en.html.erb
@@ -1,0 +1,7 @@
+<tr>
+  <td valign="middle"><%= result.reference %></td>
+  <td valign="middle"><%= result.created_at %></td>
+  <td valign="middle"><%= result.sent_at %></td>
+  <td valign="middle"><%= result.completed_at %></td>
+  <td valign="middle"><%= result.status %></td>
+</tr>

--- a/app/views/backoffice/emails/index.en.html.erb
+++ b/app/views/backoffice/emails/index.en.html.erb
@@ -4,6 +4,12 @@
   <div class="column-full">
     <h1 class="heading-xlarge gv-u-heading-xxlarge">Back office: emails</h1>
 
+    <%= render partial: 'lookup_form' %>
+
+    <p class="heading-medium">
+      Failed emails
+    </p>
+
     <div class="govuk-govspeak gv-s-prose">
       <p>
         This is a report of any failed submission emails (court or applicant confirmation), in the last 7 days.

--- a/app/views/backoffice/emails/lookup.en.html.erb
+++ b/app/views/backoffice/emails/lookup.en.html.erb
@@ -1,0 +1,31 @@
+<% title 'Back office: emails' %>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Back office: emails</h1>
+
+    <%= render partial: 'lookup_form', locals: { reference_code: @reference_code, email_address: @email_address } %>
+
+    <table class="backoffice-table">
+      <thead>
+        <tr>
+          <th>Reference</th>
+          <th>Created at</th>
+          <th>Sent at</th>
+          <th>Completed at</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% if @report.any? %>
+          <%= render partial: 'results_table', collection: @report, as: :result %>
+        <% else %>
+          <tr>
+            <td colspan="6">No emails were found</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
     end
 
     resources :emails, only: [:index] do
+      post :lookup, on: :collection
       put :resend
     end
   end


### PR DESCRIPTION
A simple way of searching sent emails, given the application reference code and, optionally, the email address where the application was sent.

Only exact matches will be returned.

<img width="1013" alt="Screen Shot 2019-12-16 at 08 54 14" src="https://user-images.githubusercontent.com/687910/70895905-aab33880-1fe7-11ea-93f7-db0358ba0fc3.png">
