### PR TITLE
Replace declaration checkbox with full name input

### DIFF
--- a/app/assets/stylesheets/local/check_answers.scss
+++ b/app/assets/stylesheets/local/check_answers.scss
@@ -93,4 +93,8 @@
 div.declaration-box {
   padding: 1px 20px 20px;
   background-color: #ddd;
+
+  label {
+    font-weight: normal;
+  }
 }

--- a/app/forms/steps/application/declaration_form.rb
+++ b/app/forms/steps/application/declaration_form.rb
@@ -1,9 +1,15 @@
 module Steps
   module Application
     class DeclarationForm < BaseForm
-      attribute :declaration_made, Boolean
+      attribute :declaration_signee, StrippedString
+      attribute :declaration_signee_capacity, String
 
-      validates_presence_of :declaration_made
+      validates_presence_of  :declaration_signee
+      validates_inclusion_of :declaration_signee_capacity, in: UserType.string_values
+
+      def has_solicitor?
+        c100_application.has_solicitor.eql?(GenericYesNo::YES.to_s)
+      end
 
       private
 
@@ -11,7 +17,8 @@ module Steps
         raise C100ApplicationNotFound unless c100_application
 
         c100_application.update(
-          declaration_made: declaration_made
+          declaration_signee: declaration_signee,
+          declaration_signee_capacity: declaration_signee_capacity,
         )
       end
     end

--- a/app/models/completed_applications_audit.rb
+++ b/app/models/completed_applications_audit.rb
@@ -29,6 +29,7 @@ class CompletedApplicationsAudit < ApplicationRecord
       urgent_hearing: c100_application.urgent_hearing,
       without_notice: c100_application.without_notice,
       payment_type: c100_application.payment_type,
+      signee_capacity: c100_application.declaration_signee_capacity,
     }
   end
 

--- a/app/models/completed_applications_audit.rb
+++ b/app/models/completed_applications_audit.rb
@@ -25,7 +25,7 @@ class CompletedApplicationsAudit < ApplicationRecord
       c1a_form: c100_application.has_safety_concerns?,
       c8_form: c100_application.confidentiality_enabled?,
       saved_for_later: c100_application.user_id.present?,
-      legal_representation: c100_application.has_solicitor,
+      legal_representation: c100_application.has_solicitor || 'no',
       urgent_hearing: c100_application.urgent_hearing,
       without_notice: c100_application.without_notice,
       payment_type: c100_application.payment_type,

--- a/app/presenters/summary/sections/statement_of_truth.rb
+++ b/app/presenters/summary/sections/statement_of_truth.rb
@@ -11,14 +11,24 @@ module Summary
 
       def answers
         [
-          Partial.new(:statement_of_truth, applicant_name),
+          Partial.new(:statement_of_truth, signee_name: signee_name, signee_capacity: signee_capacity),
         ]
       end
 
       private
 
-      def applicant_name
-        c100.applicants.first&.full_name
+      # We must consider `nil` values, for backward compatibility and also because
+      # for quick tests we might bypass and render the PDF with details missing.
+      #
+      def signee_name
+        c100.declaration_signee || c100.applicants.first&.full_name || '<name not entered>'
+      end
+
+      def signee_capacity
+        I18n.translate!(
+          c100.declaration_signee_capacity || UserType::APPLICANT,
+          scope: 'shared.statement_of_truth_signee_capacity'
+        )
       end
     end
   end

