### PR TITLE
Change order of the litigation capacity step

### DIFF
--- a/app/presenters/summary/html_sections/attending_court.rb
+++ b/app/presenters/summary/html_sections/attending_court.rb
@@ -13,8 +13,8 @@ module Summary
 
       def answers
         [
-          language_assistance,
           litigation_capacity,
+          language_assistance,
           intermediary,
           special_assistance,
           special_arrangements,

--- a/app/presenters/summary/html_sections/attending_court_v2.rb
+++ b/app/presenters/summary/html_sections/attending_court_v2.rb
@@ -13,6 +13,7 @@ module Summary
 
       def answers
         [
+          litigation_capacity,
           language_interpreter,
         ].flatten.select(&:show?)
       end
@@ -21,6 +22,27 @@ module Summary
 
       def arrangement
         @_arrangement ||= c100.court_arrangement
+      end
+
+      # Note: this for now maintains the same DB model as before (dupe from `AttendingCourt`)
+      # To be evaluated if it is worth move the fields to the new `court_arrangements` table.
+      def litigation_capacity
+        [
+          Answer.new(
+            :reduced_litigation_capacity,
+            c100.reduced_litigation_capacity,
+            change_path: edit_steps_application_litigation_capacity_path
+          ),
+          AnswersGroup.new(
+            :litigation_capacity,
+            [
+              FreeTextAnswer.new(:participation_capacity_details, c100.participation_capacity_details),
+              FreeTextAnswer.new(:participation_other_factors_details, c100.participation_other_factors_details),
+              FreeTextAnswer.new(:participation_referral_or_assessment_details, c100.participation_referral_or_assessment_details),
+            ],
+            change_path: edit_steps_application_litigation_capacity_details_path
+          )
+        ]
       end
 
       # Note: we convert the booleans in the `Answer` object with `to_s`, so `true` and `false`

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -18,12 +18,12 @@ module C100App
       when :without_notice_details
         start_international_journey
       when :application_details
-        edit(:language)
-      when :language
         edit(:litigation_capacity)
       when :litigation_capacity
         after_litigation_capacity
       when :litigation_capacity_details
+        edit(:language)
+      when :language
         edit(:intermediary)
       when :intermediary
         edit(:special_assistance)
@@ -73,7 +73,7 @@ module C100App
       if question(:reduced_litigation_capacity).yes?
         edit(:litigation_capacity_details)
       else
-        edit(:intermediary)
+        edit(:language)
       end
     end
 

--- a/app/services/c100_app/attending_court_decision_tree.rb
+++ b/app/services/c100_app/attending_court_decision_tree.rb
@@ -5,7 +5,7 @@ module C100App
 
       case step_name
       when :language
-        edit('/steps/application/litigation_capacity')
+        edit('/steps/application/intermediary')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/views/steps/application/details/edit.html.erb
+++ b/app/views/steps/application/details/edit.html.erb
@@ -10,12 +10,14 @@
       <%=t '.info_html' %>
     </div>
 
-    <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
-      <p><%=t '.timeout_warning', session_timeout: session_expire_in_minutes %></p>
-    </div>
+    <% unless user_signed_in? %>
+      <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
+        <p><%=t '.timeout_warning', session_timeout: session_expire_in_minutes %></p>
+      </div>
+    <% end %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.text_area :application_details, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.text_area :application_details, size: '40x8', class: 'form-control-3-4' %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -105,7 +105,7 @@ en:
       international_jurisdiction: Do you think another person in this application may be able to apply for a similar order in a country outside England or Wales?
       international_request: Has a request for information or other assistance involving the children been made to or by another country?
       language_help: Does anyone in this application need help with language?
-      litigation_capacity: Are there any factors that may affect any adult in this application taking part in the court proceedings?
+      litigation_capacity: Factors affecting ability to participate
       intermediary: Does anyone in this application need someone to help them communicate in court?
       special_assistance: Does anyone in this application need assistance or special facilities when attending court?
       special_arrangements: Do you or the children need specific arrangements when you attend court?

--- a/spec/presenters/summary/html_sections/attending_court_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_spec.rb
@@ -50,18 +50,18 @@ module Summary
       it 'has the correct rows' do
         expect(answers.count).to eq(6)
 
-        expect(answers[0]).to be_an_instance_of(AnswersGroup)
-        expect(answers[0].name).to eq(:language_help)
-        expect(answers[0].change_path).to eq('/steps/application/language')
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:reduced_litigation_capacity)
+        expect(answers[0].value).to eq('yes')
+        expect(answers[0].change_path).to eq('/steps/application/litigation_capacity')
 
