### PR TITLE
Enable solicitor's journey by bumping version

### DIFF
--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -49,9 +49,9 @@ module C100App
       next_record_id(c100_application.applicant_ids)
     end
 
-    # TODO: change this to use `version >= 4` when releasing to production
+    # TODO: leave this until all applications are migrated to version >= 4
     def show_solicitor_journey?
-      dev_tools_enabled?
+      c100_application.version >= 4
     end
   end
 end

--- a/db/migrate/20200121092151_bump_c100_application_version_for_solicitors.rb
+++ b/db/migrate/20200121092151_bump_c100_application_version_for_solicitors.rb
@@ -1,0 +1,7 @@
+class BumpC100ApplicationVersionForSolicitors < ActiveRecord::Migration[5.2]
+  def change
+    # Version 4 introduces the ability to have a solicitor
+    # New records will be created with version=4
+    change_column_default :c100_applications, :version, from: 3, to: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_20_120828) do
+ActiveRecord::Schema.define(version: 2020_01_21_092151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -148,7 +148,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_120828) do
     t.string "urgent_hearing_short_notice"
     t.text "urgent_hearing_short_notice_details"
     t.string "has_solicitor"
-    t.integer "version", default: 3
+    t.integer "version", default: 4
     t.string "declaration_signee"
     t.string "declaration_signee_capacity"
     t.index ["status"], name: "index_c100_applications_on_status"

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -115,30 +115,23 @@ RSpec.describe C100App::ApplicantDecisionTree do
     context 'when all applicants have been edited' do
       let(:record) { double('Applicant', id: 3) }
 
-      let(:dev_tools_enabled) { 'false' }
-      let(:development_env) { true }
-
       before do
-        allow(ENV).to receive(:[]).with('DEV_TOOLS_ENABLED').and_return(dev_tools_enabled)
-        allow(Rails.env).to receive(:development?).and_return(development_env)
+        allow(c100_application).to receive(:version).and_return(version)
       end
 
-      context 'on development environments' do
-        it { is_expected.to have_destination(:has_solicitor, :edit) }
-      end
-
-      context 'on production environments with DEV_TOOLS_ENABLED' do
-        let(:dev_tools_enabled) { 'true' }
-        let(:development_env) { false }
-
-        it { is_expected.to have_destination(:has_solicitor, :edit) }
-      end
-
-      context 'on production environments without DEV_TOOLS_ENABLED' do
-        let(:dev_tools_enabled) { 'false' }
-        let(:development_env) { false }
-
+      context 'when C100 application version is < 4' do
+        let(:version) { 3 }
         it { is_expected.to have_destination('/steps/respondent/names', :edit) }
+      end
+
+      context 'when C100 application version is = 4' do
+        let(:version) { 4 }
+        it { is_expected.to have_destination(:has_solicitor, :edit) }
+      end
+
+      context 'when C100 application version is > 4' do
+        let(:version) { 5 }
+        it { is_expected.to have_destination(:has_solicitor, :edit) }
       end
     end
   end


### PR DESCRIPTION
Bump the C100 Application record version from 3 to 4.

New applications created right after this migration will have version = 4 and will be shown the question 'do you have a solicitor?'

Current applications in-progress, or drafts, will maintain their version = 3 and we will not show them the new question.

Once all applications are in version >= 4, we can remove the feature-flag code.