### PR TITLE
Add Welsh option to the language step

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -182,7 +182,8 @@
   }
 
   #attending_court {
-    #sign_language_interpreter td {
+    #sign_language_interpreter td,
+    #welsh_language td {
       padding-top: 8px;
     }
 

--- a/app/forms/steps/attending_court/language_form.rb
+++ b/app/forms/steps/attending_court/language_form.rb
@@ -7,9 +7,16 @@ module Steps
       # any other attributes
       attribute :language_interpreter_details, String
       attribute :sign_language_interpreter_details, String
+      attribute :welsh_language_details, String
 
-      validates_presence_of :language_interpreter_details, if: :language_interpreter?
-      validates_presence_of :sign_language_interpreter_details, if: :sign_language_interpreter?
+      validates_presence_of :language_interpreter_details,
+                            if: :language_interpreter?
+
+      validates_presence_of :sign_language_interpreter_details,
+                            if: :sign_language_interpreter?
+
+      validates_presence_of :welsh_language_details,
+                            if: :welsh_language?
 
       private
 
@@ -17,6 +24,7 @@ module Steps
         {
           language_interpreter_details: (language_interpreter_details if language_interpreter?),
           sign_language_interpreter_details: (sign_language_interpreter_details if sign_language_interpreter?),
+          welsh_language_details: (welsh_language_details if welsh_language?),
         }
       end
     end

--- a/app/presenters/summary/html_sections/attending_court_v2.rb
+++ b/app/presenters/summary/html_sections/attending_court_v2.rb
@@ -42,6 +42,7 @@ module Summary
       # i.e. checkbox was not selected. If `language_options` is `nil`, it means the user didn't
       # yet reach this step and only in that case we skip this block.
       #
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def language_interpreter
         # Do not show this block in CYA if the user didn't yet reach this step
         # (we know because the array will be `nil` in that case).
@@ -60,10 +61,16 @@ module Summary
               arrangement.language_options.include?(LanguageHelp::SIGN_LANGUAGE_INTERPRETER.to_s).to_s
             ),
             FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
+            Answer.new(
+              :welsh_language,
+              arrangement.language_options.include?(LanguageHelp::WELSH_LANGUAGE.to_s).to_s
+            ),
+            FreeTextAnswer.new(:welsh_language_details, arrangement.welsh_language_details),
           ],
           change_path: edit_steps_attending_court_language_path
         )
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def special_arrangements
         # Do not show this block in CYA if the user didn't yet reach this step

--- a/app/presenters/summary/sections/attending_court_v2.rb
+++ b/app/presenters/summary/sections/attending_court_v2.rb
@@ -43,6 +43,7 @@ module Summary
       # i.e. checkbox was not selected. If `language_options` is `nil`, it means the user didn't
       # yet reach this step and only in that case we skip this block.
       #
+      # rubocop:disable Metrics/AbcSize
       def language_interpreter
         [
           Separator.new(:language_assistance),
@@ -58,8 +59,15 @@ module Summary
             arrangement.language_options.include?(LanguageHelp::SIGN_LANGUAGE_INTERPRETER.to_s).to_s
           ),
           FreeTextAnswer.new(:sign_language_interpreter_details, arrangement.sign_language_interpreter_details),
+
+          Answer.new(
+            :welsh_language,
+            arrangement.language_options.include?(LanguageHelp::WELSH_LANGUAGE.to_s).to_s
+          ),
+          FreeTextAnswer.new(:welsh_language_details, arrangement.welsh_language_details),
         ]
       end
