### PR TITLE
remove over18 attribute from screen answers

### DIFF
--- a/db/migrate/20200317155024_remove_over18_from_screener_answers.rb
+++ b/db/migrate/20200317155024_remove_over18_from_screener_answers.rb
@@ -1,0 +1,5 @@
+class RemoveOver18FromScreenerAnswers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :screener_answers, :over18
+  end
+end

--- a/db/migrate/20200317155024_remove_over18_from_screener_answers.rb
+++ b/db/migrate/20200317155024_remove_over18_from_screener_answers.rb
@@ -1,5 +1,5 @@
 class RemoveOver18FromScreenerAnswers < ActiveRecord::Migration[5.2]
   def change
-    remove_column :screener_answers, :over18
+    remove_column :screener_answers, :over18, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_151742) do
+ActiveRecord::Schema.define(version: 2020_03_17_155024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -325,7 +325,6 @@ ActiveRecord::Schema.define(version: 2020_03_10_151742) do
     t.uuid "c100_application_id"
     t.json "local_court"
     t.string "parent"
-    t.string "over18"
     t.string "written_agreement"
     t.string "email_consent"
     t.string "email_address"

--- a/spec/models/screener_answers_spec.rb
+++ b/spec/models/screener_answers_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe ScreenerAnswers, type: :model do
         children_postcodes
         local_court
         parent
-        over18
         written_agreement
         email_consent
       ))

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -173,7 +173,6 @@ RSpec.shared_examples 'a savepoint step controller' do
     ScreenerAnswers.new(
       children_postcodes: 'MK9 2DT',
       parent: 'yes',
-      over18: 'yes',
       written_agreement: 'no',
       email_consent: 'no',
       local_court: { name: 'whatever' }


### PR DESCRIPTION
This is because there is validation on the table attributes,
if those attributes are not filled, the screener never reaches the "completion" status that is needed.