### PR TITLE
Add new language block to CYA and PDF

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -145,10 +145,6 @@ IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   Enabled: false
 
-MethodCalledOnDoEndBlock:
-  Description: Avoid chaining a method call on a do...end block.
-  Enabled: true
-
 MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   Enabled: true
@@ -488,6 +484,10 @@ MultilineIfModifier:
 AccessModifierIndentation:
   Enabled: true
   EnforcedStyle: indent
+
+ClassLength:
+  Enabled: true
+  Max: 105
 
 MethodLength:
   Enabled: true

--- a/app/presenters/summary/c100_form.rb
+++ b/app/presenters/summary/c100_form.rb
@@ -88,6 +88,7 @@ module Summary
         Sections::LitigationCapacity.new(c100_application),
         Sections::SectionHeader.new(c100_application, name: :attending_court),
         Sections::AttendingCourt.new(c100_application),
+        Sections::AttendingCourtV2.new(c100_application),
       ]
     end
 

--- a/app/presenters/summary/c1a_form.rb
+++ b/app/presenters/summary/c1a_form.rb
@@ -86,6 +86,7 @@ module Summary
       [
         Sections::SectionHeader.new(c100_application, name: :c1a_attending_court),
         Sections::AttendingCourt.new(c100_application),
+        Sections::AttendingCourtV2.new(c100_application),
       ]
     end
   end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -6,6 +6,7 @@ module Summary
       @c100_application = c100_application
     end
 
+    # rubocop:disable Metrics/AbcSize
     def sections
       [
         *miam_questions,
@@ -20,9 +21,11 @@ module Summary
         HtmlSections::InternationalElement.new(c100_application),
         HtmlSections::ApplicationReasons.new(c100_application),
         HtmlSections::AttendingCourt.new(c100_application),
+        HtmlSections::AttendingCourtV2.new(c100_application),
         *payment_and_submission_sections,
       ].flatten.select(&:show?)
     end
+    # rubocop:enable Metrics/AbcSize
 
     def before_submit_warning
       ['.submit_warning', submission_type].join('.')

--- a/app/presenters/summary/html_sections/attending_court.rb
+++ b/app/presenters/summary/html_sections/attending_court.rb
@@ -5,6 +5,12 @@ module Summary
         :attending_court
       end
 
