### PR TITLE
Remove unneeded email submission code

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -4,15 +4,6 @@ class NotifyMailer < GovukNotifyRails::Mailer
     @template_ids = Rails.configuration.govuk_notify_templates
   end
 
-  # When logging exceptions, filter the following keys from the personalisation hash
-  FILTERED = '[FILTERED]'.freeze
-  PERSONALISATION_ERROR_FILTER = [
-    :reset_password_url,
-    :applicant_name,
-    :link_to_pdf,
-    :link_to_c8_pdf,
-  ].freeze
-
   # Triggered automatically by Devise when the user resets its password.
   # Do not change the method name unless you configure Devise with the new name.
   def reset_password_instructions(user, token, _opts = {})

--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -53,7 +53,7 @@ class NotifySubmissionMailer < NotifyMailer
 
   def shared_personalisation
     {
-      applicant_name: @c100_application.applicants.first&.full_name || '[name not entered]',
+      applicant_name: @c100_application.declaration_signee,
       reference_code: @c100_application.reference_code,
       link_to_pdf: prepare_upload(@documents[:bundle]),
     }

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       urgent_hearing: 'yes',
       address_confidentiality: address_confidentiality,
       payment_type: payment_type,
+      declaration_signee: 'John Doe',
     )
   }
 
@@ -58,7 +59,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
     it 'has the right personalisation' do
       expect(mail.govuk_notify_personalisation).to eq({
         service_name: 'Apply to court about child arrangements',
-        applicant_name: '[name not entered]',
+        applicant_name: 'John Doe',
         reference_code: '1970/01/4A362E1C',
         urgent: 'yes',
         c8_included: 'no',
@@ -112,7 +113,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
     it 'has the right personalisation' do
       expect(mail.govuk_notify_personalisation).to eq({
         service_name: 'Apply to court about child arrangements',
-        applicant_name: '[name not entered]',
+        applicant_name: 'John Doe',
         reference_code: '1970/01/4A362E1C',
         court_name: 'Test court',
         court_email: 'court@example.com',


### PR DESCRIPTION
We don't need the filter constant anymore as we are not using them. It was a leftover from a previous PR.

Also, now that we have a `declaration signee` we can use this instead of the ugliness of picking the first applicant (in case there are more than one). It is more accurate and also works fine for solicitors submitting an application for their client.