### PR TITLE
Mechanism to refresh stale CTF court data

### DIFF
--- a/app/jobs/screener_court_refresh_job.rb
+++ b/app/jobs/screener_court_refresh_job.rb
@@ -1,0 +1,7 @@
+class ScreenerCourtRefreshJob < ApplicationJob
+  queue_as :default
+
+  def perform(screener)
+    screener.refresh_local_court!
+  end
+end

--- a/app/models/screener_answers.rb
+++ b/app/models/screener_answers.rb
@@ -10,4 +10,15 @@ class ScreenerAnswers < ApplicationRecord
   def court
     Court.new(local_court) if local_court
   end
+
+  # Can be used to repeat the postcode lookup in CTF and save the
+  # new court details to the database, when court/slug changes.
+  #
+  def refresh_local_court!
+    courts = C100App::CourtPostcodeChecker.new.courts_for(children_postcodes)
+    return unless courts.any?
+
+    court = Court.new(courts.first)
+    update_column(:local_court, court)
+  end
 end

--- a/lib/tasks/court_refresh.rake
+++ b/lib/tasks/court_refresh.rake
@@ -1,0 +1,45 @@
+require 'optparse'
+
+namespace :court_refresh do
+  #
+  # Use with (provide a slug, email or both):
+  #   bundle exec rake court_refresh:slug -- --slug test-foobar --email email@test.com
+  #
+  # Note the criteria will only select applications saved (`with_owner`)
+  # and not yet completed. We should never change a completed application.
+  #
+  task slug: :environment do
+    ARGV.shift(2)
+
+    slug, email = nil
+    count = 0
+
+    OptionParser.new do |opts|
+      opts.on("--slug ARG",  String) { |str| slug = str }
+      opts.on("--email ARG", String) { |str| email = str }
+    end.parse!
+
+    unless slug || email
+      raise ArgumentError, '`--slug ARG` or `--email ARG` needs to be provided'
+    end
+
+    criteria = [].tap do |c|
+      c << "screener_answers.local_court->>'slug' = ?"  if slug
+      c << "screener_answers.local_court->>'email' = ?" if email
+    end.join(' AND ')
+
+    C100Application.with_owner.not_completed.joins(:screener_answers).where(
+      criteria, *[slug, email].compact
+    ).find_each(batch_size: 25) do |record|
+      screener = record.screener_answers
+
+      puts "Enqueuing court refresh for ID #{screener.id}..."
+      ScreenerCourtRefreshJob.perform_later(screener)
+
+      count += 1
+    end
+
+    puts "Finished. Total: #{count}"
+    exit(0)
+  end
+end

--- a/spec/jobs/screener_court_refresh_job_spec.rb
+++ b/spec/jobs/screener_court_refresh_job_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe ScreenerCourtRefreshJob, type: :job do
+  let(:screener_answers) { instance_double(ScreenerAnswers) }
+
+  describe '#perform' do
+    it 'calls `refresh_local_court!` to refresh the local court' do
+      expect(screener_answers).to receive(:refresh_local_court!)
+      described_class.perform_now(screener_answers)
+    end
+  end
+end

--- a/spec/models/screener_answers_spec.rb
+++ b/spec/models/screener_answers_spec.rb
@@ -51,4 +51,35 @@ RSpec.describe ScreenerAnswers, type: :model do
       end
     end
   end
+
+  describe '#refresh_local_court!' do
+    before do
+      allow(subject).to receive(:children_postcodes).and_return('ABC 123')
+    end
+
+    context 'when at least one court was found' do
+      it 'updates the local court' do
+        expect_any_instance_of(
+          C100App::CourtPostcodeChecker
+        ).to receive(:courts_for).with('ABC 123').and_return(%w(foobar another))
+
+        expect(Court).to receive(:new).with('foobar').and_return('foobar')
+        expect(subject).to receive(:update_column).with(:local_court, 'foobar')
+        subject.refresh_local_court!
+      end
+    end
+
+    context 'when no courts were found' do
+      let(:court_results) { [] }
+
+      it 'returns without any update' do
+        expect_any_instance_of(
+          C100App::CourtPostcodeChecker
+        ).to receive(:courts_for).with('ABC 123').and_return([])
+
+        expect(subject).not_to receive(:update_column)
+        subject.refresh_local_court!
+      end
+    end
+  end
 end


### PR DESCRIPTION
As we retrieve these details from CTF on the screener phase of the application, there might be cases where by the time the application gets to be submitted, the data is stale.

This only happens if CTF update the court page with a different email, or they change the slug, etc.
Should be a very rare case.

The idea is to have a rake task that can be run on demand to update stale `screener_answers` based on a search criteria (slug, email or both).

Also this will only apply to saved, not completed applications.