+      # TODO: Temporary conditional reveal until all applications
+      # are migrated to the new version
+      def show?
+        arrangement.nil? && super
+      end
+
       def answers
         [
           language_assistance,
@@ -16,6 +22,10 @@ module Summary
       end
 
       private
+
+      def arrangement
+        @_arrangement ||= c100.court_arrangement
+      end
 
       def language_assistance
         AnswersGroup.new(

--- a/app/presenters/summary/html_sections/attending_court_v2.rb
+++ b/app/presenters/summary/html_sections/attending_court_v2.rb
@@ -1,0 +1,46 @@
+module Summary
+  module HtmlSections
+    class AttendingCourtV2 < Sections::BaseSectionPresenter
+      def name
+        :attending_court
+      end
+
+      # TODO: Temporary conditional reveal until all applications
+      # are migrated to the new version
+      def show?
+        arrangement.present? && super
+      end
+
+      def answers
+        [
+          language_interpreter,
+        ].flatten.select(&:show?)
+      end
+
+      private
+
+      def arrangement
+        @_arrangement ||= c100.court_arrangement
+      end
+
+      # Note: we convert the booleans in the `Answer` object with `to_s`, so `true` and `false`
+      # are true for `#present?` but not for nil (''), meaning if the user didn't reach this
+      # question yet, the value will be `nil` and `Answer` will not show, but once they reach
+      # this question and continue, it will become `true` or `false`, and we want it to show
+      # (even if it is `false` i.e. checkbox not selected).
+      #
+      def language_interpreter
+        AnswersGroup.new(
+          :language_interpreter,
+          [
+            Answer.new(:language_interpreter, arrangement.language_interpreter.to_s),
+            FreeTextAnswer.new(:language_interpreter_details, arrangement.language_interpreter_details),
+            Answer.new(:sign_language_interpreter, arrangement.sign_language_interpreter.to_s),
+            FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
+          ],
+          change_path: edit_steps_attending_court_language_path
+        )
+      end
+    end
+  end
+end

--- a/app/presenters/summary/html_sections/people_details.rb
+++ b/app/presenters/summary/html_sections/people_details.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 module Summary
   module HtmlSections
     class PeopleDetails < Sections::BaseSectionPresenter
@@ -125,4 +124,3 @@ module Summary
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/presenters/summary/sections/attending_court.rb
+++ b/app/presenters/summary/sections/attending_court.rb
@@ -9,6 +9,12 @@ module Summary
         false
       end
 
+      # TODO: Temporary conditional reveal until all applications
+      # are migrated to the new version
+      def show?
+        arrangement.nil? && super
+      end
+
       def answers
         [
           *language_assistance_answers,
@@ -18,6 +24,10 @@ module Summary
       end
 
       private
+
+      def arrangement
+        @_arrangement ||= c100.court_arrangement
+      end
 
       def language_assistance_answers
         [

--- a/app/presenters/summary/sections/attending_court_v2.rb
+++ b/app/presenters/summary/sections/attending_court_v2.rb
@@ -1,0 +1,47 @@
+module Summary
+  module Sections
+    class AttendingCourtV2 < BaseSectionPresenter
+      def name
+        :attending_court
+      end
+
+      def show_header?
+        false
+      end
+
+      # TODO: Temporary conditional reveal until all applications
+      # are migrated to the new version
+      def show?
+        arrangement.present? && super
+      end
+
+      def answers
+        [
+          *language_interpreter,
+        ].select(&:show?)
+      end
+
+      private
+
+      def arrangement
+        @_arrangement ||= c100.court_arrangement
+      end
+
+      # Note: we convert the booleans in the `Answer` object with `to_s`, so `true` and `false`
+      # are true for `#present?` but not for nil (''), meaning if the user didn't reach this
+      # question yet, the value will be `nil` and `Answer` will not show, but once they reach
+      # this question and continue, it will become `true` or `false`, and we want it to show
+      # (even if it is `false` i.e. checkbox not selected).
+      #
+      def language_interpreter
+        [
+          Separator.new(:language_assistance),
+          Answer.new(:language_interpreter, arrangement.language_interpreter.to_s),
+          FreeTextAnswer.new(:language_interpreter_details, arrangement.language_interpreter_details),
+          Answer.new(:sign_language_interpreter, arrangement.sign_language_interpreter.to_s),
+          FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
+        ]
+      end
+    end
+  end
+end

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -109,6 +109,9 @@ en:
       intermediary: Does anyone in this application need someone to help them communicate in court?
       special_assistance: Does anyone in this application need assistance or special facilities when attending court?
       special_arrangements: Do you or the children need specific arrangements when you attend court?
+      # attending court redesign -- begin
+      language_interpreter: Does anyone in this application need help with language?
+      # attending court redesign -- end
       help_with_fees: Do you have a ‘Help with fees’ reference number?
       payment_type: Payment type
       submission_type: Submission type
@@ -579,6 +582,22 @@ en:
         <<: *YESNO
     special_arrangements_details:
       question: ''
+    # attending court redesign -- begin
+    language_interpreter:
+      question: Interpreter
+      answers:
+        'true': 'Yes'
+        'false': Not needed
+    sign_language_interpreter:
+      question: Sign language interpreter
+      answers:
+        'true': 'Yes'
+        'false': Not needed
+    language_interpreter_details:
+      question: ''
+    sign_language_interpreter_details:
+      question: ''
+    # attending court redesign -- end
     hwf_reference_number:
       question: Reference number
     solicitor_account_number:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -567,9 +567,9 @@ en:
         steps/attending_court/language_form:
           attributes:
             language_interpreter_details:
-              blank: Enter details of your interpreter needs
+              blank: You must give interpreter details
             sign_language_interpreter_details:
-              blank: Enter details of your sign language interpreter needs
+              blank: You must give sign language interpreter details
         # attending court redesign -- end
         steps/application/payment_form:
           attributes:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -393,6 +393,22 @@ en:
         <<: *YESNO
     special_arrangements_details:
       question: *details
+    # attending court redesign -- begin
+    language_interpreter:
+      question: Interpreter
+      answers:
+        'true': 'Yes'
+        'false': Not needed
+    sign_language_interpreter:
+      question: Sign language interpreter
+      answers:
+        'true': 'Yes'
+        'false': Not needed
+    language_interpreter_details:
+      question: *details
+    sign_language_interpreter_details:
+      question: *details
+    # attending court redesign -- end
 
     person_full_name:
       question: Full name

--- a/spec/presenters/summary/c100_form_spec.rb
+++ b/spec/presenters/summary/c100_form_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 module Summary
   describe C100Form do
-    let(:c100_application) { instance_double(C100Application) }
+    let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
+    let(:court_arrangement) { nil }
+
     subject { described_class.new(c100_application) }
 
     describe '#name' do
@@ -67,6 +69,28 @@ module Summary
           Sections::StatementOfTruth,
           Sections::CourtFee,
         ])
+      end
+
+      context 'when not using the new special court arrangement details' do
+        it 'does not include the `AttendingCourtV2` section' do
+          expect(subject.sections).not_to include(Sections::AttendingCourtV2)
+        end
+
+        it 'includes the `AttendingCourt` section' do
+          expect(subject.sections).to include(Sections::AttendingCourt)
+        end
+      end
+
+      context 'when using the new special court arrangement details' do
+        let(:court_arrangement) { instance_double(CourtArrangement) }
+
+        it 'includes the `AttendingCourtV2` section' do
+          expect(subject.sections).to include(Sections::AttendingCourtV2)
+        end
+
+        it 'does not include the `AttendingCourt` section' do
+          expect(subject.sections).not_to include(Sections::AttendingCourt)
+        end
       end
     end
   end

--- a/spec/presenters/summary/c1a_form_spec.rb
+++ b/spec/presenters/summary/c1a_form_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 module Summary
   describe C1aForm do
-    let(:c100_application) { instance_double(C100Application) }
+    let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
+    let(:court_arrangement) { nil }
+
     subject { described_class.new(c100_application) }
 
     describe '#name' do
@@ -49,6 +51,28 @@ module Summary
           Sections::AttendingCourt,
           Sections::C1aGettingSupport,
         ])