+      # rubocop:enable Metrics/AbcSize
 
       def special_arrangements
         [

--- a/app/views/steps/attending_court/language/edit.html.erb
+++ b/app/views/steps/attending_court/language/edit.html.erb
@@ -7,8 +7,6 @@
     <p class="app__section_heading"><%=t '.section' %></p>
     <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
 
-    <p><%=t '.info_html' %></p>
-
     <%= step_form @form_object do |f| %>
       <%=
         f.check_box_fieldset :help_with_language, LanguageHelp.values do |fieldset|

--- a/app/views/steps/attending_court/language/edit.html.erb
+++ b/app/views/steps/attending_court/language/edit.html.erb
@@ -18,6 +18,9 @@
           fieldset.check_box_input(:sign_language_interpreter) {
             f.text_area :sign_language_interpreter_details, size: '40x4', class: 'form-control-3-4'
           }
+          fieldset.check_box_input(:welsh_language) {
+            f.text_area :welsh_language_details, size: '40x4', class: 'form-control-3-4'
+          }
         end
       %>
 

--- a/app/views/steps/completion/shared/_multi_answer_row.html.erb
+++ b/app/views/steps/completion/shared/_multi_answer_row.html.erb
@@ -3,7 +3,7 @@
     <%=t "check_answers_html.#{multi_answer_row.question}.question" %>
   </dt>
   <dd class="answer">
-    <% if multi_answer_row.value.any? %>
+    <% if Array(multi_answer_row.value).any? %>
       <ul class="list list-bullet">
         <% multi_answer_row.value.each do |value| %>
           <li>

--- a/app/views/steps/completion/shared/_multi_answer_row.pdf.erb
+++ b/app/views/steps/completion/shared/_multi_answer_row.pdf.erb
@@ -4,7 +4,7 @@
   </td>
 
   <td class="answer answer-value">
-    <% if multi_answer_row.value.any? %>
+    <% if Array(multi_answer_row.value).any? %>
       <%= multi_answer_row.value.map do |value| %>
         <% t("check_answers.#{multi_answer_row.question}.answers.#{value}") %>
       <% end.join('; ') %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -113,7 +113,7 @@ en:
       special_assistance: Does anyone in this application need assistance or special facilities when attending court?
       special_arrangements: Do you or the children need specific safety arrangements at court?
       # attending court redesign -- begin
-      language_interpreter: Does anyone in this application need help with language?
+      language_interpreter: Does anyone in this application have special language requirements?
       # attending court redesign -- end
       help_with_fees: Do you have a ‘Help with fees’ reference number?
       payment_type: Payment type
@@ -568,6 +568,13 @@ en:
     participation_referral_or_assessment_details:
       question: Details of anyone in this application who has been referred to or assessed by an Adult Learning Disability team or any adult health service and what the outcome was
     # attending court redesign -- begin
+    intermediary_help:
+      question: ''
+      answers:
+        <<: *YESNO
+      intermediary_help_details:
+        question: ''
+
     language_interpreter:
       question: Interpreter
       answers:
@@ -578,16 +585,18 @@ en:
       answers:
         'true': 'Yes'
         'false': *not_needed
-    language_interpreter_details:
-      question: ''
-    intermediary_help:
-      question: ''
+    welsh_language:
+      question: Welsh language
       answers:
-        <<: *YESNO
-    intermediary_help_details:
+        'true': 'Yes'
+        'false': *not_needed
+    language_interpreter_details:
       question: ''
     sign_language_interpreter_details:
       question: ''
+    welsh_language_details:
+      question: ''
+
     special_arrangements:
       question: ''
       absence_answer: None selected
@@ -601,6 +610,7 @@ en:
         video_link: Video links
     special_arrangements_details:
       question: Additional details
+
     special_assistance:
       question: ''
       absence_answer: None selected

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -805,8 +805,7 @@ en:
         edit:
           page_title: Language help
           section: *attending_court
-          heading: Does anyone in this application need help with language?
-          info_html: You can ask for an interpreter. In Wales, you have the right to speak Welsh at any court hearing.
+          heading: Does anyone in this application have special language requirements?
       intermediary:
         edit:
           page_title: Intermediary help

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1190,8 +1190,10 @@ en:
       steps_attending_court_language_form:
         language_interpreter: An interpreter
         sign_language_interpreter: A sign language interpreter
+        welsh_language: To speak Welsh at a court hearing, or read court documents in Welsh
         language_interpreter_details: Give details of who needs an interpreter and the language they require (including dialect, if applicable)
         sign_language_interpreter_details: Give details of who needs a British Sign Language interpreter
+        welsh_language_details: Give details of who needs to speak or read in Welsh
       steps_attending_court_intermediary_form:
         intermediary_help_details: *provide_details
         intermediary_help:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -568,6 +568,8 @@ en:
               blank: You must give interpreter details
             sign_language_interpreter_details:
               blank: You must give sign language interpreter details
+            welsh_language_details:
+              blank: You must give Welsh details
         steps/attending_court/intermediary_form:
           attributes:
             intermediary_help:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -565,11 +565,11 @@ en:
         steps/attending_court/language_form:
           attributes:
             language_interpreter_details:
-              blank: You must give interpreter details
+              blank: You must give interpreter requirements
             sign_language_interpreter_details:
-              blank: You must give sign language interpreter details
+              blank: You must give sign language requirements
             welsh_language_details:
-              blank: You must give Welsh details
+              blank: You must give Welsh language requirements
         steps/attending_court/intermediary_form:
           attributes:
             intermediary_help:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -378,6 +378,13 @@ en:
     language_help_details:
       question: *details
     # attending court redesign -- begin
+    intermediary_help:
+      question: Are you aware of whether an intermediary will be required?
+      answers:
+        <<: *YESNO
+      intermediary_help_details:
+        question: *details
+
     language_interpreter:
       question: Interpreter
       answers:
@@ -388,16 +395,18 @@ en:
       answers:
         'true': 'Yes'
         'false': *not_needed
+    welsh_language:
+      question: Welsh language
+      answers:
+        'true': 'Yes'
+        'false': *not_needed
     language_interpreter_details:
       question: *details
     sign_language_interpreter_details:
       question: *details
-    intermediary_help:
-      question: Are you aware of whether an intermediary will be required?
-      answers:
-        <<: *YESNO
-    intermediary_help_details:
+    welsh_language_details:
       question: *details
+
     special_arrangements:
       question: Special arrangements for applicant or relevant children to attend court
       absence_answer: *not_needed
@@ -411,6 +420,7 @@ en:
         video_link: Video links
     special_arrangements_details:
       question: *details
+
     special_assistance:
       question: Assistance or special facilities required for applicant or any of the parties
       absence_answer: *not_needed

--- a/spec/forms/steps/attending_court/language_form_spec.rb
+++ b/spec/forms/steps/attending_court/language_form_spec.rb
@@ -5,17 +5,30 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
     c100_application: c100_application,
     language_interpreter: language_interpreter,
     sign_language_interpreter: sign_language_interpreter,
+    welsh_language: welsh_language,
     language_interpreter_details: language_interpreter_details,
     sign_language_interpreter_details: sign_language_interpreter_details,
+    welsh_language_details: welsh_language_details,
   } }
 
   let(:language_interpreter) { '1' }
   let(:language_interpreter_details) { 'details' }
