### PR TITLE
Present fulfilment errors in CYA page

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -62,6 +62,7 @@ class SessionsController < ApplicationController
       written_agreement: 'no',
       email_consent: 'no',
       local_court: {
+        _fixture: true, # this flag indicates the court data is "fake" (bypass)
         "address" => {
           "address_lines" => ["351 Silbury Boulevard", "Witan Gate East"],
           "town" => "Central Milton Keynes",

--- a/app/forms/steps/application/declaration_form.rb
+++ b/app/forms/steps/application/declaration_form.rb
@@ -7,7 +7,15 @@ module Steps
       validates_presence_of  :declaration_signee
       validates_inclusion_of :declaration_signee_capacity, in: UserType.string_values
 
+      # This final form object performs a `c100_application` fulfilment validation,
+      # essentially a top level sanity check. Refer to `ApplicationFulfilmentValidator`
+      validate :application_fulfilment, if: :c100_application
+
       private
+
+      def application_fulfilment
+        c100_application.valid?(:completion) || errors.add(:c100_application)
+      end
 
       def persist!
         raise C100ApplicationNotFound unless c100_application

--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -24,6 +24,10 @@ module Summary
       ].flatten.select(&:show?)
     end
 
+    def errors
+      FulfilmentErrorsPresenter.new(c100_application).errors
+    end
+
     def before_submit_warning
       ['.submit_warning', submission_type].join('.')
     end

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -2,6 +2,8 @@ class ApplicationFulfilmentValidator < ActiveModel::Validator
   include Rails.application.routes.url_helpers
 
   def validate(record)
+    return unless must_validate?(record)
+
     validations.each do |validation|
       if (attribute, error, change_path = validation.call(record))
         record.errors.add(attribute, error, change_path: change_path)
@@ -10,6 +12,18 @@ class ApplicationFulfilmentValidator < ActiveModel::Validator
   end
 
   private
+
+  # As we are not yet releasing this to final users, we enable/disable these
+  # validations by using a feature-flag based on whether the court data is fake
+  # (a fixture) or not.
+  #
+  # Currently, ONLY if the court data is fake (meaning we've used the `bypass`
+  # functionality) these validations will run. This allow us to easily "see"
+  # the validations and check the design until it is ready for release.
+  #
+  def must_validate?(record)
+    record.screener_answers.local_court.key?('_fixture')
+  end
 
   # Individual validations to be added here
   # Final list to be defined

--- a/app/views/steps/application/check_your_answers/_fulfilment_error.html.erb
+++ b/app/views/steps/application/check_your_answers/_fulfilment_error.html.erb
@@ -1,0 +1,6 @@
+<%# TODO: this partial is pending design. It is just a placeholder %>
+
+<p id="error_steps_application_declaration_form_c100_application_attributes_<%= fulfilment_error.attribute %>">
+  <%= fulfilment_error.message %>
+</p>
+<p><%= link_to 'Fix this error', fulfilment_error.change_path %></p>

--- a/app/views/steps/application/check_your_answers/_fulfilment_summary.html.erb
+++ b/app/views/steps/application/check_your_answers/_fulfilment_summary.html.erb
@@ -1,0 +1,7 @@
+<%# TODO: this partial is pending design. It is just a placeholder %>
+
+<h1 class="app__heading heading-xlarge gv-u-heading-xxlarge util_mt-large">
+  <%=t '.errors_heading' %>
+</h1>
+
+<%= render errors %>

--- a/app/views/steps/application/check_your_answers/edit.html.erb
+++ b/app/views/steps/application/check_your_answers/edit.html.erb
@@ -8,6 +8,9 @@
 
 <%= render @presenter.sections %>
 
+<%= render partial: 'fulfilment_summary',
+           locals: { errors: @presenter.errors } if @presenter.errors.any? %>
+
 <%= step_form @form_object,
               html: { class: 'util_mt-large ga-submitForm' },
               data: { ga_category: 'application completed', ga_label: 'declaration' } do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -768,6 +768,8 @@ en:
           heading: Resume application
           lead_text: Review your current progress and resume this application
           resume: Resume application
+        fulfilment_summary:
+          errors_heading: Errors found in your application
       urgent_hearing:
         edit:
           page_title: Urgent hearing

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -603,3 +603,5 @@ en:
               blank: Enter your full name
             declaration_signee_capacity:
               inclusion: Select who is making this declaration
+            c100_application:
+              invalid: "" # do not show this error message, we show the specific ones

--- a/spec/forms/steps/application/declaration_form_spec.rb
+++ b/spec/forms/steps/application/declaration_form_spec.rb
@@ -23,18 +23,53 @@ RSpec.describe Steps::Application::DeclarationForm do
     end
 
     context 'validations' do
+      before do
+        allow(c100_application).to receive(:valid?)
+      end
+
       it { should validate_presence_of(:declaration_signee) }
       it { should validate_presence_of(:declaration_signee_capacity, :inclusion) }
     end
 
-    context 'when form is valid' do
-      it 'saves the record' do
-        expect(c100_application).to receive(:update).with(
-          declaration_signee: 'Full Name',
-          declaration_signee_capacity: 'applicant',
-        ).and_return(true)
+    context 'when application fulfilment is successful' do
+      before do
+        allow(c100_application).to receive(:valid?).with(:completion).and_return(true)
+      end
 
-        expect(subject.save).to be(true)
+      context 'and form is valid' do
+        it 'saves the record' do
+          expect(c100_application).to receive(:update).with(
+            declaration_signee: 'Full Name',
+            declaration_signee_capacity: 'applicant',
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'and form is not valid' do
+        let(:declaration_signee_capacity) { nil }
+
+        it 'returns false' do
+          expect(c100_application).not_to receive(:update)
+          expect(subject.save).to eq(false)
+        end
+      end
+    end
+
+    context 'when application fulfilment fails' do
+      before do
+        allow(c100_application).to receive(:valid?).with(:completion).and_return(false)
+      end
+
+      it 'has an error in the `c100_application` attribute' do
+        subject.save
+        expect(subject.errors.added?(:c100_application, :invalid)).to eq(true)
+      end
+
+      it 'returns false' do
+        expect(c100_application).not_to receive(:update)
+        expect(subject.save).to eq(false)
       end
     end
   end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -121,4 +121,16 @@ describe Summary::HtmlPresenter do
       end
     end
   end
+
+  describe '#errors' do
+    let(:errors_presenter) { instance_double(FulfilmentErrorsPresenter, errors: [Object]) }
+
+    before do
+      allow(FulfilmentErrorsPresenter).to receive(:new).with(c100_application).and_return(errors_presenter)
+    end
+
+    it 'returns application fulfilment errors' do
+      expect(subject.errors).to eq([Object])
+    end
+  end
 end

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module Test
-  C100ApplicationValidatable = Struct.new(:applicants, keyword_init: true) do
+  C100ApplicationValidatable = Struct.new(:screener_answers, :applicants, keyword_init: true) do
     include ActiveModel::Validations
     validates_with ApplicationFulfilmentValidator
   end
@@ -10,7 +10,39 @@ end
 RSpec.describe ApplicationFulfilmentValidator, type: :model do
   subject { Test::C100ApplicationValidatable.new(arguments) }
 
+  # TODO: feature-flag code, to be remove once released
+  context 'validations are run based on feature flag' do
+    let(:screener_answers) { instance_double(ScreenerAnswers, local_court: local_court) }
+    let(:arguments) { { applicants: [] } }
+
+    before do
+      allow(subject).to receive(:screener_answers).and_return(screener_answers)
+    end
+
+    context 'when the court data is a fixture' do
+      let(:local_court) { { "_fixture" => true } }
+
+      it 'runs the validations' do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context 'when the court data is not a fixture' do
+      let(:local_court) { {} }
+
+      it 'does not run the validations' do
+        expect(subject).to be_valid
+      end
+    end
+  end
+
   describe 'applicants validation' do
+    # TODO: feature-flag code, to be remove once released
+    # Assume in following tests we must always validate
+    before do
+      allow_any_instance_of(described_class).to receive(:must_validate?).and_return(true)
+    end
+
     context 'there are no applicants' do
       let(:arguments) { { applicants: [] } }
 


### PR DESCRIPTION
Follow-up to PR #818.

Show the errors, if any, in the CYA page. Still design is TBD so the partials are just placeholders, showing basic details about the error.

As part of this PR and to protect this new feature from being released to production before is ready, added a simple mechanism to feature-flag the validations: it will run ONLY if we are using fake court data (a fixture, like we do when ue the bypass functionality on local/staging envs).

This way, on production there is no risk of this validation being run just yet.

Note: it is possible to avoid the validations also on local/staging if you start the screener and answer at least one question, then you can use the bypass functionality (or just continue all the way to the end answering questions) and the fulfilment validator will not trigger.

<img width="1034" alt="Screen Shot 2020-03-09 at 13 23 45" src="https://user-images.githubusercontent.com/687910/76217561-8b086680-620a-11ea-852b-2feee2ed608f.png">
