### PR TITLE
remove Respondent age check

### DIFF
--- a/app/services/c100_app/respondent_decision_tree.rb
+++ b/app/services/c100_app/respondent_decision_tree.rb
@@ -9,7 +9,7 @@ module C100App
       when :names_finished
         edit(:personal_details, id: next_respondent_id)
       when :personal_details
-        after_personal_details
+        after_personal_details(age_check: false)
       when :under_age
         edit_first_child_relationships
       when :relationship

--- a/app/services/c100_app/respondent_decision_tree.rb
+++ b/app/services/c100_app/respondent_decision_tree.rb
@@ -43,14 +43,6 @@ module C100App
       end
     end
 
-    def dob_under_age?
-      # Respondents, unlike Applicants, can have an 'unknown' DoB and they can fill
-      # an 'approximate age or year born' free input text. The prototype does some fancy
-      # stuff to try to come up with a valid date/age from the text field, but for now,
-      # I will leave out that functionality as there are more important things to do!
-      record.reload.dob.present? && (record.dob > 18.years.ago)
-    end
-
     def next_respondent_id
       next_record_id(c100_application.respondent_ids)
     end

--- a/spec/services/c100_app/respondent_decision_tree_spec.rb
+++ b/spec/services/c100_app/respondent_decision_tree_spec.rb
@@ -36,43 +36,11 @@ RSpec.describe C100App::RespondentDecisionTree do
 
   context 'when the step is `personal_details`' do
     let(:step_params) {{'personal_details' => 'anything'}}
-    let(:record) { double('Respondent', id: 1, dob: dob) }
+    let(:record) { double('Respondent', id: 1) }
 
-    before do
-      expect(record).to receive(:reload).and_return(record)
-      travel_to Date.new(2018, 1, 5) # Stub current date to 5 Jan 2018
-    end
-
-    context 'and the DoB is under age' do
-      let(:dob) { Date.new(2000, 1, 6) }
-
-      it 'goes to the warning under age page' do
-        expect(subject.destination).to eq(controller: :under_age, action: :edit, id: record)
-      end
-    end
-
-    context 'and the DoB is not under age' do
-      let(:dob) { Date.new(2000, 1, 5) }
-
-      it 'goes to edit the first child relationship for the current record' do
-        expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
-      end
-    end
-
-    context 'and the DoB is nil' do
-      let(:dob) { nil }
-
-      it 'goes to edit the first child relationship for the current record' do
-        expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
-      end
-    end
-
-    context 'and the DoB is an empty string (mutant kill)' do
-      let(:dob) { '' }
-
-      it 'goes to edit the first child relationship for the current record' do
-        expect(subject.destination).to eq(controller: :relationship, action: :edit, id: record, child_id: 1)
-      end
+    it 'does not run an age check' do
+      expect(subject).to receive(:after_personal_details).with(age_check: false)
+      subject.destination
     end
   end
 


### PR DESCRIPTION
We are rolling out an allowance for under age Participant and Respondents to be able to fill the form.

This commit is about removing the age check on the Respondent.

There will be more follow up PR's