### PR TITLE
Update Luton slug

### DIFF
--- a/config/court_slugs.yml
+++ b/config/court_slugs.yml
@@ -48,7 +48,7 @@
 - yeovil-county-family-and-magistrates-court
 - norwich-combined-court-centre
 - kings-lynn-magistrates-court-and-family-court
-- luton-county-court-and-family-court
+- luton-justice-centre
 - bedford-county-court-and-family-court
 - chelmsford-county-and-family-court
 - canterbury-combined-court-centre


### PR DESCRIPTION
Court Tribunal Finder has split the old slug into two, but only one is the court handling family cases.

Old slug does not exist anymore:
https://courttribunalfinder.service.gov.uk/courts/luton-county-court-and-family-court

This fixes the smoke errors.