### PR TITLE
Customise email copy when applicant is under age

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -61,4 +61,10 @@ class NotifyMailer < GovukNotifyRails::Mailer
     super({ service_name: @service_name }.merge(personalisation))
   end
   # rubocop:enable Naming/AccessorMethodName
+
+  # GOV.UK Notify expects booleans to be literals `yes` or `no`
+  # to show/hide optional content.
+  def notify_boolean(value)
+    value.present? ? 'yes' : 'no'
+  end
 end

--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -42,6 +42,7 @@ class NotifySubmissionMailer < NotifyMailer
         court_name: court.name,
         court_email: court.email,
         court_url: C100App::CourtfinderAPI.new.court_url(court.slug),
+        is_under_age: notify_boolean(@c100_application.applicants.under_age?),
         payment_instructions: payment_instructions,
       )
     )

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,2 +1,7 @@
 class Applicant < Person
+  # In the case of more than one applicant, if at least one of them
+  # is under age, the whole application is considered as "under age"
+  def self.under_age?
+    any?(&:under_age)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1741,10 +1741,11 @@ en:
         Your solicitor will pay the court fee by direct debit, through their fee account.
       help_with_fees: |
         You may not need to pay the full amount if you have a valid ‘Help with fees’ reference.
-        The court will phone you (it may come from a ‘private number’) if they require payment.
+        The court will phone you (it may look like a ‘private number’) if they require payment.
       self_payment_card: |
-        You need to pay the £215 court fee. The court will phone you (it may come from a ‘private number’) within 3 working days of receiving your application to take payment using a credit or debit card.
-        If you did not enter a telephone number or you do not get a call, please contact the court to pay. You may also pay in person at the court.
+        You need to pay the £215 court fee. You’ll either:
+        * receive a call from the court in the next 3 working days if you entered your phone number (it may look like a ‘private number’)
+        * or you need to contact the court, by phone or in person to make payment
       self_payment_cheque: |
         You need to pay the £215 court fee. Post a cheque made out to ‘HM Courts and Tribunals Service’. Write your reference code, last name and ‘C100’ on the back of your cheque.
         Send your cheque or pay in person within 3 working days.

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         court_name: 'Test court',
         court_email: 'court@example.com',
         court_url: 'https://courttribunalfinder.service.gov.uk/courts/test-court',
+        is_under_age: 'no',
         payment_instructions: 'payment instructions from locales',
         link_to_pdf: { file: 'YnVuZGxlIHBkZg==' },
       })
@@ -136,6 +137,20 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         expect(
           mail.govuk_notify_personalisation
         ).to include(payment_instructions: 'hwf payment instructions')
+      end
+    end
+
+    context 'when at least one applicant is under age' do
+      let(:applicants_collection_double) { double(under_age?: true) }
+
+      before do
+        allow(c100_application).to receive(:applicants).and_return(applicants_collection_double)
+      end
+
+      it 'has the right personalisation' do
+        expect(
+          mail.govuk_notify_personalisation
+        ).to include(is_under_age: 'yes')
       end
     end
   end

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -44,4 +44,22 @@ RSpec.describe Applicant, type: :model do
       end
     end
   end
+
+  describe '.under_age?' do
+    subject { c100_application.applicants }
+
+    context 'there are not under age applicants' do
+      let(:c100_application) { C100Application.new }
+      it { expect(subject.under_age?).to eq(false) }
+    end
+
+    context 'there is at least 1 under age applicant' do
+      let(:c100_application) { C100Application.create(applicants: [app1, app2]) }
+
+      let(:app1) { Applicant.new(under_age: true) }
+      let(:app2) { Applicant.new(under_age: false) }
+
+      it { expect(subject.under_age?).to eq(true) }
+    end
+  end
 end


### PR DESCRIPTION
Expose a helper method on the `Applicants` collection to query if there is at least one applicant under age (returning true or false).

This method is later used on Notify emails, but can also be used for the confirmation pages or any other place where we need to know if the application as a whole contains at least one under age.

Send the yes/no to Notify to be able to show/hide the instructions when applicant is under age in the confirmation email.

Tweaked a bit the card payment instructions as per suggestions from content designer.
The under18s instructions are part of the Notify template.

Example of email with the under 18s code inserted (and the payment instructions tweaked):

<img width="603" alt="Screen Shot 2020-03-16 at 12 41 07" src="https://user-images.githubusercontent.com/687910/76759924-94eb1600-6784-11ea-8f63-48de06789710.png">
