### PR TITLE
Change order of the special assistance step

### DIFF
--- a/app/presenters/summary/html_sections/attending_court.rb
+++ b/app/presenters/summary/html_sections/attending_court.rb
@@ -16,8 +16,8 @@ module Summary
           litigation_capacity,
           language_assistance,
           intermediary,
-          special_assistance,
           special_arrangements,
+          special_assistance,
         ].flatten.select(&:show?)
       end
 
@@ -68,17 +68,6 @@ module Summary
         )
       end
 
-      def special_assistance
-        AnswersGroup.new(
-          :special_assistance,
-          [
-            Answer.new(:special_assistance, c100.special_assistance),
-            FreeTextAnswer.new(:special_assistance_details, c100.special_assistance_details),
-          ],
-          change_path: edit_steps_application_special_assistance_path
-        )
-      end
-
       def special_arrangements
         AnswersGroup.new(
           :special_arrangements,
@@ -87,6 +76,17 @@ module Summary
             FreeTextAnswer.new(:special_arrangements_details, c100.special_arrangements_details),
           ],
           change_path: edit_steps_application_special_arrangements_path
+        )
+      end
+
+      def special_assistance
+        AnswersGroup.new(
+          :special_assistance,
+          [
+            Answer.new(:special_assistance, c100.special_assistance),
+            FreeTextAnswer.new(:special_assistance_details, c100.special_assistance_details),
+          ],
+          change_path: edit_steps_application_special_assistance_path
         )
       end
     end

--- a/app/presenters/summary/sections/attending_court.rb
+++ b/app/presenters/summary/sections/attending_court.rb
@@ -19,6 +19,7 @@ module Summary
         [
           *language_assistance_answers,
           *intermediary_answers,
+          *special_arrangements_answers,
           *special_assistance_answers,
         ].select(&:show?)
       end
@@ -45,13 +46,19 @@ module Summary
         ]
       end
 
+      def special_arrangements_answers
+        [
+          Separator.new(:special_arrangements),
+          Answer.new(:special_arrangements, c100.special_arrangements),
+          FreeTextAnswer.new(:special_arrangements_details, c100.special_arrangements_details),
+        ]
+      end
+
       def special_assistance_answers
         [
           Separator.new(:special_assistance),
           Answer.new(:special_assistance, c100.special_assistance),
           FreeTextAnswer.new(:special_assistance_details, c100.special_assistance_details),
-          Answer.new(:special_arrangements, c100.special_arrangements),
-          FreeTextAnswer.new(:special_arrangements_details, c100.special_arrangements_details),
         ]
       end
     end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -26,10 +26,10 @@ module C100App
       when :language
         edit(:intermediary)
       when :intermediary
-        edit(:special_assistance)
-      when :special_assistance
         edit(:special_arrangements)
       when :special_arrangements
+        edit(:special_assistance)
+      when :special_assistance
         edit(:payment)
       when :payment
         edit(:submission)

--- a/app/views/steps/application/special_arrangements/edit.html.erb
+++ b/app/views/steps/application/special_arrangements/edit.html.erb
@@ -9,6 +9,7 @@
 
     <div class="govuk-govspeak gv-s-prose">
       <p><%= t '.lead_text' %></p>
+      <p><%= t '.court_contact' %></p>
     </div>
 
     <%= step_form @form_object do |f| %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -108,7 +108,7 @@ en:
       litigation_capacity: Factors affecting ability to participate
       intermediary: Does anyone in this application need an intermediary to help them communicate in court?
       special_assistance: Does anyone in this application need assistance or special facilities when attending court?
-      special_arrangements: Do you or the children need specific arrangements when you attend court?
+      special_arrangements: Do you or the children need specific safety arrangements at court?
       # attending court redesign -- begin
       language_interpreter: Does anyone in this application need help with language?
       # attending court redesign -- end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -707,13 +707,14 @@ en:
           page_title: Special Assistance
           section: *attending_court
           heading: Does anyone in this application need assistance or special facilities when attending court?
-          lead_text: For example they need to use British Sign Language, a hearing loop or documents in braille
+          lead_text: For example they need a hearing loop or documents in braille.
       special_arrangements:
         edit:
           page_title: Special Arrangements
           section: *attending_court
-          heading: Do you or the children need specific arrangements when you attend court?
-          lead_text: For example you need a separate waiting room to the other person, video link or protective screen due to safety concerns. The court may contact you to discuss your requirements.
+          heading: Do you or the children need specific safety arrangements at court?
+          lead_text: For example you need a separate waiting room to the other person, video link or protective screen due to safety concerns.
+          court_contact: The court will contact you to discuss safety arrangements before your hearing.
       details:
         edit:
           page_title: Application details

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -560,7 +560,7 @@ en:
         steps/application/special_arrangements_form:
           attributes:
             special_arrangements:
-              inclusion: Select yes if you need specific arrangements
+              inclusion: Select yes if you need specific safety arrangements
             special_arrangements_details:
               blank: *blank_details_error
         # attending court redesign -- begin

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -153,7 +153,8 @@ en:
       contact_details: Contact details
       language_assistance: Language assistance
       intermediary: Intermediary
-      special_assistance: Special assistance / facilities
+      special_arrangements: Special safety arrangements
+      special_assistance: Special assistance or facilities
       child_index_title: Child %{index}
       other_child_index_title: Other child %{index}
       applicants_details_index_title: Applicant %{index}
@@ -382,7 +383,7 @@ en:
     intermediary_help_details:
       question: *details
     special_assistance:
