### PR TITLE
Remove litigation fields from court arrangements table

### DIFF
--- a/app/forms/steps/attending_court/special_assistance_form.rb
+++ b/app/forms/steps/attending_court/special_assistance_form.rb
@@ -9,28 +9,8 @@ module Steps
 
       private
 
-      # TODO: temporarily until all applications are migrated to version >= 5,
-      # we copy whatever the values of the litigation capacity attributes from
-      # the main `c100_application` table to the new `court_arrangement` table,
-      # so when we do the cleanup of the old code and old attributes from the
-      # database, we can start using the attributes in the new table easily.
-      #
       def additional_attributes_map
-        {
-          special_assistance_details: special_assistance_details,
-        }.merge(litigation_capacity_attributes)
-      end
-
-      # We just store them, we do nothing with them afterwards for now.
-      # These come from `LitigationCapacityForm` and `LitigationCapacityDetailsForm`.
-      #
-      def litigation_capacity_attributes
-        {
-          reduced_litigation_capacity: c100_application.reduced_litigation_capacity,
-          participation_capacity_details: c100_application.participation_capacity_details,
-          participation_other_factors_details: c100_application.participation_other_factors_details,
-          participation_referral_or_assessment_details: c100_application.participation_referral_or_assessment_details,
-        }
+        { special_assistance_details: special_assistance_details }
       end
     end
   end

--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -16,6 +16,7 @@ class AuditHelper
       legal_representation: c100.has_solicitor || 'no',
       urgent_hearing: c100.urgent_hearing,
       without_notice: c100.without_notice,
+      reduced_litigation: c100.reduced_litigation_capacity,
       payment_type: c100.payment_type,
       signee_capacity: c100.declaration_signee_capacity,
       arrangements: arrangements_metadata,

--- a/db/migrate/20200218143731_remove_litigator_fields_from_court_arrangements.rb
+++ b/db/migrate/20200218143731_remove_litigator_fields_from_court_arrangements.rb
@@ -1,0 +1,8 @@
+class RemoveLitigatorFieldsFromCourtArrangements < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :court_arrangements, :reduced_litigation_capacity, :string
+    remove_column :court_arrangements, :participation_capacity_details, :text
+    remove_column :court_arrangements, :participation_other_factors_details, :text
+    remove_column :court_arrangements, :participation_referral_or_assessment_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_18_092658) do
+ActiveRecord::Schema.define(version: 2020_02_18_143731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -191,10 +191,6 @@ ActiveRecord::Schema.define(version: 2020_02_18_092658) do
     t.text "special_arrangements_details"
     t.string "special_assistance", array: true
     t.text "special_assistance_details"
-    t.string "reduced_litigation_capacity"
-    t.text "participation_capacity_details"
-    t.text "participation_other_factors_details"
-    t.text "participation_referral_or_assessment_details"
     t.index ["c100_application_id"], name: "index_court_arrangements_on_c100_application_id", unique: true
   end
 

--- a/spec/forms/steps/attending_court/special_assistance_form_spec.rb
+++ b/spec/forms/steps/attending_court/special_assistance_form_spec.rb
@@ -33,27 +33,10 @@ RSpec.describe Steps::AttendingCourt::SpecialAssistanceForm do
     end
 
     context 'when form is valid' do
-      # TODO: temporarily until all applications are migrated to version >= 5
-      let(:c100_application) {
-        instance_double(
-          C100Application,
-          reduced_litigation_capacity: 'yes',
-          participation_capacity_details: 'participation_capacity_details',
-          participation_other_factors_details: 'participation_other_factors_details',
-          participation_referral_or_assessment_details: 'participation_referral_or_assessment_details',
-          court_arrangement: court_arrangement,
-        )
-      }
-
       it 'saves the record' do
         expect(court_arrangement).to receive(:update).with(
           special_assistance: [:hearing_loop],
           special_assistance_details: 'details',
-          # litigation capacity attributes
-          reduced_litigation_capacity: 'yes',
-          participation_capacity_details: 'participation_capacity_details',
-          participation_other_factors_details: 'participation_other_factors_details',
-          participation_referral_or_assessment_details: 'participation_referral_or_assessment_details',
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -5,6 +5,7 @@ describe AuditHelper do
     C100Application.new(
       version: 123,
       has_solicitor: has_solicitor,
+      reduced_litigation_capacity: 'yes',
       urgent_hearing: 'no',
       without_notice: 'yes',
       payment_type: 'cash',
@@ -41,6 +42,7 @@ describe AuditHelper do
         legal_representation: 'yes',
         urgent_hearing: 'no',
         without_notice: 'yes',
+        reduced_litigation: 'yes',
         payment_type: 'cash',
         signee_capacity: 'applicant',
         arrangements: [],


### PR DESCRIPTION
It does not make too much sense to move these fields to the `court_arrangements` table because in reality these are not arrangements.

So this is pretty much a rollout of the PR #792

Also, add back reduced litigation attr to the audit metadata.