### PR TITLE
Implement more audit records in back office

### DIFF
--- a/app/assets/stylesheets/local/app/backoffice.scss
+++ b/app/assets/stylesheets/local/app/backoffice.scss
@@ -2,6 +2,9 @@ table.backoffice-table {
   td {
     font-size: 85%;
   }
+  td.xsmall {
+    font-size: 75%;
+  }
   td.no-border {
     border: 0;
   }

--- a/app/controllers/backoffice/application_controller.rb
+++ b/app/controllers/backoffice/application_controller.rb
@@ -13,6 +13,12 @@ module Backoffice
 
     private
 
+    def audit!(args)
+      BackofficeAuditRecord.log!(
+        { author: helpers.admin_name }.merge(args)
+      )
+    end
+
     # This is required to get request attributes in to the production logs.
     # See the various lograge configurations in `production.rb`.
     def append_info_to_payload(payload)

--- a/app/controllers/backoffice/auth0_controller.rb
+++ b/app/controllers/backoffice/auth0_controller.rb
@@ -5,7 +5,7 @@ module Backoffice
     end
 
     def logout
-      BackofficeAuditRecord.log!(author: helpers.admin_name, action: :logout)
+      audit!(action: :logout)
       session.delete(:backoffice_userinfo)
 
       redirect_to helpers.admin_logout_url

--- a/app/controllers/backoffice/dashboard_controller.rb
+++ b/app/controllers/backoffice/dashboard_controller.rb
@@ -9,6 +9,11 @@ module Backoffice
     def lookup
       @reference_code = params[:reference_code]
       @report = CompletedApplicationsAudit.where(reference_code: @reference_code)
+
+      audit!(
+        action: :application_lookup,
+        details: { reference_code: @reference_code, found: @report.size }
+      )
     end
   end
 end

--- a/app/controllers/backoffice/emails_controller.rb
+++ b/app/controllers/backoffice/emails_controller.rb
@@ -11,15 +11,39 @@ module Backoffice
       @email_address  = params[:email_address]
 
       @report = EmailSubmissionsAudit.find_records(@reference_code, @email_address)
+
+      audit!(
+        action: :email_lookup,
+        details: { reference_code: @reference_code, email_address: @email_address, found: @report.size }
+      )
     end
 
     def resend
       email = EmailSubmission.find(params[:email_id])
-      email.resend!(type: params[:type])
+      type  = params[:type]
+
+      email.resend!(type: type)
+      audit_resend(email, resend_type: type)
 
       redirect_to backoffice_emails_path, flash: {
         alert: 'Email resend in progress. Please reload the page in a few seconds.'
       }
+    end
+
+    private
+
+    def audit_resend(email, resend_type:)
+      details = {
+        reference_code: email.c100_application.reference_code
+      }
+
+      if resend_type == 'court'
+        details.merge!(recipient: email.to_address)
+      elsif resend_type == 'user'
+        details.merge!(recipient: email.email_copy_to)
+      end
+
+      audit!(action: :resend_email, details: details)
     end
   end
 end

--- a/app/controllers/backoffice/users_controller.rb
+++ b/app/controllers/backoffice/users_controller.rb
@@ -28,11 +28,11 @@ module Backoffice
       user.current_login_at = Time.now.utc
       user.save
 
-      BackofficeAuditRecord.log!(author: user.email, action: :login)
+      audit!(author: user.email, action: :login)
     end
 
     def process_forbidden(email)
-      BackofficeAuditRecord.log!(author: email, action: :forbidden)
+      audit!(author: email, action: :forbidden)
     end
 
     def authenticate

--- a/app/models/backoffice_audit_record.rb
+++ b/app/models/backoffice_audit_record.rb
@@ -6,6 +6,9 @@ class BackofficeAuditRecord < ApplicationRecord
     login: 'login',
     logout: 'logout',
     forbidden: 'forbidden',
+    application_lookup: 'application_lookup',
+    email_lookup: 'email_lookup',
+    resend_email: 'resend_email',
   }
 
   def self.log!(author:, action:, details: {})

--- a/app/views/backoffice/audit/_record.en.html.erb
+++ b/app/views/backoffice/audit/_record.en.html.erb
@@ -1,6 +1,22 @@
 <tr>
-  <td valign="middle" width="200"><%= record.created_at %></td>
-  <td valign="middle" width="350"><%= record.author %></td>
-  <td valign="middle" width="150"><%= record.action.upcase %></td>
-  <td valign="middle"><%= record.details %></td>
+  <td valign="middle" width="220"><%= record.created_at %></td>
+  <td valign="middle" width="200"><%= record.action.upcase %></td>
+  <td valign="middle"><%= record.author %></td>
 </tr>
+
+<% if record.details.present? %>
+  <tr>
+    <td valign="middle" colspan="3" class="xsmall no-border">
+      <details data-block-name="audit-details">
+        <summary>
+          <span class="summary">
+            show details
+          </span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <%= record.details %>
+        </div>
+      </details>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/backoffice/audit/index.en.html.erb
+++ b/app/views/backoffice/audit/index.en.html.erb
@@ -12,9 +12,8 @@
       <thead>
         <tr>
           <th>Timestamp</th>
-          <th>Author</th>
           <th>Action</th>
-          <th>Details</th>
+          <th>Author</th>
         </tr>
       </thead>
 
@@ -23,7 +22,7 @@
           <%= render partial: 'record', collection: @report, as: :record %>
         <% else %>
           <tr>
-            <td colspan="4">No records were found in the time period</td>
+            <td colspan="3">No records were found in the time period</td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/backoffice/emails/_failure.en.html.erb
+++ b/app/views/backoffice/emails/_failure.en.html.erb
@@ -4,7 +4,7 @@
   <td valign="middle"><%= failure.type %></td>
   <td valign="middle"><%= failure.error %></td>
   <td valign="middle">
-    <%= button_to 'Resend email', backoffice_email_resend_path(failure.record, type: failure.type), method: :put, data: { confirm: 'Are you sure' }, class: 'button' %>
+    <%= button_to 'Resend email', backoffice_email_resend_path(failure.record, type: failure.type), method: :put, data: { confirm: 'Are you sure?' }, class: 'button' %>
   </td>
 </tr>
 


### PR DESCRIPTION
All actions in the back office will now produce an audit record, some of them with additional details for further analysis.

Tweaked a bit the layout of the table, and refactored the call to the `BackofficeAuditRecord.log!` method to DRY.