### PR TITLE
Reposition intermediary step before language step

### DIFF
--- a/app/presenters/summary/html_sections/attending_court_v2.rb
+++ b/app/presenters/summary/html_sections/attending_court_v2.rb
@@ -14,8 +14,8 @@ module Summary
       def answers
         [
           litigation_capacity,
-          language_interpreter,
           intermediary,
+          language_interpreter,
           special_arrangements,
           special_assistance,
         ].flatten.select(&:show?)
@@ -48,6 +48,17 @@ module Summary
         ]
       end
 
+      def intermediary
+        AnswersGroup.new(
+          :intermediary,
+          [
+            Answer.new(:intermediary_help, arrangement.intermediary_help),
+            FreeTextAnswer.new(:intermediary_help_details, arrangement.intermediary_help_details),
+          ],
+          change_path: edit_steps_attending_court_intermediary_path
+        )
+      end
+
       # Note: we convert the booleans in the `Answer` object with `to_s`, so `true` and `false`
       # are true for `#present?` but not for nil (''), meaning if the user didn't reach this
       # question yet, the value will be `nil` and `Answer` will not show, but once they reach
@@ -64,17 +75,6 @@ module Summary
             FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
           ],
           change_path: edit_steps_attending_court_language_path
-        )
-      end
-
-      def intermediary
-        AnswersGroup.new(
-          :intermediary,
-          [
-            Answer.new(:intermediary_help, arrangement.intermediary_help),
-            FreeTextAnswer.new(:intermediary_help_details, arrangement.intermediary_help_details),
-          ],
-          change_path: edit_steps_attending_court_intermediary_path
         )
       end
 

--- a/app/presenters/summary/sections/attending_court_v2.rb
+++ b/app/presenters/summary/sections/attending_court_v2.rb
@@ -17,8 +17,8 @@ module Summary
 
       def answers
         [
-          *language_interpreter,
           *intermediary,
+          *language_interpreter,
           *special_arrangements,
           *special_assistance,
         ].select(&:show?)
@@ -28,6 +28,14 @@ module Summary
 
       def arrangement
         @_arrangement ||= c100.court_arrangement
+      end
+
+      def intermediary
+        [
+          Separator.new(:intermediary),
+          Answer.new(:intermediary_help, arrangement.intermediary_help),
+          FreeTextAnswer.new(:intermediary_help_details, arrangement.intermediary_help_details),
+        ]
       end
 
       # Note: we convert the booleans in the `Answer` object with `to_s`, so `true` and `false`
@@ -43,14 +51,6 @@ module Summary
           FreeTextAnswer.new(:language_interpreter_details, arrangement.language_interpreter_details),
           Answer.new(:sign_language_interpreter, arrangement.sign_language_interpreter.to_s),
           FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
-        ]
-      end
-
-      def intermediary
-        [
-          Separator.new(:intermediary),
-          Answer.new(:intermediary_help, arrangement.intermediary_help),
-          FreeTextAnswer.new(:intermediary_help_details, arrangement.intermediary_help_details),
         ]
       end
 

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -22,10 +22,10 @@ module C100App
       when :litigation_capacity
         after_litigation_capacity
       when :litigation_capacity_details
-        language_step_for_version
-      when :language
-        edit(:intermediary)
+        intermediary_step_for_version
       when :intermediary
+        edit(:language)
+      when :language
         edit(:special_arrangements)
       when :special_arrangements
         edit(:special_assistance)
@@ -73,7 +73,7 @@ module C100App
       if question(:reduced_litigation_capacity).yes?
         edit(:litigation_capacity_details)
       else
-        language_step_for_version
+        intermediary_step_for_version
       end
     end
 
@@ -99,11 +99,11 @@ module C100App
     end
 
     # TODO: leave this until all applications are migrated to version >= 5
-    def language_step_for_version
+    def intermediary_step_for_version
       if c100_application.version >= 5
-        edit('/steps/attending_court/language')
+        edit('/steps/attending_court/intermediary')
       else
-        edit(:language)
+        edit(:intermediary)
       end
     end
   end

--- a/app/services/c100_app/attending_court_decision_tree.rb
+++ b/app/services/c100_app/attending_court_decision_tree.rb
@@ -4,9 +4,9 @@ module C100App
       return next_step if next_step
 
       case step_name