+
   let(:sign_language_interpreter) { '0' }
   let(:sign_language_interpreter_details) { 'details' }
 
+  let(:welsh_language) { '0' }
+  let(:welsh_language_details) { 'details' }
+
   let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
-  let(:court_arrangement) { CourtArrangement.new(language_options: ['language_interpreter'], language_interpreter_details: 'details', sign_language_interpreter_details: '') }
+  let(:court_arrangement) {
+    CourtArrangement.new(
+      language_options: ['language_interpreter'],
+      language_interpreter_details: 'details',
+      sign_language_interpreter_details: '',
+      welsh_language_details: '',
+    )
+  }
 
   subject { described_class.new(arguments) }
 
@@ -26,6 +39,10 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
 
     it 'returns false if the attribute is not in the list' do
       expect(subject.sign_language_interpreter).to eq(false)
+    end
+
+    it 'returns false if the attribute is not in the list' do
+      expect(subject.welsh_language).to eq(false)
     end
   end
 
@@ -58,6 +75,16 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
         let(:sign_language_interpreter) { false }
         it { should_not validate_presence_of(:sign_language_interpreter_details) }
       end
+
+      context 'when `welsh_language` is checked' do
+        let(:welsh_language) { true }
+        it { should validate_presence_of(:welsh_language_details) }
+      end
+
+      context 'when `welsh_language` is not checked' do
+        let(:welsh_language) { false }
+        it { should_not validate_presence_of(:welsh_language_details) }
+      end
     end
 
     context 'when form is valid' do
