### PR TITLE
Send Device emails asynchronously

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,4 +18,11 @@ class User < ApplicationRecord
     # This does *not* automatically happen when they create their account.
     where('last_sign_in_at <= :date OR (created_at <= :date AND last_sign_in_at IS NULL)', date: date).destroy_all
   end
+
+  # Needed in order to deliver Devise emails in the background.
+  # https://github.com/heartcombo/devise#activejob-integration
+  #
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
 end

--- a/app/presenters/c8_confidentiality_presenter.rb
+++ b/app/presenters/c8_confidentiality_presenter.rb
@@ -18,6 +18,12 @@ class C8ConfidentialityPresenter < SimpleDelegator
 
   private
 
+  # This is just to remove from the logs:
+  #   `warning: delegator does not forward private method #to_ary`
+  def to_ary
+    [self]
+  end
+
   def confidential_detail?(attribute, value)
     DETAILS_UNDER_C8.include?(attribute) && value.present?
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,4 +62,20 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#send_devise_notification' do
+    let(:devise_mailer) { double('devise_mailer') }
+    let(:mailer) { double('mailer') }
+
+    before do
+      allow(subject).to receive(:devise_mailer).and_return(devise_mailer)
+    end
+
+    it 'uses `deliver_later`' do
+      expect(devise_mailer).to receive(:send).with(:test_email, subject, :hello).and_return(mailer)
+      expect(mailer).to receive(:deliver_later)
+
+      subject.send_devise_notification(:test_email, :hello)
+    end
+  end
 end

--- a/spec/presenters/c8_confidentiality_presenter_spec.rb
+++ b/spec/presenters/c8_confidentiality_presenter_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe C8ConfidentialityPresenter do
     }
   end
 
+  describe '#to_ary' do
+    it 'forwards private method' do
+      x, y = subject
+      expect(x).to eq(subject)
+      expect(y).to be_nil
+    end
+  end
+
   describe '.replacement_answer' do
     it { expect(described_class.replacement_answer).to eq('[See C8]') }
   end


### PR DESCRIPTION
Now that we have Sidekiq up and running we can also incorporate any Devise emails (reset password, etc.) as per instructions here:
https://github.com/heartcombo/devise#activejob-integration

Also, although unrelated, there was a pesky warning in the Sidekiq logs when generating the C8 form: `delegator does not forward private method #to_ary`
Removed this warning by implementing the missing method.