-      when :language
-        edit(:intermediary)
       when :intermediary
+        edit(:language)
+      when :language
         edit(:special_arrangements)
       when :special_arrangements
         edit(:special_assistance)

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -581,8 +581,7 @@ en:
     intermediary_help:
       question: ''
       answers:
-        'yes': 'Yes'
-        'no': *not_needed
+        <<: *YESNO
     intermediary_help_details:
       question: ''
     sign_language_interpreter_details:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -395,8 +395,7 @@ en:
     intermediary_help:
       question: Are you aware of whether an intermediary will be required?
       answers:
-        'yes': 'Yes'
-        'no': *not_needed
+        <<: *YESNO
     intermediary_help_details:
       question: *details
     special_arrangements:

--- a/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
@@ -54,12 +54,12 @@ module Summary
         expect(answers[1].change_path).to eq('/steps/application/litigation_capacity_details')
 
         expect(answers[2]).to be_an_instance_of(AnswersGroup)
-        expect(answers[2].name).to eq(:language_interpreter)
-        expect(answers[2].change_path).to eq('/steps/attending_court/language')
+        expect(answers[2].name).to eq(:intermediary)
+        expect(answers[2].change_path).to eq('/steps/attending_court/intermediary')
 
         expect(answers[3]).to be_an_instance_of(AnswersGroup)
-        expect(answers[3].name).to eq(:intermediary)
-        expect(answers[3].change_path).to eq('/steps/attending_court/intermediary')
+        expect(answers[3].name).to eq(:language_interpreter)
+        expect(answers[3].change_path).to eq('/steps/attending_court/language')
 
         expect(answers[4]).to be_an_instance_of(AnswersGroup)
         expect(answers[4].name).to eq(:special_arrangements)
@@ -108,8 +108,24 @@ module Summary
         end
       end
 
-      context 'language_interpreter' do
+      context 'intermediary' do
         let(:group_answers) { answers[2].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(2)
+
+          expect(group_answers[0]).to be_an_instance_of(Answer)
+          expect(group_answers[0].question).to eq(:intermediary_help)
+          expect(group_answers[0].value).to eq('yes')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:intermediary_help_details)
+          expect(group_answers[1].value).to eq('intermediary_help_details')
+        end
+      end
+
+      context 'language_interpreter' do
+        let(:group_answers) { answers[3].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(4)
@@ -129,22 +145,6 @@ module Summary
           expect(group_answers[3]).to be_an_instance_of(FreeTextAnswer)
           expect(group_answers[3].question).to eq(:sign_language_interpreter_details)
           expect(group_answers[3].value).to eq('sign_language_interpreter_details')
-        end
-      end
-
-      context 'intermediary' do
-        let(:group_answers) { answers[3].answers }
-
-        it 'has the correct rows in the right order' do
-          expect(group_answers.count).to eq(2)
-
-          expect(group_answers[0]).to be_an_instance_of(Answer)
-          expect(group_answers[0].question).to eq(:intermediary_help)
-          expect(group_answers[0].value).to eq('yes')
-
-          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
-          expect(group_answers[1].question).to eq(:intermediary_help_details)
-          expect(group_answers[1].value).to eq('intermediary_help_details')
         end
       end
 

--- a/spec/presenters/summary/sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/sections/attending_court_v2_spec.rb
@@ -61,29 +61,29 @@ module Summary
         expect(answers.count).to eq(14)
 
         expect(answers[0]).to be_an_instance_of(Separator)
-        expect(answers[0].title).to eq(:language_assistance)
+        expect(answers[0].title).to eq(:intermediary)
 
-        expect(answers[1].question).to eq(:language_interpreter)
-        expect(answers[1].value).to eq('true')
+        expect(answers[1].question).to eq(:intermediary_help)
+        expect(answers[1].value).to eq('yes')
 
-        expect(answers[2].question).to eq(:language_interpreter_details)
-        expect(answers[2].value).to eq('language_interpreter_details')
+        expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[2].question).to eq(:intermediary_help_details)
+        expect(answers[2].value).to eq('intermediary_help_details')
 
-        expect(answers[3].question).to eq(:sign_language_interpreter)
-        expect(answers[3].value).to eq('true')
+        expect(answers[3]).to be_an_instance_of(Separator)
+        expect(answers[3].title).to eq(:language_assistance)
 