@@ -66,6 +93,7 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
           language_options: [:language_interpreter],
           language_interpreter_details: 'details',
           sign_language_interpreter_details: nil,
+          welsh_language_details: nil,
         ).and_return(true)
 
         expect(subject.save).to be(true)
@@ -73,10 +101,17 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
     end
 
     context 'ensure leftovers are deleted when deselecting a checkbox' do
+      let(:language_interpreter) { '0' }
+      let(:sign_language_interpreter) { '0' }
+      let(:welsh_language) { '0' }
+      let(:language_interpreter_details) { nil }
+      let(:sign_language_interpreter_details) { nil }
+      let(:welsh_language_details) { nil }
+
       context '`language_interpreter` is not checked and `language_interpreter_details` is filled' do
         let(:language_interpreter) { '0' }
-        let(:sign_language_interpreter) { '1' }
         let(:language_interpreter_details) { 'language_interpreter_details' }
+        let(:sign_language_interpreter) { '1' }
         let(:sign_language_interpreter_details) { 'sign_language_interpreter_details' }
 
         it 'saves the record' do
@@ -84,6 +119,7 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
             language_options: [:sign_language_interpreter],
             language_interpreter_details: nil,
             sign_language_interpreter_details: 'sign_language_interpreter_details',
+            welsh_language_details: nil,
           ).and_return(true)
 
           expect(subject.save).to be(true)
@@ -91,16 +127,35 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
       end
 
       context '`sign_language_interpreter` is not checked and `sign_language_interpreter_details` is filled' do
-        let(:language_interpreter) { '1' }
         let(:sign_language_interpreter) { '0' }
-        let(:language_interpreter_details) { 'language_interpreter_details' }
         let(:sign_language_interpreter_details) { 'sign_language_interpreter_details' }
+        let(:welsh_language) { '1' }
+        let(:welsh_language_details) { 'welsh_language_details' }
+
+        it 'saves the record' do
+          expect(court_arrangement).to receive(:update).with(
+            language_options: [:welsh_language],
+            language_interpreter_details: nil,
+            sign_language_interpreter_details: nil,
+            welsh_language_details: 'welsh_language_details',
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context '`welsh_language` is not checked and `welsh_language_details` is filled' do
+        let(:welsh_language) { '0' }
+        let(:welsh_language_details) { 'welsh_language_details' }
+        let(:language_interpreter) { '1' }
+        let(:language_interpreter_details) { 'language_interpreter_details' }
 
         it 'saves the record' do
           expect(court_arrangement).to receive(:update).with(
             language_options: [:language_interpreter],
             language_interpreter_details: 'language_interpreter_details',
             sign_language_interpreter_details: nil,
+            welsh_language_details: nil,
           ).and_return(true)
 
           expect(subject.save).to be(true)

--- a/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/html_sections/attending_court_v2_spec.rb
@@ -13,13 +13,14 @@ module Summary
         language_options: language_options,
         language_interpreter_details: 'language_interpreter_details',
         sign_language_interpreter_details: 'sign_language_interpreter_details',
+        welsh_language_details: 'welsh_language_details',
         special_arrangements: special_arrangements,
         special_arrangements_details: special_arrangements_details,
         special_assistance: special_assistance,
         special_assistance_details: special_assistance_details,
     )}
 
-    let(:language_options) { %w(language_interpreter sign_language_interpreter) }
+    let(:language_options) { %w(language_interpreter sign_language_interpreter welsh_language) }
     let(:special_arrangements) { ['video_link'] }
     let(:special_arrangements_details) { 'special_arrangements_details' }
     let(:special_assistance) { ['hearing_loop'] }
@@ -96,7 +97,7 @@ module Summary
         let(:group_answers) { answers[1].answers }
 
         it 'has the correct rows in the right order' do
-          expect(group_answers.count).to eq(4)
+          expect(group_answers.count).to eq(6)
 
           expect(group_answers[0]).to be_an_instance_of(Answer)
           expect(group_answers[0].question).to eq(:language_interpreter)
