### PR TITLE
Stop using ministryofjustice/docker-templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,8 @@ gem 'redis'
 
 # PDF generation
 gem 'combine_pdf', '~> 1.0'
-gem 'wicked_pdf', '~> 1.1.0'
-gem 'wkhtmltopdf-binary', '0.12.3.1'
+gem 'wicked_pdf', '~> 1.4.0'
+gem 'wkhtmltopdf-binary-edge-alpine', '~> 0.12.5'
 
 group :production do
   gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,8 +411,9 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    wicked_pdf (1.1.0)
-    wkhtmltopdf-binary (0.12.3.1)
+    wicked_pdf (1.4.0)
+      activesupport
+    wkhtmltopdf-binary-edge-alpine (0.12.5.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -468,8 +469,8 @@ DEPENDENCIES
   virtus
   web-console
   webmock
-  wicked_pdf (~> 1.1.0)
-  wkhtmltopdf-binary (= 0.12.3.1)
+  wicked_pdf (~> 1.4.0)
+  wkhtmltopdf-binary-edge-alpine (~> 0.12.5)
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -11,4 +11,5 @@
 WickedPdf.config ||= {}
 WickedPdf.config.merge!({
   encoding: 'utf-8',
+  zoom: 1.3,
 })

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cd /usr/src/app
 
 bundle exec rake db:create db:migrate

--- a/worker.sh
+++ b/worker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cd /usr/src/app
 
 bundle exec rake daily_tasks


### PR DESCRIPTION
The Dockerfiles in the repo [docker-templates](https://github.com/ministryofjustice/docker-templates) is being deprecated and it is recommended to keep Dockerfiles and docker images as lightweight and simple as possible.

In this case we are going to refactor the Dockerfile to use an alpine image and add dependencies on top.

This service is a bit special as it requires some extra dependencies in order for the PDF generation to work fine and with nice fonts.

These PDF gems had to be updated to work with the new Alpine-based image.