### PR TITLE
Duplicate intermediary step in new namespace

### DIFF
--- a/app/controllers/steps/attending_court/intermediary_controller.rb
+++ b/app/controllers/steps/attending_court/intermediary_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module AttendingCourt
+    class IntermediaryController < Steps::AttendingCourtStepController
+      def edit
+        @form_object = IntermediaryForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(IntermediaryForm, as: :intermediary)
+      end
+    end
+  end
+end

--- a/app/forms/steps/attending_court/intermediary_form.rb
+++ b/app/forms/steps/attending_court/intermediary_form.rb
@@ -1,0 +1,15 @@
+module Steps
+  module AttendingCourt
+    class IntermediaryForm < BaseForm
+      include SingleQuestionForm
+      include HasOneAssociationForm
+
+      has_one_association :court_arrangement
+      yes_no_attribute :intermediary_help, reset_when_no: [:intermediary_help_details]
+
+      attribute :intermediary_help_details, String
+
+      validates_presence_of :intermediary_help_details, if: -> { intermediary_help&.yes? }
+    end
+  end
+end

--- a/app/services/c100_app/attending_court_decision_tree.rb
+++ b/app/services/c100_app/attending_court_decision_tree.rb
@@ -5,7 +5,9 @@ module C100App
 
       case step_name
       when :language
-        edit('/steps/application/intermediary')
+        edit(:intermediary)
+      when :intermediary
+        edit('/steps/application/special_assistance')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/views/steps/attending_court/intermediary/edit.html.erb
+++ b/app/views/steps/attending_court/intermediary/edit.html.erb
@@ -1,0 +1,28 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <p class="app__section_heading"><%=t '.section' %></p>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <div class="govuk-govspeak gv-s-prose">
+      <p><%= t '.lead_text' %></p>
+    </div>
+
+    <%= step_form @form_object do |f| %>
+      <%=
+        f.radio_button_fieldset :intermediary_help, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
+          fieldset.radio_input(GenericYesNo::YES, panel_id: :intermediary_help_panel)
+          fieldset.radio_input(GenericYesNo::NO)
+          fieldset.revealing_panel(:intermediary_help_panel) do |panel|
+            panel.text_area :intermediary_help_details, size: '40x4', class: 'form-control-3-4'
+          end
+        end
+      %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -106,7 +106,7 @@ en:
       international_request: Has a request for information or other assistance involving the children been made to or by another country?
       language_help: Does anyone in this application need help with language?
       litigation_capacity: Factors affecting ability to participate
-      intermediary: Does anyone in this application need someone to help them communicate in court?
+      intermediary: Does anyone in this application need an intermediary to help them communicate in court?
       special_assistance: Does anyone in this application need assistance or special facilities when attending court?
       special_arrangements: Do you or the children need specific arrangements when you attend court?
       # attending court redesign -- begin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -737,8 +737,8 @@ en:
         edit:
           page_title: Intermediary help
           section: *attending_court
-          heading: Does anyone in this application need someone to help them communicate in court?
-          lead_text: They may need a person (also known as an intermediary) to help them understand and participate in the court process
+          heading: Does anyone in this application need an intermediary to help them communicate in court?
+          lead_text: An intermediary is appointed by the court to help people understand and participate in court. For example, you may need an intermediary if you have a learning, mental or physical disability.
       payment:
         edit:
           page_title: Payment type
@@ -812,6 +812,12 @@ en:
           section: *attending_court
           heading: Does anyone in this application need help with language?
           info_html: You can ask for an interpreter. In Wales, you have the right to speak Welsh at any court hearing.
+      intermediary:
+        edit:
+          page_title: Intermediary help
+          section: *attending_court
+          heading: Does anyone in this application need an intermediary to help them communicate in court?
+          lead_text: An intermediary is appointed by the court to help people understand and participate in court. For example, you may need an intermediary if you have a learning, mental or physical disability.
     # attending court redesign -- end
     international:
       resident:
@@ -1167,12 +1173,18 @@ en:
         language_help_details: *provide_details
       steps_application_intermediary_form:
         intermediary_help_details: *provide_details
+        intermediary_help:
+          <<: *YESNO
       # attending court redesign -- begin
       steps_attending_court_language_form:
         language_interpreter: An interpreter
         sign_language_interpreter: A sign language interpreter
         language_interpreter_details: Give details of who needs an interpreter and the language they require (including dialect, if applicable)
         sign_language_interpreter_details: Give details of who needs a British Sign Language interpreter
