### PR TITLE
Add new intermediary block to CYA and PDF

### DIFF
--- a/app/presenters/summary/html_sections/attending_court_v2.rb
+++ b/app/presenters/summary/html_sections/attending_court_v2.rb
@@ -15,6 +15,7 @@ module Summary
         [
           litigation_capacity,
           language_interpreter,
+          intermediary,
         ].flatten.select(&:show?)
       end
 
@@ -61,6 +62,17 @@ module Summary
             FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
           ],
           change_path: edit_steps_attending_court_language_path
+        )
+      end
+
+      def intermediary
+        AnswersGroup.new(
+          :intermediary,
+          [
+            Answer.new(:intermediary_help, arrangement.intermediary_help),
+            FreeTextAnswer.new(:intermediary_help_details, arrangement.intermediary_help_details),
+          ],
+          change_path: edit_steps_attending_court_intermediary_path
         )
       end
     end

--- a/app/presenters/summary/sections/attending_court_v2.rb
+++ b/app/presenters/summary/sections/attending_court_v2.rb
@@ -18,6 +18,7 @@ module Summary
       def answers
         [
           *language_interpreter,
+          *intermediary,
         ].select(&:show?)
       end
 
@@ -40,6 +41,14 @@ module Summary
           FreeTextAnswer.new(:language_interpreter_details, arrangement.language_interpreter_details),
           Answer.new(:sign_language_interpreter, arrangement.sign_language_interpreter.to_s),
           FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
+        ]
+      end
+
+      def intermediary
+        [
+          Separator.new(:intermediary),
+          Answer.new(:intermediary_help, arrangement.intermediary_help),
+          FreeTextAnswer.new(:intermediary_help_details, arrangement.intermediary_help_details),
         ]
       end
     end

--- a/app/services/c100_app/attending_court_decision_tree.rb
+++ b/app/services/c100_app/attending_court_decision_tree.rb
@@ -7,7 +7,7 @@ module C100App
       when :language
         edit(:intermediary)
       when :intermediary
-        edit('/steps/application/special_assistance')
+        edit('/steps/application/special_arrangements')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,13 +129,13 @@ Rails.application.routes.draw do
       edit_step :urgent_hearing_details
       edit_step :without_notice
       edit_step :without_notice_details
+      edit_step :details
       edit_step :litigation_capacity
       edit_step :litigation_capacity_details
-      edit_step :special_assistance
-      edit_step :special_arrangements
-      edit_step :details
       edit_step :language
       edit_step :intermediary
+      edit_step :special_arrangements
+      edit_step :special_assistance
       edit_step :payment
       edit_step :submission
       show_step :receipt_email_check

--- a/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
@@ -20,7 +20,9 @@ module Summary
         language_interpreter: true,
         language_interpreter_details: 'language_interpreter_details',
         sign_language_interpreter: true,
-        sign_language_interpreter_details: 'sign_language_interpreter_details'
+        sign_language_interpreter_details: 'sign_language_interpreter_details',
+        intermediary_help: 'yes',
+        intermediary_help_details: 'intermediary_help_details',
     )}
 
     let(:answers) { subject.answers }
@@ -31,7 +33,7 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(3)
+        expect(answers.count).to eq(4)
 
         expect(answers[0]).to be_an_instance_of(Answer)
         expect(answers[0].question).to eq(:reduced_litigation_capacity)
@@ -45,6 +47,30 @@ module Summary
         expect(answers[2]).to be_an_instance_of(AnswersGroup)
         expect(answers[2].name).to eq(:language_interpreter)
         expect(answers[2].change_path).to eq('/steps/attending_court/language')
+
+        expect(answers[3]).to be_an_instance_of(AnswersGroup)
+        expect(answers[3].name).to eq(:intermediary)
+        expect(answers[3].change_path).to eq('/steps/attending_court/intermediary')
+      end
+
+      context 'litigation_capacity' do
+        let(:group_answers) { answers[1].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(3)
+
+          expect(group_answers[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[0].question).to eq(:participation_capacity_details)
+          expect(group_answers[0].value).to eq('participation_capacity_details')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:participation_other_factors_details)
+          expect(group_answers[1].value).to eq('participation_other_factors_details')
+
+          expect(group_answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[2].question).to eq(:participation_referral_or_assessment_details)
+          expect(group_answers[2].value).to eq('participation_referral_or_assessment_details')
+        end
       end
 
       context 'language_interpreter' do
@@ -68,6 +94,22 @@ module Summary
           expect(group_answers[3]).to be_an_instance_of(FreeTextAnswer)
           expect(group_answers[3].question).to eq(:sign_language_interpreter_details)
           expect(group_answers[3].value).to eq('sign_language_interpreter_details')
+        end
+      end
+
+      context 'intermediary' do
+        let(:group_answers) { answers[3].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(2)
+
+          expect(group_answers[0]).to be_an_instance_of(Answer)
+          expect(group_answers[0].question).to eq(:intermediary_help)
+          expect(group_answers[0].value).to eq('yes')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:intermediary_help_details)
+          expect(group_answers[1].value).to eq('intermediary_help_details')
         end
       end
     end

--- a/spec/presenters/summary/sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/sections/attending_court_v2_spec.rb
@@ -11,7 +11,9 @@ module Summary
         language_interpreter: true,
         language_interpreter_details: 'language_interpreter_details',
         sign_language_interpreter: true,
-        sign_language_interpreter_details: 'sign_language_interpreter_details'
+        sign_language_interpreter_details: 'sign_language_interpreter_details',
+        intermediary_help: 'yes',
+        intermediary_help_details: 'intermediary_help_details',
     )}
 
     let(:answers) { subject.answers }
@@ -47,7 +49,7 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(5)
+        expect(answers.count).to eq(8)
 
         expect(answers[0]).to be_an_instance_of(Separator)
         expect(answers[0].title).to eq(:language_assistance)
@@ -63,6 +65,16 @@ module Summary
 
         expect(answers[4].question).to eq(:sign_language_interpreter_details)
         expect(answers[4].value).to eq('sign_language_interpreter_details')
+
+        expect(answers[5]).to be_an_instance_of(Separator)
+        expect(answers[5].title).to eq(:intermediary)
+
+        expect(answers[6].question).to eq(:intermediary_help)
+        expect(answers[6].value).to eq('yes')
+
+        expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[7].question).to eq(:intermediary_help_details)
+        expect(answers[7].value).to eq('intermediary_help_details')
       end
     end
   end

--- a/spec/services/c100_app/attending_court_decision_tree_spec.rb
+++ b/spec/services/c100_app/attending_court_decision_tree_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe C100App::AttendingCourtDecisionTree do
 
   context 'when the step is `intermediary`' do
     let(:step_params) { { intermediary: 'anything' } }
-    it { is_expected.to have_destination('/steps/application/special_assistance', :edit) }
+    it { is_expected.to have_destination('/steps/application/special_arrangements', :edit) }
   end
 end


### PR DESCRIPTION
As we did with language, we are adding this block, identical to the existing block but using the new attributes (from the `court_arrangements` table).