### PR TITLE
Add under age data to the audit table

### DIFF
--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -6,12 +6,14 @@ class AuditHelper
     @c100_application = c100_application
   end
 
+  # rubocop:disable Metrics/AbcSize
   def metadata
     {
       v: c100.version,
       postcode: postcode,
       c1a_form: c100.has_safety_concerns?,
       c8_form: c100.confidentiality_enabled?,
+      under_age: c100.applicants.under_age?,
       saved_for_later: c100.user_id.present?,
       legal_representation: c100.has_solicitor,
       urgent_hearing: c100.urgent_hearing,
@@ -22,6 +24,7 @@ class AuditHelper
       arrangements: arrangements_metadata,
     }
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -19,13 +19,15 @@
                 <dd><%= completion.started_at %> (v:<%= completion.metadata['v'] || '1-3' %>)</dd>
                 <dt>Saved for later?</dt>
                 <dd><%= completion.metadata['saved_for_later'] %></dd>
+                <dt>Any applicant under 18?</dt>
+                <dd><%= completion.metadata['under_age'] || false %></dd>
                 <dt>Payment type</dt>
                 <dd><%= completion.metadata['payment_type'] || 'N/A' %></dd>
                 <dt>Legal representation</dt>
                 <dd><%= completion.metadata['legal_representation'] || 'N/A' %></dd>
-                <dt>Urgent hearing?</dt>
+                <dt>Urgent hearing</dt>
                 <dd><%= completion.metadata['urgent_hearing'] || 'N/A' %></dd>
-                <dt>Without notice hearing?</dt>
+                <dt>Without notice hearing</dt>
                 <dd><%= completion.metadata['without_notice'] || 'N/A' %></dd>
               </dl>
             </td>

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -37,6 +37,7 @@ describe AuditHelper do
         postcode: 'ABCD1**',
         c1a_form: false,
         c8_form: false,
+        under_age: false,
         saved_for_later: false,
         legal_representation: 'yes',
         urgent_hearing: 'no',


### PR DESCRIPTION
In order to accurately track the number of applications considered 'under age' (containing at least 1 applicant under 18s), we add this data to the audit table, as we've done with other details.

Also show this in the back office when retrieving the details of an application.

The default for old applications (lacking this data) is false as we've had the screener question all this time and didn't allow under 18s.