### PR TITLE
Move the basic HTTP auth to a method

### DIFF
--- a/app/assets/javascripts/modules/session-timeout.js
+++ b/app/assets/javascripts/modules/session-timeout.js
@@ -146,7 +146,7 @@ moj.Modules.sessionTimeout = {
     //
     // So we've decided to make this function non-destructive. Just close the modal
     // and do not trigger any further server-side requests. Still the server will check
-    // the validity of the session on each request (refer to module `SecurityHandling`).
+    // the validity of the session on each request (refer to module `SessionHandling`).
 
     this.hideModal();
   }

--- a/app/controllers/backoffice/application_controller.rb
+++ b/app/controllers/backoffice/application_controller.rb
@@ -2,6 +2,7 @@ module Backoffice
   class ApplicationController < ActionController::Base
     include SecurityHandling
 
+    skip_before_action :check_http_credentials
     layout 'backoffice'
 
     rescue_from Exception do |exception|

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe ApplicationController do
         expect(request.env).not_to include('HTTP_X_FORWARDED_HOST')
       end
     end
+
+    context 'basic HTTP auth' do
+      it 'checks for the ENV variable' do
+        expect(ENV).to receive(:key?).with('HTTP_AUTH_ENABLED')
+        get :my_url
+      end
+    end
   end
 
   context 'Session handling' do


### PR DESCRIPTION
So we can easily bypass it on areas where we don't need it, like in the back office (it has its own auth mechanism, with Auth0).