--- a/app/value_objects/user_type.rb
+++ b/app/value_objects/user_type.rb
@@ -1,0 +1,10 @@
+class UserType < ValueObject
+  VALUES = [
+    APPLICANT      = new(:applicant),
+    REPRESENTATIVE = new(:representative),
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -37,6 +37,9 @@
                 <dd><%= completion.metadata['c1a_form'] %></dd>
                 <dt>C8 form?</dt>
                 <dd><%= completion.metadata['c8_form'] %></dd>
+                <dt>Signee capacity</dt>
+                <dd><%= completion.metadata['signee_capacity'] %></dd>
+
                 <% if c100 %>
                   <dt>Court receipt email address</dt>
                   <dd><%= c100.screener_answers_court.email %> | <%= link_to 'web', C100App::CourtfinderAPI.new.court_url(c100.screener_answers_court.slug), rel: 'external', target: '_blank' %></dd>

--- a/app/views/steps/application/check_your_answers/edit.html.erb
+++ b/app/views/steps/application/check_your_answers/edit.html.erb
@@ -24,7 +24,14 @@
       </strong>
     </div>
 
-    <%= f.single_check_box :declaration_made %>
+    <%= f.text_field :declaration_signee, class: 'narrow' %>
+
+    <% if @form_object.has_solicitor? %>
+      <%= f.radio_button_fieldset :declaration_signee_capacity, choices: UserType.values %>
+    <% else %>
+      <%# No need to ask the capacity if the applicant does not have a solicitor, so we default to `applicant` %>
+      <%= f.hidden_field :declaration_signee_capacity, value: UserType::APPLICANT %>
+    <% end %>
   </div>
 
   <div class="panel panel-border-narrow util_mt-medium">

--- a/app/views/steps/completion/shared/_statement_of_truth.pdf.erb
+++ b/app/views/steps/completion/shared/_statement_of_truth.pdf.erb
@@ -1,6 +1,9 @@
 <p>
-  <%=t 'shared.statement_of_truth', applicant_name: statement_of_truth.ivar %>
+  <%=t 'shared.statement_of_truth', statement_of_truth.ivar %>
 </p>
 <p>
   <strong><%=t 'shared.statement_of_truth_hmcts_instructions' %></strong>
+</p>
+<p>
+  <%=t 'shared.statement_of_truth_disclaimer' %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -761,9 +761,9 @@ en:
           heading: Check your answers
           lead_text: Please review your answers before you finish your application
           declaration_heading: Declaration
-          declaration_lead_text: You must confirm that the information you’ve provided in your application is true.
+          declaration_lead_text: You must confirm that the information you’ve provided in this application is true.
           warning_title: Warning
-          false_information_warning: You could be fined or imprisoned for contempt of court if you deliberately submit false information.
+          false_information_warning: Proceedings for contempt of court may be brought against a person who makes or causes to be made, a false statement in a document verified by a statement of truth.
           submit_warning:
             online: Once you submit your application, you cannot make any further changes. You can download a copy of your submitted application on the next page.
             print_and_post: Once you continue, you cannot make any further changes to your application. You can download a copy of your application on the next page.
@@ -1125,6 +1125,8 @@ en:
         has_previous_name: Have they changed their name?
         gender: Sex
         dob_unknown_html: ""
+      steps_application_declaration_form:
+        declaration_signee_capacity_html: ""
 
     label:
       steps_shared_relationship_form:
@@ -1175,7 +1177,10 @@ en:
           print_and_post: Print and send by post
         receipt_email: Enter an email address if you would like to get a confirmation
       steps_application_declaration_form:
-        declaration_made: I confirm that I believe that the facts stated in this application are true
+        declaration_signee: By entering your full name, you confirm that the facts stated in this application are true
+        declaration_signee_capacity:
+          applicant: I am the applicant
+          representative: I am the solicitor and I have been given the authority to make this declaration
       steps_alternatives_court_form:
         court_acknowledgement: I understand what’s involved if I decide to go to court
       steps_miam_acknowledgement_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -583,5 +583,7 @@ en:
               invalid: *invalid_email_error
         steps/application/declaration_form:
           attributes:
-            declaration_made:
-              blank: You must accept the declaration
+            declaration_signee:
+              blank: Enter your full name
+            declaration_signee_capacity:
+              inclusion: Select who is making this declaration

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -71,8 +71,12 @@ en:
     intentional_blank_page: This page intentionally left blank
     c8_confidential_answer: *c8_attached
     miam_exemptions_info: "The applicant has not attended a MIAM because the following exemption(s) applies:"
-    statement_of_truth: "%{applicant_name} believes that the facts stated in this application are true."
+    statement_of_truth: "%{signee_name} (%{signee_capacity}) believes that the facts stated in this application are true."
     statement_of_truth_hmcts_instructions: Statement of truth has been completed online - no signature required
+    statement_of_truth_disclaimer: Proceedings for contempt of court may be brought against a person who makes or causes to be made, a false statement in a document verified by a statement of truth.
+    statement_of_truth_signee_capacity:
+      applicant: Applicant
+      representative: Applicant’s solicitor
     relationship_to_child:
       show_person_html: "<div>%{person_name} - %{relation} to %{child_name}</div>"
       hide_person_html: "<div>%{relation} to %{child_name}</div>"

--- a/db/migrate/20200115151905_add_declaration_of_truth_attributes.rb
+++ b/db/migrate/20200115151905_add_declaration_of_truth_attributes.rb
@@ -1,0 +1,6 @@
+class AddDeclarationOfTruthAttributes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :c100_applications, :declaration_signee, :string
+    add_column :c100_applications, :declaration_signee_capacity, :string
+  end
+end

--- a/db/migrate/20200116142446_migrate_declaration_of_truth.rb
+++ b/db/migrate/20200116142446_migrate_declaration_of_truth.rb
@@ -1,0 +1,21 @@
+class MigrateDeclarationOfTruth < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :c100_applications, :declaration_made
+    change_column :completed_applications_audit, :metadata, :jsonb, default: {}, null: false
+
+    C100Application.completed.update_all(declaration_signee_capacity: 'applicant')
+
+    # Up until now all applications have been done by the applicant,
+    # with no legal representation, so for the sake of maintaining
+    # accurate stats we are going to save these details.
+    #
+    CompletedApplicationsAudit.unscoped.update_all(
+      "metadata = jsonb_set(jsonb_set(metadata, '{legal_representation}', to_json('no'::varchar)::jsonb), '{signee_capacity}', to_json('applicant'::varchar)::jsonb)"
+    )
+  end
+
+  # Most of the stuff we do on the `up`, we do not need to revert on rollback
+  def down
+    add_column :c100_applications, :declaration_made, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_15_151905) do
+ActiveRecord::Schema.define(version: 2020_01_16_142446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -138,7 +138,6 @@ ActiveRecord::Schema.define(version: 2020_01_15_151905) do
     t.integer "status", default: 0
     t.string "protection_orders"
     t.text "protection_orders_details"
-    t.boolean "declaration_made"
     t.string "payment_type"
     t.string "solicitor_account_number"
     t.string "submission_type"
@@ -174,7 +173,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_151905) do
     t.string "submission_type"
     t.string "court", null: false
     t.string "reference_code", null: false
