### PR TITLE
Allow resending emails in back office, even not failed ones

### DIFF
--- a/app/controllers/backoffice/emails_controller.rb
+++ b/app/controllers/backoffice/emails_controller.rb
@@ -11,6 +11,7 @@ module Backoffice
       @email_address  = params[:email_address]&.strip
 
       @report = EmailSubmissionsAudit.find_records(@reference_code, @email_address)
+      @submission = C100Application.find_by_reference_code(@reference_code)&.email_submission
 
       audit!(
         action: :email_lookup,
@@ -26,7 +27,7 @@ module Backoffice
       audit_resend(email, resend_type: type)
 
       redirect_to backoffice_emails_path, flash: {
-        alert: 'Email resend in progress. Please reload the page in a few seconds.'
+        alert: 'Email resend in progress.'
       }
     end
 

--- a/app/models/concerns/application_reference.rb
+++ b/app/models/concerns/application_reference.rb
@@ -8,7 +8,7 @@ module ApplicationReference
       where(
         created_at: date_range(year, month)
       ).where(
-        'id::text ILIKE :uuid_filter', uuid_filter: "#{uuid_part}%"
+        'id::text ILIKE :uuid_filter', uuid_filter: "#{uuid_part}-%"
       ).take
     end
 

--- a/app/views/backoffice/emails/_submission.en.html.erb
+++ b/app/views/backoffice/emails/_submission.en.html.erb
@@ -1,0 +1,39 @@
+<p class="heading-medium">
+  Resend emails
+</p>
+
+<div class="govuk-govspeak gv-s-prose">
+  <p>
+    Emails can be triggered again up to 28 days after the application was created. Use this functionality when, for
+    whatever reason, an application was not received or can't be found.
+  </p>
+</div>
+
+<table class="backoffice-table">
+  <thead>
+    <tr>
+      <th>Recipient</th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% if submission.to_address %>
+      <tr>
+        <td><%= submission.to_address %></td>
+        <td valign="middle">
+          <%= button_to 'Resend email', backoffice_email_resend_path(submission, type: 'court'), method: :put, data: { confirm: 'Are you sure?' }, class: 'button' %>
+        </td>
+      </tr>
+    <% end %>
+
+    <% if submission.email_copy_to %>
+      <tr>
+        <td><%= submission.email_copy_to %></td>
+        <td valign="middle">
+          <%= button_to 'Resend email', backoffice_email_resend_path(submission, type: 'user'), method: :put, data: { confirm: 'Are you sure?' }, class: 'button' %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/backoffice/emails/lookup.en.html.erb
+++ b/app/views/backoffice/emails/lookup.en.html.erb
@@ -27,5 +27,9 @@
         <% end %>
       </tbody>
     </table>
+
+    <% if @submission %>
+      <%= render partial: 'submission', locals: { submission: @submission } %>
+    <% end %>
   </div>
 </div>

--- a/spec/models/concerns/application_reference_spec.rb
+++ b/spec/models/concerns/application_reference_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ApplicationReference do
       expect(test_class).to receive(:where).and_return(date_finder_double)
 
       expect(date_finder_double).to receive(:where).with(
-        "id::text ILIKE :uuid_filter", uuid_filter: 'DB2ED4FD%'
+        "id::text ILIKE :uuid_filter", uuid_filter: 'DB2ED4FD-%'
       ).and_return(uuid_finder_double)
 
       test_class.find_by_reference_code('2018/05/DB2ED4FD')


### PR DESCRIPTION
There is a requirement to be able to resend recent emails that were successfully sent but for whatever reason, they need to be resend.

In particular, due to an IT outage, some emails where sent without error, but some courts did not receive them.
But can also happen when an applicant or a court says they've not received anything (or they deleted the email by mistake).

This expose a new functionality in the back office so, given a reference code, it is possible to trigger again the sending of emails (court or applicant) at any time, during the 28 days from the creation of the application.