+      end
+
+      context 'when not using the new special court arrangement details' do
+        it 'does not include the `AttendingCourtV2` section' do
+          expect(subject.sections).not_to include(Sections::AttendingCourtV2)
+        end
+
+        it 'includes the `AttendingCourt` section' do
+          expect(subject.sections).to include(Sections::AttendingCourt)
+        end
+      end
+
+      context 'when using the new special court arrangement details' do
+        let(:court_arrangement) { instance_double(CourtArrangement) }
+
+        it 'includes the `AttendingCourtV2` section' do
+          expect(subject.sections).to include(Sections::AttendingCourtV2)
+        end
+
+        it 'does not include the `AttendingCourt` section' do
+          expect(subject.sections).not_to include(Sections::AttendingCourt)
+        end
       end
     end
   end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -43,11 +43,17 @@ describe Summary::HtmlPresenter do
   end
 
   describe '#sections' do
+    let(:abduction_detail) { instance_double(AbductionDetail) }
+    let(:court_arrangement) { nil }
+
     before do
       allow_any_instance_of(Summary::Sections::BaseSectionPresenter).to receive(:show?).and_return(true)
 
       # Abduction section
-      allow(c100_application).to receive(:abduction_detail).and_return(AbductionDetail.new)
+      allow(c100_application).to receive(:abduction_detail).and_return(abduction_detail)
+
+      # Special court arrangements section
+      allow(c100_application).to receive(:court_arrangement).and_return(court_arrangement)
     end
 
     it 'has the right sections in the right order' do
@@ -80,6 +86,38 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::Payment,
         Summary::HtmlSections::Submission,
       ])
+    end
+
+    context 'when there are not yet abduction details' do
+      let(:abduction_detail) { nil }
+
+      it 'does not include the section' do
+        expect(subject.sections).not_to include(Summary::HtmlSections::Abduction)
+      end
+    end
+
+    context 'when not using the new special court arrangement details' do
+      let(:court_arrangement) { nil }
+
+      it 'does not include the `AttendingCourtV2` section' do
+        expect(subject.sections).not_to include(Summary::HtmlSections::AttendingCourtV2)
+      end
+
+      it 'includes the `AttendingCourt` section' do
+        expect(subject.sections).to include(Summary::HtmlSections::AttendingCourt)
+      end
+    end
+
+    context 'when using the new special court arrangement details' do
+      let(:court_arrangement) { instance_double(CourtArrangement) }
+
+      it 'includes the `AttendingCourtV2` section' do
+        expect(subject.sections).to include(Summary::HtmlSections::AttendingCourtV2)
+      end
+
+      it 'does not include the `AttendingCourt` section' do
+        expect(subject.sections).not_to include(Summary::HtmlSections::AttendingCourt)
+      end
     end
   end
 end

--- a/spec/presenters/summary/html_sections/attending_court_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_spec.rb
@@ -16,14 +16,34 @@ module Summary
         special_assistance_details: 'special_assistance_details',
         special_arrangements: 'yes',
         special_arrangements_details: 'special_arrangements_details',
+        court_arrangement: court_arrangement,
     ) }
 
     subject { described_class.new(c100_application) }
 
     let(:answers) { subject.answers }
+    let(:court_arrangement) { nil }
 
     describe '#name' do
       it { expect(subject.name).to eq(:attending_court) }
+    end
+
+    describe '#show?' do
+      context 'when not using the new special court arrangement details' do
+        let(:court_arrangement) { nil }
+
+        it 'returns true (we use this class, `AttendingCourt`)' do
+          expect(subject.show?).to eq(true)
+        end
+      end
+
+      context 'when using the new special court arrangement details' do
+        let(:court_arrangement) { double }
+
+        it 'returns false (we use the new class, `AttendingCourtV2`)' do
+          expect(subject.show?).to eq(false)
+        end
+      end
     end
 
     describe '#answers' do

