### PR TITLE
Add the application version to the audit record

### DIFF
--- a/app/models/completed_applications_audit.rb
+++ b/app/models/completed_applications_audit.rb
@@ -21,6 +21,7 @@ class CompletedApplicationsAudit < ApplicationRecord
     postcode = postcode.sub(/\s+/, '').upcase.at(0..-3) + '**'
 
     {
+      v: c100_application.version,
       postcode: postcode,
       c1a_form: c100_application.has_safety_concerns?,
       c8_form: c100_application.confidentiality_enabled?,

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -16,7 +16,7 @@
             <td width="300" class="no-border">
               <dl>
                 <dt>Application started at</dt>
-                <dd><%= completion.started_at %></dd>
+                <dd><%= completion.started_at %> (v:<%= completion.metadata['v'] || '1-3' %>)</dd>
                 <dt>Saved for later?</dt>
                 <dd><%= completion.metadata['saved_for_later'] %></dd>
                 <dt>Payment type</dt>

--- a/spec/models/completed_applications_audit_spec.rb
+++ b/spec/models/completed_applications_audit_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
   let(:c100_application) {
     C100Application.new(
       id: '449362af-0bc3-4953-82a7-1363d479b876',
+      version: 123,
       created_at: Time.at(0),
       updated_at: Time.at(100),
       has_solicitor: has_solicitor,
@@ -45,6 +46,7 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
         submission_type: 'online',
         court: 'Test Court',
         metadata: {
+          v: 123,
           postcode: 'ABCD1**',
           c1a_form: false,
           c8_form: false,


### PR DESCRIPTION
This will help when creating statistics, as some fields or questions were introduced in different versions of the application and thus it is not expected old audit records will contain all metadata fields.

As of today, current version is 4, saved applications (drafts) are in 3, and old audit records might be in any version from 1 to 3. We are not going to backdate these old audit records as would be difficult to pinpoint the exact version and it is not needed for current statistics.