-      question: Special assistance or special facilities required for any of the parties
+      question: Special assistance or special facilities required for applicant or any of the parties
       answers:
         <<: *YESNO
     special_assistance_details:

--- a/spec/presenters/summary/html_sections/attending_court_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_spec.rb
@@ -68,12 +68,12 @@ module Summary
         expect(answers[3].change_path).to eq('/steps/application/intermediary')
 
         expect(answers[4]).to be_an_instance_of(AnswersGroup)
-        expect(answers[4].name).to eq(:special_assistance)
-        expect(answers[4].change_path).to eq('/steps/application/special_assistance')
+        expect(answers[4].name).to eq(:special_arrangements)
+        expect(answers[4].change_path).to eq('/steps/application/special_arrangements')
 
         expect(answers[5]).to be_an_instance_of(AnswersGroup)
-        expect(answers[5].name).to eq(:special_arrangements)
-        expect(answers[5].change_path).to eq('/steps/application/special_arrangements')
+        expect(answers[5].name).to eq(:special_assistance)
+        expect(answers[5].change_path).to eq('/steps/application/special_assistance')
       end
 
       context 'language_assistance' do
@@ -128,24 +128,8 @@ module Summary
         end
       end
 
-      context 'special_assistance' do
-        let(:group_answers) { answers[4].answers }
-
-        it 'has the correct rows in the right order' do
-          expect(group_answers.count).to eq(2)
-
-          expect(group_answers[0]).to be_an_instance_of(Answer)
-          expect(group_answers[0].question).to eq(:special_assistance)
-          expect(group_answers[0].value).to eq('yes')
-
-          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
-          expect(group_answers[1].question).to eq(:special_assistance_details)
-          expect(group_answers[1].value).to eq('special_assistance_details')
-        end
-      end
-
       context 'special_arrangements' do
-        let(:group_answers) { answers[5].answers }
+        let(:group_answers) { answers[4].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(2)
@@ -157,6 +141,22 @@ module Summary
           expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
           expect(group_answers[1].question).to eq(:special_arrangements_details)
           expect(group_answers[1].value).to eq('special_arrangements_details')
+        end
+      end
+
+      context 'special_assistance' do
+        let(:group_answers) { answers[5].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(2)
+
+          expect(group_answers[0]).to be_an_instance_of(Answer)
+          expect(group_answers[0].question).to eq(:special_assistance)
+          expect(group_answers[0].value).to eq('yes')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:special_assistance_details)
+          expect(group_answers[1].value).to eq('special_assistance_details')
         end
       end
     end

--- a/spec/presenters/summary/sections/attending_court_spec.rb
+++ b/spec/presenters/summary/sections/attending_court_spec.rb
@@ -53,7 +53,7 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(11)
+        expect(answers.count).to eq(12)
 
         expect(answers[0]).to be_an_instance_of(Separator)
         expect(answers[0].title).to eq(:language_assistance)
@@ -76,23 +76,27 @@ module Summary
         expect(answers[5].value).to eq('intermediary_help_details')
 
         expect(answers[6]).to be_an_instance_of(Separator)
-        expect(answers[6].title).to eq(:special_assistance)
+        expect(answers[6].title).to eq(:special_arrangements)
 
         expect(answers[7]).to be_an_instance_of(Answer)
-        expect(answers[7].question).to eq(:special_assistance)
+        expect(answers[7].question).to eq(:special_arrangements)
         expect(answers[7].value).to eq('yes')
 
         expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[8].question).to eq(:special_assistance_details)
-        expect(answers[8].value).to eq('assistance_details')
+        expect(answers[8].question).to eq(:special_arrangements_details)
+        expect(answers[8].value).to eq('arrangements_details')
 
-        expect(answers[9]).to be_an_instance_of(Answer)
-        expect(answers[9].question).to eq(:special_arrangements)
-        expect(answers[9].value).to eq('yes')
+        expect(answers[9]).to be_an_instance_of(Separator)
+        expect(answers[9].title).to eq(:special_assistance)
 
-        expect(answers[10]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[10].question).to eq(:special_arrangements_details)
-        expect(answers[10].value).to eq('arrangements_details')
+        expect(answers[10]).to be_an_instance_of(Answer)
+        expect(answers[10].question).to eq(:special_assistance)
+        expect(answers[10].value).to eq('yes')
+
+        expect(answers[11]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[11].question).to eq(:special_assistance_details)
+        expect(answers[11].value).to eq('assistance_details')
+
       end
     end
   end

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -102,16 +102,16 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
   context 'when the step is `intermediary`' do
     let(:step_params) { { intermediary: 'anything' } }
-    it { is_expected.to have_destination(:special_assistance, :edit) }
-  end
-
-  context 'when the step is `special_assistance`' do
-    let(:step_params) { { special_assistance: 'anything' } }
     it { is_expected.to have_destination(:special_arrangements, :edit) }
   end
 
   context 'when the step is `special_arrangements`' do
     let(:step_params) { { special_arrangements: 'anything' } }
+    it { is_expected.to have_destination(:special_assistance, :edit) }
+  end
+
+  context 'when the step is `special_assistance`' do
+    let(:step_params) { { special_assistance: 'anything' } }
     it { is_expected.to have_destination(:payment, :edit) }
   end
 


### PR DESCRIPTION
We are moving the special safety arrangements one step back, so it goes before the special assistance question, instead of after, like it is now.

This will help with the reorganising of the rest of the attending court questions. For now we maintain the attributes the same, but we tweak the copy. In a following PR we will redesign these steps to use the new DB table and check boxes instead of radios.