### PR TITLE
Refactor language form to use `ArrangementsCheckBoxesForm` concern

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -495,7 +495,7 @@ MethodLength:
 
 AbcSize:
   Enabled: true
-  Max: 23
+  Max: 24
 
 CyclomaticComplexity:
   Enabled: true

--- a/app/forms/concerns/arrangements_check_boxes_form.rb
+++ b/app/forms/concerns/arrangements_check_boxes_form.rb
@@ -18,7 +18,7 @@ module ArrangementsCheckBoxesForm
       # can retrieve their state (checked/unchecked) from the DB array column.
       attribute_names.each do |name|
         define_method(name) do
-          selected_options.include?(name) || record_to_persist[group_name].include?(name.to_s)
+          selected_options.include?(name) || Array(record_to_persist[group_name]).include?(name.to_s)
         end
 
         define_method("#{name}?") do

--- a/app/forms/concerns/arrangements_check_boxes_form.rb
+++ b/app/forms/concerns/arrangements_check_boxes_form.rb
@@ -17,7 +17,13 @@ module ArrangementsCheckBoxesForm
       # We override the getter methods for each of the attributes so we
       # can retrieve their state (checked/unchecked) from the DB array column.
       attribute_names.each do |name|
-        define_method(name) { record_to_persist[group_name].include?(name.to_s) }
+        define_method(name) do
+          selected_options.include?(name) || record_to_persist[group_name].include?(name.to_s)
+        end
+
+        define_method("#{name}?") do
+          selected_options.include?(name)
+        end
       end
     end
   end

--- a/app/forms/steps/attending_court/language_form.rb
+++ b/app/forms/steps/attending_court/language_form.rb
@@ -1,14 +1,11 @@
 module Steps
   module AttendingCourt
     class LanguageForm < BaseForm
-      include HasOneAssociationForm
+      include ArrangementsCheckBoxesForm
+      setup_attributes_for LanguageHelp, group_name: :language_options
 
-      has_one_association :court_arrangement
-
-      attribute :language_interpreter, Boolean
+      # any other attributes
       attribute :language_interpreter_details, String
-
-      attribute :sign_language_interpreter, Boolean
       attribute :sign_language_interpreter_details, String
 
       validates_presence_of :language_interpreter_details, if: :language_interpreter?
@@ -16,15 +13,11 @@ module Steps
 
       private
 
-      def persist!
-        raise C100ApplicationNotFound unless c100_application
-
-        record_to_persist.update(
-          attributes_map.merge(
-            language_interpreter_details: (language_interpreter_details if language_interpreter?),
-            sign_language_interpreter_details: (sign_language_interpreter_details if sign_language_interpreter?),
-          )
-        )
+      def additional_attributes_map
+        {
+          language_interpreter_details: (language_interpreter_details if language_interpreter?),
+          sign_language_interpreter_details: (sign_language_interpreter_details if sign_language_interpreter?),
+        }
       end
     end
   end

--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -38,18 +38,10 @@ class AuditHelper
     return [] unless arrangement.present?
 
     [].tap do |options|
-      options << litigation_intermediary_language
+      options << 'intermediary' if arrangement.intermediary_help.eql?(GenericYesNo::YES.to_s)
+      options << arrangement.language_options
       options << arrangement.special_arrangements
       options << arrangement.special_assistance
     end.flatten
-  end
-
-  def litigation_intermediary_language
-    [].tap do |options|
-      options << 'reduced_litigation'        if arrangement.reduced_litigation_capacity.eql?(GenericYesNo::YES.to_s)
-      options << 'intermediary'              if arrangement.intermediary_help.eql?(GenericYesNo::YES.to_s)
-      options << 'language_interpreter'      if arrangement.language_interpreter?
-      options << 'sign_language_interpreter' if arrangement.sign_language_interpreter?
-    end
   end
 end

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -6,7 +6,6 @@ module Summary
       @c100_application = c100_application
     end
 
-    # rubocop:disable Metrics/AbcSize
     def sections
       [
         *miam_questions,
@@ -25,7 +24,6 @@ module Summary
         *payment_and_submission_sections,
       ].flatten.select(&:show?)
     end
-    # rubocop:enable Metrics/AbcSize
 
     def before_submit_warning
       ['.submit_warning', submission_type].join('.')

--- a/app/presenters/summary/html_sections/attending_court_v2.rb
+++ b/app/presenters/summary/html_sections/attending_court_v2.rb
@@ -60,18 +60,27 @@ module Summary
       end
 
       # Note: we convert the booleans in the `Answer` object with `to_s`, so `true` and `false`
