### PR TITLE
Protect from emails edge case race condition

### DIFF
--- a/db/migrate/20200210092306_add_unique_index_to_email_submissions.rb
+++ b/db/migrate/20200210092306_add_unique_index_to_email_submissions.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToEmailSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :email_submissions, :c100_application_id
+    add_index    :email_submissions, :c100_application_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_21_092151) do
+ActiveRecord::Schema.define(version: 2020_02_10_092306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -238,7 +238,7 @@ ActiveRecord::Schema.define(version: 2020_01_21_092151) do
     t.uuid "c100_application_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["c100_application_id"], name: "index_email_submissions_on_c100_application_id"
+    t.index ["c100_application_id"], name: "index_email_submissions_on_c100_application_id", unique: true
   end
 
   create_table "email_submissions_audit", id: :uuid, default: nil, force: :cascade do |t|

--- a/spec/services/c100_app/online_submission_queue_spec.rb
+++ b/spec/services/c100_app/online_submission_queue_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe C100App::OnlineSubmissionQueue do
   describe '#process' do
     context 'when `email_submission` record already exists' do
       before do
-        allow(c100_application).to receive(:email_submission).and_return(double)
+        allow(EmailSubmission).to receive(:create).with(
+          c100_application: c100_application
+        ).and_raise(ActiveRecord::RecordNotUnique)
       end
 
       it 'does not process the jobs' do
@@ -21,26 +23,12 @@ RSpec.describe C100App::OnlineSubmissionQueue do
 
     context 'when `email_submission` record does not exist' do
       before do
-        allow(c100_application).to receive(:email_submission).and_return(nil)
-        allow(c100_application).to receive(:create_email_submission)
-      end
-
-      # mutant kill
-      context 'uses `present?`' do
-        let(:finder_double) { double }
-
-        before do
-          allow(c100_application).to receive(:email_submission).and_return(finder_double)
-        end
-
-        it {
-          expect(finder_double).to receive(:present?)
-          subject.process
-        }
+        allow(EmailSubmission).to receive(:create).with(
+          c100_application: c100_application
+        ).and_return(double.as_null_object)
       end
 
       it 'creates the `email_submission` record' do
-        expect(c100_application).to receive(:create_email_submission)
         subject.process
       end
 


### PR DESCRIPTION
The code we previously had was making use of a thread-unsafe "find first and if not found, write to database" mechanism to check if we had an `EmailSubmission` record in order to avoid running again the code that sends these emails.

However, this mechanism is actually prone to a race condition. It’s possible that user may double-click a submit button and duplicate a HTTP request. If the timing is perfect, both select would then see no records, then try to do the INSERT.
In the end, we will end up with two rows with the same value in the database.

This has been changed to a "write first, and ignore if you can't" mechanism, where only the first thread will be able to write the record and any later try will fail with a `ActiveRecord::RecordNotUnique` exception.

Changed the `email_submissions` DB table to enforce the unique index.