### PR TITLE
Refactor `has_solicitor` method

### DIFF
--- a/app/forms/steps/application/declaration_form.rb
+++ b/app/forms/steps/application/declaration_form.rb
@@ -7,10 +7,6 @@ module Steps
       validates_presence_of  :declaration_signee
       validates_inclusion_of :declaration_signee_capacity, in: UserType.string_values
 
-      def has_solicitor?
-        c100_application.has_solicitor.eql?(GenericYesNo::YES.to_s)
-      end
-
       private
 
       def persist!

--- a/app/forms/steps/application/payment_form.rb
+++ b/app/forms/steps/application/payment_form.rb
@@ -12,10 +12,6 @@ module Steps
 
       validates :hwf_reference_number, allow_blank: true, help_with_fees_reference: true, if: :help_with_fees_payment?
 
-      def has_solicitor?
-        c100_application.has_solicitor.eql?(GenericYesNo::YES.to_s)
-      end
-
       private
 
       def help_with_fees_payment?

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -48,6 +48,10 @@ class C100Application < ApplicationRecord
     address_confidentiality.eql?(GenericYesNo::YES.to_s)
   end
 
+  def has_solicitor?
+    has_solicitor.eql?(GenericYesNo::YES.to_s)
+  end
+
   def has_safety_concerns?
     [
       domestic_abuse,

--- a/app/views/steps/application/check_your_answers/edit.html.erb
+++ b/app/views/steps/application/check_your_answers/edit.html.erb
@@ -28,7 +28,7 @@
 
     <%= f.text_field :declaration_signee, class: 'narrow' %>
 
-    <% if @form_object.has_solicitor? %>
+    <% if current_c100_application.has_solicitor? %>
       <%= f.radio_button_fieldset :declaration_signee_capacity, choices: UserType.values %>
     <% else %>
       <%# No need to ask the capacity if the applicant does not have a solicitor, so we default to `applicant` %>

--- a/app/views/steps/application/payment/edit.html.erb
+++ b/app/views/steps/application/payment/edit.html.erb
@@ -14,7 +14,7 @@
           fieldset.radio_input(PaymentType::SELF_PAYMENT_CARD)
           fieldset.radio_input(PaymentType::SELF_PAYMENT_CHEQUE)
           fieldset.radio_input(PaymentType::HELP_WITH_FEES) { f.text_field :hwf_reference_number, class: 'narrow' }
-          fieldset.radio_input(PaymentType::SOLICITOR) { f.text_field :solicitor_account_number, class: 'narrow' } if @form_object.has_solicitor?
+          fieldset.radio_input(PaymentType::SOLICITOR) { f.text_field :solicitor_account_number, class: 'narrow' } if current_c100_application.has_solicitor?
         end
       %>
 

--- a/spec/forms/steps/application/declaration_form_spec.rb
+++ b/spec/forms/steps/application/declaration_form_spec.rb
@@ -13,27 +13,6 @@ RSpec.describe Steps::Application::DeclarationForm do
 
   subject { described_class.new(arguments) }
 
-  describe '#has_solicitor?' do
-    before do
-      allow(c100_application).to receive(:has_solicitor).and_return(has_solicitor)
-    end
-
-    context 'for a `nil` value' do
-      let(:has_solicitor) { nil }
-      it { expect(subject.has_solicitor?).to eq(false) }
-    end
-
-    context 'for a `no` value' do
-      let(:has_solicitor) { 'no' }
-      it { expect(subject.has_solicitor?).to eq(false) }
-    end
-
-    context 'for a `yes` value' do
-      let(:has_solicitor) { 'yes' }
-      it { expect(subject.has_solicitor?).to eq(true) }
-    end
-  end
-
   describe '#save' do
     context 'when no c100_application is associated with the form' do
       let(:c100_application) { nil }

--- a/spec/forms/steps/application/payment_form_spec.rb
+++ b/spec/forms/steps/application/payment_form_spec.rb
@@ -16,27 +16,6 @@ RSpec.describe Steps::Application::PaymentForm do
 
   subject { described_class.new(arguments) }
 
-  describe '#has_solicitor?' do
-    before do
-      allow(c100_application).to receive(:has_solicitor).and_return(has_solicitor)
-    end
-
-    context 'for a `nil` value' do
-      let(:has_solicitor) { nil }
-      it { expect(subject.has_solicitor?).to eq(false) }
-    end
-
-    context 'for a `no` value' do
-      let(:has_solicitor) { 'no' }
-      it { expect(subject.has_solicitor?).to eq(false) }
-    end
-
-    context 'for a `yes` value' do
-      let(:has_solicitor) { 'yes' }
-      it { expect(subject.has_solicitor?).to eq(true) }
-    end
-  end
-
   describe '#save' do
     context 'validations' do
       it { should validate_presence_of(:payment_type, :inclusion) }

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe C100Application, type: :model do
     end
   end
 
+  describe '#has_solicitor?' do
+    context 'for a `nil` value' do
+      let(:attributes) { {has_solicitor: nil} }
+      it { expect(subject.has_solicitor?).to eq(false) }
+    end
+
+    context 'for a `no` value' do
+      let(:attributes) { {has_solicitor: 'no'} }
+      it { expect(subject.has_solicitor?).to eq(false) }
+    end
+
+    context 'for a `yes` value' do
+      let(:attributes) { {has_solicitor: 'yes'} }
+      it { expect(subject.has_solicitor?).to eq(true) }
+    end
+  end
+
   describe '#has_safety_concerns?' do
     let(:attributes) { {
       domestic_abuse: domestic_abuse,


### PR DESCRIPTION
Move from the individual form objects where we are using it to the C100Application model to DRY and because it will probably be used more times in the future in other places.