### PR TITLE
Update PDF additional information section

### DIFF
--- a/app/presenters/summary/sections/additional_information.rb
+++ b/app/presenters/summary/sections/additional_information.rb
@@ -12,11 +12,15 @@ module Summary
           Answer.new(:children_previous_proceedings, c100.children_previous_proceedings, default: default_value),
           Answer.new(:consent_order,                 c100.consent_order,                 default: default_value),
           Answer.new(:international_or_capacity,     international_or_capacity_value,    default: default_value),
-          Answer.new(:language_assistance,           c100.language_help,                 default: default_value),
+          Answer.new(:language_assistance,           language_assistance_value,          default: default_value),
         ]
       end
 
       private
+
+      def arrangement
+        @_arrangement ||= c100.court_arrangement
+      end
 
       def urgent_or_without_notice_value
         [
@@ -32,6 +36,18 @@ module Summary
           c100.international_request,
           c100.reduced_litigation_capacity,
         ].detect { |answer| answer.eql?(GenericYesNo::YES.to_s) }
+      end
+
+      # TODO: maintain for a while until all applications are using the new table
+      def language_assistance_value
+        return c100.language_help if arrangement.nil?
+
+        return GenericYesNo::YES if [
+          arrangement.language_interpreter,
+          arrangement.sign_language_interpreter,
+        ].any?
+
+        default_value
       end
 
       def default_value

--- a/spec/presenters/summary/sections/additional_information_spec.rb
+++ b/spec/presenters/summary/sections/additional_information_spec.rb
@@ -41,7 +41,6 @@ module Summary
 
         expect(answers[5]).to be_an_instance_of(Answer)
         expect(answers[5].question).to eq(:language_assistance)
-        expect(c100_application).to have_received(:language_help)
       end
     end
 
@@ -89,6 +88,54 @@ module Summary
 
         it 'returns the default value for the answer' do
           expect(answers[4].value).to eq(GenericYesNo::NO)
+        end
+      end
+    end
+
+    describe '`language_assistance` answer values' do
+      before do
+        allow(c100_application).to receive(:court_arrangement).and_return(court_arrangement)
+        allow(c100_application).to receive(:language_help).and_return(language_help)
+      end
+
+      let(:language_help) { nil }
+      let(:court_arrangement) { nil }
+
+      # new version
+      context 'when we have a `court_arrangement` record' do
+        let(:court_arrangement) {
+          instance_double(
+            CourtArrangement,
+            language_interpreter: language_interpreter,
+            sign_language_interpreter:sign_language_interpreter,
+          )
+        }
+
+        context 'at least one check box was selected' do
+          let(:language_interpreter) { false }
+          let(:sign_language_interpreter) { true }
+
+          it 'returns a `YES` value' do
+            expect(answers[5].value).to eq(GenericYesNo::YES)
+          end
+        end
+
+        context 'no check box was selected' do
+          let(:language_interpreter) { false }
+          let(:sign_language_interpreter) { false }
+
+          it 'returns the default value' do
+            expect(answers[5].value).to eq(GenericYesNo::NO)
+          end
+        end
+      end
+
+      # old version
+      context 'when we do not have a `court_arrangement` record' do
+        let(:language_help) { 'yes' }
+
+        it 'returns the question value' do
+          expect(answers[5].value).to eq('yes')
         end
       end
     end


### PR DESCRIPTION
This needs to cope with the old version of the language question, and the new version.

New version works with check boxes so we need to see if at least one, no matter which one, was selected.

Once all applications are migrated to the new version, we can cleanup the code.