### PR TITLE
Ensure draft reminder emails play nice when async

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,6 +1,4 @@
 class NotifyMailer < GovukNotifyRails::Mailer
-  rescue_from Exception, with: :log_error_and_raise
-
   before_action do
     @service_name = I18n.translate!('service.name')
     @template_ids = Rails.configuration.govuk_notify_templates
@@ -72,29 +70,4 @@ class NotifyMailer < GovukNotifyRails::Mailer
     super({ service_name: @service_name }.merge(personalisation))
   end
   # rubocop:enable Naming/AccessorMethodName
-
-  private
-
-  def log_error_and_raise
-    Raven.extra_context(
-      method: action_name,
-      template_id: govuk_notify_template,
-      personalisation: filtered_personalisation
-    )
-
-    # The error is sent to Sentry automatically with extra context and the job
-    # is re-enqueued, as some errors can be retried and succeed (Notify blips).
-    raise
-  end
-
-  def filtered_personalisation
-    personalisation = govuk_notify_personalisation&.dup || {}
-    personalisation.each_key do |key|
-      personalisation[key] = FILTERED if filter_key?(key)
-    end
-  end
-
-  def filter_key?(key)
-    PERSONALISATION_ERROR_FILTER.include?(key)
-  end
 end

--- a/app/services/c100_app/reminder_rule_set.rb
+++ b/app/services/c100_app/reminder_rule_set.rb
@@ -19,7 +19,7 @@ module C100App
         created_days_ago: 23,
         status: :in_progress,
         status_transition_to: :first_reminder_sent,
-        email_template_name: :draft_first_reminder
+        email_template_name: 'draft_first_reminder'
       )
     end
 
@@ -28,7 +28,7 @@ module C100App
         created_days_ago: 27,
         status: :first_reminder_sent,
         status_transition_to: :last_reminder_sent,
-        email_template_name: :draft_last_reminder
+        email_template_name: 'draft_last_reminder'
       )
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,7 @@ class Application < Rails::Application
   # Load the templates set (refer to `config/govuk_notify_templates.yml` for details)
   config.govuk_notify_templates = config_for(
     :govuk_notify_templates, env: ENV.fetch('GOVUK_NOTIFY_ENV', 'integration')
-  ).symbolize_keys
+  ).with_indifferent_access
 
   config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 60).to_i
   config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -105,30 +105,11 @@ RSpec.describe NotifyMailer, type: :mailer do
     end
   end
 
-  context 'capturing unexpected errors' do
+  context 'unexpected errors' do
     let(:mail) { described_class.reset_password_instructions(nil, 'token') }
 
-    it 'should add extra details for Sentry and re-raise it' do
-      expect(Raven).to receive(:extra_context).with(
-        {
-          method: 'reset_password_instructions',
-          template_id: 'reset_password_template_id',
-          personalisation: {
-            service_name: 'Apply to court about child arrangements',
-            reset_password_url: '[FILTERED]',
-          }
-        }
-      )
-
+    it 'should just raise the error (let the job processor handle it)' do
       expect { mail.deliver_now }.to raise_error
     end
-  end
-
-  describe 'personalisation logging filter' do
-    it {
-      expect(
-        described_class::PERSONALISATION_ERROR_FILTER
-      ).to match_array([:reset_password_url, :applicant_name, :link_to_pdf, :link_to_c8_pdf])
-    }
   end
 end

--- a/spec/services/c100_app/reminder_rule_set_spec.rb
+++ b/spec/services/c100_app/reminder_rule_set_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe C100App::ReminderRuleSet do
     it { expect(subject.created_days_ago).to eq(23) }
     it { expect(subject.status).to eq(:in_progress) }
     it { expect(subject.status_transition_to).to eq(:first_reminder_sent) }
-    it { expect(subject.email_template_name).to eq(:draft_first_reminder) }
+    it { expect(subject.email_template_name).to eq('draft_first_reminder') }
   end
 
   describe '.last_reminder' do
@@ -16,7 +16,7 @@ RSpec.describe C100App::ReminderRuleSet do
     it { expect(subject.created_days_ago).to eq(27) }
     it { expect(subject.status).to eq(:first_reminder_sent) }
     it { expect(subject.status_transition_to).to eq(:last_reminder_sent) }
-    it { expect(subject.email_template_name).to eq(:draft_last_reminder) }
+    it { expect(subject.email_template_name).to eq('draft_last_reminder') }
   end
 
   describe '#find_each' do


### PR DESCRIPTION
Symbols will raise an `ActiveJob::SerializationError: Unsupported argument type: Symbol` exception.

In the draft reminders we used as an argument to the mailer method a symbol for the name of the template. This made these reminders fail now that they are sent asynchronously.

Made so the collection of templates works with strings or symbols (indifferent access) and pass a string arg to the draft reminders method.

Also, removed the custom exception handling on `NotifyMailer` class `rescue_from Exception, with: :log_error_and_raise` because it was stopping Sidekiq from actually re-enqueue the job for retry.