### PR TITLE
Refactor the failed emails report notification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ SESSION_WARNING_WHEN_REMAINING=5
 GOVUK_NOTIFY_API_KEY=notify-api-key
 GOVUK_NOTIFY_BEARER_TOKEN=notify-callback-token
 
+# Set this variable on production environments to receive alerts when
+# completion emails fail to be sent (court emails only).
+# SEND_FAILED_EMAILS_REPORT=1
+
 # By default, if this env variable is not set, we use MemoryStore
 # URI format: redis://[:password@]host[:port][/database]
 #

--- a/app/controllers/backoffice/dashboard_controller.rb
+++ b/app/controllers/backoffice/dashboard_controller.rb
@@ -7,7 +7,7 @@ module Backoffice
     end
 
     def lookup
-      @reference_code = params[:reference_code]
+      @reference_code = params[:reference_code]&.strip
       @report = CompletedApplicationsAudit.where(reference_code: @reference_code)
 
       audit!(

--- a/app/controllers/backoffice/emails_controller.rb
+++ b/app/controllers/backoffice/emails_controller.rb
@@ -7,8 +7,8 @@ module Backoffice
     end
 
     def lookup
-      @reference_code = params[:reference_code]
-      @email_address  = params[:email_address]
+      @reference_code = params[:reference_code]&.strip
+      @email_address  = params[:email_address]&.strip
 
       @report = EmailSubmissionsAudit.find_records(@reference_code, @email_address)
 

--- a/app/mailers/reports_mailer.rb
+++ b/app/mailers/reports_mailer.rb
@@ -2,15 +2,10 @@ class ReportsMailer < NotifyMailer
   #
   # Internal reports to be sent by email. Triggered by `daily_tasks`.
   #
-  def failed_emails_report(report_content)
+  def failed_emails_report(report_content, to_address:)
     set_template(:failed_emails_report)
     set_personalisation(report_content: report_content)
 
-    # Unset the env variable to stop the emails (for example
-    # on staging we don't want these emails, only on production)
-    recipient = ENV['FAILED_EMAILS_REPORT_RECIPIENT']
-    return if recipient.nil?
-
-    mail to: recipient
+    mail to: to_address
   end
 end

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -10,51 +10,49 @@
 
   <tr>
     <td valign="middle" colspan="4" class="no-border">
-      <details data-block-name="application-extra-details">
-        <summary>
-          <span class="summary">
-            show details
-          </span>
-        </summary>
-        <div class="panel panel-border-narrow application-extra-details">
-          <table>
-            <tr>
-              <td width="300" class="no-border">
-                <dl>
-                  <dt>Application started at</dt>
-                  <dd><%= completion.started_at %></dd>
-                  <dt>Saved for later?</dt>
-                  <dd><%= completion.metadata['saved_for_later'] %></dd>
-                  <dt>Payment type</dt>
-                  <dd><%= completion.metadata['payment_type'] || 'N/A' %></dd>
-                  <dt>Legal representation</dt>
-                  <dd><%= completion.metadata['legal_representation'] || 'N/A' %></dd>
-                  <dt>Urgent hearing?</dt>
-                  <dd><%= completion.metadata['urgent_hearing'] || 'N/A' %></dd>
-                  <dt>Without notice hearing?</dt>
-                  <dd><%= completion.metadata['without_notice'] || 'N/A' %></dd>
-                </dl>
-              </td>
-              <td class="no-border">
-                <dl>
-                  <dt>Postcode</dt>
-                  <dd><%= completion.metadata['postcode'] %></dd>
-                  <dt>C1A form?</dt>
-                  <dd><%= completion.metadata['c1a_form'] %></dd>
-                  <dt>C8 form?</dt>
-                  <dd><%= completion.metadata['c8_form'] %></dd>
-                  <% if c100 %>
-                    <dt>Court receipt email address</dt>
-                    <dd><%= c100.screener_answers_court.email %> | <%= link_to 'web', C100App::CourtfinderAPI.new.court_url(c100.screener_answers_court.slug), rel: 'external', target: '_blank' %></dd>
-                    <dt>Applicant receipt email address</dt>
-                    <dd><%= c100.receipt_email || 'none' %></dd>
-                  <% end %>
-                </dl>
-              </td>
-            </tr>
-          </table>
-        </div>
-      </details>
+      <div class="panel panel-border-narrow application-extra-details">
+        <table>
+          <tr>
+            <td width="300" class="no-border">
+              <dl>
+                <dt>Application started at</dt>
+                <dd><%= completion.started_at %></dd>
+                <dt>Saved for later?</dt>
+                <dd><%= completion.metadata['saved_for_later'] %></dd>
+                <dt>Payment type</dt>
+                <dd><%= completion.metadata['payment_type'] || 'N/A' %></dd>
+                <dt>Legal representation</dt>
+                <dd><%= completion.metadata['legal_representation'] || 'N/A' %></dd>
+                <dt>Urgent hearing?</dt>
+                <dd><%= completion.metadata['urgent_hearing'] || 'N/A' %></dd>
+                <dt>Without notice hearing?</dt>
+                <dd><%= completion.metadata['without_notice'] || 'N/A' %></dd>
+              </dl>
+            </td>
+            <td class="no-border">
+              <dl>
+                <dt>Postcode</dt>
+                <dd><%= completion.metadata['postcode'] %></dd>
+                <dt>C1A form?</dt>
+                <dd><%= completion.metadata['c1a_form'] %></dd>
+                <dt>C8 form?</dt>
+                <dd><%= completion.metadata['c8_form'] %></dd>
+                <% if !c100 %>
+                  <dt>Court receipt email address</dt>
+                  <dd><%= c100.screener_answers_court.email %> | <%= link_to 'web', C100App::CourtfinderAPI.new.court_url(c100.screener_answers_court.slug), rel: 'external', target: '_blank' %></dd>
+                  <dt>Applicant receipt email address</dt>
+                  <dd><%= c100.receipt_email || 'none' %></dd>
+                <% else %>
+                  <dt>Court receipt email address</dt>
+                  <dd>(purged from database)</dd>
+                  <dt>Applicant receipt email address</dt>
+                  <dd>(purged from database)</dd>
+                <% end %>
+              </dl>
+            </td>
+          </tr>
+        </table>
+      </div>
     </td>
   </tr>
 <% end %>

--- a/app/views/backoffice/dashboard/_lookup_form.en.html.erb
+++ b/app/views/backoffice/dashboard/_lookup_form.en.html.erb
@@ -2,6 +2,12 @@
   Lookup an application by reference code
 </p>
 
+<div class="govuk-govspeak gv-s-prose">
+  <p>
+    This will search the given reference in the historical audit table, no matter how old the application is.
+  </p>
+</div>
+
 <%= form_with(url: lookup_backoffice_dashboard_index_path, local: true) do |f| %>
   <%= f.text_field :reference_code, class: 'narrow', value: @reference_code %>
   <%= f.submit 'Lookup application', class: 'button' %>

--- a/app/views/backoffice/emails/index.en.html.erb
+++ b/app/views/backoffice/emails/index.en.html.erb
@@ -7,7 +7,7 @@
     <%= render partial: 'lookup_form' %>
 
     <p class="heading-medium">
-      Failed emails
+      Failed emails (last 7 days)
     </p>
 
     <div class="govuk-govspeak gv-s-prose">

--- a/spec/mailers/reports_mailer_spec.rb
+++ b/spec/mailers/reports_mailer_spec.rb
@@ -10,12 +10,7 @@ RSpec.describe ReportsMailer, type: :mailer do
   end
 
   describe '#failed_emails_report' do
-    let(:mail) { described_class.failed_emails_report('report content') }
-    let(:reports_email) { 'reports@example.com' }
-
-    before do
-      allow(ENV).to receive(:[]).with('FAILED_EMAILS_REPORT_RECIPIENT').and_return(reports_email)
-    end
+    let(:mail) { described_class.failed_emails_report('report content', to_address: 'reports@example.com') }
 
     it_behaves_like 'a Notify mail', template_id: 'failed_emails_report_template_id'
 
@@ -26,11 +21,6 @@ RSpec.describe ReportsMailer, type: :mailer do
         service_name: 'Apply to court about child arrangements',
         report_content: 'report content',
       })
-    end
-
-    context 'when the ENV variable is not set' do
-      let(:reports_email) { nil }
-      it { expect(mail.to).to eq(nil) }
     end
   end
 end


### PR DESCRIPTION
Previously this email was sent to a single recipient address, declared on an ENV variable.

Now that we have a functional back office, with the ability to retry these failed emails, we can send the notification to all the back office admin users so they are aware and can trigger the email resend themselves.

Still an ENV variable needs to be set in order for these emails to be sent, otherwise they will be disabled.