### PR TITLE
Add validation for children and respondents

### DIFF
--- a/app/presenters/fulfilment_errors_presenter.rb
+++ b/app/presenters/fulfilment_errors_presenter.rb
@@ -8,7 +8,13 @@ class FulfilmentErrorsPresenter
   end
 
   def errors
-    @errors.map.with_index do |(attribute, message), index|
+    @errors.keys.map(&method(:build_errors)).flatten
+  end
+
+  private
+
+  def build_errors(attribute)
+    @errors[attribute].map.with_index do |message, index|
       FulfilmentError.new(
         attribute: attribute,
         message: message,
@@ -17,8 +23,6 @@ class FulfilmentErrorsPresenter
       )
     end
   end
-
-  private
 
   def details(attribute, index, key)
     @errors.details[attribute][index][key]

--- a/app/validators/application_fulfilment_validator.rb
+++ b/app/validators/application_fulfilment_validator.rb
@@ -26,11 +26,13 @@ class ApplicationFulfilmentValidator < ActiveModel::Validator
   end
 
   # Individual validations to be added here
-  # Final list to be defined
+  # Errors, when more than one, will maintain this order
   #
   def validations
     [
+      ->(record) { [:children, :blank, edit_steps_children_names_path(id: '')] unless record.children.any? },
       ->(record) { [:applicants, :blank, edit_steps_applicant_names_path(id: '')] unless record.applicants.any? },
+      ->(record) { [:respondents, :blank, edit_steps_respondent_names_path(id: '')] unless record.respondents.any? },
     ]
   end
 end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -82,8 +82,12 @@ en:
         # Fulfillment validation errors
         c100_application:
           attributes:
+            children:
+              blank: You must add at least one child
             applicants:
               blank: You must add at least one applicant
+            respondents:
+              blank: You must add at least one respondent
 
   activemodel:
     errors:

--- a/spec/presenters/fulfilment_errors_presenter_spec.rb
+++ b/spec/presenters/fulfilment_errors_presenter_spec.rb
@@ -14,22 +14,36 @@ RSpec.describe FulfilmentErrorsPresenter do
 
     context 'there are errors' do
       before do
-        # Add a fake error as an example (the attribute must exist)
+        # Add a couple fake errors as an example (the attributes must exist)
         c100_application.errors.add(:miam_acknowledgement, :blank, change_path: 'steps/foo/bar')
+        c100_application.errors.add(:substance_abuse, :blank, change_path: 'steps/xyz')
       end
 
       it 'returns a collection of errors' do
         expect(subject.errors).to be_an_instance_of(Array)
       end
 
-      context 'returned error' do
-        let(:error) { subject.errors.first }
+      context 'returned errors' do
+        context 'first error' do
+          let(:error) { subject.errors[0] }
 
-        it 'contains all the information needed' do
-          expect(error.attribute).to eq(:miam_acknowledgement)
-          expect(error.message).to eq('Enter an answer')
-          expect(error.error).to eq(:blank)
-          expect(error.change_path).to eq('steps/foo/bar')
+          it 'contains all the information needed' do
+            expect(error.attribute).to eq(:miam_acknowledgement)
+            expect(error.message).to eq('Enter an answer')
+            expect(error.error).to eq(:blank)
+            expect(error.change_path).to eq('steps/foo/bar')
+          end
+        end
+
+        context 'second error' do
+          let(:error) { subject.errors[1] }
+
+          it 'contains all the information needed' do
+            expect(error.attribute).to eq(:substance_abuse)
+            expect(error.message).to eq('Enter an answer')
+            expect(error.error).to eq(:blank)
+            expect(error.change_path).to eq('steps/xyz')
+          end
         end
       end
     end

--- a/spec/validators/application_fulfilment_validator_spec.rb
+++ b/spec/validators/application_fulfilment_validator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module Test
-  C100ApplicationValidatable = Struct.new(:screener_answers, :applicants, keyword_init: true) do
+  C100ApplicationValidatable = Struct.new(:screener_answers, :children, :applicants, :respondents, keyword_init: true) do
     include ActiveModel::Validations
     validates_with ApplicationFulfilmentValidator
   end
@@ -10,10 +10,18 @@ end
 RSpec.describe ApplicationFulfilmentValidator, type: :model do
   subject { Test::C100ApplicationValidatable.new(arguments) }
 
+  let(:arguments) { { children: children, applicants: applicants, respondents: respondents } }
+
+  let(:children)    { [Object] }
+  let(:applicants)  { [Object] }
+  let(:respondents) { [Object] }
+
   # TODO: feature-flag code, to be remove once released
   context 'validations are run based on feature flag' do
     let(:screener_answers) { instance_double(ScreenerAnswers, local_court: local_court) }
-    let(:arguments) { { applicants: [] } }
+
+    # make it fail by not having children
+    let(:children) { [] }
 
     before do
       allow(subject).to receive(:screener_answers).and_return(screener_answers)
@@ -36,29 +44,67 @@ RSpec.describe ApplicationFulfilmentValidator, type: :model do
     end
   end
 
-  describe 'applicants validation' do
+  context 'individual validations' do
     # TODO: feature-flag code, to be remove once released
     # Assume in following tests we must always validate
     before do
       allow_any_instance_of(described_class).to receive(:must_validate?).and_return(true)
     end
 
-    context 'there are no applicants' do
-      let(:arguments) { { applicants: [] } }
+    context 'children' do
+      context 'there is at least one child' do
+        it 'is valid' do
+          subject.valid?
+          expect(subject.errors.details.include?(:children)).to eq(false)
+        end
+      end
 
-      it 'is invalid' do
-        expect(subject).not_to be_valid
-        expect(subject.errors.details[:applicants][0][:error]).to eq(:blank)
-        expect(subject.errors.details[:applicants][0][:change_path]).to eq('/steps/applicant/names/')
+      context 'there are no children' do
+        let(:children) { [] }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.details[:children][0][:error]).to eq(:blank)
+          expect(subject.errors.details[:children][0][:change_path]).to eq('/steps/children/names/')
+        end
       end
     end
 
-    context 'there is at least one applicant' do
-      let(:arguments) { { applicants: [Object] } }
+    context 'applicants' do
+      context 'there is at least one applicant' do
+        it 'is valid' do
+          subject.valid?
+          expect(subject.errors.details.include?(:applicants)).to eq(false)
+        end
+      end
 
-      it 'is valid' do
-        subject.valid?
-        expect(subject.errors.details.include?(:applicants)).to eq(false)
+      context 'there are no applicants' do
+        let(:applicants) { [] }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.details[:applicants][0][:error]).to eq(:blank)
+          expect(subject.errors.details[:applicants][0][:change_path]).to eq('/steps/applicant/names/')
+        end
+      end
+    end
+
+    context 'respondents' do
+      context 'there is at least one respondent' do
+        it 'is valid' do
+          subject.valid?
+          expect(subject.errors.details.include?(:respondents)).to eq(false)
+        end
+      end
+
+      context 'there are no respondents' do
+        let(:respondents) { [] }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.details[:respondents][0][:error]).to eq(:blank)
+          expect(subject.errors.details[:respondents][0][:change_path]).to eq('/steps/respondent/names/')
+        end
       end
     end
   end


### PR DESCRIPTION
Same as we did with applicants, we add validation for having at least one child and at least one respondent.

For now this will be all. We can decide to include more validations later on.

Reworked a bit the loop to retrieve the error details so it works when there is more than one, like we have now.

The final little PR after this one will be to enable this for all users (without feature-flag) to be able to release to production.