-        expect(answers[1]).to be_an_instance_of(Answer)
-        expect(answers[1].question).to eq(:reduced_litigation_capacity)
-        expect(answers[1].value).to eq('yes')
-        expect(answers[1].change_path).to eq('/steps/application/litigation_capacity')
+        expect(answers[1]).to be_an_instance_of(AnswersGroup)
+        expect(answers[1].name).to eq(:litigation_capacity)
+        expect(answers[1].change_path).to eq('/steps/application/litigation_capacity_details')
 
         expect(answers[2]).to be_an_instance_of(AnswersGroup)
-        expect(answers[2].name).to eq(:litigation_capacity)
-        expect(answers[2].change_path).to eq('/steps/application/litigation_capacity_details')
+        expect(answers[2].name).to eq(:language_help)
+        expect(answers[2].change_path).to eq('/steps/application/language')
 
         expect(answers[3]).to be_an_instance_of(AnswersGroup)
         expect(answers[3].name).to eq(:intermediary)
@@ -77,7 +77,7 @@ module Summary
       end
 
       context 'language_assistance' do
-        let(:group_answers) { answers[0].answers }
+        let(:group_answers) { answers[2].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(2)
@@ -93,7 +93,7 @@ module Summary
       end
 
       context 'litigation_capacity' do
-        let(:group_answers) { answers[2].answers }
+        let(:group_answers) { answers[1].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(3)

--- a/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
@@ -4,7 +4,16 @@ module Summary
   describe HtmlSections::AttendingCourtV2 do
     subject { described_class.new(c100_application) }
 
-    let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
+    let(:c100_application) {
+      instance_double(
+        C100Application,
+        reduced_litigation_capacity: 'yes',
+        participation_capacity_details: 'participation_capacity_details',
+        participation_other_factors_details: 'participation_other_factors_details',
+        participation_referral_or_assessment_details: 'participation_referral_or_assessment_details',
+        court_arrangement: court_arrangement
+      )
+    }
 
     let(:court_arrangement) {
       instance_double(CourtArrangement,
@@ -22,15 +31,24 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(1)
+        expect(answers.count).to eq(3)
 
-        expect(answers[0]).to be_an_instance_of(AnswersGroup)
-        expect(answers[0].name).to eq(:language_interpreter)
-        expect(answers[0].change_path).to eq('/steps/attending_court/language')
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:reduced_litigation_capacity)
+        expect(answers[0].value).to eq('yes')
+        expect(answers[0].change_path).to eq('/steps/application/litigation_capacity')
+
+        expect(answers[1]).to be_an_instance_of(AnswersGroup)
+        expect(answers[1].name).to eq(:litigation_capacity)
+        expect(answers[1].change_path).to eq('/steps/application/litigation_capacity_details')
+
+        expect(answers[2]).to be_an_instance_of(AnswersGroup)
+        expect(answers[2].name).to eq(:language_interpreter)
+        expect(answers[2].change_path).to eq('/steps/attending_court/language')
       end
 
       context 'language_interpreter' do
-        let(:group_answers) { answers[0].answers }
+        let(:group_answers) { answers[2].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(4)

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -72,11 +72,6 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
   context 'when the step is `application_details`' do
     let(:step_params) { { application_details: 'anything' } }
-    it { is_expected.to have_destination(:language, :edit) }
-  end
-
-  context 'when the step is `language`' do
-    let(:step_params) { { language: 'anything' } }
     it { is_expected.to have_destination(:litigation_capacity, :edit) }
   end
 
@@ -91,12 +86,17 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
     context 'and the answer is `no`' do
       let(:answer) { 'no' }
-      it { is_expected.to have_destination(:intermediary, :edit) }
+      it { is_expected.to have_destination(:language, :edit) }
     end
   end
 
   context 'when the step is `litigation_capacity_details`' do
     let(:step_params) { { litigation_capacity_details: 'anything' } }
+    it { is_expected.to have_destination(:language, :edit) }
+  end
+
+  context 'when the step is `language`' do
+    let(:step_params) { { language: 'anything' } }
     it { is_expected.to have_destination(:intermediary, :edit) }
   end
 

--- a/spec/services/c100_app/attending_court_decision_tree_spec.rb
+++ b/spec/services/c100_app/attending_court_decision_tree_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe C100App::AttendingCourtDecisionTree do
 
   context 'when the step is `language`' do
     let(:step_params) { { language: 'anything' } }
-    it { is_expected.to have_destination('/steps/application/litigation_capacity', :edit) }
+    it { is_expected.to have_destination('/steps/application/intermediary', :edit) }
   end
 end


### PR DESCRIPTION
We are moving this question one step back, so it goes before the language question, instead of after, like it is now.

This will help with the reorganising of the rest of the attending court questions. In essence we maintain this question as it is, and we will not use the new table for these fields, at least for now.

The PDF order does not change.