-        expect(answers[4].question).to eq(:sign_language_interpreter_details)
-        expect(answers[4].value).to eq('sign_language_interpreter_details')
+        expect(answers[4].question).to eq(:language_interpreter)
+        expect(answers[4].value).to eq('true')
 
-        expect(answers[5]).to be_an_instance_of(Separator)
-        expect(answers[5].title).to eq(:intermediary)
+        expect(answers[5].question).to eq(:language_interpreter_details)
+        expect(answers[5].value).to eq('language_interpreter_details')
 
-        expect(answers[6].question).to eq(:intermediary_help)
-        expect(answers[6].value).to eq('yes')
+        expect(answers[6].question).to eq(:sign_language_interpreter)
+        expect(answers[6].value).to eq('true')
 
-        expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[7].question).to eq(:intermediary_help_details)
-        expect(answers[7].value).to eq('intermediary_help_details')
+        expect(answers[7].question).to eq(:sign_language_interpreter_details)
+        expect(answers[7].value).to eq('sign_language_interpreter_details')
 
         expect(answers[8]).to be_an_instance_of(Separator)
         expect(answers[8].title).to eq(:special_arrangements)

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -90,17 +90,17 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
       context 'when C100 application version is < 5' do
         let(:version) { 4 }
-        it { is_expected.to have_destination(:language, :edit) }
+        it { is_expected.to have_destination(:intermediary, :edit) }
       end
 
       context 'when C100 application version is = 5' do
         let(:version) { 5 }
-        it { is_expected.to have_destination('/steps/attending_court/language', :edit) }
+        it { is_expected.to have_destination('/steps/attending_court/intermediary', :edit) }
       end
 
       context 'when C100 application version is > 5' do
         let(:version) { 6 }
-        it { is_expected.to have_destination('/steps/attending_court/language', :edit) }
+        it { is_expected.to have_destination('/steps/attending_court/intermediary', :edit) }
       end
     end
   end
@@ -112,27 +112,27 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
     context 'when C100 application version is < 5' do
       let(:version) { 4 }
-      it { is_expected.to have_destination(:language, :edit) }
+      it { is_expected.to have_destination(:intermediary, :edit) }
     end
 
     context 'when C100 application version is = 5' do
       let(:version) { 5 }
-      it { is_expected.to have_destination('/steps/attending_court/language', :edit) }
+      it { is_expected.to have_destination('/steps/attending_court/intermediary', :edit) }
     end
 
     context 'when C100 application version is > 5' do
       let(:version) { 6 }
-      it { is_expected.to have_destination('/steps/attending_court/language', :edit) }
+      it { is_expected.to have_destination('/steps/attending_court/intermediary', :edit) }
     end
-  end
-
-  context 'when the step is `language`' do
-    let(:step_params) { { language: 'anything' } }
-    it { is_expected.to have_destination(:intermediary, :edit) }
   end
 
   context 'when the step is `intermediary`' do
     let(:step_params) { { intermediary: 'anything' } }
+    it { is_expected.to have_destination(:language, :edit) }
+  end
+
+  context 'when the step is `language`' do
+    let(:step_params) { { language: 'anything' } }
     it { is_expected.to have_destination(:special_arrangements, :edit) }
   end
 

--- a/spec/services/c100_app/attending_court_decision_tree_spec.rb
+++ b/spec/services/c100_app/attending_court_decision_tree_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe C100App::AttendingCourtDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-  context 'when the step is `language`' do
-    let(:step_params) { { language: 'anything' } }
-    it { is_expected.to have_destination(:intermediary, :edit) }
-  end
-
   context 'when the step is `intermediary`' do
     let(:step_params) { { intermediary: 'anything' } }
+    it { is_expected.to have_destination(:language, :edit) }
+  end
+
+  context 'when the step is `language`' do
+    let(:step_params) { { language: 'anything' } }
     it { is_expected.to have_destination(:special_arrangements, :edit) }
   end
 


### PR DESCRIPTION
This way, litigation capacity and intermediary are together, as these steps use radio options, and then we start with the redesigned steps using check boxes.

Changed the order accordingly in the CYA page and PDF.