### PR TITLE
Refactor completions audit log

### DIFF
--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -1,0 +1,55 @@
+class AuditHelper
+  attr_reader :c100_application
+  alias_attribute :c100, :c100_application
+
+  def initialize(c100_application)
+    @c100_application = c100_application
+  end
+
+  def metadata
+    {
+      v: c100.version,
+      postcode: postcode,
+      c1a_form: c100.has_safety_concerns?,
+      c8_form: c100.confidentiality_enabled?,
+      saved_for_later: c100.user_id.present?,
+      legal_representation: c100.has_solicitor || 'no',
+      urgent_hearing: c100.urgent_hearing,
+      without_notice: c100.without_notice,
+      payment_type: c100.payment_type,
+      signee_capacity: c100.declaration_signee_capacity,
+      arrangements: arrangements_metadata,
+    }
+  end
+
+  private
+
+  def arrangement
+    @_arrangement ||= c100.court_arrangement
+  end
+
+  def postcode
+    # We blind a bit the postcode to anonymize it
+    postcode = c100.screener_answers.children_postcodes
+    postcode.sub(/\s+/, '').upcase.at(0..-3) + '**'
+  end
+
+  def arrangements_metadata
+    return [] unless arrangement.present?
+
+    [].tap do |options|
+      options << litigation_intermediary_language
+      options << arrangement.special_arrangements
+      options << arrangement.special_assistance
+    end.flatten
+  end
+
+  def litigation_intermediary_language
+    [].tap do |options|
+      options << 'reduced_litigation'        if arrangement.reduced_litigation_capacity.eql?(GenericYesNo::YES.to_s)
+      options << 'intermediary'              if arrangement.intermediary_help.eql?(GenericYesNo::YES.to_s)
+      options << 'language_interpreter'      if arrangement.language_interpreter?
+      options << 'sign_language_interpreter' if arrangement.sign_language_interpreter?
+    end
+  end
+end

--- a/app/models/completed_applications_audit.rb
+++ b/app/models/completed_applications_audit.rb
@@ -16,22 +16,7 @@ class CompletedApplicationsAudit < ApplicationRecord
   end
 
   def self.metadata(c100_application)
-    # We blind a bit the postcode to anonymize it
-    postcode = c100_application.screener_answers.children_postcodes
-    postcode = postcode.sub(/\s+/, '').upcase.at(0..-3) + '**'
-
-    {
-      v: c100_application.version,
-      postcode: postcode,
-      c1a_form: c100_application.has_safety_concerns?,
-      c8_form: c100_application.confidentiality_enabled?,
-      saved_for_later: c100_application.user_id.present?,
-      legal_representation: c100_application.has_solicitor || 'no',
-      urgent_hearing: c100_application.urgent_hearing,
-      without_notice: c100_application.without_notice,
-      payment_type: c100_application.payment_type,
-      signee_capacity: c100_application.declaration_signee_capacity,
-    }
+    AuditHelper.new(c100_application).metadata
   end
 
   # This will be `nil` if the application has been purged from database already

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+describe AuditHelper do
+  let(:c100_application) {
+    C100Application.new(
+      version: 123,
+      has_solicitor: has_solicitor,
+      urgent_hearing: 'no',
+      without_notice: 'yes',
+      payment_type: 'cash',
+      declaration_signee_capacity: 'applicant',
+    )
+  }
+
+  let(:user_id) { nil }
+  let(:has_solicitor) { 'yes' }
+  let(:screener_answers_court) { instance_double(Court, name: 'Test Court') }
+  let(:screener_answers) { instance_double(ScreenerAnswers, children_postcodes: 'abcd 123') }
+
+  let(:court_arrangement) { nil }
+
+  subject { described_class.new(c100_application) }
+
+  before do
+    allow(c100_application).to receive(:user_id).and_return(user_id)
+    allow(c100_application).to receive(:screener_answers).and_return(screener_answers)
+    allow(c100_application).to receive(:screener_answers_court).and_return(screener_answers_court)
+    allow(c100_application).to receive(:court_arrangement).and_return(court_arrangement)
+  end
+
+  describe '#metadata' do
+    it 'returns the expected information' do
+      expect(
+        subject.metadata
+      ).to eq(
+        v: 123,
+        postcode: 'ABCD1**',
+        c1a_form: false,
+        c8_form: false,
+        saved_for_later: false,
+        legal_representation: 'yes',
+        urgent_hearing: 'no',
+        without_notice: 'yes',
+        payment_type: 'cash',
+        signee_capacity: 'applicant',
+        arrangements: [],
+      )
+    end
+
+    # TODO we can cleanup this when all applications are using the new table
+    context 'when we have court arrangements' do
+      let(:court_arrangement) {
+        CourtArrangement.new(
+          reduced_litigation_capacity: 'no',
+          intermediary_help: 'yes',
+          language_interpreter: true,
+          sign_language_interpreter: false,
+          special_arrangements: %w(video_link protective_screens),
+          special_assistance: %w(hearing_loop),
+        )
+      }
+
+      it 'returns the expected information' do
+        expect(
+          subject.metadata[:arrangements]
+        ).to match_array(%w(
+          intermediary
+          language_interpreter
+          video_link
+          protective_screens
+          hearing_loop
+        ))
+      end
+    end
+
+    context 'for an application with `has_solicitor` attribute set to `nil`' do
+      let(:has_solicitor) { nil }
+
+      it 'defaults to `no`' do
+        expect(
+          subject.metadata
+        ).to include(legal_representation: 'no')
+      end
+    end
+
+    context 'for a saved application' do
+      let(:user_id) { 123 }
+
+      it 'returns the expected information' do
+        expect(
+          subject.metadata
+        ).to include(saved_for_later: true)
+      end
+    end
+  end
+end