--- a/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::AttendingCourtV2 do
+    subject { described_class.new(c100_application) }
+
+    let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
+
+    let(:court_arrangement) {
+      instance_double(CourtArrangement,
+        language_interpreter: true,
+        language_interpreter_details: 'language_interpreter_details',
+        sign_language_interpreter: true,
+        sign_language_interpreter_details: 'sign_language_interpreter_details'
+    )}
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:attending_court) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(1)
+
+        expect(answers[0]).to be_an_instance_of(AnswersGroup)
+        expect(answers[0].name).to eq(:language_interpreter)
+        expect(answers[0].change_path).to eq('/steps/attending_court/language')
+      end
+
+      context 'language_interpreter' do
+        let(:group_answers) { answers[0].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(4)
+
+          expect(group_answers[0]).to be_an_instance_of(Answer)
+          expect(group_answers[0].question).to eq(:language_interpreter)
+          expect(group_answers[0].value).to eq('true')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:language_interpreter_details)
+          expect(group_answers[1].value).to eq('language_interpreter_details')
+
+          expect(group_answers[2]).to be_an_instance_of(Answer)
+          expect(group_answers[2].question).to eq(:sign_language_interpreter)
+          expect(group_answers[2].value).to eq('true')
+
+          expect(group_answers[3]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[3].question).to eq(:sign_language_interpreter_details)
+          expect(group_answers[3].value).to eq('sign_language_interpreter_details')
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/summary/sections/attending_court_spec.rb
+++ b/spec/presenters/summary/sections/attending_court_spec.rb
@@ -12,11 +12,13 @@ module Summary
         language_help_details: 'language_help_details',
         intermediary_help: 'yes',
         intermediary_help_details: 'intermediary_help_details',
+        court_arrangement: court_arrangement,
     ) }
 
     subject { described_class.new(c100_application) }
 
     let(:answers) { subject.answers }
+    let(:court_arrangement) { nil }
 
     describe '#name' do
       it { expect(subject.name).to eq(:attending_court) }
@@ -24,6 +26,24 @@ module Summary
 
     describe '#show_header?' do
       it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#show?' do
+      context 'when not using the new special court arrangement details' do
+        let(:court_arrangement) { nil }
+
+        it 'returns true (we use this class, `AttendingCourt`)' do
+          expect(subject.show?).to eq(true)
+        end
+      end
+
+      context 'when using the new special court arrangement details' do
+        let(:court_arrangement) { double }
+
+        it 'returns false (we use the new class, `AttendingCourtV2`)' do
+          expect(subject.show?).to eq(false)
+        end
+      end
     end
 
     # The following tests can be fragile, but on purpose. During the development phase

--- a/spec/presenters/summary/sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/sections/attending_court_v2_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::AttendingCourtV2 do
+    subject { described_class.new(c100_application) }
+
+    let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
+
+    let(:court_arrangement) {
+      instance_double(CourtArrangement,
+        language_interpreter: true,
+        language_interpreter_details: 'language_interpreter_details',
+        sign_language_interpreter: true,
+        sign_language_interpreter_details: 'sign_language_interpreter_details'
+    )}
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:attending_court) }
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#show?' do
+      context 'when not using the new special court arrangement details' do
+        let(:court_arrangement) { nil }
+
+        it 'returns true (we use this class, `AttendingCourt`)' do
+          expect(subject.show?).to eq(false)
+        end
+      end
+
+      context 'when using the new special court arrangement details' do
+        it 'returns false (we use the new class, `AttendingCourtV2`)' do
+          expect(subject.show?).to eq(true)
+        end
+      end
+    end
+
+    # The following tests can be fragile, but on purpose. During the development phase
+    # we have to update the tests each time we introduce a new row or remove another.
+    # But once it is finished and stable, it will raise a red flag if it ever gets out
+    # of sync, which means a quite solid safety net for any maintainers in the future.
+    #
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(5)
+
+        expect(answers[0]).to be_an_instance_of(Separator)
+        expect(answers[0].title).to eq(:language_assistance)
+
+        expect(answers[1].question).to eq(:language_interpreter)
+        expect(answers[1].value).to eq('true')
+
+        expect(answers[2].question).to eq(:language_interpreter_details)
+        expect(answers[2].value).to eq('language_interpreter_details')
+
+        expect(answers[3].question).to eq(:sign_language_interpreter)
+        expect(answers[3].value).to eq('true')
+
+        expect(answers[4].question).to eq(:sign_language_interpreter_details)
+        expect(answers[4].value).to eq('sign_language_interpreter_details')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Individual commits for more detail.

While we migrate all the applications to the new version, we must support old applications, so both blocks will continue working in parallel, but the new one will only show if we have a `court_arrangement` DB record.