### PR TITLE
Use `current_sign_in_at` instead of `last_sign_in_at`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,10 +13,10 @@ class User < ApplicationRecord
   attr_accessor :last_sign_in_ip, :current_sign_in_ip, :sign_in_count
 
   def self.purge!(date)
-    # Using `#created_at` as the secondary criteria because `#last_sign_in_at`
-    # does not get set until after the first time they have actually signed in.
+    # Using `#created_at` as the secondary criteria because `#current_sign_in_at`
+    # does not get set until the first time they have actually signed in.
     # This does *not* automatically happen when they create their account.
-    where('last_sign_in_at <= :date OR (created_at <= :date AND last_sign_in_at IS NULL)', date: date).destroy_all
+    where('current_sign_in_at <= :date OR (created_at <= :date AND current_sign_in_at IS NULL)', date: date).destroy_all
   end
 
   # Needed in order to deliver Devise emails in the background.

--- a/spec/controllers/users/logins_controller_spec.rb
+++ b/spec/controllers/users/logins_controller_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Users::LoginsController do
         expect(warden).to receive(:authenticate!).and_return(user)
       end
 
-      it 'does not update `last_sign_in_at` attribute (user is not automatically signed-in)' do
-        expect { do_post }.not_to change(user, :last_sign_in_at)
+      it 'does not update `current_sign_in_at` attribute (user is not automatically signed-in)' do
+        expect { do_post }.not_to change(user, :current_sign_in_at)
       end
 
       it 'redirects to the confirmation page' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe User, type: :model do
     specify { expect(described_class.column_names).to include('last_sign_in_at') }
   end
 
+  describe '#current_sign_in_at' do
+    specify { expect(described_class.column_names).to include('current_sign_in_at') }
+  end
+
   describe '.purge!' do
     let(:finder_double) { double.as_null_object }
 
@@ -14,7 +18,7 @@ RSpec.describe User, type: :model do
 
     it 'picks records equal to or older than the passed-in date' do
       expect(described_class).to receive(:where).with(
-        'last_sign_in_at <= :date OR (created_at <= :date AND last_sign_in_at IS NULL)', date: 30.days.ago
+        'current_sign_in_at <= :date OR (created_at <= :date AND current_sign_in_at IS NULL)', date: 30.days.ago
       ).and_return(finder_double)
 
       described_class.purge!(30.days.ago)


### PR DESCRIPTION
This is a more accurate way of purging accounts because the `last_sign_in_at` is always 1 sign-in behind (except in the first sign-in where both dates are the same).

The `current_sign_in_at` gets updated in each sign-in.