### PR TITLE
Update Southend court slugs

### DIFF
--- a/config/court_slugs.yml
+++ b/config/court_slugs.yml
@@ -42,7 +42,8 @@
 - central-family-court
 - clerkenwell-and-shoreditch-county-court-and-family-court
 - bury-st-edmunds-county-court-and-family-court
-- southend-magistrates-court-and-family-court
+- southend-county-court-and-family-court
+- southend-magistrates-court
 - taunton-crown-county-and-family-court
 - yeovil-county-family-and-magistrates-court
 - norwich-combined-court-centre

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe C100App::CourtPostcodeChecker do
   describe 'COURT_SLUGS_USING_THIS_APP' do
     it 'returns the expected number' do
-      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(104)
+      expect(described_class::COURT_SLUGS_USING_THIS_APP.size).to eq(105)
     end
   end
 


### PR DESCRIPTION
The old slug has been split into 2 different court tribunal pages
and thus we now have 2 new slugs.