### PR TITLE
Redesign the special assistance step with check boxes

### DIFF
--- a/app/controllers/steps/attending_court/special_assistance_controller.rb
+++ b/app/controllers/steps/attending_court/special_assistance_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module AttendingCourt
+    class SpecialAssistanceController < Steps::AttendingCourtStepController
+      def edit
+        @form_object = SpecialAssistanceForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(SpecialAssistanceForm, as: :special_assistance)
+      end
+    end
+  end
+end

--- a/app/forms/steps/attending_court/special_assistance_form.rb
+++ b/app/forms/steps/attending_court/special_assistance_form.rb
@@ -1,0 +1,17 @@
+module Steps
+  module AttendingCourt
+    class SpecialAssistanceForm < BaseForm
+      include ArrangementsCheckBoxesForm
+      setup_attributes_for SpecialAssistance, group_name: :special_assistance
+
+      # any other attributes
+      attribute :special_assistance_details, String
+
+      private
+
+      def additional_attributes_map
+        { special_assistance_details: special_assistance_details }
+      end
+    end
+  end
+end

--- a/app/services/c100_app/attending_court_decision_tree.rb
+++ b/app/services/c100_app/attending_court_decision_tree.rb
@@ -9,7 +9,9 @@ module C100App
       when :intermediary
         edit(:special_arrangements)
       when :special_arrangements
-        edit('/steps/application/special_assistance')
+        edit(:special_assistance)
+      when :special_assistance
+        edit('/steps/application/payment')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/value_objects/special_arrangements.rb
+++ b/app/value_objects/special_arrangements.rb
@@ -2,7 +2,6 @@ class SpecialArrangements < ValueObject
   VALUES = [
     SEPARATE_WAITING_ROOMS = new(:separate_waiting_rooms),
     SEPARATE_ENTRANCE_EXIT = new(:separate_entrance_exit),
-    ADVANCE_COURT_VIEWING  = new(:advance_court_viewing),
     PROTECTIVE_SCREENS     = new(:protective_screens),
     VIDEO_LINK             = new(:video_link),
   ].freeze

--- a/app/value_objects/special_assistance.rb
+++ b/app/value_objects/special_assistance.rb
@@ -1,0 +1,14 @@
+class SpecialAssistance < ValueObject
+  VALUES = [
+    HEARING_LOOP          = new(:hearing_loop),
+    BRAILLE_DOCUMENTS     = new(:braille_documents),
+    ADVANCE_COURT_VIEWING = new(:advance_court_viewing),
+    OTHER_ASSISTANCE      = new(:other_assistance),
+  ].freeze
+
+  # :nocov:
+  def self.values
+    VALUES
+  end
+  # :nocov:
+end

--- a/app/views/steps/attending_court/special_assistance/edit.html.erb
+++ b/app/views/steps/attending_court/special_assistance/edit.html.erb
@@ -1,0 +1,17 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <p class="app__section_heading"><%=t '.section' %></p>
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.check_box_fieldset :special_assistance, SpecialAssistance.values %>
+      <%= f.text_area :special_assistance_details, size: '40x4', class: 'form-control-3-4' %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -602,7 +602,6 @@ en:
         # new version
         separate_waiting_rooms: Separate waiting rooms
         separate_entrance_exit: Separate exits and entrances
-        advance_court_viewing: Advance viewing of the court
         protective_screens: Protective screens
         video_link: Video links
     special_arrangements_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1206,7 +1206,6 @@ en:
       steps_attending_court_special_arrangements_form:
         separate_waiting_rooms: Separate waiting rooms
         separate_entrance_exit: Separate exits and entrances
-        advance_court_viewing: Advance viewing of the court
         protective_screens: Protective screens - this needs to be approved by a judge
         video_link: Video links - this needs to be approved by a judge
         special_arrangements_details: You can add more detail if neccessary

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -827,6 +827,11 @@ en:
           heading: Do you or the children need specific safety arrangements at court?
           lead_text: Not every court has the facilities listed here, and some need to be agreed by a judge, for example the use of protective screens.
           court_contact: The court will contact you to discuss safety arrangements before your hearing.
+      special_assistance:
+        edit:
+          page_title: Special assistance
+          section: *attending_court
+          heading: Does anyone in this application need assistance or special facilities when attending court?
     # attending court redesign -- end
     international:
       resident:
@@ -1147,6 +1152,8 @@ en:
         help_with_language: *one_of_the_people_needs
       steps_attending_court_special_arrangements_form:
         special_arrangements: *one_of_the_people_needs
+      steps_attending_court_special_assistance_form:
+        special_assistance: *one_of_the_people_needs
       # attending court redesign -- end
 
     label:
@@ -1203,6 +1210,12 @@ en:
         protective_screens: Protective screens - this needs to be approved by a judge
         video_link: Video links - this needs to be approved by a judge
         special_arrangements_details: You can add more detail if neccessary
+      steps_attending_court_special_assistance_form:
+        hearing_loop: A hearing loop
+        braille_documents: Documents in Braille
+        advance_court_viewing: Advance viewing of the court
+        other_assistance: Other assistance or facilities
+        special_assistance_details: You can add more detail if neccessary
       # attending court redesign -- end
       steps_application_payment_form:
         payment_type:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -550,7 +550,7 @@ en:
             intermediary_help:
               inclusion: Select yes if an intermediary is needed in court
             intermediary_help_details:
-              blank: You must give details of who needs help communicating in court
+              blank: You must give details of who needs help in court
         steps/application/special_assistance_form:
           attributes:
             special_assistance:
@@ -575,7 +575,7 @@ en:
             intermediary_help:
               inclusion: Select yes if an intermediary is needed in court
             intermediary_help_details:
-              blank: You must give details of who needs help communicating in court
+              blank: You must give details of who needs help in court
         # attending court redesign -- end
         steps/application/payment_form:
           attributes:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -414,7 +414,6 @@ en:
         # new version
         separate_waiting_rooms: Separate waiting rooms
         separate_entrance_exit: Separate exits and entrances
-        advance_court_viewing: Advance viewing of the court
         protective_screens: Protective screens
         video_link: Video links
     special_arrangements_details:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,6 +273,7 @@ Rails.application.routes.draw do
       edit_step :language
       edit_step :intermediary
       edit_step :special_arrangements
+      edit_step :special_assistance
     end
     namespace :completion do
       show_step :confirmation

--- a/db/migrate/20200213163220_add_special_assistance_fields_v2.rb
+++ b/db/migrate/20200213163220_add_special_assistance_fields_v2.rb
@@ -1,0 +1,6 @@
+class AddSpecialAssistanceFieldsV2 < ActiveRecord::Migration[5.2]
+  def change
+    add_column :court_arrangements, :special_assistance, :string, array: true, default: []
+    add_column :court_arrangements, :special_assistance_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_13_102002) do
+ActiveRecord::Schema.define(version: 2020_02_13_163220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -191,6 +191,8 @@ ActiveRecord::Schema.define(version: 2020_02_13_102002) do
     t.text "intermediary_help_details"
     t.string "special_arrangements", default: [], array: true
     t.text "special_arrangements_details"
+    t.string "special_assistance", default: [], array: true
+    t.text "special_assistance_details"
     t.index ["c100_application_id"], name: "index_court_arrangements_on_c100_application_id", unique: true
   end
 

--- a/spec/controllers/steps/attending_court/special_assistance_controller_spec.rb
+++ b/spec/controllers/steps/attending_court/special_assistance_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::AttendingCourt::SpecialAssistanceController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::AttendingCourt::SpecialAssistanceForm, C100App::AttendingCourtDecisionTree
+end

--- a/spec/forms/steps/attending_court/special_assistance_form_spec.rb
+++ b/spec/forms/steps/attending_court/special_assistance_form_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Steps::AttendingCourt::SpecialAssistanceForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    hearing_loop: '1',
+    braille_documents: '0',
+    special_assistance_details: 'details',
+  } }
+
+  let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
+  let(:court_arrangement) { CourtArrangement.new(special_assistance: ['hearing_loop'], special_assistance_details: 'details') }
+
+  subject { described_class.new(arguments) }
+
+  describe 'custom getters override' do
+    it 'returns true if the attribute is in the list' do
+      expect(subject.hearing_loop).to eq(true)
+    end
+
+    it 'returns false if the attribute is not in the list' do
+      expect(subject.braille_documents).to eq(false)
+    end
+  end
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(court_arrangement).to receive(:update).with(
+          special_assistance: [:hearing_loop],
+          special_assistance_details: 'details'
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/attending_court_decision_tree_spec.rb
+++ b/spec/services/c100_app/attending_court_decision_tree_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe C100App::AttendingCourtDecisionTree do
 
   context 'when the step is `special_arrangements`' do
     let(:step_params) { { special_arrangements: 'anything' } }
-    it { is_expected.to have_destination('/steps/application/special_assistance', :edit) }
+    it { is_expected.to have_destination(:special_assistance, :edit) }
+  end
+
+  context 'when the step is `special_assistance`' do
+    let(:step_params) { { special_assistance: 'anything' } }
+    it { is_expected.to have_destination('/steps/application/payment', :edit) }
   end
 end

--- a/spec/value_objects/special_arrangements_spec.rb
+++ b/spec/value_objects/special_arrangements_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe SpecialArrangements do
       expect(described_class.values.map(&:to_s)).to eq(%w(
         separate_waiting_rooms
         separate_entrance_exit
-        advance_court_viewing
         protective_screens
         video_link
       ))

--- a/spec/value_objects/special_assistance_spec.rb
+++ b/spec/value_objects/special_assistance_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe SpecialAssistance do
+  let(:value) { :foo }
+  subject     { described_class.new(value) }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(
+        hearing_loop
+        braille_documents
+        advance_court_viewing
+        other_assistance
+      ))
+    end
+  end
+end


### PR DESCRIPTION
Individual commits for more detail.

This is not yet wired to the main journey, and can only be accessed by knowing the URL.
Also, CYA and PDF blocks will be added in the next PR.

<img width="659" alt="Screen Shot 2020-02-14 at 10 21 11" src="https://user-images.githubusercontent.com/687910/74522761-bc478c80-4f13-11ea-8484-84a8aecd9302.png">