-    t.json "metadata", default: {}
+    t.jsonb "metadata", default: {}, null: false
     t.index ["reference_code"], name: "index_completed_applications_audit_on_reference_code", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_113022) do
+ActiveRecord::Schema.define(version: 2020_01_15_151905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -150,6 +150,8 @@ ActiveRecord::Schema.define(version: 2020_01_09_113022) do
     t.text "urgent_hearing_short_notice_details"
     t.string "has_solicitor"
     t.integer "version", default: 3
+    t.string "declaration_signee"
+    t.string "declaration_signee_capacity"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/forms/steps/application/declaration_form_spec.rb
+++ b/spec/forms/steps/application/declaration_form_spec.rb
@@ -3,12 +3,36 @@ require 'spec_helper'
 RSpec.describe Steps::Application::DeclarationForm do
   let(:arguments) { {
     c100_application: c100_application,
-    declaration_made: declaration_made,
+    declaration_signee: declaration_signee,
+    declaration_signee_capacity: declaration_signee_capacity,
   } }
-  let(:c100_application) { instance_double(C100Application, declaration_made: nil) }
-  let(:declaration_made) { '1' }
+
+  let(:c100_application) { instance_double(C100Application) }
+  let(:declaration_signee) { 'Full Name' }
+  let(:declaration_signee_capacity) { 'applicant' }
 
   subject { described_class.new(arguments) }
+
+  describe '#has_solicitor?' do
+    before do
+      allow(c100_application).to receive(:has_solicitor).and_return(has_solicitor)
+    end
+
+    context 'for a `nil` value' do
+      let(:has_solicitor) { nil }
+      it { expect(subject.has_solicitor?).to eq(false) }
+    end
+
+    context 'for a `no` value' do
+      let(:has_solicitor) { 'no' }
+      it { expect(subject.has_solicitor?).to eq(false) }
+    end
+
+    context 'for a `yes` value' do
+      let(:has_solicitor) { 'yes' }
+      it { expect(subject.has_solicitor?).to eq(true) }
+    end
+  end
 
   describe '#save' do
     context 'when no c100_application is associated with the form' do
@@ -20,13 +44,15 @@ RSpec.describe Steps::Application::DeclarationForm do
     end
 
     context 'validations' do
-      it { should validate_presence_of(:declaration_made) }
+      it { should validate_presence_of(:declaration_signee) }
+      it { should validate_presence_of(:declaration_signee_capacity, :inclusion) }
     end
 
     context 'when form is valid' do
       it 'saves the record' do
         expect(c100_application).to receive(:update).with(
-          declaration_made: true
+          declaration_signee: 'Full Name',
+          declaration_signee_capacity: 'applicant',
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -85,23 +85,23 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   describe '#single_check_box' do
     let(:c100_application) { C100Application.new }
     let(:builder) { described_class.new :c100_application, c100_application, helper, {} }
-    let(:html_output) { builder.single_check_box(:declaration_made) }
+    let(:html_output) { builder.single_check_box(:miam_acknowledgement) }
 
     it 'outputs the check box' do
       expect(
         html_output
-      ).to eq('<div class="multiple-choice single-cb"><input name="c100_application[declaration_made]" type="hidden" value="0" /><input type="checkbox" value="1" name="c100_application[declaration_made]" id="c100_application_declaration_made" /><label for="c100_application_declaration_made">Declaration made</label></div>')
+      ).to eq('<div class="multiple-choice single-cb"><input name="c100_application[miam_acknowledgement]" type="hidden" value="0" /><input type="checkbox" value="1" name="c100_application[miam_acknowledgement]" id="c100_application_miam_acknowledgement" /><label for="c100_application_miam_acknowledgement">Miam acknowledgement</label></div>')
     end
 
     context 'when there are errors' do
       before do
-        c100_application.errors.add(:declaration_made, :blank)
+        c100_application.errors.add(:miam_acknowledgement, :blank)
       end
 
       it 'outputs the check box with the error markup' do
         expect(
           html_output
-        ).to eq('<div class="multiple-choice single-cb" id="error_c100_application_declaration_made"><input name="c100_application[declaration_made]" type="hidden" value="0" /><input aria-describedby="error_message_c100_application_declaration_made" type="checkbox" value="1" name="c100_application[declaration_made]" id="c100_application_declaration_made" /><label for="c100_application_declaration_made">Declaration made<span class="error-message" id="error_message_c100_application_declaration_made">Enter an answer</span></label></div>')
+        ).to eq('<div class="multiple-choice single-cb" id="error_c100_application_miam_acknowledgement"><input name="c100_application[miam_acknowledgement]" type="hidden" value="0" /><input aria-describedby="error_message_c100_application_miam_acknowledgement" type="checkbox" value="1" name="c100_application[miam_acknowledgement]" id="c100_application_miam_acknowledgement" /><label for="c100_application_miam_acknowledgement">Miam acknowledgement<span class="error-message" id="error_message_c100_application_miam_acknowledgement">Enter an answer</span></label></div>')
       end
     end
   end

