### PR TITLE
Enable redesigned attending court journey by bumping version

### DIFF
--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -22,7 +22,7 @@ module C100App
       when :litigation_capacity
         after_litigation_capacity
       when :litigation_capacity_details
-        edit(:language)
+        language_step_for_version
       when :language
         edit(:intermediary)
       when :intermediary
@@ -73,7 +73,7 @@ module C100App
       if question(:reduced_litigation_capacity).yes?
         edit(:litigation_capacity_details)
       else
-        edit(:language)
+        language_step_for_version
       end
     end
 
@@ -96,6 +96,15 @@ module C100App
 
     def start_international_journey
       edit('/steps/international/resident')
+    end
+
+    # TODO: leave this until all applications are migrated to version >= 5
+    def language_step_for_version
+      if c100_application.version >= 5
+        edit('/steps/attending_court/language')
+      else
+        edit(:language)
+      end
     end
   end
 end

--- a/db/migrate/20200214120733_bump_version_for_new_court_arrangements.rb
+++ b/db/migrate/20200214120733_bump_version_for_new_court_arrangements.rb
@@ -1,0 +1,7 @@
+class BumpVersionForNewCourtArrangements < ActiveRecord::Migration[5.2]
+  def change
+    # Version 5 introduces the new redesigned attending court journey.
+    # New records will be created with version=5
+    change_column_default :c100_applications, :version, from: 4, to: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_13_163220) do
+ActiveRecord::Schema.define(version: 2020_02_14_120733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -148,7 +148,7 @@ ActiveRecord::Schema.define(version: 2020_02_13_163220) do
     t.string "urgent_hearing_short_notice"
     t.text "urgent_hearing_short_notice_details"
     t.string "has_solicitor"
-    t.integer "version", default: 4
+    t.integer "version", default: 5
     t.string "declaration_signee"
     t.string "declaration_signee_capacity"
     t.index ["status"], name: "index_c100_applications_on_status"


### PR DESCRIPTION
Bump the C100 Application record version from 4 to 5.

New applications created right after this migration will have version = 5 and will be shown the new attending court journey, using check boxes instead of radios for language, special arrangements and special assistance.

Current applications in-progress, or drafts, will maintain their version < 5 and will not see the new journey. They continue seeing the old, existing steps.

Once all applications are in version >= 5, we can remove the feature-flag code.