### PR TITLE
Rearrange security concern

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include SecurityHandling
+  include SessionHandling
   include ErrorHandling
 
   # This is required to get request attributes in to the production logs.

--- a/app/controllers/backoffice/application_controller.rb
+++ b/app/controllers/backoffice/application_controller.rb
@@ -1,8 +1,8 @@
 module Backoffice
   class ApplicationController < ActionController::Base
-    layout 'backoffice'
+    include SecurityHandling
 
-    protect_from_forgery with: :exception, prepend: true
+    layout 'backoffice'
 
     rescue_from Exception do |exception|
       raise if Rails.application.config.consider_all_requests_local

--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -10,33 +10,11 @@ module SecurityHandling
 
     protect_from_forgery with: :exception, prepend: true
 
-    before_action :drop_dangerous_headers!,
-                  :ensure_session_validity
-
-    after_action :set_security_headers
-
-    helper_method :session_expire_in_minutes
-  end
-
-  def session_expire_in_minutes
-    Rails.configuration.x.session.expires_in_minutes
-  end
-
-  def session_expire_in_seconds
-    session_expire_in_minutes * 60
+    before_action :drop_dangerous_headers!
+    after_action  :set_security_headers
   end
 
   private
-
-  def ensure_session_validity
-    epoch = Time.now.to_i
-
-    if epoch - session.fetch(:last_seen, epoch) > session_expire_in_seconds
-      reset_session
-    end
-
-    session[:last_seen] = epoch
-  end
 
   def drop_dangerous_headers!
     request.env.except!('HTTP_X_FORWARDED_HOST') # just drop the variable
@@ -54,6 +32,6 @@ module SecurityHandling
       'X-XSS-Protection'          => '1; mode=block',
       'X-Content-Type-Options'    => 'nosniff',
       'Strict-Transport-Security' => 'max-age=15768000; includeSubDomains',
-    }
+    }.freeze
   end
 end

--- a/app/controllers/concerns/session_handling.rb
+++ b/app/controllers/concerns/session_handling.rb
@@ -1,0 +1,28 @@
+module SessionHandling
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :ensure_session_validity
+    helper_method :session_expire_in_minutes
+  end
+
+  def session_expire_in_minutes
+    Rails.configuration.x.session.expires_in_minutes
+  end
+
+  def session_expire_in_seconds
+    session_expire_in_minutes * 60
+  end
+
+  private
+
+  def ensure_session_validity
+    epoch = Time.now.to_i
+
+    if epoch - session.fetch(:last_seen, epoch) > session_expire_in_seconds
+      reset_session
+    end
+
+    session[:last_seen] = epoch
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe ApplicationController do
   end
 
   context 'Security handling' do
+    before do
+      routes.draw { get 'my_url' => 'anonymous#my_url' }
+    end
+
+    context '#drop_dangerous_headers!' do
+      it 'removes dangerous headers' do
+        request.headers.merge!('HTTP_X_FORWARDED_HOST' => 'foobar.com')
+        get :my_url
+        expect(request.env).not_to include('HTTP_X_FORWARDED_HOST')
+      end
+    end
+  end
+
+  context 'Session handling' do
     context 'ensure_session_validity' do
       before do
         travel_to Time.at(555555)


### PR DESCRIPTION
Split the code dealing with the session to a separate `SessionHandling` concern.

This way we can use the much simple `SecurityHandling` in the back office too.

Current functionality is mantained.