### PR TITLE
Fix locale for intermediary_help_details

### DIFF
--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -572,8 +572,8 @@ en:
       question: ''
       answers:
         <<: *YESNO
-      intermediary_help_details:
-        question: ''
+    intermediary_help_details:
+      question: ''
 
     language_interpreter:
       question: Interpreter

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -382,8 +382,8 @@ en:
       question: Are you aware of whether an intermediary will be required?
       answers:
         <<: *YESNO
-      intermediary_help_details:
-        question: *details
+    intermediary_help_details:
+      question: *details
 
     language_interpreter:
       question: Interpreter


### PR DESCRIPTION
The copy&paste messed up the tab.