### PR TITLE
Track completion form submissions

### DIFF
--- a/app/views/steps/application/check_your_answers/edit.html.erb
+++ b/app/views/steps/application/check_your_answers/edit.html.erb
@@ -8,8 +8,10 @@
 
 <%= render @presenter.sections %>
 
-<div class="util_mt-large"></div>
-<%= step_form @form_object do |f| %>
+<%= step_form @form_object,
+              html: { class: 'util_mt-large ga-submitForm' },
+              data: { ga_category: 'application completed', ga_label: 'declaration' } do |f| %>
+
   <div class="declaration-box util_mt-medium">
     <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge util_mb-medium"><%=t '.declaration_heading' %></h1>
 


### PR DESCRIPTION
As we don't have the declaration checkbox anymore, and instead we have an input text, this will not get tracked automatically in GA.

We add the event to the form to track on submit. If the signee capacity radios are also present, these will track as well as a separate event (as before with the checkbox).