### PR TITLE
Reduce sidekiq max retries

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :concurrency: 3
-:max_retries: 15
+:max_retries: 10
 :timeout: 25
 :queues:
   - submissions


### PR DESCRIPTION
This will retry up to 10 times, or equivalent to 4h 31m total waiting time.

As most failures will come from intermitent network issues when sending emails with Notify, there is no point on retrying for longer.

If it is not fixed by the 10th retry, for example in the case of a real bug, the job moves to a dead queue and notify us by email so we can fix the bug and manually retry from the web admin.