--- a/spec/models/completed_applications_audit_spec.rb
+++ b/spec/models/completed_applications_audit_spec.rb
@@ -1,29 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe CompletedApplicationsAudit, type: :model do
+  let(:screener_answers_court) { instance_double(Court, name: 'Test Court') }
+
   let(:c100_application) {
     C100Application.new(
       id: '449362af-0bc3-4953-82a7-1363d479b876',
-      version: 123,
       created_at: Time.at(0),
       updated_at: Time.at(100),
-      has_solicitor: has_solicitor,
-      urgent_hearing: 'no',
-      without_notice: 'yes',
       submission_type: 'online',
-      payment_type: 'cash',
-      declaration_signee_capacity: 'applicant',
     )
   }
 
-  let(:user_id) { nil }
-  let(:has_solicitor) { 'yes' }
-  let(:screener_answers_court) { instance_double(Court, name: 'Test Court') }
-  let(:screener_answers) { instance_double(ScreenerAnswers, children_postcodes: 'abcd 123') }
-
   before do
-    allow(c100_application).to receive(:user_id).and_return(user_id)
-    allow(c100_application).to receive(:screener_answers).and_return(screener_answers)
     allow(c100_application).to receive(:screener_answers_court).and_return(screener_answers_court)
   end
 
@@ -36,6 +25,13 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
   end
 
   describe '.log!' do
+    # Metadata tested separately in the `AuditHelper` spec
+    let(:audit_helper) { instance_double(AuditHelper, metadata: { foo: 'bar' }) }
+
+    before do
+      allow(AuditHelper).to receive(:new).with(c100_application).and_return(audit_helper)
+    end
+
     it 'creates a record with the expected information' do
       expect(
         described_class
@@ -45,49 +41,10 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
         reference_code: '1970/01/449362AF',
         submission_type: 'online',
         court: 'Test Court',
-        metadata: {
-          v: 123,
-          postcode: 'ABCD1**',
-          c1a_form: false,
-          c8_form: false,
-          saved_for_later: false,
-          legal_representation: 'yes',
-          urgent_hearing: 'no',
-          without_notice: 'yes',
-          payment_type: 'cash',
-          signee_capacity: 'applicant',
-        }
+        metadata: { foo: 'bar' },
       )
 
       described_class.log!(c100_application)
-    end
-
-    context 'for an application with `has_solicitor` attribute set to `nil`' do
-      let(:has_solicitor) { nil }
-
-      it 'defaults to `no`' do
-        expect(
-          described_class
-        ).to receive(:create).with(
-          hash_including(metadata: hash_including(legal_representation: 'no'))
-        )
-
-        described_class.log!(c100_application)
-      end
-    end
-
-    context 'for a saved application' do
-      let(:user_id) { 123 }
-
-      it 'creates a record with the expected information' do
-        expect(
-          described_class
-        ).to receive(:create).with(
-          hash_including(metadata: hash_including(saved_for_later: true))
-        )
-
-        described_class.log!(c100_application)
-      end
     end
   end
 


### PR DESCRIPTION
This is growing too much with the addition of the special arrangements metadata.

Refactor a bit the code to split the metadata to a separate helper class.

Added a new metadata attribute (`arrangements`) to store a collection (array) of arrangement strings based on what options the applicant chose, either yes-no or check boxes.
Only for new applications using the new `court_arrangements` table. Older applications will just store an empty array.