### PR TITLE
Remove unneeded headers code

### DIFF
--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -6,29 +6,12 @@ module SecurityHandling
 
     before_action :drop_dangerous_headers!,
                   :check_http_credentials
-
-    after_action :set_security_headers
   end
 
   private
 
   def drop_dangerous_headers!
     request.env.except!('HTTP_X_FORWARDED_HOST') # just drop the variable
-  end
-
-  def set_security_headers
-    additional_headers_for_all_requests.each do |name, value|
-      response.set_header(name, value)
-    end
-  end
-
-  def additional_headers_for_all_requests
-    {
-      'X-Frame-Options'           => 'SAMEORIGIN',
-      'X-XSS-Protection'          => '1; mode=block',
-      'X-Content-Type-Options'    => 'nosniff',
-      'Strict-Transport-Security' => 'max-age=15768000; includeSubDomains',
-    }.freeze
   end
 
   def check_http_credentials


### PR DESCRIPTION
It turns out these headers are not longer needed as they are being set out of the box for us, and in some cases this code was duplicating some of the headers.

This code was originally carried over from Heroku where these where needed.