### PR TITLE
Restore old solicitor's journey, with feature flag

### DIFF
--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -18,9 +18,8 @@ module C100App
         edit_contact_details
       when :contact_details
         after_contact_details
-      # TODO: the solicitor details steps are not enabled currently
-      # when :has_solicitor
-      #   after_has_solicitor
+      when :has_solicitor
+        after_has_solicitor
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
@@ -31,21 +30,28 @@ module C100App
     def after_contact_details
       if next_applicant_id
         edit(:personal_details, id: next_applicant_id)
+      elsif show_solicitor_journey?
+        edit(:has_solicitor)
       else
         edit('/steps/respondent/names')
       end
     end
 
-    # def after_has_solicitor
-    #   if question(:has_solicitor).yes?
-    #     edit('/steps/solicitor/personal_details')
-    #   else
-    #     edit('/steps/respondent/names')
-    #   end
-    # end
+    def after_has_solicitor
+      if question(:has_solicitor).yes?
+        edit('/steps/solicitor/personal_details')
+      else
+        edit('/steps/respondent/names')
+      end
+    end
 
     def next_applicant_id
       next_record_id(c100_application.applicant_ids)
+    end
+
+    # TODO: change this to use `version >= 4` when releasing to production
+    def show_solicitor_journey?
+      dev_tools_enabled?
     end
   end
 end

--- a/app/views/steps/application/payment/edit.html.erb
+++ b/app/views/steps/application/payment/edit.html.erb
@@ -13,6 +13,7 @@
         f.radio_button_fieldset :payment_type, legend_options: { class: 'visually-hidden', text: t('.heading') } do |fieldset|
           fieldset.radio_input(PaymentType::SELF_PAYMENT_CARD)
           fieldset.radio_input(PaymentType::SELF_PAYMENT_CHEQUE)
+          fieldset.radio_input(PaymentType::SOLICITOR) { f.text_field :solicitor_account_number, class: 'narrow' } if dev_tools_enabled?
           fieldset.radio_input(PaymentType::HELP_WITH_FEES) { f.text_field :hwf_reference_number, class: 'narrow' }
         end
       %>

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -560,6 +560,8 @@ en:
           attributes:
             payment_type:
               inclusion: Select how you’ll pay
+            solicitor_account_number:
+              blank: Enter your solicitor’s fee account number
             hwf_reference_number:
               invalid: Enter a valid ‘Help with fees’ reference number
               blank: Enter your ‘Help with fees’ reference number

--- a/db/migrate/20200109113022_add_unique_index_to_solicitors.rb
+++ b/db/migrate/20200109113022_add_unique_index_to_solicitors.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToSolicitors < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :solicitors, :c100_application_id
+    add_index    :solicitors, :c100_application_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_18_120550) do
+ActiveRecord::Schema.define(version: 2020_01_09_113022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -339,7 +339,7 @@ ActiveRecord::Schema.define(version: 2019_12_18_120550) do
     t.string "fax_number"
     t.string "email"
     t.uuid "c100_application_id"
-    t.index ["c100_application_id"], name: "index_solicitors_on_c100_application_id"
+    t.index ["c100_application_id"], name: "index_solicitors_on_c100_application_id", unique: true
   end
 
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -114,27 +114,50 @@ RSpec.describe C100App::ApplicantDecisionTree do
 
     context 'when all applicants have been edited' do
       let(:record) { double('Applicant', id: 3) }
-      it {is_expected.to have_destination('/steps/respondent/names', :edit)}
+
+      let(:dev_tools_enabled) { 'false' }
+      let(:development_env) { true }
+
+      before do
+        allow(ENV).to receive(:[]).with('DEV_TOOLS_ENABLED').and_return(dev_tools_enabled)
+        allow(Rails.env).to receive(:development?).and_return(development_env)
+      end
+
+      context 'on development environments' do
+        it { is_expected.to have_destination(:has_solicitor, :edit) }
+      end
+
+      context 'on production environments with DEV_TOOLS_ENABLED' do
+        let(:dev_tools_enabled) { 'true' }
+        let(:development_env) { false }
+
+        it { is_expected.to have_destination(:has_solicitor, :edit) }
+      end
+
+      context 'on production environments without DEV_TOOLS_ENABLED' do
+        let(:dev_tools_enabled) { 'false' }
+        let(:development_env) { false }
+
+        it { is_expected.to have_destination('/steps/respondent/names', :edit) }
+      end
     end
   end
 
+  context 'when the step is `has_solicitor`' do
+    let(:step_params) { { has_solicitor: 'anything' } }
 
-  # TODO: the solicitor's details steps are not enabled currently
-  # context 'when the step is `has_solicitor`' do
-  #   let(:step_params) { { has_solicitor: 'anything' } }
-  #
-  #   before do
-  #     allow(c100_application).to receive(:has_solicitor).and_return(value)
-  #   end
-  #
-  #   context 'and the answer is `yes`' do
-  #     let(:value) { 'yes' }
-  #     it { is_expected.to have_destination('/steps/solicitor/personal_details', :edit) }
-  #   end
-  #
-  #   context 'and the answer is `no`' do
-  #     let(:value) { 'no' }
-  #     it { is_expected.to have_destination('/steps/respondent/names', :edit) }
-  #   end
-  # end
+    before do
+      allow(c100_application).to receive(:has_solicitor).and_return(value)
+    end
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+      it { is_expected.to have_destination('/steps/solicitor/personal_details', :edit) }
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+      it { is_expected.to have_destination('/steps/respondent/names', :edit) }
+    end
+  end
 end


### PR DESCRIPTION
We had most of the code for the solicitor's journey commented out.

We are going to start development on this, but first, we are enabling the parts that we had completed, but we are using a feature flag so only show in local and staging environments.

Once we have this ready for release, we will change the feature flag to use the `version` attribute of the C100 Application record so new applications show the solicitor question but existing in progress, or saved applications, don't.

Copy TBD.