### PR TITLE
Fix nil when there is no back office session yet

### DIFF
--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -4,7 +4,7 @@ module Auth0Helper
   end
 
   def admin_name
-    session[:backoffice_userinfo].dig('info', 'name')
+    session[:backoffice_userinfo].dig('info', 'name') if admin_signed_in?
   end
 
   def admin_auth_url


### PR DESCRIPTION
If we don't have a session yet, the method `#admin_name` should just return nil, instead of blowing up.