-      # are true for `#present?` but not for nil (''), meaning if the user didn't reach this
-      # question yet, the value will be `nil` and `Answer` will not show, but once they reach
-      # this question and continue, it will become `true` or `false`, and we want it to show
-      # (even if it is `false` i.e. checkbox not selected).
+      # are both true for `#present?` as we want to show this question even if it is `false`
+      # i.e. checkbox was not selected. If `language_options` is `nil`, it means the user didn't
+      # yet reach this step and only in that case we skip this block.
       #
       def language_interpreter
+        # Do not show this block in CYA if the user didn't yet reach this step
+        # (we know because the array will be `nil` in that case).
+        return [] if arrangement.language_options.nil?
+
         AnswersGroup.new(
           :language_interpreter,
           [
-            Answer.new(:language_interpreter, arrangement.language_interpreter.to_s),
+            Answer.new(
+              :language_interpreter,
+              arrangement.language_options.include?(LanguageHelp::LANGUAGE_INTERPRETER.to_s).to_s
+            ),
             FreeTextAnswer.new(:language_interpreter_details, arrangement.language_interpreter_details),
-            Answer.new(:sign_language_interpreter, arrangement.sign_language_interpreter.to_s),
+            Answer.new(
+              :sign_language_interpreter,
+              arrangement.language_options.include?(LanguageHelp::SIGN_LANGUAGE_INTERPRETER.to_s).to_s
+            ),
             FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
           ],
           change_path: edit_steps_attending_court_language_path
@@ -80,8 +89,8 @@ module Summary
 
       def special_arrangements
         # Do not show this block in CYA if the user didn't yet reach this step
-        # (we know because the text attribute will be `nil` in that case).
-        return [] if arrangement.special_arrangements_details.nil?
+        # (we know because the array will be `nil` in that case).
+        return [] if arrangement.special_arrangements.nil?
 
         AnswersGroup.new(
           :special_arrangements,
@@ -95,8 +104,8 @@ module Summary
 
       def special_assistance
         # Do not show this block in CYA if the user didn't yet reach this step
-        # (we know because the text attribute will be `nil` in that case).
-        return [] if arrangement.special_assistance_details.nil?
+        # (we know because the array will be `nil` in that case).
+        return [] if arrangement.special_assistance.nil?
 
         AnswersGroup.new(
           :special_assistance,

--- a/app/presenters/summary/html_sections/other_court_cases.rb
+++ b/app/presenters/summary/html_sections/other_court_cases.rb
@@ -22,7 +22,6 @@ module Summary
 
       private
 
-      # rubocop:disable Metrics/AbcSize
       def other_court_cases_details
         return [] if court_proceeding.nil?
 
@@ -36,7 +35,6 @@ module Summary
           FreeTextAnswer.new(:court_proceeding_previous_details, court_proceeding.previous_details),
         ]
       end
-      # rubocop:enable Metrics/AbcSize
 
       def court_proceeding
         @_court_proceeding ||= c100.court_proceeding

--- a/app/presenters/summary/sections/additional_information.rb
+++ b/app/presenters/summary/sections/additional_information.rb
@@ -41,11 +41,7 @@ module Summary
       # TODO: maintain for a while until all applications are using the new table
       def language_assistance_value
         return c100.language_help if arrangement.nil?
-
-        return GenericYesNo::YES if [
-          arrangement.language_interpreter,
-          arrangement.sign_language_interpreter,
-        ].any?
+        return GenericYesNo::YES  if (LanguageHelp.string_values & arrangement.language_options).any?
 
         default_value
       end

--- a/app/presenters/summary/sections/attending_court_v2.rb
+++ b/app/presenters/summary/sections/attending_court_v2.rb
@@ -39,17 +39,24 @@ module Summary
       end
 
       # Note: we convert the booleans in the `Answer` object with `to_s`, so `true` and `false`
-      # are true for `#present?` but not for nil (''), meaning if the user didn't reach this
-      # question yet, the value will be `nil` and `Answer` will not show, but once they reach
-      # this question and continue, it will become `true` or `false`, and we want it to show
-      # (even if it is `false` i.e. checkbox not selected).
+      # are both true for `#present?` as we want to show this question even if it is `false`
+      # i.e. checkbox was not selected. If `language_options` is `nil`, it means the user didn't
+      # yet reach this step and only in that case we skip this block.
       #
       def language_interpreter
         [
           Separator.new(:language_assistance),
-          Answer.new(:language_interpreter, arrangement.language_interpreter.to_s),
+
+          Answer.new(
+            :language_interpreter,
+            arrangement.language_options.include?(LanguageHelp::LANGUAGE_INTERPRETER.to_s).to_s
+          ),
           FreeTextAnswer.new(:language_interpreter_details, arrangement.language_interpreter_details),
-          Answer.new(:sign_language_interpreter, arrangement.sign_language_interpreter.to_s),
+
+          Answer.new(
+            :sign_language_interpreter,
+            arrangement.language_options.include?(LanguageHelp::SIGN_LANGUAGE_INTERPRETER.to_s).to_s
+          ),
           FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
         ]
       end

--- a/app/presenters/summary/sections/c1a_base_abuse_details.rb
+++ b/app/presenters/summary/sections/c1a_base_abuse_details.rb
@@ -1,7 +1,6 @@
 module Summary
   module Sections
     class C1aBaseAbuseDetails < BaseSectionPresenter
-      # rubocop:disable Metrics/AbcSize
       def answers
         abuses_suffered.map do |abuse|
           [
@@ -18,7 +17,6 @@ module Summary
           ].select(&:show?)
         end.flatten
       end
-      # rubocop:enable Metrics/AbcSize
 
       private
 

--- a/app/value_objects/language_help.rb
+++ b/app/value_objects/language_help.rb
@@ -1,0 +1,13 @@
+class LanguageHelp < ValueObject
+  VALUES = [
+    LANGUAGE_INTERPRETER      = new(:language_interpreter),
+    SIGN_LANGUAGE_INTERPRETER = new(:sign_language_interpreter),
+    WELSH_LANGUAGE            = new(:welsh_language),
+  ].freeze
+
+  # :nocov:
+  def self.values
+    VALUES
+  end
+  # :nocov:
+end

--- a/app/views/steps/attending_court/language/edit.html.erb
+++ b/app/views/steps/attending_court/language/edit.html.erb
@@ -11,9 +11,7 @@
 
     <%= step_form @form_object do |f| %>
       <%=
-        f.check_box_fieldset :help_with_language, [
-          :language_interpreter, :sign_language_interpreter
-        ] do |fieldset|
+        f.check_box_fieldset :help_with_language, LanguageHelp.values do |fieldset|
           fieldset.check_box_input(:language_interpreter) {
             f.text_area :language_interpreter_details, size: '40x4', class: 'form-control-3-4'
           }

--- a/db/migrate/20200218092658_change_language_fields.rb
+++ b/db/migrate/20200218092658_change_language_fields.rb
@@ -1,0 +1,14 @@
+class ChangeLanguageFields < ActiveRecord::Migration[5.2]
+  def up
+    CourtArrangement.update_all(language_interpreter: nil)
+
+    remove_column :court_arrangements, :sign_language_interpreter
+    remove_column :court_arrangements, :welsh_language
+
+    rename_column :court_arrangements, :language_interpreter, :language_options
+
+    # 2-steps change because otherwise cast will fail even tho we don't care about data being lost
+    change_column :court_arrangements, :language_options, :string
+    change_column :court_arrangements, :language_options, :string, array: true, default: [], using: "string_to_array(language_options, ',')"
+  end
+end

--- a/db/migrate/20200218092658_change_language_fields.rb
+++ b/db/migrate/20200218092658_change_language_fields.rb
@@ -10,5 +10,12 @@ class ChangeLanguageFields < ActiveRecord::Migration[5.2]
     # 2-steps change because otherwise cast will fail even tho we don't care about data being lost
     change_column :court_arrangements, :language_options, :string
     change_column :court_arrangements, :language_options, :string, array: true, default: [], using: "string_to_array(language_options, ',')"
+
+    # Remove the empty array defaults as otherwise we do not know when
+    # a step (form object) has been reached or not yet (important for CYA)
+    #
+    change_column_default :court_arrangements, :language_options, nil
+    change_column_default :court_arrangements, :special_arrangements, nil
+    change_column_default :court_arrangements, :special_assistance, nil
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -180,16 +180,16 @@ ActiveRecord::Schema.define(version: 2020_02_18_092658) do
   create_table "court_arrangements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "language_options", default: [], array: true
+    t.string "language_options", array: true
     t.text "language_interpreter_details"
     t.text "sign_language_interpreter_details"
     t.uuid "c100_application_id"
     t.text "welsh_language_details"
     t.string "intermediary_help"
     t.text "intermediary_help_details"
-    t.string "special_arrangements", default: [], array: true
+    t.string "special_arrangements", array: true
     t.text "special_arrangements_details"
-    t.string "special_assistance", default: [], array: true
+    t.string "special_assistance", array: true
     t.text "special_assistance_details"
     t.string "reduced_litigation_capacity"
     t.text "participation_capacity_details"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_14_125702) do
+ActiveRecord::Schema.define(version: 2020_02_18_092658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -180,12 +180,10 @@ ActiveRecord::Schema.define(version: 2020_02_14_125702) do
   create_table "court_arrangements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "language_interpreter"
+    t.string "language_options", default: [], array: true
     t.text "language_interpreter_details"
-    t.boolean "sign_language_interpreter"
     t.text "sign_language_interpreter_details"
     t.uuid "c100_application_id"
-    t.boolean "welsh_language"
     t.text "welsh_language_details"
     t.string "intermediary_help"
     t.text "intermediary_help_details"

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -51,10 +51,8 @@ describe AuditHelper do
     context 'when we have court arrangements' do
       let(:court_arrangement) {
         CourtArrangement.new(
-          reduced_litigation_capacity: 'no',
           intermediary_help: 'yes',
-          language_interpreter: true,
-          sign_language_interpreter: false,
+          language_options: %w(language_interpreter),
           special_arrangements: %w(video_link protective_screens),
           special_assistance: %w(hearing_loop),
         )

--- a/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
@@ -17,18 +17,18 @@ module Summary
 
     let(:court_arrangement) {
       instance_double(CourtArrangement,
-        language_interpreter: true,
-        language_interpreter_details: 'language_interpreter_details',
-        sign_language_interpreter: true,
-        sign_language_interpreter_details: 'sign_language_interpreter_details',
         intermediary_help: 'yes',
         intermediary_help_details: 'intermediary_help_details',
+        language_options: language_options,
+        language_interpreter_details: 'language_interpreter_details',
+        sign_language_interpreter_details: 'sign_language_interpreter_details',
         special_arrangements: special_arrangements,
         special_arrangements_details: special_arrangements_details,
         special_assistance: special_assistance,
         special_assistance_details: special_assistance_details,
     )}
 
+    let(:language_options) { %w(language_interpreter sign_language_interpreter) }
     let(:special_arrangements) { ['video_link'] }
     let(:special_arrangements_details) { 'special_arrangements_details' }
     let(:special_assistance) { ['hearing_loop'] }
@@ -70,9 +70,16 @@ module Summary
         expect(answers[5].change_path).to eq('/steps/attending_court/special_assistance')
       end
 
+      context 'when the language step has not been visited yet' do
+        let(:language_options) { nil }
+
+        it 'does not show the block' do
+          expect(answers.count).to eq(5)
+        end
+      end
+
       context 'when the special arrangements step has not been visited yet' do
-        let(:special_arrangements) { [] }
-        let(:special_arrangements_details) { nil }
+        let(:special_arrangements) { nil }
 
         it 'does not show the block' do
           expect(answers.count).to eq(5)
@@ -80,8 +87,7 @@ module Summary
       end
 
       context 'when the special assistance step has not been visited yet' do
-        let(:special_assistance) { [] }
-        let(:special_assistance_details) { nil }
+        let(:special_assistance) { nil }
 
         it 'does not show the block' do
           expect(answers.count).to eq(5)
@@ -145,6 +151,30 @@ module Summary
           expect(group_answers[3]).to be_an_instance_of(FreeTextAnswer)
           expect(group_answers[3].question).to eq(:sign_language_interpreter_details)
           expect(group_answers[3].value).to eq('sign_language_interpreter_details')
+        end
+
+        context 'when no check boxes were selected' do
+          let(:language_options) { [] }
+
+          it 'still shows the block because we convert booleans to strings' do
+            expect(group_answers.count).to eq(4)
+
+            expect(group_answers[0]).to be_an_instance_of(Answer)
+            expect(group_answers[0].question).to eq(:language_interpreter)
+            expect(group_answers[0].value).to eq('false')
+
+            expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+            expect(group_answers[1].question).to eq(:language_interpreter_details)
+            expect(group_answers[1].value).to eq('language_interpreter_details')
+
+            expect(group_answers[2]).to be_an_instance_of(Answer)
+            expect(group_answers[2].question).to eq(:sign_language_interpreter)
+            expect(group_answers[2].value).to eq('false')
+
+            expect(group_answers[3]).to be_an_instance_of(FreeTextAnswer)
+            expect(group_answers[3].question).to eq(:sign_language_interpreter_details)
+            expect(group_answers[3].value).to eq('sign_language_interpreter_details')
+          end
         end
       end
 

--- a/spec/presenters/summary/sections/additional_information_spec.rb
+++ b/spec/presenters/summary/sections/additional_information_spec.rb
@@ -7,6 +7,10 @@ module Summary
 
     let(:answers) { subject.answers }
 
+    before do
+      allow(c100_application).to receive(:court_arrangement).and_return(nil)
+    end
+
     describe '#name' do
       it 'is expected to be correct' do
         expect(subject.name).to eq(:additional_information)
@@ -103,17 +107,10 @@ module Summary
 
       # new version
       context 'when we have a `court_arrangement` record' do
-        let(:court_arrangement) {
-          instance_double(
-            CourtArrangement,
-            language_interpreter: language_interpreter,
-            sign_language_interpreter:sign_language_interpreter,
-          )
-        }
+        let(:court_arrangement) { instance_double(CourtArrangement, language_options: language_options) }
 
         context 'at least one check box was selected' do
-          let(:language_interpreter) { false }
-          let(:sign_language_interpreter) { true }
+          let(:language_options) { ['language_interpreter'] }
 
           it 'returns a `YES` value' do
             expect(answers[5].value).to eq(GenericYesNo::YES)
@@ -121,8 +118,7 @@ module Summary
         end
 
         context 'no check box was selected' do
-          let(:language_interpreter) { false }
-          let(:sign_language_interpreter) { false }
+          let(:language_options) { [] }
 
           it 'returns the default value' do
             expect(answers[5].value).to eq(GenericYesNo::NO)

--- a/spec/presenters/summary/sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/sections/attending_court_v2_spec.rb
@@ -8,17 +8,20 @@ module Summary
 
     let(:court_arrangement) {
       instance_double(CourtArrangement,
-        language_interpreter: true,
-        language_interpreter_details: 'language_interpreter_details',
-        sign_language_interpreter: true,
-        sign_language_interpreter_details: 'sign_language_interpreter_details',
         intermediary_help: 'yes',
         intermediary_help_details: 'intermediary_help_details',
+        language_options: language_options,
+        language_interpreter_details: language_interpreter_details,
+        sign_language_interpreter_details: sign_language_interpreter_details,
         special_arrangements: special_arrangements,
         special_arrangements_details: special_arrangements_details,
         special_assistance: special_assistance,
         special_assistance_details: special_assistance_details,
     )}
+
+    let(:language_options) { %w(language_interpreter sign_language_interpreter) }
+    let(:language_interpreter_details) { 'language_interpreter_details' }
+    let(:sign_language_interpreter_details) { 'sign_language_interpreter_details' }
 
     let(:special_arrangements) { ['video_link'] }
     let(:special_arrangements_details) { 'special_arrangements_details' }
@@ -106,6 +109,23 @@ module Summary
         expect(answers[13]).to be_an_instance_of(FreeTextAnswer)
         expect(answers[13].question).to eq(:special_assistance_details)
         expect(answers[13].value).to eq('special_assistance_details')
+      end
+    end
+
+    describe 'no language options selected' do
+      let(:language_options) { [] }
+      let(:language_interpreter_details) { '' }
+      let(:sign_language_interpreter_details) { '' }
+
+      it 'still shows the block because we convert booleans to strings' do
+        expect(answers.count).to eq(12)
+
+        # Note it only shows the multi answer, not the free text because it is empty
+        expect(answers[4].question).to eq(:language_interpreter)
+        expect(answers[4].value).to eq('false')
+
+        expect(answers[5].question).to eq(:sign_language_interpreter)
+        expect(answers[5].value).to eq('false')
       end
     end
 

--- a/spec/value_objects/language_help_spec.rb
+++ b/spec/value_objects/language_help_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe LanguageHelp do
+  let(:value) { :foo }
+  subject     { described_class.new(value) }
+
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(
+        language_interpreter
+        sign_language_interpreter
+        welsh_language
+      ))
+    end
+  end
+end


### PR DESCRIPTION
Same as with `SpecialArrangementsForm` and `SpecialAssistanceForm`, for consistency.

Individual commits for more detail because a lot of things are affected by this change.