### PR TITLE
Add an application fulfilment custom validator

### DIFF
--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -37,6 +37,11 @@ class C100Application < ApplicationRecord
 
   delegate :court, to: :screener_answers, prefix: true, allow_nil: true
 
+  # Before marking the application as completed we run a final
+  # validation to ensure the basic details are fulfilled.
+  #
+  validates_with ApplicationFulfilmentValidator, on: :completion
+
   def self.purge!(date)
     where('c100_applications.created_at <= :date', date: date).destroy_all
   end

--- a/app/presenters/fulfilment_error.rb
+++ b/app/presenters/fulfilment_error.rb
@@ -1,0 +1,15 @@
+class FulfilmentError
+  attr_reader :attribute, :message, :error, :change_path
+
+  def initialize(attribute, message:, error:, change_path:)
+    @attribute = attribute
+    @message = message
+    @error = error
+    @change_path = change_path
+  end
+
+  # Used by Rails to determine which partial to render.
+  def to_partial_path
+    'steps/application/check_your_answers/fulfilment_error'
+  end
+end

--- a/app/presenters/fulfilment_errors_presenter.rb
+++ b/app/presenters/fulfilment_errors_presenter.rb
@@ -1,0 +1,24 @@
+class FulfilmentErrorsPresenter
+  attr_writer :errors
+
+  def initialize(c100_application)
+    @errors = c100_application.errors
+  end
+
+  def errors
+    @errors.map.with_index do |(attribute, message), index|
+      FulfilmentError.new(
+        attribute,
+        message: message,
+        error: details(attribute, index, :error),
+        change_path: details(attribute, index, :change_path),
+      )
+    end
+  end
+
+  private
+
+  def details(attribute, index, key)
+    @errors.details[attribute][index][key]
+  end
+end

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -1,0 +1,22 @@
+class ApplicationFulfilmentValidator < ActiveModel::Validator
+  include Rails.application.routes.url_helpers
+
+  def validate(record)
+    validations.each do |validation|
+      if (attribute, error, change_path = validation.call(record))
+        record.errors.add(attribute, error, change_path: change_path)
+      end
+    end
+  end
+
+  private
+
+  # Individual validations to be added here
+  # Final list to be defined
+  #
+  def validations
+    [
+      ->(record) { [:applicants, :blank, edit_steps_applicant_names_path(id: '')] unless record.applicants.any? },
+    ]
+  end
+end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -79,6 +79,11 @@ en:
             current_password:
               blank: Enter your current password
               invalid: The password is not valid
+        # Fulfillment validation errors
+        c100_application:
+          attributes:
+            applicants:
+              blank: You must add at least one applicant
 
   activemodel:
     errors:

--- a/spec/presenters/fulfilment_error_spec.rb
+++ b/spec/presenters/fulfilment_error_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe FulfilmentError do
+  subject {
+    described_class.new(:foobar, message: 'Foobar message', error: :blank, change_path: 'steps/foo/bar')
+  }
+
+  describe '#to_partial_path' do
+    it 'returns the correct partial path' do
+      expect(subject.to_partial_path).to eq('steps/application/check_your_answers/fulfilment_error')
+    end
+  end
+
+  context 'expose the error details as attributes' do
+    describe '#attribute' do
+      it { is_expected.to have_attributes(attribute: :foobar) }
+    end
+
+    describe '#message' do
+      it { is_expected.to have_attributes(message: 'Foobar message') }
+    end
+
+    describe '#error' do
+      it { is_expected.to have_attributes(error: :blank) }
+    end
+
+    describe '#change_path' do
+      it { is_expected.to have_attributes(change_path: 'steps/foo/bar') }
+    end
+  end
+end

--- a/spec/presenters/fulfilment_errors_presenter_spec.rb
+++ b/spec/presenters/fulfilment_errors_presenter_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe FulfilmentErrorsPresenter do
+  subject { described_class.new(c100_application) }
+
+  let(:c100_application) { C100Application.new }
+
+  describe '#errors' do
+    context 'there are no errors' do
+      it 'returns an empty collection' do
+        expect(subject.errors).to be_empty
+      end
+    end
+
+    context 'there are errors' do
+      before do
+        # Add a fake error as an example (the attribute must exist)
+        c100_application.errors.add(:miam_acknowledgement, :blank, change_path: 'steps/foo/bar')
+      end
+
+      it 'returns a collection of `FulfilmentError` instances' do
+        expect(subject.errors).to match_instances_array([FulfilmentError])
+      end
+
+      it 'the `FulfilmentError` contains all the information needed' do
+        error = subject.errors.first
+
+        expect(error.attribute).to eq(:miam_acknowledgement)
+        expect(error.message).to eq('Enter an answer')
+        expect(error.error).to eq(:blank)
+        expect(error.change_path).to eq('steps/foo/bar')
+      end
+    end
+  end
+end

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+module Test
+  C100ApplicationValidatable = Struct.new(:applicants, keyword_init: true) do
+    include ActiveModel::Validations
+    validates_with ApplicationFulfilmentValidator
+  end
+end
+
+RSpec.describe ApplicationFulfilmentValidator, type: :model do
+  subject { Test::C100ApplicationValidatable.new(arguments) }
+
+  describe 'applicants validation' do
+    context 'there are no applicants' do
+      let(:arguments) { { applicants: [] } }
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.details[:applicants][0][:error]).to eq(:blank)
+        expect(subject.errors.details[:applicants][0][:change_path]).to eq('/steps/applicant/names/')
+      end
+    end
+
+    context 'there is at least one applicant' do
+      let(:arguments) { { applicants: [Object] } }
+
+      it 'is valid' do
+        subject.valid?
+        expect(subject.errors.details.include?(:applicants)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This validator will run only on completion of the application (still not wired up, that will come up in a follow-up PR) and will check some preconditions are met in order for the application to be considered "valid" and to be submitted to court. Essentially a quick sanity check.

This is not intended to be an in-deep validation of every single attribute (as that already happens at the step level, one by one as the applicant progress through the application) but more for cases where the user jumped some steps or deleted by mistake all applicants, or all respondents, etc.

Still to do in a follow-up PR the wiring to the CYA page, and the presentation of the errors using the `FulfilmentErrorsPresenter` class and the `check_your_answers/fulfilment_error` partial (not included in this PR as we are awaiting design).

Note: as there is nothing yet on the service to "see" this working, apart from the tests, this can also be tested quickly by going to the rails console and running:

```ruby
a = C100Application.new
a.valid?(:completion)
FulfilmentErrorsPresenter.new(a).errors
```