### PR TITLE
Update applicant under age form

### DIFF
--- a/app/forms/steps/shared/under_age_form.rb
+++ b/app/forms/steps/shared/under_age_form.rb
@@ -1,13 +1,18 @@
 module Steps
   module Shared
     class UnderAgeForm < BaseForm
-      # This form does nothing really, but we use it for the interstitials 'under 18 years'
-      # warning pages, which are complex in the sense we need to keep track of the current
-      # applicant and, for the following page, the child to ask for their relationship.
+      attribute :under_age, Boolean
+
+      validates_presence_of :under_age
 
       def persist!
         raise C100ApplicationNotFound unless c100_application
-        true
+
+        applicant = c100_application.applicants.find_or_initialize_by(id: record_id)
+
+        applicant.update(
+          under_age: under_age
+        )
       end
     end
   end

--- a/app/views/steps/applicant/under_age/edit.html.erb
+++ b/app/views/steps/applicant/under_age/edit.html.erb
@@ -8,6 +8,9 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <%= render partial: '/steps/shared/screener_exit_actions' %>
+    <%= step_form @form_object do |f| %>
+      <%= f.single_check_box :under_age %>
+      <%= f.continue_button %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1153,6 +1153,8 @@ en:
       # attending court redesign -- end
 
     label:
+      steps_shared_under_age_form:
+        under_age: I understand I need to be represented by a litigation friend, and that my application won’t be processed until the court receives a certificate of suitability or copy of the court order appointing a litigation friend.
       steps_shared_relationship_form:
         relation_other_value: Please specify
         relation:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -111,6 +111,10 @@ en:
               inclusion: Select yes if you’re willing to be contacted about using this service
         # End screener
 
+        steps/shared/under_age_form:
+          attributes:
+            under_age:
+              blank: You must confirm you understand
         steps/miam/child_protection_cases_form:
           attributes:
             child_protection_cases:


### PR DESCRIPTION
This commit updates the under age form to save the answer given on the form,
the answer is an acknowlegment that they understand what they need to do and
that they acknowlege they are of under age.

<img width="704" alt="Screenshot 2020-03-13 at 12 10 30" src="https://user-images.githubusercontent.com/136777/76619907-e052b980-6523-11ea-8a32-9d7d89023404.png">
