### PR TITLE
Decouple litigation capacity from attending court in CYA

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -19,8 +19,7 @@ module Summary
         *urgent_and_without_notice_sections,
         HtmlSections::InternationalElement.new(c100_application),
         HtmlSections::ApplicationReasons.new(c100_application),
-        HtmlSections::AttendingCourt.new(c100_application),
-        HtmlSections::AttendingCourtV2.new(c100_application),
+        *litigation_and_assistance_sections,
         *payment_and_submission_sections,
       ].flatten.select(&:show?)
     end
@@ -75,6 +74,14 @@ module Summary
       [
         HtmlSections::UrgentHearingDetails.new(c100_application),
         HtmlSections::WithoutNoticeDetails.new(c100_application),
+      ]
+    end
+
+    def litigation_and_assistance_sections
+      [
+        HtmlSections::LitigationCapacity.new(c100_application),
+        HtmlSections::AttendingCourt.new(c100_application),
+        HtmlSections::AttendingCourtV2.new(c100_application),
       ]
     end
 

--- a/app/presenters/summary/html_sections/attending_court.rb
+++ b/app/presenters/summary/html_sections/attending_court.rb
@@ -13,9 +13,8 @@ module Summary
 
       def answers
         [
-          litigation_capacity,
-          language_assistance,
           intermediary,
+          language_assistance,
           special_arrangements,
           special_assistance,
         ].flatten.select(&:show?)
@@ -36,25 +35,6 @@ module Summary
           ],
           change_path: edit_steps_application_language_path
         )
-      end
-
-      def litigation_capacity
-        [
-          Answer.new(
-            :reduced_litigation_capacity,
-            c100.reduced_litigation_capacity,
-            change_path: edit_steps_application_litigation_capacity_path
-          ),
-          AnswersGroup.new(
-            :litigation_capacity,
-            [
-              FreeTextAnswer.new(:participation_capacity_details, c100.participation_capacity_details),
-              FreeTextAnswer.new(:participation_other_factors_details, c100.participation_other_factors_details),
-              FreeTextAnswer.new(:participation_referral_or_assessment_details, c100.participation_referral_or_assessment_details),
-            ],
-            change_path: edit_steps_application_litigation_capacity_details_path
-          )
-        ]
       end
 
       def intermediary

