### PR TITLE
Add new court arrangements table, starting with language

### DIFF
--- a/app/controllers/steps/attending_court/language_controller.rb
+++ b/app/controllers/steps/attending_court/language_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module AttendingCourt
+    class LanguageController < Steps::AttendingCourtStepController
+      def edit
+        @form_object = LanguageForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(LanguageForm, as: :language)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/attending_court_step_controller.rb
+++ b/app/controllers/steps/attending_court_step_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class AttendingCourtStepController < StepController
+    private
+
+    def decision_tree_class
+      C100App::AttendingCourtDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/attending_court/language_form.rb
+++ b/app/forms/steps/attending_court/language_form.rb
@@ -1,0 +1,31 @@
+module Steps
+  module AttendingCourt
+    class LanguageForm < BaseForm
+      include HasOneAssociationForm
+
+      has_one_association :court_arrangement
+
+      attribute :language_interpreter, Boolean
+      attribute :language_interpreter_details, String
+
+      attribute :sign_language_interpreter, Boolean
+      attribute :sign_language_interpreter_details, String
+
+      validates_presence_of :language_interpreter_details, if: :language_interpreter?
+      validates_presence_of :sign_language_interpreter_details, if: :sign_language_interpreter?
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record_to_persist.update(
+          attributes_map.merge(
+            language_interpreter_details: (language_interpreter_details if language_interpreter?),
+            sign_language_interpreter_details: (sign_language_interpreter_details if sign_language_interpreter?),
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -11,24 +11,25 @@ class C100Application < ApplicationRecord
 
   belongs_to :user, optional: true
 
-  has_one  :solicitor,        dependent: :destroy
-  has_one  :abduction_detail, dependent: :destroy
-  has_one  :court_order,      dependent: :destroy
-  has_one  :court_proceeding, dependent: :destroy
-  has_one  :miam_exemption,   dependent: :destroy
-  has_one  :screener_answers, dependent: :destroy
-  has_one  :email_submission, dependent: :destroy
+  has_one  :solicitor,          dependent: :destroy
+  has_one  :abduction_detail,   dependent: :destroy
+  has_one  :court_order,        dependent: :destroy
+  has_one  :court_proceeding,   dependent: :destroy
+  has_one  :court_arrangement,  dependent: :destroy
+  has_one  :miam_exemption,     dependent: :destroy
+  has_one  :screener_answers,   dependent: :destroy
+  has_one  :email_submission,   dependent: :destroy
 
-  has_many :abuse_concerns,   dependent: :destroy
-  has_many :relationships,    dependent: :destroy
+  has_many :abuse_concerns,     dependent: :destroy
+  has_many :relationships,      dependent: :destroy
 
-  has_many :people,           dependent: :destroy
+  has_many :people,             dependent: :destroy
   has_many :minors
   has_many :children
   has_many :applicants
   has_many :respondents
-  has_many :other_children,   dependent: :destroy
-  has_many :other_parties,    dependent: :destroy
+  has_many :other_children,     dependent: :destroy
+  has_many :other_parties,      dependent: :destroy
 
   scope :with_owner,    -> { where.not(user: nil) }
   scope :not_completed, -> { where.not(status: :completed) }

--- a/app/models/court_arrangement.rb
+++ b/app/models/court_arrangement.rb
@@ -1,0 +1,3 @@
+class CourtArrangement < ApplicationRecord
+  belongs_to :c100_application
+end

--- a/app/services/c100_app/attending_court_decision_tree.rb
+++ b/app/services/c100_app/attending_court_decision_tree.rb
@@ -1,0 +1,14 @@
+module C100App
+  class AttendingCourtDecisionTree < BaseDecisionTree
+    def destination
+      return next_step if next_step
+
+      case step_name
+      when :language
+        edit('/steps/application/litigation_capacity')
+      else
+        raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+  end
+end

--- a/app/views/steps/attending_court/language/edit.html.erb
+++ b/app/views/steps/attending_court/language/edit.html.erb
@@ -1,0 +1,29 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <p class="app__section_heading"><%=t '.section' %></p>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <p><%=t '.info_html' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.check_box_fieldset :help_with_language, [
+          :language_interpreter, :sign_language_interpreter
+        ] do |fieldset|
+          fieldset.check_box_input(:language_interpreter) {
+            f.text_area :language_interpreter_details, size: '40x4', class: 'form-control-3-4'
+          }
+          fieldset.check_box_input(:sign_language_interpreter) {
+            f.text_area :sign_language_interpreter_details, size: '40x4', class: 'form-control-3-4'
+          }
+        end
+      %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -804,6 +804,15 @@ en:
           page_title: Details of urgent hearing
           heading: Details of urgent hearing
           court_info_html: If you need to go to court now, <a href="https://courttribunalfinder.service.gov.uk/search/" rel="external" target="_blank">contact your nearest family court</a> for assistance.
+    # attending court redesign -- begin
+    attending_court:
+      language:
+        edit:
+          page_title: Language help
+          section: *attending_court
+          heading: Does anyone in this application need help with language?
+          info_html: You can ask for an interpreter. In Wales, you have the right to speak Welsh at any court hearing.
+    # attending court redesign -- end
     international:
       resident:
         edit:
@@ -1118,6 +1127,10 @@ en:
         dob_unknown_html: ""
       steps_application_declaration_form:
         declaration_signee_capacity_html: ""
+      # attending court redesign -- begin
+      steps_attending_court_language_form:
+        help_with_language: 'One of the people named in this application needs:'
+      # attending court redesign -- end
 
     label:
       steps_shared_relationship_form:
@@ -1154,6 +1167,13 @@ en:
         language_help_details: *provide_details
       steps_application_intermediary_form:
         intermediary_help_details: *provide_details
+      # attending court redesign -- begin
+      steps_attending_court_language_form:
+        language_interpreter: An interpreter
+        sign_language_interpreter: A sign language interpreter
+        language_interpreter_details: Give details of who needs an interpreter and the language they require (including dialect, if applicable)
+        sign_language_interpreter_details: Give details of who needs a British Sign Language interpreter
+      # attending court redesign -- end
       steps_application_payment_form:
         payment_type:
           help_with_fees_html: '<strong>Help with fees</strong><br>You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" rel="external" target="_blank">get help paying</a> if you’re on a low income, receive certain benefits or have little or no savings. If you do qualify, you’ll need to provide your reference number.'

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -563,6 +563,14 @@ en:
               inclusion: Select yes if you need specific arrangements
             special_arrangements_details:
               blank: *blank_details_error
+        # attending court redesign -- begin
+        steps/attending_court/language_form:
+          attributes:
+            language_interpreter_details:
+              blank: Enter details of your interpreter needs
+            sign_language_interpreter_details:
+              blank: Enter details of your sign language interpreter needs
+        # attending court redesign -- end
         steps/application/payment_form:
           attributes:
             payment_type:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,9 @@ Rails.application.routes.draw do
       edit_step :jurisdiction
       edit_step :request
     end
+    namespace :attending_court do
+      edit_step :language
+    end
     namespace :completion do
       show_step :confirmation
       show_step :what_next

--- a/db/migrate/20200207123819_create_court_arrangements_table.rb
+++ b/db/migrate/20200207123819_create_court_arrangements_table.rb
@@ -1,0 +1,14 @@
+class CreateCourtArrangementsTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :court_arrangements, id: :uuid do |t|
+      t.timestamps null: false
+
+      t.boolean :language_interpreter
+      t.text :language_interpreter_details
+      t.boolean :sign_language_interpreter
+      t.text :sign_language_interpreter_details
+    end
+
+    add_reference :court_arrangements, :c100_application, type: :uuid, foreign_key: true, index: { unique: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -177,6 +177,17 @@ ActiveRecord::Schema.define(version: 2020_02_10_092306) do
     t.index ["reference_code"], name: "index_completed_applications_audit_on_reference_code", unique: true
   end
 
+  create_table "court_arrangements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "language_interpreter"
+    t.text "language_interpreter_details"
+    t.boolean "sign_language_interpreter"
+    t.text "sign_language_interpreter_details"
+    t.uuid "c100_application_id"
+    t.index ["c100_application_id"], name: "index_court_arrangements_on_c100_application_id", unique: true
+  end
+
   create_table "court_orders", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "non_molestation"
     t.date "non_molestation_issue_date"
@@ -361,6 +372,7 @@ ActiveRecord::Schema.define(version: 2020_02_10_092306) do
   add_foreign_key "c100_applications", "users"
   add_foreign_key "child_orders", "people", column: "child_id"
   add_foreign_key "child_residences", "people", column: "child_id"
+  add_foreign_key "court_arrangements", "c100_applications"
   add_foreign_key "court_orders", "c100_applications"
   add_foreign_key "court_proceedings", "c100_applications"
   add_foreign_key "email_submissions", "c100_applications"

--- a/spec/controllers/steps/attending_court/language_controller_spec.rb
+++ b/spec/controllers/steps/attending_court/language_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::AttendingCourt::LanguageController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::AttendingCourt::LanguageForm, C100App::AttendingCourtDecisionTree
+end

--- a/spec/forms/steps/attending_court/language_form_spec.rb
+++ b/spec/forms/steps/attending_court/language_form_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+RSpec.describe Steps::AttendingCourt::LanguageForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    language_interpreter: language_interpreter,
+    language_interpreter_details: language_interpreter_details,
+    sign_language_interpreter: sign_language_interpreter,
+    sign_language_interpreter_details: sign_language_interpreter_details,
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:language_interpreter) { true }
+  let(:language_interpreter_details) { 'details' }
+  let(:sign_language_interpreter) { true }
+  let(:sign_language_interpreter_details) { 'details' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      context 'when `language_interpreter` is checked' do
+        let(:language_interpreter) { true }
+        it { should validate_presence_of(:language_interpreter_details) }
+      end
+
+      context 'when `language_interpreter` is not checked' do
+        let(:language_interpreter) { false }
+        it { should_not validate_presence_of(:language_interpreter_details) }
+      end
+
+      context 'when `sign_language_interpreter` is checked' do
+        let(:sign_language_interpreter) { true }
+        it { should validate_presence_of(:sign_language_interpreter_details) }
+      end
+
+      context 'when `sign_language_interpreter` is not checked' do
+        let(:sign_language_interpreter) { false }
+        it { should_not validate_presence_of(:sign_language_interpreter_details) }
+      end
+    end
+
+    context 'ensure leftovers are deleted when deselecting a checkbox' do
+      context '`language_interpreter` is true and `language_interpreter_details` is filled' do
+        let(:language_interpreter) { true }
+        let(:language_interpreter_details) { 'blah blah' }
+
+        it_behaves_like 'a has-one-association form',
+                        association_name: :court_arrangement,
+                        expected_attributes: {
+                          language_interpreter: true,
+                          language_interpreter_details: 'blah blah',
+                          sign_language_interpreter: true,
+                          sign_language_interpreter_details: 'details'
+                        }
+      end
+
+      context '`language_interpreter` is false and `language_interpreter_details` is filled' do
+        let(:language_interpreter) { false }
+        let(:language_interpreter_details) { 'blah blah' }
+
+        it_behaves_like 'a has-one-association form',
+                        association_name: :court_arrangement,
+                        expected_attributes: {
+                          language_interpreter: false,
+                          language_interpreter_details: nil,
+                          sign_language_interpreter: true,
+                          sign_language_interpreter_details: 'details'
+                        }
+      end
+
+      context '`sign_language_interpreter` is true and `sign_language_interpreter_details` is filled' do
+        let(:sign_language_interpreter) { true }
+        let(:sign_language_interpreter_details) { 'blah blah' }
+
+        it_behaves_like 'a has-one-association form',
+                        association_name: :court_arrangement,
+                        expected_attributes: {
+                          language_interpreter: true,
+                          language_interpreter_details: 'details',
+                          sign_language_interpreter: true,
+                          sign_language_interpreter_details: 'blah blah'
+                        }
+      end
+
+      context '`sign_language_interpreter` is false and `sign_language_interpreter_details` is filled' do
+        let(:sign_language_interpreter) { false }
+        let(:sign_language_interpreter_details) { 'blah blah' }
+
+        it_behaves_like 'a has-one-association form',
+                        association_name: :court_arrangement,
+                        expected_attributes: {
+                            language_interpreter: true,
+                            language_interpreter_details: 'details',
+                            sign_language_interpreter: false,
+                            sign_language_interpreter_details: nil
+                        }
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/attending_court_decision_tree_spec.rb
+++ b/spec/services/c100_app/attending_court_decision_tree_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe C100App::AttendingCourtDecisionTree do
+  let(:c100_application) { double('Object') }
+  let(:step_params)      { double('Step') }
+  let(:next_step)        { nil }
+  let(:as)               { nil }
+
+  subject { described_class.new(c100_application: c100_application, step_params: step_params, as: as, next_step: next_step) }
+
+  it_behaves_like 'a decision tree'
+
+  context 'when the step is `language`' do
+    let(:step_params) { { language: 'anything' } }
+    it { is_expected.to have_destination('/steps/application/litigation_capacity', :edit) }
+  end
+end


### PR DESCRIPTION
Individual commits for more detail.

This new table will be used to create the new fields needed for the redesign of the special measures steps, beginning with the language step.

Once all the special measures steps have been migrated, we will be able to remove the old DB fields from the main `c100_applications` table.

Add language step in new `attending_court` namespace.
The main objective here will be to replicate the existing special measures steps, but in a separate namespace so they can be independent from each other and let us introduce new fields.

For a while these 2 journeys will have to cohabit together until all new applications are migrated to the new version.

We are not enabling yet in this PR the new journey.
Following PR's will introduce the changes to the CYA page and the PDF.