--- a/spec/models/completed_applications_audit_spec.rb
+++ b/spec/models/completed_applications_audit_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
       without_notice: 'yes',
       submission_type: 'online',
       payment_type: 'cash',
+      declaration_signee_capacity: 'applicant',
     )
   }
 
@@ -51,6 +52,7 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
           urgent_hearing: 'no',
           without_notice: 'yes',
           payment_type: 'cash',
+          signee_capacity: 'applicant',
         }
       )
 

--- a/spec/models/completed_applications_audit_spec.rb
+++ b/spec/models/completed_applications_audit_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
       id: '449362af-0bc3-4953-82a7-1363d479b876',
       created_at: Time.at(0),
       updated_at: Time.at(100),
-      has_solicitor: 'no',
+      has_solicitor: has_solicitor,
       urgent_hearing: 'no',
       without_notice: 'yes',
       submission_type: 'online',
@@ -16,6 +16,7 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
   }
 
   let(:user_id) { nil }
+  let(:has_solicitor) { 'yes' }
   let(:screener_answers_court) { instance_double(Court, name: 'Test Court') }
   let(:screener_answers) { instance_double(ScreenerAnswers, children_postcodes: 'abcd 123') }
 
@@ -48,7 +49,7 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
           c1a_form: false,
           c8_form: false,
           saved_for_later: false,