@@ -113,13 +114,21 @@ module Summary
           expect(group_answers[3]).to be_an_instance_of(FreeTextAnswer)
           expect(group_answers[3].question).to eq(:sign_language_interpreter_details)
           expect(group_answers[3].value).to eq('sign_language_interpreter_details')
+
+          expect(group_answers[4]).to be_an_instance_of(Answer)
+          expect(group_answers[4].question).to eq(:welsh_language)
+          expect(group_answers[4].value).to eq('true')
+
+          expect(group_answers[5]).to be_an_instance_of(FreeTextAnswer)
+          expect(group_answers[5].question).to eq(:welsh_language_details)
+          expect(group_answers[5].value).to eq('welsh_language_details')
         end
 
         context 'when no check boxes were selected' do
           let(:language_options) { [] }
 
           it 'still shows the block because we convert booleans to strings' do
-            expect(group_answers.count).to eq(4)
+            expect(group_answers.count).to eq(6)
 
             expect(group_answers[0]).to be_an_instance_of(Answer)
             expect(group_answers[0].question).to eq(:language_interpreter)
@@ -136,6 +145,14 @@ module Summary
             expect(group_answers[3]).to be_an_instance_of(FreeTextAnswer)
             expect(group_answers[3].question).to eq(:sign_language_interpreter_details)
             expect(group_answers[3].value).to eq('sign_language_interpreter_details')
+
+            expect(group_answers[4]).to be_an_instance_of(Answer)
+            expect(group_answers[4].question).to eq(:welsh_language)
+            expect(group_answers[4].value).to eq('false')
+
+            expect(group_answers[5]).to be_an_instance_of(FreeTextAnswer)
+            expect(group_answers[5].question).to eq(:welsh_language_details)
+            expect(group_answers[5].value).to eq('welsh_language_details')
           end
         end
       end

--- a/spec/presenters/summary/sections/attending_court_v2_spec.rb
+++ b/spec/presenters/summary/sections/attending_court_v2_spec.rb
@@ -13,15 +13,17 @@ module Summary
         language_options: language_options,
         language_interpreter_details: language_interpreter_details,
         sign_language_interpreter_details: sign_language_interpreter_details,
+        welsh_language_details: welsh_language_details,
         special_arrangements: special_arrangements,
         special_arrangements_details: special_arrangements_details,
         special_assistance: special_assistance,
         special_assistance_details: special_assistance_details,
     )}
 
-    let(:language_options) { %w(language_interpreter sign_language_interpreter) }
+    let(:language_options) { %w(language_interpreter sign_language_interpreter welsh_language) }
     let(:language_interpreter_details) { 'language_interpreter_details' }
     let(:sign_language_interpreter_details) { 'sign_language_interpreter_details' }
+    let(:welsh_language_details) { 'welsh_language_details' }
 
     let(:special_arrangements) { ['video_link'] }
     let(:special_arrangements_details) { 'special_arrangements_details' }
@@ -61,7 +63,7 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(14)
+        expect(answers.count).to eq(16)
 
         expect(answers[0]).to be_an_instance_of(Separator)
         expect(answers[0].title).to eq(:intermediary)
@@ -88,27 +90,33 @@ module Summary
         expect(answers[7].question).to eq(:sign_language_interpreter_details)
         expect(answers[7].value).to eq('sign_language_interpreter_details')
 
-        expect(answers[8]).to be_an_instance_of(Separator)
-        expect(answers[8].title).to eq(:special_arrangements)
+        expect(answers[8].question).to eq(:welsh_language)
+        expect(answers[8].value).to eq('true')
 
-        expect(answers[9]).to be_an_instance_of(MultiAnswer)
-        expect(answers[9].question).to eq(:special_arrangements)
-        expect(answers[9].value).to eq(['video_link'])
+        expect(answers[9].question).to eq(:welsh_language_details)
+        expect(answers[9].value).to eq('welsh_language_details')
 
-        expect(answers[10]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[10].question).to eq(:special_arrangements_details)
-        expect(answers[10].value).to eq('special_arrangements_details')
+        expect(answers[10]).to be_an_instance_of(Separator)
+        expect(answers[10].title).to eq(:special_arrangements)
 