+      steps_attending_court_intermediary_form:
+        intermediary_help_details: *provide_details
+        intermediary_help:
+          <<: *YESNO
       # attending court redesign -- end
       steps_application_payment_form:
         payment_type:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -548,9 +548,9 @@ en:
         steps/application/intermediary_form:
           attributes:
             intermediary_help:
-              inclusion: *yes_no_error
+              inclusion: Select yes if an intermediary is needed in court
             intermediary_help_details:
-              blank: *blank_details_error
+              blank: You must give details of who needs help communicating in court
         steps/application/special_assistance_form:
           attributes:
             special_assistance:
@@ -570,6 +570,12 @@ en:
               blank: You must give interpreter details
             sign_language_interpreter_details:
               blank: You must give sign language interpreter details
+        steps/attending_court/intermediary_form:
+          attributes:
+            intermediary_help:
+              inclusion: Select yes if an intermediary is needed in court
+            intermediary_help_details:
+              blank: You must give details of who needs help communicating in court
         # attending court redesign -- end
         steps/application/payment_form:
           attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,6 +271,7 @@ Rails.application.routes.draw do
     end
     namespace :attending_court do
       edit_step :language
+      edit_step :intermediary
     end
     namespace :completion do
       show_step :confirmation

--- a/db/migrate/20200211152952_add_welsh_fields_to_court_arrangements.rb
+++ b/db/migrate/20200211152952_add_welsh_fields_to_court_arrangements.rb
@@ -1,0 +1,6 @@
+class AddWelshFieldsToCourtArrangements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :court_arrangements, :welsh_language, :boolean
+    add_column :court_arrangements, :welsh_language_details, :text
+  end
+end

--- a/db/migrate/20200211153458_add_intermediary_fields_to_court_arrangements.rb
+++ b/db/migrate/20200211153458_add_intermediary_fields_to_court_arrangements.rb
@@ -1,0 +1,6 @@
+class AddIntermediaryFieldsToCourtArrangements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :court_arrangements, :intermediary_help, :string
+    add_column :court_arrangements, :intermediary_help_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_092306) do
+ActiveRecord::Schema.define(version: 2020_02_11_153458) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -185,6 +185,10 @@ ActiveRecord::Schema.define(version: 2020_02_10_092306) do
     t.boolean "sign_language_interpreter"
     t.text "sign_language_interpreter_details"
     t.uuid "c100_application_id"
+    t.boolean "welsh_language"
+    t.text "welsh_language_details"
+    t.string "intermediary_help"
+    t.text "intermediary_help_details"
     t.index ["c100_application_id"], name: "index_court_arrangements_on_c100_application_id", unique: true
   end
 

--- a/spec/controllers/steps/attending_court/intermediary_controller_spec.rb
+++ b/spec/controllers/steps/attending_court/intermediary_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::AttendingCourt::IntermediaryController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::AttendingCourt::IntermediaryForm, C100App::AttendingCourtDecisionTree
+end

--- a/spec/forms/steps/attending_court/intermediary_form_spec.rb
+++ b/spec/forms/steps/attending_court/intermediary_form_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Steps::AttendingCourt::IntermediaryForm do
+  it_behaves_like 'a yes-no question form',
+                  association_name: :court_arrangement,
+                  attribute_name:   :intermediary_help,
+                  linked_attribute: :intermediary_help_details,
+                  reset_when_no:   [:intermediary_help_details]
+end

--- a/spec/services/c100_app/attending_court_decision_tree_spec.rb
+++ b/spec/services/c100_app/attending_court_decision_tree_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe C100App::AttendingCourtDecisionTree do
 
   context 'when the step is `language`' do
     let(:step_params) { { language: 'anything' } }
-    it { is_expected.to have_destination('/steps/application/intermediary', :edit) }
+    it { is_expected.to have_destination(:intermediary, :edit) }
+  end
+
+  context 'when the step is `intermediary`' do
+    let(:step_params) { { intermediary: 'anything' } }
+    it { is_expected.to have_destination('/steps/application/special_assistance', :edit) }
   end
 end


### PR DESCRIPTION
As we did with language we are creating (in this case an identical) copy of the already existing `intermediary` step, but in the new namespace `AttendingCourt`, and using the DB fields from the associated table `court_arrangement`.

Some minor copy changes along the way as per design.

This is not yet wired to the main journey, but can be accessed knowing the URL.

Next PR will add the neccessary CYA and PDF changes.

Also, for future needs, a couple of fields for Welsh language have been added to the `court_arrangements` table. We are not using them at the moment.