### PR TITLE
Add back office audit records list page

### DIFF
--- a/app/controllers/backoffice/audit_controller.rb
+++ b/app/controllers/backoffice/audit_controller.rb
@@ -1,0 +1,13 @@
+module Backoffice
+  class AuditController < Backoffice::ApplicationController
+    include Auth0Secured
+
+    AUDIT_TIME_PERIOD ||= 30.days
+
+    def index
+      @report = BackofficeAuditRecord.where(
+        'created_at >= :date', date: Time.current - AUDIT_TIME_PERIOD
+      ).order(created_at: :desc)
+    end
+  end
+end

--- a/app/controllers/backoffice/auth0_controller.rb
+++ b/app/controllers/backoffice/auth0_controller.rb
@@ -5,7 +5,9 @@ module Backoffice
     end
 
     def logout
+      BackofficeAuditRecord.log!(author: helpers.admin_name, action: :logout)
       session.delete(:backoffice_userinfo)
+
       redirect_to helpers.admin_logout_url
     end
 

--- a/app/models/backoffice_audit_record.rb
+++ b/app/models/backoffice_audit_record.rb
@@ -1,4 +1,13 @@
 class BackofficeAuditRecord < ApplicationRecord
+  # Do not remove or rename any of these to ensure the audit trail
+  # is maintained. Only add new actions when needed.
+  #
+  enum action: {
+    login: 'login',
+    logout: 'logout',
+    forbidden: 'forbidden',
+  }
+
   def self.log!(author:, action:, details: {})
     create(
       author: author,

--- a/app/models/backoffice_audit_record.rb
+++ b/app/models/backoffice_audit_record.rb
@@ -1,0 +1,9 @@
+class BackofficeAuditRecord < ApplicationRecord
+  def self.log!(author:, action:, details: {})
+    create(
+      author: author,
+      action: action,
+      details: details
+    )
+  end
+end

--- a/app/views/backoffice/audit/_record.en.html.erb
+++ b/app/views/backoffice/audit/_record.en.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td valign="middle" width="200"><%= record.created_at %></td>
+  <td valign="middle" width="350"><%= record.author %></td>
+  <td valign="middle" width="150"><%= record.action.upcase %></td>
+  <td valign="middle"><%= record.details %></td>
+</tr>

--- a/app/views/backoffice/audit/index.en.html.erb
+++ b/app/views/backoffice/audit/index.en.html.erb
@@ -1,0 +1,32 @@
+<% title 'Back office: audit records' %>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Back office: audit records</h1>
+
+    <p class="heading-medium">
+      Actions performed in the last 30 days
+    </p>
+
+    <table class="backoffice-table">
+      <thead>
+        <tr>
+          <th>Timestamp</th>
+          <th>Author</th>
+          <th>Action</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% if @report.any? %>
+          <%= render partial: 'record', collection: @report, as: :record %>
+        <% else %>
+          <tr>
+            <td colspan="4">No records were found in the time period</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/backoffice/emails/lookup.en.html.erb
+++ b/app/views/backoffice/emails/lookup.en.html.erb
@@ -22,7 +22,7 @@
           <%= render partial: 'results_table', collection: @report, as: :result %>
         <% else %>
           <tr>
-            <td colspan="6">No emails were found</td>
+            <td colspan="5">No emails were found</td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/backoffice/shared/_menu.en.html.erb
+++ b/app/views/backoffice/shared/_menu.en.html.erb
@@ -6,8 +6,11 @@
     <li>
       <%= link_to_unless_current 'Emails', backoffice_emails_path %>
     </li>
+    <li>
+      <%= link_to_unless_current 'Audit', backoffice_audit_index_path %>
+    </li>
     <li class="util_ml-medium">
-      <%= link_to 'Logout', backoffice_auth0_logout_path, method: :delete, data: { confirm: 'Are you sure?' } %> (<%= admin_name %>)
+      <%= link_to 'Logout', backoffice_auth0_logout_path, method: :delete %> (<%= admin_name %>)
     </li>
   </ul>
 </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do
       post :lookup, on: :collection
       put :resend
     end
+
+    resources :audit, only: [:index]
   end
 
   devise_for :users,

--- a/db/migrate/20191218120550_create_backoffice_audit_records_table.rb
+++ b/db/migrate/20191218120550_create_backoffice_audit_records_table.rb
@@ -1,0 +1,13 @@
+class CreateBackofficeAuditRecordsTable < ActiveRecord::Migration[5.2]
+  def change
+    # we do not need this field in the backoffice_users table
+    remove_column :backoffice_users, :user_id, :string
+
+    create_table :backoffice_audit_records, id: :uuid do |t|
+      t.datetime :created_at, null: false
+      t.string :author, null: false, index: true
+      t.string :action, null: false
+      t.json :details, default: {}
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_09_103137) do
+ActiveRecord::Schema.define(version: 2019_12_18_120550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -53,9 +53,16 @@ ActiveRecord::Schema.define(version: 2019_12_09_103137) do
     t.index ["c100_application_id"], name: "index_abuse_concerns_on_c100_application_id"
   end
 
+  create_table "backoffice_audit_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "author", null: false
+    t.string "action", null: false
+    t.json "details", default: {}
+    t.index ["author"], name: "index_backoffice_audit_records_on_author"
+  end
+
   create_table "backoffice_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", null: false
-    t.string "user_id"
     t.boolean "active", default: true
     t.integer "logins_count", default: 0
     t.datetime "current_login_at"


### PR DESCRIPTION
A DB table will hold the information of the actions performed in the back office.

As part of this first PR only logins/forbidden actions are logged.

Individual commits with more details.