-        expect(answers[11]).to be_an_instance_of(Separator)
-        expect(answers[11].title).to eq(:special_assistance)
+        expect(answers[11]).to be_an_instance_of(MultiAnswer)
+        expect(answers[11].question).to eq(:special_arrangements)
+        expect(answers[11].value).to eq(['video_link'])
 
-        expect(answers[12]).to be_an_instance_of(MultiAnswer)
-        expect(answers[12].question).to eq(:special_assistance)
-        expect(answers[12].value).to eq(['hearing_loop'])
+        expect(answers[12]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[12].question).to eq(:special_arrangements_details)
+        expect(answers[12].value).to eq('special_arrangements_details')
 
-        expect(answers[13]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[13].question).to eq(:special_assistance_details)
-        expect(answers[13].value).to eq('special_assistance_details')
+        expect(answers[13]).to be_an_instance_of(Separator)
+        expect(answers[13].title).to eq(:special_assistance)
+
+        expect(answers[14]).to be_an_instance_of(MultiAnswer)
+        expect(answers[14].question).to eq(:special_assistance)
+        expect(answers[14].value).to eq(['hearing_loop'])
+
+        expect(answers[15]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[15].question).to eq(:special_assistance_details)
+        expect(answers[15].value).to eq('special_assistance_details')
       end
     end
 
@@ -116,9 +124,10 @@ module Summary
       let(:language_options) { [] }
       let(:language_interpreter_details) { '' }
       let(:sign_language_interpreter_details) { '' }
+      let(:welsh_language_details) { '' }
 
       it 'still shows the block because we convert booleans to strings' do
-        expect(answers.count).to eq(12)
+        expect(answers.count).to eq(13)
 
         # Note it only shows the multi answer, not the free text because it is empty
         expect(answers[4].question).to eq(:language_interpreter)
@@ -126,6 +135,9 @@ module Summary
 
         expect(answers[5].question).to eq(:sign_language_interpreter)
         expect(answers[5].value).to eq('false')
+
+        expect(answers[6].question).to eq(:welsh_language)
+        expect(answers[6].value).to eq('false')
       end
     end
 
@@ -134,12 +146,12 @@ module Summary
       let(:special_arrangements_details) { '' }
 
       it 'still shows the block because `show: true` (will use the `absence_answer`)' do
-        expect(answers.count).to eq(13)
+        expect(answers.count).to eq(15)
 
         # Note it only shows the multi answer, not the free text because it is empty
-        expect(answers[9]).to be_an_instance_of(MultiAnswer)
-        expect(answers[9].question).to eq(:special_arrangements)
-        expect(answers[9].value).to eq([])
+        expect(answers[11]).to be_an_instance_of(MultiAnswer)
+        expect(answers[11].question).to eq(:special_arrangements)
+        expect(answers[11].value).to eq([])
       end
     end
 
@@ -148,12 +160,12 @@ module Summary
       let(:special_assistance_details) { '' }
 
       it 'still shows the block because `show: true` (will use the `absence_answer`)' do
-        expect(answers.count).to eq(13)
+        expect(answers.count).to eq(15)
 
         # Note it only shows the multi answer, not the free text because it is empty
-        expect(answers[12]).to be_an_instance_of(MultiAnswer)
-        expect(answers[12].question).to eq(:special_assistance)
-        expect(answers[12].value).to eq([])
+        expect(answers[14]).to be_an_instance_of(MultiAnswer)
+        expect(answers[14].question).to eq(:special_assistance)
+        expect(answers[14].value).to eq([])
       end
     end
   end


### PR DESCRIPTION
We had already these fields in the database but we were not exposing them.
Now we are going to show them in the same way we do for other language options.

Updated the form object and view, as well as CYA and PDF to show the relevant Welsh section.

Minor copy changes according to the design to accommodate this change.

<img width="666" alt="Screen Shot 2020-02-27 at 12 49 12" src="https://user-images.githubusercontent.com/687910/75446586-9680a580-595f-11ea-95a5-709224ab72ad.png">
