### PR TITLE
Send daily task emails asynchronously

### DIFF
--- a/app/services/c100_app/draft_reminders.rb
+++ b/app/services/c100_app/draft_reminders.rb
@@ -7,25 +7,15 @@ module C100App
     end
 
     def run
-      rule_set.find_each do |c100_application|
-        send_reminder(c100_application)
-      end
+      rule_set.find_each(&method(:send_reminder))
     end
 
     private
 
-    # Note: the reminders are sent outside of the request-response cycle, via a
-    # rake task (lib/tasks/daily_tasks.rake) and thus using `deliver_later` will not
-    # work unless setting up a persistent queue.
-    #
-    # For this service this is not an issue as the number of emails that are likely
-    # to be sent is very low, and we can afford the rake task to take a bit longer to
-    # complete. But if this assumption ever changes, a persistent queue will be needed.
-    #
     def send_reminder(c100_application)
       NotifyMailer.draft_expire_reminder(
         c100_application, rule_set.email_template_name
-      ).deliver_now
+      ).deliver_later
 
       c100_application.update(
         status: rule_set.status_transition_to

--- a/app/services/reports/failed_emails_report.rb
+++ b/app/services/reports/failed_emails_report.rb
@@ -105,7 +105,7 @@ module Reports
         puts "[#{Time.now}] Sending failed emails report to #{recipients.size} recipients..."
 
         recipients.each do |recipient|
-          ReportsMailer.failed_emails_report(report, to_address: recipient).deliver_now
+          ReportsMailer.failed_emails_report(report, to_address: recipient).deliver_later
         end
       end
     end

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-cd /usr/src/app
+cd /usr/src/app 2> /dev/null
 
 bundle exec rake db:create db:migrate
 bundle exec pumactl -F config/puma.rb start

--- a/spec/services/c100_app/draft_reminders_spec.rb
+++ b/spec/services/c100_app/draft_reminders_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe C100App::DraftReminders do
     end
 
     it 'should send the email and update the C100 application status' do
-      expect(mailer_double).to receive(:deliver_now)
+      expect(mailer_double).to receive(:deliver_later)
       expect(c100_application).to receive(:update).with(status: :another_status)
       subject.run
     end

--- a/worker.sh
+++ b/worker.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-cd /usr/src/app
-
-bundle exec rake daily_tasks


### PR DESCRIPTION
The `daily_tasks` rake task run daily at night and can send quite a lot of emails, depending on how many draft applications are about to expire (reminders).

Up until now we didn't have a background job queue but now we have Sidekiq and can enqueue all these emails for sending later which will make the task run faster and terminate without risk of emails not being sent.

Removed the `worker.sh` script as it will be replaced with  a simpler `bin/rails daily_tasks` in the cronjob kubernetes deployment.