### PR TITLE
Prepare litigation capacity for later migration

### DIFF
--- a/app/forms/steps/attending_court/special_assistance_form.rb
+++ b/app/forms/steps/attending_court/special_assistance_form.rb
@@ -9,8 +9,28 @@ module Steps
 
       private
 
+      # TODO: temporarily until all applications are migrated to version >= 5,
+      # we copy whatever the values of the litigation capacity attributes from
+      # the main `c100_application` table to the new `court_arrangement` table,
+      # so when we do the cleanup of the old code and old attributes from the
+      # database, we can start using the attributes in the new table easily.
+      #
       def additional_attributes_map
-        { special_assistance_details: special_assistance_details }
+        {
+          special_assistance_details: special_assistance_details,
+        }.merge(litigation_capacity_attributes)
+      end
+
+      # We just store them, we do nothing with them afterwards for now.
+      # These come from `LitigationCapacityForm` and `LitigationCapacityDetailsForm`.
+      #
+      def litigation_capacity_attributes
+        {
+          reduced_litigation_capacity: c100_application.reduced_litigation_capacity,
+          participation_capacity_details: c100_application.participation_capacity_details,
+          participation_other_factors_details: c100_application.participation_other_factors_details,
+          participation_referral_or_assessment_details: c100_application.participation_referral_or_assessment_details,
+        }
       end
     end
   end

--- a/db/migrate/20200214125702_copy_litigator_capacity_into_court_arrangements.rb
+++ b/db/migrate/20200214125702_copy_litigator_capacity_into_court_arrangements.rb
@@ -1,0 +1,8 @@
+class CopyLitigatorCapacityIntoCourtArrangements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :court_arrangements, :reduced_litigation_capacity, :string
+    add_column :court_arrangements, :participation_capacity_details, :text
+    add_column :court_arrangements, :participation_other_factors_details, :text
+    add_column :court_arrangements, :participation_referral_or_assessment_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_14_120733) do
+ActiveRecord::Schema.define(version: 2020_02_14_125702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -193,6 +193,10 @@ ActiveRecord::Schema.define(version: 2020_02_14_120733) do
     t.text "special_arrangements_details"
     t.string "special_assistance", default: [], array: true
     t.text "special_assistance_details"
+    t.string "reduced_litigation_capacity"
+    t.text "participation_capacity_details"
+    t.text "participation_other_factors_details"
+    t.text "participation_referral_or_assessment_details"
     t.index ["c100_application_id"], name: "index_court_arrangements_on_c100_application_id", unique: true
   end
 

--- a/spec/forms/steps/attending_court/special_assistance_form_spec.rb
+++ b/spec/forms/steps/attending_court/special_assistance_form_spec.rb
@@ -33,10 +33,27 @@ RSpec.describe Steps::AttendingCourt::SpecialAssistanceForm do
     end
 
     context 'when form is valid' do
+      # TODO: temporarily until all applications are migrated to version >= 5
+      let(:c100_application) {
+        instance_double(
+          C100Application,
+          reduced_litigation_capacity: 'yes',
+          participation_capacity_details: 'participation_capacity_details',
+          participation_other_factors_details: 'participation_other_factors_details',
+          participation_referral_or_assessment_details: 'participation_referral_or_assessment_details',
+          court_arrangement: court_arrangement,
+        )
+      }
+
       it 'saves the record' do
         expect(court_arrangement).to receive(:update).with(
           special_assistance: [:hearing_loop],
-          special_assistance_details: 'details'
+          special_assistance_details: 'details',
+          # litigation capacity attributes
+          reduced_litigation_capacity: 'yes',
+          participation_capacity_details: 'participation_capacity_details',
+          participation_other_factors_details: 'participation_other_factors_details',
+          participation_referral_or_assessment_details: 'participation_referral_or_assessment_details',
         ).and_return(true)
 
         expect(subject.save).to be(true)


### PR DESCRIPTION
So we don't have to duplicate the form objects, controllers, views, etc. as well as changes to CYA and PDF for litigator capacity questions, we are goint to take a pragmatic approach where we continue using the existing code, but copy over the values to the new database table.

When the time comes to delete the old code and attributes for the old attending court journey, it will be much easier just to start using the new table as values for existing applications will be present.