### PR TITLE
Refactor status endpoint

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -7,11 +7,16 @@ class StatusController < BareApplicationController
     commit_id: ENV['APP_GIT_COMMIT'],
   }.freeze
 
+  # Use the `ping` endpoint for kubernetes probes, and this one
+  # for Pingdom or similar monitoring systems. Reason being this
+  # endpoint reports external dependencies that can fail, and
+  # kubernetes would kill the pods/containers if this happens.
+  #
   def index
     check = C100App::Status.new
     status_code = check.success? ? :ok : :service_unavailable
 
-    respond_with(check.result, status: status_code)
+    respond_with(check.response, status: status_code)
   end
 
   def ping

--- a/app/services/c100_app/status.rb
+++ b/app/services/c100_app/status.rb
@@ -1,37 +1,36 @@
 module C100App
   class Status
-    def result
-      {
-        service_status: service_status,
-        dependencies: {
-          database_status: database_status,
-          courtfinder_status: courtfinder_status
-        }
-      }
+    def response
+      { healthy: success?, dependencies: results }
     end
 
     def success?
-      service_status.eql?('ok')
+      results.values.all?
     end
 
     private
 
-    def database_status
-      # This will only catch high-level failures.  PG::ConnectionBad gets
-      # raised too early in the stack to rescue here.
-      @database_status ||= (ActiveRecord::Base.connection ? 'ok' : 'failed')
+    def results
+      checks.map(&:call).to_h
     end
 
-    def courtfinder_status
-      @courtfinder_status ||= (CourtfinderAPI.new.is_ok? ? 'ok' : 'failed')
+    # If more checks are needed add them to this collection with the same syntax.
+    # Redis is checked via Sidekiq so no need to add an explicit check.
+    #
+    # Note: `courtfinder` disabled because it is just too unreliable and we don't have
+    # any control over it so even if it goes down, we should not consider our service
+    # unhealthy. After all, in-progress/saved applications will continue working, it
+    # only affects new applications the check the postcode in the screener.
+    #
+    # rubocop:disable Style/RescueModifier
+    def checks
+      [
+        ->(name: 'database') { [name, (ActiveRecord::Base.connection.active? rescue false)] },
+        ->(name: 'sidekiq') { [name, (Sidekiq::ProcessSet.new.size.positive? rescue false)] },
+        ->(name: 'sidekiq_latency') { [name, (Sidekiq::Queue.all.sum(&:latency) rescue false)] },
+        #->(name: 'courtfinder'){ [name, (C100App::CourtfinderAPI.new.is_ok? rescue false)] },
+      ]
     end
-
-    def service_status
-      if [database_status, courtfinder_status].all? { |status| status.eql? 'ok' }
-        'ok'
-      else
-        'failed'
-      end
-    end
+    # rubocop:enable Style/RescueModifier
   end
 end

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -4,14 +4,16 @@ RSpec.describe StatusController, type: :controller do
   # This is very-happy-path to ensure the controller responds.  The bulk of the
   # status is tested in spec/services/status_spec.rb.
   describe '#index' do
-    let(:status) { instance_double(C100App::Status, result: result, success?: success) }
+    let(:status) { instance_double(C100App::Status, response: result, success?: success) }
 
     let(:result) {
       {
-        service_status: 'ok',
+        healthy: true,
         dependencies: {
-          database_status: 'ok',
-          courtfinder_status: 'ok'
+          database: true,
+          redis: true,
+          sidekiq: true,
+          courtfinder: true,
         }
       }.to_json
     }


### PR DESCRIPTION
Make it a bit more useful including Sidekiq checks, and also remove
the dependency we had with Court Tribunal Finder because it is just
too unreliable and we don't have any control over it so even if it
goes down, we should not consider our service unhealthy.

Still, this endpoint should not be used for kubernetes probes.
Use `ping` instead.