--- a/app/presenters/summary/html_sections/attending_court_v2.rb
+++ b/app/presenters/summary/html_sections/attending_court_v2.rb
@@ -13,7 +13,6 @@ module Summary
 
       def answers
         [
-          litigation_capacity,
           intermediary,
           language_interpreter,
           special_arrangements,
@@ -25,27 +24,6 @@ module Summary
 
       def arrangement
         @_arrangement ||= c100.court_arrangement
-      end
-
-      # Note: this for now maintains the same DB model as before (dupe from `AttendingCourt`)
-      # To be evaluated if it is worth move the fields to the new `court_arrangements` table.
-      def litigation_capacity
-        [
-          Answer.new(
-            :reduced_litigation_capacity,
-            c100.reduced_litigation_capacity,
-            change_path: edit_steps_application_litigation_capacity_path
-          ),
-          AnswersGroup.new(
-            :litigation_capacity,
-            [
-              FreeTextAnswer.new(:participation_capacity_details, c100.participation_capacity_details),
-              FreeTextAnswer.new(:participation_other_factors_details, c100.participation_other_factors_details),
-              FreeTextAnswer.new(:participation_referral_or_assessment_details, c100.participation_referral_or_assessment_details),
-            ],
-            change_path: edit_steps_application_litigation_capacity_details_path
-          )
-        ]
       end
 
       def intermediary

--- a/app/presenters/summary/html_sections/litigation_capacity.rb
+++ b/app/presenters/summary/html_sections/litigation_capacity.rb
@@ -1,0 +1,28 @@
+module Summary
+  module HtmlSections
+    class LitigationCapacity < Sections::BaseSectionPresenter
+      def name
+        :litigation_capacity
+      end
+
+      def answers
+        [
+          Answer.new(
+            :reduced_litigation_capacity,
+            c100.reduced_litigation_capacity,
+            change_path: edit_steps_application_litigation_capacity_path
+          ),
+          AnswersGroup.new(
+            :litigation_capacity,
+            [
+              FreeTextAnswer.new(:participation_capacity_details, c100.participation_capacity_details),
+              FreeTextAnswer.new(:participation_other_factors_details, c100.participation_other_factors_details),
+              FreeTextAnswer.new(:participation_referral_or_assessment_details, c100.participation_referral_or_assessment_details),
+            ],
+            change_path: edit_steps_application_litigation_capacity_details_path
+          )
+        ].select(&:show?)
+      end
+    end
+  end
+end

--- a/app/views/steps/application/litigation_capacity/edit.html.erb
+++ b/app/views/steps/application/litigation_capacity/edit.html.erb
@@ -4,7 +4,6 @@
   <div class="column-two-thirds">
     <%= step_header %>
 
-    <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <div class="govuk-govspeak gv-s-prose">

--- a/app/views/steps/application/litigation_capacity_details/edit.html.erb
+++ b/app/views/steps/application/litigation_capacity_details/edit.html.erb
@@ -4,7 +4,6 @@
   <div class="column-two-thirds">
     <%= step_header %>
 
-    <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -84,6 +84,7 @@ en:
       without_notice_hearing: Without notice hearing
       international_element: International information
       application_reasons: Reasons for application
+      litigation_capacity: Factors affecting ability to participate
       attending_court: Attending court
       help_with_fees: Help with fees
       payment: How will you pay the application fee?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -695,13 +695,11 @@ en:
       litigation_capacity:
         edit:
           page_title: Factors affecting taking part in court proceedings
-          section: *attending_court
           heading: Are there any factors that may affect any adult in this application taking part in the court proceedings?
           lead_text: For example, they may lack the capacity to conduct legal proceedings, or suffer from a mental or physical impairment or other health problem
       litigation_capacity_details:
         edit:
           page_title: Factors affecting ability to participate
-          section: *attending_court
           heading: Factors affecting ability to participate
       special_assistance:
         edit:

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -82,6 +82,7 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::WithoutNoticeDetails,
         Summary::HtmlSections::InternationalElement,
         Summary::HtmlSections::ApplicationReasons,
+        Summary::HtmlSections::LitigationCapacity,
         Summary::HtmlSections::AttendingCourt,
         Summary::HtmlSections::Payment,
         Summary::HtmlSections::Submission,

--- a/spec/presenters/summary/html_sections/attending_court_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_spec.rb
@@ -4,14 +4,10 @@ module Summary
   describe HtmlSections::AttendingCourt do
     let(:c100_application) {
       instance_double(C100Application,
-        language_help: 'yes',
-        language_help_details: 'language_help_details',
-        reduced_litigation_capacity: 'yes',
-        participation_capacity_details: 'participation_capacity_details',
-        participation_other_factors_details: 'participation_other_factors_details',
-        participation_referral_or_assessment_details: 'participation_referral_or_assessment_details',
         intermediary_help: 'yes',
         intermediary_help_details: 'intermediary_help_details',
+        language_help: 'yes',
+        language_help_details: 'language_help_details',
         special_assistance: 'yes',
         special_assistance_details: 'special_assistance_details',
         special_arrangements: 'yes',
@@ -48,72 +44,27 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(6)
+        expect(answers.count).to eq(4)
 
-        expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:reduced_litigation_capacity)
-        expect(answers[0].value).to eq('yes')
-        expect(answers[0].change_path).to eq('/steps/application/litigation_capacity')
+        expect(answers[0]).to be_an_instance_of(AnswersGroup)
+        expect(answers[0].name).to eq(:intermediary)
+        expect(answers[0].change_path).to eq('/steps/application/intermediary')
 
         expect(answers[1]).to be_an_instance_of(AnswersGroup)
-        expect(answers[1].name).to eq(:litigation_capacity)
-        expect(answers[1].change_path).to eq('/steps/application/litigation_capacity_details')
+        expect(answers[1].name).to eq(:language_help)
+        expect(answers[1].change_path).to eq('/steps/application/language')
 
         expect(answers[2]).to be_an_instance_of(AnswersGroup)
-        expect(answers[2].name).to eq(:language_help)
-        expect(answers[2].change_path).to eq('/steps/application/language')
+        expect(answers[2].name).to eq(:special_arrangements)
+        expect(answers[2].change_path).to eq('/steps/application/special_arrangements')
 
         expect(answers[3]).to be_an_instance_of(AnswersGroup)
-        expect(answers[3].name).to eq(:intermediary)
-        expect(answers[3].change_path).to eq('/steps/application/intermediary')
-
-        expect(answers[4]).to be_an_instance_of(AnswersGroup)
-        expect(answers[4].name).to eq(:special_arrangements)
-        expect(answers[4].change_path).to eq('/steps/application/special_arrangements')
-
-        expect(answers[5]).to be_an_instance_of(AnswersGroup)
-        expect(answers[5].name).to eq(:special_assistance)
-        expect(answers[5].change_path).to eq('/steps/application/special_assistance')
-      end
-
-      context 'language_assistance' do
-        let(:group_answers) { answers[2].answers }
-
-        it 'has the correct rows in the right order' do
-          expect(group_answers.count).to eq(2)
-
-          expect(group_answers[0]).to be_an_instance_of(Answer)
-          expect(group_answers[0].question).to eq(:language_help)
-          expect(group_answers[0].value).to eq('yes')
-
-          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
-          expect(group_answers[1].question).to eq(:language_help_details)
-          expect(group_answers[1].value).to eq('language_help_details')
-        end
-      end
-
-      context 'litigation_capacity' do
-        let(:group_answers) { answers[1].answers }
-
-        it 'has the correct rows in the right order' do
-          expect(group_answers.count).to eq(3)
-
-          expect(group_answers[0]).to be_an_instance_of(FreeTextAnswer)
-          expect(group_answers[0].question).to eq(:participation_capacity_details)
-          expect(group_answers[0].value).to eq('participation_capacity_details')
-
-          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
-          expect(group_answers[1].question).to eq(:participation_other_factors_details)
-          expect(group_answers[1].value).to eq('participation_other_factors_details')
-
-          expect(group_answers[2]).to be_an_instance_of(FreeTextAnswer)
-          expect(group_answers[2].question).to eq(:participation_referral_or_assessment_details)
-          expect(group_answers[2].value).to eq('participation_referral_or_assessment_details')
-        end
+        expect(answers[3].name).to eq(:special_assistance)
+        expect(answers[3].change_path).to eq('/steps/application/special_assistance')
       end
 
       context 'intermediary' do
-        let(:group_answers) { answers[3].answers }
+        let(:group_answers) { answers[0].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(2)
@@ -128,8 +79,24 @@ module Summary
         end
       end
 
+      context 'language_assistance' do
+        let(:group_answers) { answers[1].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(2)
+
+          expect(group_answers[0]).to be_an_instance_of(Answer)
+          expect(group_answers[0].question).to eq(:language_help)
+          expect(group_answers[0].value).to eq('yes')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:language_help_details)
+          expect(group_answers[1].value).to eq('language_help_details')
+        end
+      end
+
       context 'special_arrangements' do
-        let(:group_answers) { answers[4].answers }
+        let(:group_answers) { answers[2].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(2)
@@ -145,7 +112,7 @@ module Summary
       end
 
       context 'special_assistance' do
-        let(:group_answers) { answers[5].answers }
+        let(:group_answers) { answers[3].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(2)

--- a/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
@@ -4,16 +4,7 @@ module Summary
   describe HtmlSections::AttendingCourtV2 do
     subject { described_class.new(c100_application) }
 
-    let(:c100_application) {
-      instance_double(
-        C100Application,
-        reduced_litigation_capacity: 'yes',
-        participation_capacity_details: 'participation_capacity_details',
-        participation_other_factors_details: 'participation_other_factors_details',
-        participation_referral_or_assessment_details: 'participation_referral_or_assessment_details',
-        court_arrangement: court_arrangement
-      )
-    }
+    let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
 
     let(:court_arrangement) {
       instance_double(CourtArrangement,
@@ -42,39 +33,30 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(6)
+        expect(answers.count).to eq(4)
 
-        expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:reduced_litigation_capacity)
-        expect(answers[0].value).to eq('yes')
-        expect(answers[0].change_path).to eq('/steps/application/litigation_capacity')
+        expect(answers[0]).to be_an_instance_of(AnswersGroup)
+        expect(answers[0].name).to eq(:intermediary)
+        expect(answers[0].change_path).to eq('/steps/attending_court/intermediary')
 
         expect(answers[1]).to be_an_instance_of(AnswersGroup)
-        expect(answers[1].name).to eq(:litigation_capacity)
-        expect(answers[1].change_path).to eq('/steps/application/litigation_capacity_details')
+        expect(answers[1].name).to eq(:language_interpreter)
+        expect(answers[1].change_path).to eq('/steps/attending_court/language')
 
         expect(answers[2]).to be_an_instance_of(AnswersGroup)
-        expect(answers[2].name).to eq(:intermediary)
-        expect(answers[2].change_path).to eq('/steps/attending_court/intermediary')
+        expect(answers[2].name).to eq(:special_arrangements)
+        expect(answers[2].change_path).to eq('/steps/attending_court/special_arrangements')
 
         expect(answers[3]).to be_an_instance_of(AnswersGroup)
-        expect(answers[3].name).to eq(:language_interpreter)
-        expect(answers[3].change_path).to eq('/steps/attending_court/language')
-
-        expect(answers[4]).to be_an_instance_of(AnswersGroup)
-        expect(answers[4].name).to eq(:special_arrangements)
-        expect(answers[4].change_path).to eq('/steps/attending_court/special_arrangements')
-
-        expect(answers[5]).to be_an_instance_of(AnswersGroup)
-        expect(answers[5].name).to eq(:special_assistance)
-        expect(answers[5].change_path).to eq('/steps/attending_court/special_assistance')
+        expect(answers[3].name).to eq(:special_assistance)
+        expect(answers[3].change_path).to eq('/steps/attending_court/special_assistance')
       end
 
       context 'when the language step has not been visited yet' do
         let(:language_options) { nil }
 
         it 'does not show the block' do
-          expect(answers.count).to eq(5)
+          expect(answers.count).to eq(3)
         end
       end
 
@@ -82,7 +64,7 @@ module Summary
         let(:special_arrangements) { nil }
 
         it 'does not show the block' do
-          expect(answers.count).to eq(5)
+          expect(answers.count).to eq(3)
         end
       end
 
@@ -90,32 +72,12 @@ module Summary
         let(:special_assistance) { nil }
 
         it 'does not show the block' do
-          expect(answers.count).to eq(5)
-        end
-      end
-
-      context 'litigation_capacity' do
-        let(:group_answers) { answers[1].answers }
-
-        it 'has the correct rows in the right order' do
-          expect(group_answers.count).to eq(3)
-
-          expect(group_answers[0]).to be_an_instance_of(FreeTextAnswer)
-          expect(group_answers[0].question).to eq(:participation_capacity_details)
-          expect(group_answers[0].value).to eq('participation_capacity_details')
-
-          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
-          expect(group_answers[1].question).to eq(:participation_other_factors_details)
-          expect(group_answers[1].value).to eq('participation_other_factors_details')
-
-          expect(group_answers[2]).to be_an_instance_of(FreeTextAnswer)
-          expect(group_answers[2].question).to eq(:participation_referral_or_assessment_details)
-          expect(group_answers[2].value).to eq('participation_referral_or_assessment_details')
+          expect(answers.count).to eq(3)
         end
       end
 
       context 'intermediary' do
-        let(:group_answers) { answers[2].answers }
+        let(:group_answers) { answers[0].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(2)
@@ -131,7 +93,7 @@ module Summary
       end
 
       context 'language_interpreter' do
-        let(:group_answers) { answers[3].answers }
+        let(:group_answers) { answers[1].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(4)
@@ -179,7 +141,7 @@ module Summary
       end
 
       context 'special_arrangements' do
-        let(:group_answers) { answers[4].answers }
+        let(:group_answers) { answers[2].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(2)
@@ -207,7 +169,7 @@ module Summary
       end
 
       context 'special_assistance' do
-        let(:group_answers) { answers[5].answers }
+        let(:group_answers) { answers[3].answers }
 
         it 'has the correct rows in the right order' do
           expect(group_answers.count).to eq(2)

--- a/spec/presenters/summary/html_sections/litigation_capacity_spec.rb
+++ b/spec/presenters/summary/html_sections/litigation_capacity_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::LitigationCapacity do
+    let(:c100_application) {
+      instance_double(C100Application,
+        reduced_litigation_capacity: 'yes',
+        participation_capacity_details: 'participation_capacity_details',
+        participation_other_factors_details: 'participation_other_factors_details',
+        participation_referral_or_assessment_details: 'participation_referral_or_assessment_details',
+    ) }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:litigation_capacity) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(2)
+
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:reduced_litigation_capacity)
+        expect(answers[0].value).to eq('yes')
+        expect(answers[0].change_path).to eq('/steps/application/litigation_capacity')
+
+        expect(answers[1]).to be_an_instance_of(AnswersGroup)
+        expect(answers[1].name).to eq(:litigation_capacity)
+        expect(answers[1].change_path).to eq('/steps/application/litigation_capacity_details')
+      end
+
+      context 'litigation_capacity' do
+        let(:group_answers) { answers[1].answers }
+
+        it 'has the correct rows in the right order' do
+          expect(group_answers.count).to eq(3)
+
+          expect(group_answers[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[0].question).to eq(:participation_capacity_details)
+          expect(group_answers[0].value).to eq('participation_capacity_details')
+
+          expect(group_answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[1].question).to eq(:participation_other_factors_details)
+          expect(group_answers[1].value).to eq('participation_other_factors_details')
+
+          expect(group_answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[2].question).to eq(:participation_referral_or_assessment_details)
+          expect(group_answers[2].value).to eq('participation_referral_or_assessment_details')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This was always an anomaly. In the PDF these are separate sections so there is no reason why we had this together in the CYA.

Now these are separate sections also on the CYA. Doesn't really affect anything else, other than being visually separated.