### PR TITLE
Add new page to back office to list admin users

### DIFF
--- a/app/controllers/backoffice/users_controller.rb
+++ b/app/controllers/backoffice/users_controller.rb
@@ -1,6 +1,13 @@
 module Backoffice
   class UsersController < Backoffice::ApplicationController
+    include Auth0Secured
+
+    skip_before_action :logged_in_using_omniauth?, only: [:exists]
     before_action :authenticate, only: [:exists]
+
+    def index
+      @admins = BackofficeUser.active
+    end
 
     # This endpoint is used by an Auth0 rule to ensure the user signin-in to the
     # backoffice have been granted access.

--- a/app/views/backoffice/shared/_menu.en.html.erb
+++ b/app/views/backoffice/shared/_menu.en.html.erb
@@ -9,6 +9,9 @@
     <li>
       <%= link_to_unless_current 'Audit', backoffice_audit_index_path %>
     </li>
+    <li>
+      <%= link_to_unless_current 'Users', backoffice_users_path %>
+    </li>
     <li class="util_ml-medium">
       <%= link_to 'Logout', backoffice_auth0_logout_path, method: :delete %> (<%= admin_name %>)
     </li>

--- a/app/views/backoffice/users/_admin_user.en.html.erb
+++ b/app/views/backoffice/users/_admin_user.en.html.erb
@@ -1,0 +1,5 @@
+<tr>
+  <td valign="middle"><%= admin.email %></td>
+  <td valign="middle"><%= admin.last_login_at || 'never' %></td>
+  <td valign="middle"><%= admin.current_login_at || 'never' %></td>
+</tr>

--- a/app/views/backoffice/users/index.en.html.erb
+++ b/app/views/backoffice/users/index.en.html.erb
@@ -1,0 +1,31 @@
+<% title 'Back office: admin users' %>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h1 class="heading-xlarge gv-u-heading-xxlarge">Back office: admin users</h1>
+
+    <p class="heading-medium">
+      Users with access to the back office
+    </p>
+
+    <div class="govuk-govspeak gv-s-prose">
+      <p>
+        Contact a developer with access to the service in order to add/remove access.
+      </p>
+    </div>
+
+    <table class="backoffice-table">
+      <thead>
+      <tr>
+        <th>Email</th>
+        <th>Last login at</th>
+        <th>Current login at</th>
+      </tr>
+      </thead>
+
+      <tbody>
+      <%= render partial: 'admin_user', collection: @admins, as: :admin %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
       delete :logout
     end
 
-    resources :users, only: [] do
+    resources :users, only: [:index] do
       get :exists, on: :member, constraints: { id: /[^\/]+/ }
     end
 


### PR DESCRIPTION
This only list the active admin users and some other details. It is not (just yet) a CRUD, maybe it will never be.

Exposed a new link in the menu bar.