-          legal_representation: 'no',
+          legal_representation: 'yes',
           urgent_hearing: 'no',
           without_notice: 'yes',
           payment_type: 'cash',
@@ -57,6 +58,20 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
       )
 
       described_class.log!(c100_application)
+    end
+
+    context 'for an application with `has_solicitor` attribute set to `nil`' do
+      let(:has_solicitor) { nil }
+
+      it 'defaults to `no`' do
+        expect(
+          described_class
+        ).to receive(:create).with(
+          hash_including(metadata: hash_including(legal_representation: 'no'))
+        )
+
+        described_class.log!(c100_application)
+      end
     end
 
     context 'for a saved application' do

--- a/spec/presenters/summary/sections/statement_of_truth_spec.rb
+++ b/spec/presenters/summary/sections/statement_of_truth_spec.rb
@@ -2,8 +2,17 @@ require 'spec_helper'
 
 module Summary
   describe Sections::StatementOfTruth do
-    let(:c100_application) { instance_double(C100Application, applicants: applicants) }
+    let(:c100_application) {
+      instance_double(C100Application,
+                      applicants: applicants,
+                      declaration_signee: declaration_signee,
+                      declaration_signee_capacity: declaration_signee_capacity,
+      )
+    }
+
     let(:applicants) { [instance_double(Applicant, full_name: 'John Doe')] }
+    let(:declaration_signee) { nil }
+    let(:declaration_signee_capacity) { nil }
 
     subject { described_class.new(c100_application) }
 
@@ -27,9 +36,46 @@ module Summary
         expect(answers[0].name).to eq(:statement_of_truth)
       end
 
-      it 'propagates to the Partial the name of the first applicant as an ivar' do
-        expect(applicants).to receive(:first).and_call_original
-        expect(answers[0].ivar).to eq('John Doe')
+      context 'propagates to the Partial the signee name as an ivar' do
+        context 'when there is a signee name' do
+          let(:declaration_signee) { 'Mr XYZ' }
+
+          it 'returns the signee name' do
+            expect(applicants).not_to receive(:first)
+            expect(answers[0].ivar).to include(signee_name: 'Mr XYZ')
+          end
+        end
+
+        context 'when there is no signee name but there are applicant names' do
+          it 'picks the first applicant name' do
+            expect(applicants).to receive(:first).and_call_original
+            expect(answers[0].ivar).to include(signee_name: 'John Doe')
+          end
+        end
+
+        context 'when there is no signee name and no applicant names' do
+          it 'defaults to a placeholder text' do
+            expect(applicants).to receive(:first).and_return(nil)
+            expect(answers[0].ivar).to include(signee_name: '<name not entered>')
+          end
+        end
+      end
+
+      context 'propagates to the Partial the signee capacity as an ivar' do
+        context 'when there is a signee capacity' do
+          let(:declaration_signee_capacity) { UserType::REPRESENTATIVE }
+
+          it 'returns the signee capacity' do
+            expect(answers[0].ivar).to include(signee_capacity: 'Applicant’s solicitor')
+          end
+        end
+
+        context 'when there is no signee capacity' do
+          it 'defaults to be an applicant' do
+            expect(applicants).to receive(:first).and_return(nil)
+            expect(answers[0].ivar).to include(signee_capacity: 'Applicant')
+          end
+        end
       end
     end
   end

--- a/spec/value_objects/user_type_spec.rb
+++ b/spec/value_objects/user_type_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe UserType do
+  let(:value) { :foo }
+  subject     { described_class.new(value) }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(
+        applicant
+        representative
+      ))
+    end
+  end
+end


### PR DESCRIPTION
Note: individual commits for more detail, as this PR is a bit lengthy.

In preparation for solicitor's journey, we are replacing the declaration single checkbox in the Check Your Answers page, with a full name input where the signee (whether an applicant, or a solicitor) can enter their name.

If the applicant has a solicitor, they also will be able to select who is the signee (applicant or solicitor). If they don't have a solicitor (they answered NO to that question) then we don't show these radio options and default to `applicant` as the signee capacity.

Some minor updates to the PDF so we can print these new details, and also make sure it works backwards for compatibility with completed applications still in database.