### PR TITLE
Minor styling tweaks to the PDF

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -130,7 +130,7 @@
       margin-top: 0;
     }
     p.user-free-text:last-of-type {
-      margin-bottom: 5px;
+      margin-bottom: 0;
     }
   }
 

--- a/app/presenters/relationships_presenter.rb
+++ b/app/presenters/relationships_presenter.rb
@@ -12,7 +12,7 @@ class RelationshipsPresenter
 
     relationships.where(minor: minors, person: person_or_people).map do |relationship|
       show_person_name ? present_relation_with_person(relationship) : present_relation_without_person(relationship)
-    end.join
+    end.join("\n")
   end
 
   private

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -73,8 +73,8 @@ en:
     c8_confidential_answer: *c8_attached
     miam_exemptions_info: "The applicant has not attended a MIAM because the following exemption(s) applies:"
     relationship_to_child:
-      show_person_html: "<div>%{person_name} - %{relation} to %{child_name}</div>"
-      hide_person_html: "<div>%{relation} to %{child_name}</div>"
+      show_person_html: "%{person_name} - %{relation} to %{child_name}"
+      hide_person_html: "%{relation} to %{child_name}"
     statement_of_truth:
       applicant_html: |
         <p>%{signee_name} (applicant) believes that the facts stated in this application are true.</p>

--- a/spec/presenters/relationships_presenter_spec.rb
+++ b/spec/presenters/relationships_presenter_spec.rb
@@ -31,13 +31,27 @@ RSpec.describe RelationshipsPresenter do
 
     context 'showing the person name' do
       it 'returns a string describing the relationships' do
-        expect(subject.relationship_to_children(person, show_person_name: true)).to eq('<div>Person name - Father to Child name</div>')
+        expect(subject.relationship_to_children(person, show_person_name: true)).to eq('Person name - Father to Child name')
+      end
+
+      context 'for more than one relationship' do
+        before do
+          allow(relationships).to receive(:where).with(minor: minors, person: person).and_return(
+            [child_relationship, child_relationship]
+          )
+        end
+
+        it 'joins the lines with "\n" (`simple_format` will format this on the PDF)' do
+          expect(
+            subject.relationship_to_children(person, show_person_name: true)
+          ).to eq("Person name - Father to Child name\nPerson name - Father to Child name")
+        end
       end
     end
 
     context 'hiding the person name' do
       it 'returns a string describing the relationships' do
-        expect(subject.relationship_to_children(person, show_person_name: false)).to eq('<div>Father to Child name</div>')
+        expect(subject.relationship_to_children(person, show_person_name: false)).to eq('Father to Child name')
       end
     end
 
@@ -49,13 +63,13 @@ RSpec.describe RelationshipsPresenter do
 
       context 'showing the person name' do
         it 'returns a string describing the relationships' do
-          expect(subject.relationship_to_children(person, show_person_name: true)).to eq('<div>Person name - A friend to Child name</div>')
+          expect(subject.relationship_to_children(person, show_person_name: true)).to eq('Person name - A friend to Child name')
         end
       end
 
       context 'hiding the person name' do
         it 'returns a string describing the relationships' do
-          expect(subject.relationship_to_children(person, show_person_name: false)).to eq('<div>A friend to Child name</div>')
+          expect(subject.relationship_to_children(person, show_person_name: false)).to eq('A friend to Child name')
         end
       end
     end
@@ -72,7 +86,7 @@ RSpec.describe RelationshipsPresenter do
 
         context 'but the bypass is activated' do
           it 'returns the relationship details' do
-            expect(subject.relationship_to_children(person, bypass_c8: true)).to eq('<div>Person name - Father to Child name</div>')
+            expect(subject.relationship_to_children(person, bypass_c8: true)).to eq('Person name - Father to Child name')
           end
         end
       end
@@ -81,7 +95,7 @@ RSpec.describe RelationshipsPresenter do
         let(:confidentiality_enabled) { false }
 
         it 'returns the relationship details' do
-          expect(subject.relationship_to_children(person)).to eq('<div>Person name - Father to Child name</div>')
+          expect(subject.relationship_to_children(person)).to eq('Person name - Father to Child name')
         end
       end
     end


### PR DESCRIPTION
There was unnecessary margins on paragraphs (last-of-type) and also on the relationships we were using <div> to wrap each of the relation, which was introducing a lot of spacing.

Solved by removing the <div> wrapper and instead, letting the `simple_format` format it as we want.