### PR TITLE
Migrate about pages to new design system

### DIFF
--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -5,7 +5,7 @@ moj.Modules.gaEvents = {
     checkboxClass:  '.multiple-choice input[type="checkbox"]',
     linkClass: '.ga-pageLink',
     clickActionClass: '.ga-clickAction',
-    revealingLinkClass: 'summary span.summary',
+    revealingLinkClass: 'summary span',
     submitFormClass: '.ga-submitForm',
     submitButtons: 'button[type="submit"], input[type="submit"]',
 

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -66,10 +66,6 @@
   margin: -1rem 0 2rem;
 }
 
-.about-section {
-  margin-top: 50px;
-}
-
 .prototype-step {
   padding: 20px;
   border: 1px solid #666666;

--- a/app/views/about/accessibility.en.html.erb
+++ b/app/views/about/accessibility.en.html.erb
@@ -1,42 +1,52 @@
 <% title 'Accessibility' %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">Accessibility</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Accessibility</h1>
 
-    <h2 class="heading-large gv-u-heading-large">Using this online service</h2>
+    <h2 class="govuk-heading-l">Using this online service</h2>
 
-    <p>This online service is run by the Ministry of Justice. We want as many people as possible to be able to use it.</p>
+    <p class="govuk-body">
+      This online service is run by the Ministry of Justice. We want as many people as possible to be able to use it.
+    </p>
 
-    <p>For example, that means you should be able to:</p>
+    <p class="govuk-body">For example, that means you should be able to:</p>
 
-    <ul class="list list-bullet">
+    <ul class="govuk-list govuk-list--bullet">
       <li>change colours, contrast levels and fonts</li>
       <li>zoom in up to 300% without the text spilling off the screen</li>
       <li>navigate most of the online service using just a keyboard</li>
       <li>navigate most of the online service using speech recognition software</li>
     </ul>
 
-    <p>We’ve also made the text as simple as possible to understand.</p>
+    <p class="govuk-body">We’ve also made the text as simple as possible to understand.</p>
 
-    <p><a href="https://mcmw.abilitynet.org.uk/" rel="external" target="_blank">AbilityNet</a> has advice on making your
-      device easier to use if you have a disability.</p>
+    <p class="govuk-body">
+      <a href="https://mcmw.abilitynet.org.uk/" class="govuk-link" rel="external" target="_blank">AbilityNet</a> has
+      advice on making your device easier to use if you have a disability.
+    </p>
 
-    <h2 class="heading-large gv-u-heading-large">About the accessibility of this online service</h2>
+    <h2 class="govuk-heading-l">About the accessibility of this online service</h2>
 
-    <p>We’ve used <a href="https://govuk-elements.herokuapp.com" rel="external" target="_blank">GOV.UK Elements</a> to
-      build this service. GOV.UK Elements has now been replaced by the GOV.UK Design System, but we will still carry out
-      major bug fixes and security patches.
+    <p class="govuk-body">
+      We’ve used <a href="https://govuk-elements.herokuapp.com" class="govuk-link" rel="external" target="_blank">GOV.UK
+      Elements</a> to build this service. GOV.UK Elements has now been replaced by the GOV.UK Design System, but we will
+      still carry out major bug fixes and security patches.
+    </p>
 
-    <p>Basic tests were performed on this online service on 9 October 2019. These tests were carried out by the Ministry
-      of Justice.</p>
+    <p class="govuk-body">
+      Basic tests were performed on this online service on 9 October 2019. These tests were carried out by the Ministry
+      of Justice.
+    </p>
 
-    <p>We tested the start page, the login page and the contact page, as well as the privacy policy and the terms and
-      conditions.</p>
+    <p class="govuk-body">
+      We tested the start page, the login page and the contact page, as well as the privacy policy and the terms and
+      conditions.
+    </p>
 
-    <p>We also tested the stages of the service that require different types of user interaction:</p>
+    <p class="govuk-body">We also tested the stages of the service that require different types of user interaction:</p>
 
-    <ul class="list list-bullet">
+    <ul class="govuk-list govuk-list--bullet">
       <li>inputting text</li>
       <li>inputting numbers</li>
       <li>using radio buttons</li>
@@ -46,31 +56,34 @@
       <li>reviewing answers</li>
     </ul>
 
-    <p>Finally, we tested cookies and the third-party supplier feedback survey page.</p>
+    <p class="govuk-body">Finally, we tested cookies and the third-party supplier feedback survey page.</p>
 
-    <h2 class="heading-large gv-u-heading-large">What to do if you cannot access parts of this online service</h2>
+    <h2 class="govuk-heading-l">What to do if you cannot access parts of this online service</h2>
 
-    <p>If you need information on this online service in a different format like an accessible PDF, large print, easy
+    <p class="govuk-body">
+      If you need information on this online service in a different format like an accessible PDF, large print, easy
       read, audio recording or braille, email
-      <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Accessibility">c100helpdesk@digital.justice.gov.uk</a>.
+      <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Accessibility" class="govuk-link ga-clickAction" data-ga-category="accessibility" data-ga-action="click" data-ga-label="mailto helpdesk">c100helpdesk@digital.justice.gov.uk</a>.
     </p>
 
-    <h2 class="heading-large gv-u-heading-large">Technical information about accessibility for this online service</h2>
+    <h2 class="govuk-heading-l">Technical information about accessibility for this online service</h2>
 
-    <p>
-      The Ministry of Justice is committed to making its website accessible, in accordance with the Public Sector
-      Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+    <p class="govuk-body">
+      The Ministry of Justice is committed to making its website accessible, in accordance with the Public Sector Bodies
+      (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
     </p>
 
-    <p>This online service is partially compliant with the
-      <a href="https://www.w3.org/TR/WCAG21/" rel="external" target="_blank">Web Content Accessibility Guidelines
-        version 2.1</a> AA standard, due to the non-compliances listed below.</p>
+    <p class="govuk-body">
+      This online service is partially compliant with the
+      <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link" rel="external" target="_blank">Web Content
+        Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed below.
+    </p>
 
-    <h2 class="heading-large gv-u-heading-large">Non compliance with the accessibility regulations</h2>
+    <h2 class="govuk-heading-l">Non compliance with the accessibility regulations</h2>
 
-    <p>The content listed below is non-accessible for the following reasons.</p>
+    <p class="govuk-body">The content listed below is non-accessible for the following reasons.</p>
 
-    <ul class="list list-bullet">
+    <ul class="govuk-list govuk-list--bullet">
       <li>For some browsers, the font size does not increase when changes are made in browser settings. However, zooming
         works correctly.
       </li>
@@ -78,50 +91,58 @@
       <li>We’re working to understand whether nested checkboxes are fully accessible to screen readers.</li>
     </ul>
 
-    <p>We plan to resolve the issues above by September 2020. </p>
+    <p class="govuk-body">We plan to resolve the issues above by September 2020. </p>
 
-    <h2 class="heading-large gv-u-heading-large">PDF content</h2>
+    <h2 class="govuk-heading-l">PDF content</h2>
 
-    <p>Some PDF content is essential to providing our services, but may not yet meet accessibility standards for screen
+    <p class="govuk-body">
+      Some PDF content is essential to providing our services, but may not yet meet accessibility standards for screen
       readers. The PDF content is designed to be used by the courts and is built to their specification, so any changes
-      will require their input. We plan to review this content by September 2020.</p>
+      will require their input. We plan to review this content by September 2020.
+    </p>
 
-    <h2 class="heading-large gv-u-heading-large">Third-party supplied service</h2>
+    <h2 class="govuk-heading-l">Third-party supplied service</h2>
 
-    <p>This online service uses a third-party supplied service to collect feedback.</p>
+    <p class="govuk-body">This online service uses a third-party supplied service to collect feedback.</p>
 
-    <p>This third-party supplied service is ‘skinned' to look like our website, but some parts of it do not meet
-      <a href="https://www.w3.org/TR/WCAG21/" rel="external" target="_blank">Web Content Accessibility Guidelines
-        version 2.1</a> standards because:</p>
+    <p class="govuk-body">
+      This third-party supplied service is ‘skinned' to look like our website, but some parts of it do not meet
+      <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link" rel="external" target="_blank">Web Content
+        Accessibility Guidelines version 2.1</a> standards because:
+    </p>
 
-    <ul class="list list-bullet">
+    <ul class="govuk-list govuk-list--bullet">
       <li>incorrect heading tags are used</li>
       <li>clicking the labels does not move the cursor into the corresponding text area</li>
       <li>when using the keyboard, the radio button becomes invisible</li>
     </ul>
 
-    <p>
+    <p class="govuk-body">
       The third-party supplied feedback form is one part of our overall approach to collecting feedback. We'll continue
-      to carry out further testing as we develop the service and we plan to reassess the feedback form by September 2020.
+      to carry out further testing as we develop the service and we plan to reassess the feedback form by September
+      2020.
     </p>
 
-    <h2 class="heading-large gv-u-heading-large">Reporting accessibility problems</h2>
+    <h2 class="govuk-heading-l">Reporting accessibility problems</h2>
 
-    <p>We’re always looking to improve the accessibility of this online service. If you find any problems not listed on
+    <p class="govuk-body">
+      We’re always looking to improve the accessibility of this online service. If you find any problems not listed on
       this page or you think we’re not meeting accessibility requirements, contact
-      <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Accessibility">c100helpdesk@digital.justice.gov.uk</a>.
+      <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Accessibility" class="govuk-link ga-clickAction" data-ga-category="accessibility" data-ga-action="click" data-ga-label="mailto helpdesk">c100helpdesk@digital.justice.gov.uk</a>.
     </p>
 
-    <h2 class="heading-large gv-u-heading-large">Enforcement procedure</h2>
+    <h2 class="govuk-heading-l">Enforcement procedure</h2>
 
-    <p>
+    <p class="govuk-body">
       The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites
       and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not
       happy with how we respond to your complaint,
-      <a href="https://www.equalityadvisoryservice.com/" rel="external" target="_blank">contact the Equality Advisory
-        and Support Service (EASS)</a>.
+      <a href="https://www.equalityadvisoryservice.com/" class="govuk-link" rel="external" target="_blank">contact the
+        Equality Advisory and Support Service (EASS)</a>.
     </p>
 
-    <p>This statement was prepared on 19 November 2019.<br/>It was last updated on 19 November 2019.</p>
+    <p class="govuk-body govuk-!-margin-top-8">
+      This statement was prepared on 19 November 2019.<br/>It was last updated on 19 November 2019.
+    </p>
   </div>
 </div>

--- a/app/views/about/contact.en.html.erb
+++ b/app/views/about/contact.en.html.erb
@@ -1,24 +1,24 @@
 <% title 'Contact' %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Get in touch</h1>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">Get in touch</h1>
-
-    <p>
+    <p class="govuk-body">
       If you’d like to report a problem or have a suggestion to help improve this service for others, get in touch by
       sending an email to:
     </p>
 
-    <p class="lede">
-      <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Feedback" class="ga-clickAction" data-ga-category="feedback"
-         data-ga-action="click" data-ga-label="report a problem">c100helpdesk@digital.justice.gov.uk</a>
+    <p class="govuk-body-l">
+      <a href="mailto:c100helpdesk@digital.justice.gov.uk?subject=Feedback" class="govuk-link ga-clickAction" data-ga-category="feedback" data-ga-action="click" data-ga-label="report a problem">c100helpdesk@digital.justice.gov.uk</a>
     </p>
 
-    <p>This email address should only be used for feedback on the digital service.</p>
+    <p class="govuk-body">This email address should only be used for feedback on the digital service.</p>
 
-    <p>We cannot answer any questions about applications that have already been submitted. You can
-      <a href="https://courttribunalfinder.service.gov.uk/search/spoe?aol=Children" rel="external" target="_blank">contact
-        the relevant court</a> if you need to discuss your case.</p>
+    <p class="govuk-body">
+      We cannot answer any questions about applications that have already been submitted. You can
+      <a href="https://courttribunalfinder.service.gov.uk/search/spoe?aol=Children" class="govuk-link" rel="external" target="_blank">contact
+        the relevant court</a> if you need to discuss your case.
+    </p>
   </div>
 </div>

--- a/app/views/about/cookies.en.html.erb
+++ b/app/views/about/cookies.en.html.erb
@@ -1,164 +1,172 @@
 <% title 'Cookies' %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">Cookies</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Cookies</h1>
 
-    <p>
+    <p class="govuk-body">
       <%= service_name -%> puts small files (known as ‘cookies’) onto your computer to collect
       information about how you browse the site.
     </p>
 
-    <p>Cookies are used to:</p>
+    <p class="govuk-body">Cookies are used to:</p>
 
-    <ul class="list list-bullet">
+    <ul class="govuk-list govuk-list--bullet">
       <li>remember your progress</li>
       <li>measure how you use the website so it can be updated and improved based on your needs</li>
     </ul>
 
-    <p><%= service_name -%> cookies aren't used to identify you personally.</p>
+    <p class="govuk-body"><%= service_name -%> cookies aren't used to identify you personally.</p>
 
-    <p>You'll normally see a message on the site before we store a cookie on your computer.</p>
+    <p class="govuk-body">You'll normally see a message on the site before we store a cookie on your computer.</p>
 
-    <p>Find out more about <a rel="external" target="_blank" href="https://www.aboutcookies.org">how to manage cookies</a>.</p>
+    <p class="govuk-body">
+      Find out more about
+      <a href="https://www.aboutcookies.org" class="govuk-link" rel="external" target="_blank">how to manage cookies</a>.
+    </p>
 
-    <h2 class="heading-medium">How cookies are used on <%= service_name -%></h2>
+    <h2 class="govuk-heading-l">How cookies are used on <%= service_name -%></h2>
 
-    <p><strong>Our introductory message</strong></p>
+    <h3 class="govuk-heading-m">Our introductory message</h3>
 
-    <p>You may see a pop-up welcome message when you first visit <%= service_name -%>. We'll store a cookie so that your computer knows you've seen it and knows not to show it again.</p>
+    <p class="govuk-body">
+      You may see a pop-up welcome message when you first visit <%= service_name -%>. We'll store a cookie so that your
+      computer knows you've seen it and knows not to show it again.
+    </p>
 
-    <table>
-      <thead>
-      <tr>
-        <th>Name</th>
-        <th>Purpose</th>
-        <th>Expires</th>
-      </tr>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
       </thead>
-      <tbody>
-      <tr>
-        <td>seen_cookie_message</td>
-        <td>Saves a message to let us know that you've seen our cookie message</td>
-        <td>1 month</td>
-      </tr>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">seen_cookie_message</th>
+          <td class="govuk-table__cell">Saves a message to let us know that you've seen our cookie message</td>
+          <td class="govuk-table__cell">1 month</td>
+        </tr>
       </tbody>
     </table>
 
-    <p><strong>Remembering your progress</strong></p>
+    <h3 class="govuk-heading-m">Remembering your progress</h3>
 
-    <p>We will store a cookie to remember your application progress in this computer and to expire your session
-      after <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser.</p>
+    <p class="govuk-body">
+      We will store a cookie to remember your application progress in this computer and to expire your session
+      after <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser.
+    </p>
 
-    <table>
-      <thead>
-      <tr>
-        <th>Name</th>
-        <th>Purpose</th>
-        <th>Expires</th>
-      </tr>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
       </thead>
-      <tbody>
-      <tr>
-        <td>_c100_application_session</td>
-        <td>Saves your current progress in this computer and tracks inactivity periods</td>
-        <td>After <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser</td>
-      </tr>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_c100_application_session</th>
+          <td class="govuk-table__cell">Saves your current progress in this computer and tracks inactivity periods</td>
+          <td class="govuk-table__cell">After <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser</td>
+        </tr>
       </tbody>
     </table>
 
-    <p><strong>Measuring website usage (Google Analytics)</strong></p>
+    <h3 class="govuk-heading-m">Measuring website usage (Google Analytics)</h3>
 
-    <p>We use Google Analytics software to collect information about how you use <%= service_name -%>. We do this
-      to help make sure the site is meeting the needs of its users and to help us make improvements, for example
-      <a rel="external" target="_blank" href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/">improving site search</a>.</p>
+    <p class="govuk-body">
+      We use Google Analytics software to collect information about how you use <%= service_name -%>. We do this to help
+      make sure the site is meeting the needs of its users and to help us make improvements, for example
+      <a href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/" class="govuk-link" rel="external" target="_blank">improving
+        site search</a>.
+    </p>
 
-    <p>Google Analytics stores information about:</p>
+    <p class="govuk-body">Google Analytics stores information about:</p>
 
-    <ul class="list list-bullet">
+    <ul class="govuk-list govuk-list--bullet">
       <li>the pages you visit on <%= service_name -%></li>
       <li>how long you spend on each <%= service_name -%> page </li>
-      <li>how you got to the site  </li>
+      <li>how you got to the site</li>
       <li>what you click on while you’re visiting the site</li>
     </ul>
 
-    <p>We don't collect or store your personal information (for example your name or address) so this information can't
-      be used to identify who you are.</p>
+    <p class="govuk-body">
+      We don't collect or store your personal information (for example your name or address) so this information can't
+      be used to identify who you are.
+    </p>
 
-    <p>We don’t allow Google to use or share our analytics data.</p>
+    <p class="govuk-body">We don’t allow Google to use or share our analytics data.</p>
 
-    <p>Google Analytics sets the following cookies:</p>
+    <p class="govuk-body">Google Analytics sets the following cookies:</p>
 
-    <p>Universal Analytics</p>
-
-    <table>
-      <thead>
-      <tr>
-        <th>Name</th>
-        <th>Purpose</th>
-        <th>Expires</th>
-      </tr>
+    <table class="govuk-table">
+      <caption class="govuk-table__caption">Universal Analytics</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
       </thead>
-      <tbody>
-      <tr>
-        <td>_ga</td>
-        <td>This helps us count how many people visit <%= service_name -%> by tracking if you've visited before
-        </td>
-        <td>2 years</td>
-      </tr>
-      <tr>
-        <td>_gid</td>
-        <td>This helps us count how many people visit <%= service_name -%> by tracking if you've visited before
-        </td>
-        <td>24 hours</td>
-      </tr>
-      <tr>
-        <td>_gat</td>
-        <td>Used to manage the rate at which page view requests are made</td>
-        <td>10 minutes</td>
-      </tr>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_ga</th>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= service_name -%> by tracking if you've visited before</td>
+          <td class="govuk-table__cell">2 years</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_gid</th>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= service_name -%> by tracking if you've visited before</td>
+          <td class="govuk-table__cell">24 hours</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_gat</th>
+          <td class="govuk-table__cell">Used to manage the rate at which page view requests are made</td>
+          <td class="govuk-table__cell">10 minutes</td>
+        </tr>
       </tbody>
     </table>
 
-    <p>Google Analytics</p>
-
-    <table>
-      <thead>
-      <tr>
-        <th>Name</th>
-        <th>Purpose</th>
-        <th>Expires</th>
-      </tr>
+    <table class="govuk-table">
+      <caption class="govuk-table__caption">Google Analytics</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
       </thead>
-      <tbody>
-      <tr>
-        <td>_utma</td>
-        <td>Like _ga, this lets us know if you've visited before, so we can count how many of our visitors are new to
-          <%= service_name -%> or to a certain page
-        </td>
-        <td>2 years</td>
-      </tr>
-      <tr>
-        <td>_utmb</td>
-        <td>This works with _utmc to calculate the average length of time you spend on <%= service_name -%></td>
-        <td>30 minutes</td>
-      </tr>
-      <tr>
-        <td>_utmc</td>
-        <td>This works with _utmb to calculate when you close your browser</td>
-        <td>when you close your browser</td>
-      </tr>
-      <tr>
-        <td>_utmz</td>
-        <td>This tells us how you reached <%= service_name -%> (for example from another website or a search engine)
-        </td>
-        <td>6 months</td>
-      </tr>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_utma</th>
+          <td class="govuk-table__cell">Like _ga, this lets us know if you've visited before, so we can count how many of our visitors are new to <%= service_name -%> or to a certain page</td>
+          <td class="govuk-table__cell">2 years</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_utmb</th>
+          <td class="govuk-table__cell">This works with _utmc to calculate the average length of time you spend on <%= service_name -%></td>
+          <td class="govuk-table__cell">30 minutes</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_utmc</th>
+          <td class="govuk-table__cell">This works with _utmb to calculate when you close your browser</td>
+          <td class="govuk-table__cell">When you close your browser</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_utmz</th>
+          <td class="govuk-table__cell">This tells us how you reached <%= service_name -%> (for example from another website or a search engine)</td>
+          <td class="govuk-table__cell">6 months</td>
+        </tr>
       </tbody>
     </table>
 
-    <p>You can
-      <a rel="external" target="_blank" href="https://tools.google.com/dlpage/gaoptout">opt out of Google Analytics cookies</a>.
+    <p class="govuk-body">
+      You can
+      <a href="https://tools.google.com/dlpage/gaoptout" class="govuk-link" rel="external" target="_blank">opt out of
+        Google Analytics cookies</a>.
     </p>
   </div>
 </div>

--- a/app/views/about/miam_exemptions.en.html.erb
+++ b/app/views/about/miam_exemptions.en.html.erb
@@ -1,322 +1,325 @@
 <% title 'MIAM exemptions' %>
 <% step_header(path: url_for(:back)) %>
 
-<div class="grid-row miam_exemptions_list">
-  <div class="column-two-thirds">
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">Valid reasons not to attend a MIAM</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Valid reasons not to attend a MIAM</h1>
 
-    <div class="govuk-govspeak gv-s-prose">
-      <p>If you think you’re exempt from attending a MIAM, you must be prepared to explain your reasons to the court and
-        you may be asked to provide evidence at the hearing.
-      </p>
-      <p>A MIAM is not mediation. It is an initial meeting that explains mediation and alternative ways of reaching an
-        agreement without going to court. A mediator considers with you whether these other ways are suitable in your
-        case.
-      </p>
+    <p class="govuk-body">If you think you’re exempt from attending a MIAM, you must be prepared to explain your reasons to the court and
+      you may be asked to provide evidence at the hearing.
+    </p>
 
-      <p>You do not have to attend a MIAM if:</p>
+    <p class="govuk-body">A MIAM is not mediation. It is an initial meeting that explains mediation and alternative ways of reaching an
+      agreement without going to court. A mediator considers with you whether these other ways are suitable in your
+      case.
+    </p>
 
-      <ul class="list list-bullet">
-        <li>you're applying for a consent order</li>
-        <li>any of the children in the application are involved in emergency proceedings, care proceedings or supervision proceedings</li>
-        <li>any of the children in the application are the subject of an emergency protection order, care order or supervision order</li>
-        <li>any of the following circumstances apply:</li>
-      </ul>
-    </div>
+    <p class="govuk-body">You do not have to attend a MIAM if:</p>
 
-    <div class="govuk-govspeak gv-s-prose util_mt-large">
-      <p class="heading-medium">You have evidence of domestic abuse and violence</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you're applying for a consent order</li>
+      <li>any of the children in the application are involved in emergency proceedings, care proceedings or supervision proceedings</li>
+      <li>any of the children in the application are the subject of an emergency protection order, care order or supervision order</li>
+      <li>any of the following circumstances apply:</li>
+    </ul>
 
-      <p>
-        <a href="https://www.gov.uk/government/collections/sample-letters-to-get-evidence-of-domestic-violence" rel="external" target="_blank">Sample
-          letters to get evidence of domestic violence</a>
-      </p>
+    <h2 class="govuk-heading-l">You have evidence of domestic abuse and violence</h2>
 
-      <h3 class="heading-small">
-        The police have been involved
-      </h3>
-      <p>
-        For example, you or the other people in this application (the respondents) have been arrested, cautioned, charged or convicted for <a href="https://www.gov.uk/government/publications/domestic-violence-and-child-abuse-offences" rel="external" target="_blank">domestic or child abuse offences</a>.
-      </p>
-      <details>
-        <summary>
-          <span class="summary" data-ga-category="miam exemptions" data-ga-label="police evidence">What evidence is accepted</span>
-        </summary>
-        <div class="panel panel-border-narrow">
-          <ul class="list list-bullet">
-            <li>evidence that a prospective party has been arrested for a relevant domestic violence offence</li>
-            <li>evidence of a relevant police caution for a domestic violence offence</li>
-            <li>evidence of relevant criminal proceedings for a domestic violence offence which have not concluded</li>
-            <li>evidence of a relevant conviction for a domestic violence offence</li>
-            <li>a domestic violence protection notice issued under section 24 of the Crime and Security Act 2010 against a prospective party</li>
-          </ul>
-        </div>
-      </details>
+    <p class="govuk-body">
+      <a href="https://www.gov.uk/government/collections/sample-letters-to-get-evidence-of-domestic-violence" class="govuk-link" rel="external" target="_blank">Sample
+        letters to get evidence of domestic violence</a>
+    </p>
 
-      <h3 class="heading-small">A court has already been involved</h3>
-      <p>For example, a court has made an order relating to you, the other people in this application (the respondents) or somebody close to you or them in connection with domestic violence or abuse.</p>
-      <details>
-        <summary>
-          <span class="summary" data-ga-category="miam exemptions" data-ga-label="court evidence">What evidence is accepted</span>
-        </summary>
-        <div class="panel panel-border-narrow">
-          <ul class="list list-bullet">
-            <li>a court order binding a prospective party over in connection with a domestic violence offence</li>
-            <li>a relevant protective injunction</li>
-            <li>an undertaking given in England and Wales under section 46 or 63E of the Family Law Act 1996 (or given in Scotland or Northern Ireland in place of a protective injunction) by a prospective party, provided that a cross-undertaking relating to domestic violence was not given by another prospective party</li>
-            <li>a copy of a finding of fact, made in proceedings in the UK, that there has been domestic violence by a prospective party</li>
-            <li>an expert report produced as evidence in proceedings in the UK for the benefit of a court or tribunal confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party</li>
-          </ul>
-        </div>
-      </details>
+    <h3 class="govuk-heading-m">The police have been involved</h3>
+    <p class="govuk-body">
+      For example, you or the other people in this application (the respondents) have been arrested, cautioned, charged or convicted for <a href="https://www.gov.uk/government/publications/domestic-violence-and-child-abuse-offences" class="govuk-link" rel="external" target="_blank">domestic or child abuse offences</a>.
+    </p>
 
-      <h3 class="heading-small">
-       A letter confirms you or the other people in this application (the respondents) are or have been a victim of domestic violence or abuse
-      </h3>
-      <p>
-        For example, a health professional or specialist has confirmed injuries that are or were a result of domestic violence or abuse.
-      </p>
-      <details>
-        <summary>
-          <span class="summary" data-ga-category="miam exemptions" data-ga-label="abuse evidence">What evidence is accepted</span>
-        </summary>
-        <div class="panel panel-border-narrow">
-          <ul class="list list-bullet">
-            <li>a letter or report from an appropriate health professional confirming that:
-              <ul class="list list-bullet">
-                <li>(i) that professional, or another appropriate health professional, has examined a prospective party in person; and</li>
-                <li>(ii) in the reasonable professional judgment of the author or the examining appropriate health professional, that prospective party has, or has had, injuries or a condition consistent with being a victim of domestic violence</li>
-              </ul>
-            </li>
-            <li>a letter or report from:
-              <ul class="list list-bullet">
-                <li>(i) the appropriate health professional who made the referral described below</li>
-                <li>(ii) an appropriate health professional who has access to the medical records of the prospective party referred to below; or</li>
-                <li>(iii) the person to whom the referral described below was made</li>
-              </ul>
-              <p>confirming that there was a referral by an appropriate health professional of a prospective party to a person who provides specialist support or assistance for victims of, or those at risk of, domestic violence</p>
-            </li>
-          </ul>
-        </div>
-      </details>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="miam exemptions" data-ga-label="police evidence">
+          What evidence is accepted
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>evidence that a prospective party has been arrested for a relevant domestic violence offence</li>
+          <li>evidence of a relevant police caution for a domestic violence offence</li>
+          <li>evidence of relevant criminal proceedings for a domestic violence offence which have not concluded</li>
+          <li>evidence of a relevant conviction for a domestic violence offence</li>
+          <li>a domestic violence protection notice issued under section 24 of the Crime and Security Act 2010 against a prospective party</li>
+        </ul>
+      </div>
+    </details>
 
-      <h3 class="heading-small">
-        A letter from a local authority or other agency confirms a risk of harm
-      </h3>
-      <p>
-        For example, a local authority or housing association has confirmed there is a risk of domestic violence or abuse.
-      </p>
-      <details>
-        <summary>
-          <span class="summary" data-ga-category="miam exemptions" data-ga-label="agency evidence">What evidence is accepted</span>
-        </summary>
-        <div class="panel panel-border-narrow">
-          <ul class="list list-bullet">
-            <li>a letter from any person who is a member of a multi-agency risk assessment conference (or other suitable local safeguarding forum) confirming that a prospective party, or a person with whom that prospective party is in a family relationship, is or has been at risk of harm from domestic violence by another prospective party</li>
-            <li>a letter from an officer employed by a local authority or housing association (or their equivalent in Scotland or Northern Ireland) for the purpose of supporting tenants containing:
-              <ul class="list list-bullet">
-                <li>(i) a statement to the effect that, in their reasonable professional judgment, a person with whom a prospective party is or has been in a family relationship is, or is at risk of being, a victim of domestic violence by that prospective party</li>
-                <li>(ii) a description of the specific matters relied upon to support that judgment; and</li>
-                <li>(iii) a description of the support they provided to the victim of domestic violence or the person at risk of domestic violence by that prospective party</li>
-              </ul>
-            </li>
-            <li>a letter from a public authority confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party (or a copy of that assessment)</li>
-          </ul>
-        </div>
-      </details>
+    <h3 class="govuk-heading-m">A court has already been involved</h3>
+    <p class="govuk-body">For example, a court has made an order relating to you, the other people in this application (the respondents) or somebody close to you or them in connection with domestic violence or abuse.</p>
 
-      <h3 class="heading-small">
-        You have a letter from a domestic violence or abuse support service, specialist or organisation
-      </h3>
-      <p>
-        For example, an independent domestic violence or abuse adviser has confirmed they are providing support to you or the other people in this application (the respondents)
-      </p>
-      <details>
-        <summary>
-          <span class="summary" data-ga-category="miam exemptions" data-ga-label="specialist evidence">What evidence is accepted</span>
-        </summary>
-        <div class="panel panel-border-narrow">
-          <ul class="list list-bullet">
-            <li>a letter from an independent domestic violence advisor confirming that they are providing support to a prospective party</li>
-            <li>a letter from an independent sexual violence advisor confirming that they are providing support to a prospective party relating to sexual violence by another prospective party</li>
-            <li>
-              <span class="display-block util_mt-none util_mb-none"> a letter which:</span>
-              <p>
-                (i) is from an organisation providing domestic violence support services, or a registered charity, which letter confirms that it:
-              </p>
-              <ul class="list list-bullet">
-                <li>(a) is situated in England and Wales</li>
-                <li>(b) has been operating for an uninterrupted period of six months or more; and</li>
-                <li>(c) provided a prospective party with support in relation to that person’s needs as a victim, or a person at risk, of domestic violence; and</li>
-              </ul>
-              <p>
-              (ii) contains:
-              </p>
-              <ul class="list list-bullet">
-                <li>(a) a statement to the effect that, in the reasonable professional judgment of the author of the letter, the prospective party is, or is at risk of being, a victim of domestic violence</li>
-                <li>(b) a description of the specific matters relied upon to support that judgment</li>
-                <li>(c) a description of the support provided to the prospective party; and</li>
-                <li>(d) a statement of the reasons why the prospective party needed that support</li>
-              </ul>
-            </li>
-            <li>
-              a letter or report from an organisation providing domestic violence support services in the UK confirming:
-              <ul class="list list-bullet">
-                <li>(i) that a person with whom a prospective party is or was in a family relationship was refused admission to a refuge</li>
-                <li>(ii) the date on which they were refused admission to the refuge; and</li>
-                <li>(iii) they sought admission to the refuge because of allegations of domestic violence by the prospective party referred to in paragraph (i)</li>
-              </ul>
-            </li>
-          </ul>
-        </div>
-      </details>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="miam exemptions" data-ga-label="court evidence">
+          What evidence is accepted
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>a court order binding a prospective party over in connection with a domestic violence offence</li>
+          <li>a relevant protective injunction</li>
+          <li>an undertaking given in England and Wales under section 46 or 63E of the Family Law Act 1996 (or given in Scotland or Northern Ireland in place of a protective injunction) by a prospective party, provided that a cross-undertaking relating to domestic violence was not given by another prospective party</li>
+          <li>a copy of a finding of fact, made in proceedings in the UK, that there has been domestic violence by a prospective party</li>
+          <li>an expert report produced as evidence in proceedings in the UK for the benefit of a court or tribunal confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party</li>
+        </ul>
+      </div>
+    </details>
 
-      <h3 class="heading-small">
-        You or any of the people in this application (the respondents) have been granted indefinite leave to remain in the UK as a victim of domestic abuse
-      </h3>
-      <p>
-        A letter from the Home Office will have confirmed that your leave was granted under paragraph 289B of the Immigration Rules.
-      </p>
-      <details>
-        <summary>
-          <span class="summary" data-ga-category="miam exemptions" data-ga-label="leave to remain evidence">What evidence is accepted</span>
-        </summary>
-        <div class="panel panel-border-narrow">
-          <ul class="list list-bullet">
-            <li>a letter from the Secretary of State for the Home Department confirming that a prospective party has been granted leave to remain in the UK under <a href="https://www.gov.uk/guidance/immigration-rules/immigration-rules-part-8-family-members#pt8violence" rel="external" target="_blank">paragraph 289B of the Rules made by the Home Secretary under section 3(2) of the Immigration Act 1971</a></li>
-          </ul>
-        </div>
-      </details>
+    <h3 class="govuk-heading-m">
+     A letter confirms you or the other people in this application (the respondents) are or have been a victim of domestic violence or abuse
+    </h3>
+    <p class="govuk-body">
+      For example, a health professional or specialist has confirmed injuries that are or were a result of domestic violence or abuse.
+    </p>
 
-      <h3 class="heading-small">
-        You have evidence that you or the other people in this application (the respondents) have been, or are at risk of being, financially abused by the other
-      </h3>
-      <p>
-        Financial abuse is a way of controlling someone being able to earn, spend or keep their own money. For example, preventing someone from going to work, withholding money, or putting debts in someone else’s name.
-      </p>
-      <p>Evidence could include:</p>
-      <ul class="list list-bullet">
-        <li>a copy of a credit card account, loan document or bank statements</li>
-        <li>a letter from a domestic violence support organisation</li>
-        <li>emails, text messages or a diary kept by the victim</li>
-      </ul>
-    </div>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="miam exemptions" data-ga-label="abuse evidence">What evidence is accepted</span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>a letter or report from an appropriate health professional confirming that:
+            <ul class="govuk-list govuk-list--bullet">
+              <li>(i) that professional, or another appropriate health professional, has examined a prospective party in person; and</li>
+              <li>(ii) in the reasonable professional judgment of the author or the examining appropriate health professional, that prospective party has, or has had, injuries or a condition consistent with being a victim of domestic violence</li>
+            </ul>
+          </li>
+          <li>a letter or report from:
+            <ul class="govuk-list govuk-list--bullet">
+              <li>(i) the appropriate health professional who made the referral described below</li>
+              <li>(ii) an appropriate health professional who has access to the medical records of the prospective party referred to below; or</li>
+              <li>(iii) the person to whom the referral described below was made</li>
+            </ul>
+            <p class="govuk-body">confirming that there was a referral by an appropriate health professional of a prospective party to a person who provides specialist support or assistance for victims of, or those at risk of, domestic violence</p>
+          </li>
+        </ul>
+      </div>
+    </details>
 
-    <div class="govuk-govspeak gv-s-prose util_mt-large">
-      <p class="heading-medium">There are child protection concerns</p>
-      <p>
-        These concerns are relevant where any of the following apply:
-      </p>
-      <p>
-        A local authority is carrying out enquiries or an assessment about any of the children in this application, or other child in the household
-      </p>
-      <p>
-        Any of the children in this application, or other child in the household, is the subject of a child protection plan
-      </p>
-    </div>
+    <h3 class="govuk-heading-m">
+      A letter from a local authority or other agency confirms a risk of harm
+    </h3>
+    <p class="govuk-body">
+      For example, a local authority or housing association has confirmed there is a risk of domestic violence or abuse.
+    </p>
 
-    <div class="govuk-govspeak gv-s-prose util_mt-large">
-      <p class="heading-medium">The application is urgent</p>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="miam exemptions" data-ga-label="agency evidence">What evidence is accepted</span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>a letter from any person who is a member of a multi-agency risk assessment conference (or other suitable local safeguarding forum) confirming that a prospective party, or a person with whom that prospective party is in a family relationship, is or has been at risk of harm from domestic violence by another prospective party</li>
+          <li>a letter from an officer employed by a local authority or housing association (or their equivalent in Scotland or Northern Ireland) for the purpose of supporting tenants containing:
+            <ul class="govuk-list govuk-list--bullet">
+              <li>(i) a statement to the effect that, in their reasonable professional judgment, a person with whom a prospective party is or has been in a family relationship is, or is at risk of being, a victim of domestic violence by that prospective party</li>
+              <li>(ii) a description of the specific matters relied upon to support that judgment; and</li>
+              <li>(iii) a description of the support they provided to the victim of domestic violence or the person at risk of domestic violence by that prospective party</li>
+            </ul>
+          </li>
+          <li>a letter from a public authority confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party (or a copy of that assessment)</li>
+        </ul>
+      </div>
+    </details>
 
-      <p>A court will only consider an urgent hearing where it's satisfied that there is good reason for the urgency.</p>
+    <h3 class="govuk-heading-m">
+      You have a letter from a domestic violence or abuse support service, specialist or organisation
+    </h3>
+    <p class="govuk-body">
+      For example, an independent domestic violence or abuse adviser has confirmed they are providing support to you or the other people in this application (the respondents)
+    </p>
 
-      <details>
-        <summary>
-          <span class="summary" data-ga-category="miam exemptions" data-ga-label="urgency examples">Examples of when an application may be urgent</span>
-        </summary>
-        <div class="panel panel-border-narrow">
-          <p>There is:</p>
-          <ul class="list list-bullet">
-            <li>risk to the life, liberty or physical safety of you, your family or your home</li>
-            <li>significant risk that in the period needed to arrange and attend a MIAM, proceedings relating to the dispute will be brought in another country</li>
-          </ul>
-          <p>Any delay caused by attending a MIAM would cause:</p>
-          <ul class="list list-bullet">
-            <li>unreasonable hardship for you</li>
-            <li>a risk of harm to the children</li>
-            <li>a risk of unlawful removal of a child from the UK, or a risk of unlawful retention of a child who is currently outside England and Wales</li>
-            <li>a significant risk of a miscarriage of justice</li>
-            <li>irretrievable problems in dealing with the dispute (including the irretrievable loss of significant evidence)</li>
-          </ul>
-        </div>
-      </details>
-    </div>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="miam exemptions" data-ga-label="specialist evidence">What evidence is accepted</span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>a letter from an independent domestic violence advisor confirming that they are providing support to a prospective party</li>
+          <li>a letter from an independent sexual violence advisor confirming that they are providing support to a prospective party relating to sexual violence by another prospective party</li>
+          <li>
+            a letter which:
+            <p class="govuk-body">
+              (i) is from an organisation providing domestic violence support services, or a registered charity, which letter confirms that it:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>(a) is situated in England and Wales</li>
+              <li>(b) has been operating for an uninterrupted period of six months or more; and</li>
+              <li>(c) provided a prospective party with support in relation to that person’s needs as a victim, or a person at risk, of domestic violence; and</li>
+            </ul>
+            <p class="govuk-body">
+            (ii) contains:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>(a) a statement to the effect that, in the reasonable professional judgment of the author of the letter, the prospective party is, or is at risk of being, a victim of domestic violence</li>
+              <li>(b) a description of the specific matters relied upon to support that judgment</li>
+              <li>(c) a description of the support provided to the prospective party; and</li>
+              <li>(d) a statement of the reasons why the prospective party needed that support</li>
+            </ul>
+          </li>
+          <li>
+            a letter or report from an organisation providing domestic violence support services in the UK confirming:
+            <ul class="govuk-list govuk-list--bullet">
+              <li>(i) that a person with whom a prospective party is or was in a family relationship was refused admission to a refuge</li>
+              <li>(ii) the date on which they were refused admission to the refuge; and</li>
+              <li>(iii) they sought admission to the refuge because of allegations of domestic violence by the prospective party referred to in paragraph (i)</li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </details>
 
-    <div class="govuk-govspeak gv-s-prose util_mt-large">
-      <p class="heading-medium">You’ve previously been to a MIAM or had a valid reason for not attending one</p>
+    <h3 class="govuk-heading-m">
+      You or any of the people in this application (the respondents) have been granted indefinite leave to remain in the UK as a victim of domestic abuse
+    </h3>
+    <p class="govuk-body">
+      A letter from the Home Office will have confirmed that your leave was granted under paragraph 289B of the Immigration Rules.
+    </p>
 
-      <h3 class="heading-small">
-        You’ve already been to a MIAM or are taking part in another form of non-court resolution
-      </h3>
-      <p>
-        The MIAM must have taken place within the past 4 months (or your attendance at another type of non-court resolution must be ongoing) and have been about the same or a very similar dispute.
-      </p>
-      <p>
-        You’re involved in other ongoing family court proceedings and you attended a MIAM before starting those proceedings.
-      </p>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="miam exemptions" data-ga-label="leave to remain evidence">What evidence is accepted</span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>a letter from the Secretary of State for the Home Department confirming that a prospective party has been granted leave to remain in the UK under <a href="https://www.gov.uk/guidance/immigration-rules/immigration-rules-part-8-family-members#pt8violence" class="govuk-link" rel="external" target="_blank">paragraph 289B of the Rules made by the Home Secretary under section 3(2) of the Immigration Act 1971</a></li>
+        </ul>
+      </div>
+    </details>
 
-      <h3 class="heading-small">
-        You had a valid reason for not attending a MIAM previously
-      </h3>
-      <p>
-        You have made another court application within the last 4 months about the same or a very similar dispute and you had a confirmed valid reason for not attending a MIAM before making that application.
-      </p>
-      <p>
-        You're involved in other ongoing family court proceedings where the applicant in those proceedings had a confirmed valid reason for not attending a MIAM.
-      </p>
-    </div>
+    <h3 class="govuk-heading-m">
+      You have evidence that you or the other people in this application (the respondents) have been, or are at risk of being, financially abused by the other
+    </h3>
+    <p class="govuk-body">
+      Financial abuse is a way of controlling someone being able to earn, spend or keep their own money. For example, preventing someone from going to work, withholding money, or putting debts in someone else’s name.
+    </p>
 
-    <div class="govuk-govspeak gv-s-prose util_mt-large">
-      <p class="heading-medium">Any other exemptions</p>
+    <p class="govuk-body">Evidence could include:</p>
 
-      <h3 class="heading-small">
-        You don’t have sufficient contact details for the other people in this application (the respondents)
-      </h3>
-      <p>
-        The other people can't be contacted to arrange a MIAM.
-      </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>a copy of a credit card account, loan document or bank statements</li>
+      <li>a letter from a domestic violence support organisation</li>
+      <li>emails, text messages or a diary kept by the victim</li>
+    </ul>
 
-      <h3 class="heading-small">
-        You’re applying for a without notice hearing
-      </h3>
-      <p>
-        Hearings which take place without notice to the other person will only be justified where your case is exceptionally urgent, or there is good reason not to tell the other people about your application  (either because they could take steps to obstruct the application or because doing so may expose you or the children to a risk of harm).
-      </p>
+    <h2 class="govuk-heading-l">There are child protection concerns</h2>
 
-      <h3 class="heading-small">
-        You can’t access a mediator
-      </h3>
-      <p>
-        Examples of not being able to access a mediator include:
-      </p>
-      <ul class="list list-bullet">
-        <li>you live further than 15 miles from a mediator</li>
-        <li>you’ve contacted all the mediators with an office within 15 miles of where you live (or at least 3, if there are more) and can’t get an appointment for a MIAM within 15 working days</li>
-        <li>you or any of the other people in this application (the respondents) have a disability and there are no mediators within 15 miles who can offer disabled facilities</li>
-        <li>
-          you or any of the other people in this application (the respondents) are:
-          <ul class="list list-bullet">
-            <li>in prison or any other institution</li>
-            <li>subject to bail conditions that prevent contact with each other</li>
-            <li>subject to a licence that prohibits contact with each other</li>
-          </ul>
-        </li>
-      </ul>
-      <p>The court may ask you for the contact details of the mediators and the dates you contacted them.</p>
+    <p class="govuk-body">
+      These concerns are relevant where any of the following apply:
+    </p>
 
-      <h3 class="heading-small">
-        You or the other people in this application (the respondents) don’t live in England or Wales
-      </h3>
-      <p>
-        You don’t need to attend a MIAM if the lives of you or the other people involved are mainly based outside England or Wales. This may include working, owning property, having children in school or if family life mainly takes place outside England or Wales.
-      </p>
+    <p class="govuk-body">
+      A local authority is carrying out enquiries or an assessment about any of the children in this application, or other child in the household
+    </p>
+    <p class="govuk-body">
+      Any of the children in this application, or other child in the household, is the subject of a child protection plan
+    </p>
 
-      <h3 class="heading-small">
-        The applicant or any of the other people in this application (the respondents) are under 18 years old
-      </h3>
-      <p>
-        You don’t need to attend a MIAM if you or any other person who is a respondent in this application is under 18.
-      </p>
-    </div>
+    <h2 class="govuk-heading-l">The application is urgent</h2>
+
+    <p class="govuk-body">A court will only consider an urgent hearing where it's satisfied that there is good reason for the urgency.</p>
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="miam exemptions" data-ga-label="urgency examples">Examples of when an application may be urgent</span>
+      </summary>
+      <div class="govuk-details__text">
+        <p class="govuk-body">There is:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>risk to the life, liberty or physical safety of you, your family or your home</li>
+          <li>significant risk that in the period needed to arrange and attend a MIAM, proceedings relating to the dispute will be brought in another country</li>
+        </ul>
+        <p class="govuk-body">Any delay caused by attending a MIAM would cause:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>unreasonable hardship for you</li>
+          <li>a risk of harm to the children</li>
+          <li>a risk of unlawful removal of a child from the UK, or a risk of unlawful retention of a child who is currently outside England and Wales</li>
+          <li>a significant risk of a miscarriage of justice</li>
+          <li>irretrievable problems in dealing with the dispute (including the irretrievable loss of significant evidence)</li>
+        </ul>
+      </div>
+    </details>
+
+    <h2 class="govuk-heading-l">You’ve previously been to a MIAM or had a valid reason for not attending one</h2>
+
+    <h3 class="govuk-heading-m">
+      You’ve already been to a MIAM or are taking part in another form of non-court resolution
+    </h3>
+    <p class="govuk-body">
+      The MIAM must have taken place within the past 4 months (or your attendance at another type of non-court resolution must be ongoing) and have been about the same or a very similar dispute.
+    </p>
+    <p class="govuk-body">
+      You’re involved in other ongoing family court proceedings and you attended a MIAM before starting those proceedings.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      You had a valid reason for not attending a MIAM previously
+    </h3>
+    <p class="govuk-body">
+      You have made another court application within the last 4 months about the same or a very similar dispute and you had a confirmed valid reason for not attending a MIAM before making that application.
+    </p>
+    <p class="govuk-body">
+      You're involved in other ongoing family court proceedings where the applicant in those proceedings had a confirmed valid reason for not attending a MIAM.
+    </p>
+
+    <h2 class="govuk-heading-l">Any other exemptions</h2>
+
+    <h3 class="govuk-heading-m">
+      You don’t have sufficient contact details for the other people in this application (the respondents)
+    </h3>
+    <p class="govuk-body">
+      The other people can't be contacted to arrange a MIAM.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      You’re applying for a without notice hearing
+    </h3>
+    <p class="govuk-body">
+      Hearings which take place without notice to the other person will only be justified where your case is exceptionally urgent, or there is good reason not to tell the other people about your application  (either because they could take steps to obstruct the application or because doing so may expose you or the children to a risk of harm).
+    </p>
+
+    <h3 class="govuk-heading-m">
+      You can’t access a mediator
+    </h3>
+
+    <p class="govuk-body">
+      Examples of not being able to access a mediator include:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you live further than 15 miles from a mediator</li>
+      <li>you’ve contacted all the mediators with an office within 15 miles of where you live (or at least 3, if there are more) and can’t get an appointment for a MIAM within 15 working days</li>
+      <li>you or any of the other people in this application (the respondents) have a disability and there are no mediators within 15 miles who can offer disabled facilities</li>
+      <li>
+        you or any of the other people in this application (the respondents) are:
+        <ul class="govuk-list govuk-list--bullet">
+          <li>in prison or any other institution</li>
+          <li>subject to bail conditions that prevent contact with each other</li>
+          <li>subject to a licence that prohibits contact with each other</li>
+        </ul>
+      </li>
+    </ul>
+    <p class="govuk-body">The court may ask you for the contact details of the mediators and the dates you contacted them.</p>
+
+    <h3 class="govuk-heading-m">
+      You or the other people in this application (the respondents) don’t live in England or Wales
+    </h3>
+    <p class="govuk-body">
+      You don’t need to attend a MIAM if the lives of you or the other people involved are mainly based outside England or Wales. This may include working, owning property, having children in school or if family life mainly takes place outside England or Wales.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      The applicant or any of the other people in this application (the respondents) are under 18 years old
+    </h3>
+    <p class="govuk-body">
+      You don’t need to attend a MIAM if you or any other person who is a respondent in this application is under 18.
+    </p>
   </div>
 </div>

--- a/app/views/about/privacy.en.html.erb
+++ b/app/views/about/privacy.en.html.erb
@@ -1,239 +1,209 @@
 <% title 'Privacy notice' %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <div class="grid_content_header">
-      <h1 class="app__heading  heading-xlarge gv-u-heading-xxlarge">Privacy notice</h1>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Privacy notice</h1>
 
-    <p>
+    <p class="govuk-body">
       This privacy notice explains what the Ministry of Justice (MOJ) means when we talk about personal data, why we ask
       for this information about you and what we do with it when you use the ‘<%= service_name -%>’ online service.
     </p>
 
-    <p>
+    <p class="govuk-body">
       It also explains how we store your data, how you can get a copy of the information we’ve collected about you and
       how you can complain if you think we’ve done something wrong.
     </p>
 
-    <p>
+    <p class="govuk-body">
       You should read this privacy notice alongside the
-      <a href="https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter" rel="external" target="_blank">MOJ
+      <a href="https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter" class="govuk-link" rel="external" target="_blank">MOJ
         personal information charter</a>, which sets out how you can request a copy of your personal data, and the
-      <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external" target="_blank">HM
+      <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" class="govuk-link" rel="external" target="_blank">HM
         Courts and Tribunals Service (HMCTS) privacy policy for family forms</a>, which provides more information about
       the use of your personal data in family court cases.
     </p>
 
-    <p>
+    <p class="govuk-body">
       MOJ is the data controller for the personal data collected by HMCTS.
     </p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">When we ask for personal data</h2>
+    <h2 class="govuk-heading-l">When we ask for personal data</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>Whenever we ask for information about you, we promise to:</p>
+    <p class="govuk-body">Whenever we ask for information about you, we promise to:</p>
 
-        <ul class="list list-bullet">
-          <li>always let you know why we need it</li>
-          <li>ask for relevant personal information only</li>
-          <li>make sure we don’t keep it longer than needed</li>
-          <li>keep your information safe and make sure nobody can access it unless authorised to do so</li>
-          <li>only share your data with other organisations for legitimate purposes</li>
-          <li>consider any request you make to correct or delete your personal data</li>
-        </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>always let you know why we need it</li>
+      <li>ask for relevant personal information only</li>
+      <li>make sure we don’t keep it longer than needed</li>
+      <li>keep your information safe and make sure nobody can access it unless authorised to do so</li>
+      <li>only share your data with other organisations for legitimate purposes</li>
+      <li>consider any request you make to correct or delete your personal data</li>
+    </ul>
 
-        <p>We also promise to make it easy for you to:</p>
+    <p class="govuk-body">We also promise to make it easy for you to:</p>
 
-        <ul class="list list-bullet">
-          <li>tell us at any time if you want us to stop storing your personal data</li>
-          <li>make a complaint to the supervisory authority</li>
-        </ul>
-      </div>
-    </section>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>tell us at any time if you want us to stop storing your personal data</li>
+      <li>make a complaint to the supervisory authority</li>
+    </ul>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">The personal data we collect</h2>
+    <h2 class="govuk-heading-l">The personal data we collect</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>We only collect personal data that you directly enter into this online service, although additional personal
-          data may be gathered from other sources throughout the case (see the
-          <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external" target="_blank">HMCTS
-            privacy policy for family forms</a>).</p>
+    <p class="govuk-body">We only collect personal data that you directly enter into this online service, although additional personal
+      data may be gathered from other sources throughout the case (see the
+      <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" class="govuk-link" rel="external" target="_blank">HMCTS
+        privacy policy for family forms</a>).</p>
 
-        <p>We only collect the information we need to deliver this service to you. The personal data collected
-          includes:</p>
+    <p class="govuk-body">We only collect the information we need to deliver this service to you. The personal data collected
+      includes:</p>
 
-        <ul class="list list-bullet">
-          <li>personal information about you, your children, and other people involved in the case - this includes
-            names, dates of birth or ages, addresses and contact details, and any conditions they may have which could
-            affect their understanding of or participation in court proceedings
-          </li>
-          <li>details of any Mediation Information and Assessment Meetings you may have attended or reasons why you were
-            exempt from attending
-          </li>
-          <li>any concerns you may have about child protection or other safety issues, substance abuse, physical,
-            sexual, financial, emotional or psychological abuse of you or the children
-          </li>
-          <li>previous relevant court proceedings and relevant criminal convictions or offences you think the court
-            should know about when deciding your case
-          </li>
-        </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>personal information about you, your children, and other people involved in the case - this includes
+        names, dates of birth or ages, addresses and contact details, and any conditions they may have which could
+        affect their understanding of or participation in court proceedings
+      </li>
+      <li>details of any Mediation Information and Assessment Meetings you may have attended or reasons why you were
+        exempt from attending
+      </li>
+      <li>any concerns you may have about child protection or other safety issues, substance abuse, physical,
+        sexual, financial, emotional or psychological abuse of you or the children
+      </li>
+      <li>previous relevant court proceedings and relevant criminal convictions or offences you think the court
+        should know about when deciding your case
+      </li>
+    </ul>
 
-        <p>We also collect <a href="/about/cookies">information about how you browse the online service</a>, but this is
-          not used to identify you personally.</p>
-      </div>
-    </section>
+    <p class="govuk-body">We also collect <a href="/about/cookies" class="govuk-link">information about how you browse the online service</a>, but this is
+      not used to identify you personally.</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Why we collect your personal data</h2>
+    <h2 class="govuk-heading-l">Why we collect your personal data</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>We collect data in this online service to allow you to make an application about child arrangements online
-          rather than complete a
-          <a href="https://www.gov.uk/government/publications/form-c100-application-under-the-children-act-1989-for-a-child-arrangements-prohibited-steps-specific-issue-section-8-order-or-to-vary-or-discharge" rel="external" target="_blank">paper
-            application form</a>. Both this online service and the paper application form collect
-          the same types of personal data. The processing of your personal data is necessary for the administration of
-          justice and legal claims. This is part of the work we do.</p>
+    <p class="govuk-body">We collect data in this online service to allow you to make an application about child arrangements online
+      rather than complete a
+      <a href="https://www.gov.uk/government/publications/form-c100-application-under-the-children-act-1989-for-a-child-arrangements-prohibited-steps-specific-issue-section-8-order-or-to-vary-or-discharge" class="govuk-link" rel="external" target="_blank">paper
+        application form</a>. Both this online service and the paper application form collect
+      the same types of personal data. The processing of your personal data is necessary for the administration of
+      justice and legal claims. This is part of the work we do.</p>
 
-        <p>Use of this online service is voluntary. If you do not provide all the information we ask for, we may not be
-          able to process your application.</p>
-      </div>
-    </section>
+    <p class="govuk-body">Use of this online service is voluntary. If you do not provide all the information we ask for, we may not be
+      able to process your application.</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Sharing your personal data</h2>
+    <h2 class="govuk-heading-l">Sharing your personal data</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>The information you provide us in this online service will be shared with the other parties involved in the
-          case, including their legal representatives (if they have one). You can however choose to keep your contact
-          details private from the other people named in your application if you need to.</p>
+    <p class="govuk-body">The information you provide us in this online service will be shared with the other parties involved in the
+      case, including their legal representatives (if they have one). You can however choose to keep your contact
+      details private from the other people named in your application if you need to.</p>
 
-        <p>The main organisations we share the personal data collected in this service with are:</p>
+    <p class="govuk-body">The main organisations we share the personal data collected in this service with are:</p>
 
-        <ul class="list list-bullet">
-          <li>
-            <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#hmcts-privacy-policy" rel="external" target="_blank">Her
-              Majesty’s Courts and Tribunals Service (HMCTS)</a>, who will process your application and send it to a
-            judge
-          </li>
-          <li>
-            <a href="https://www.cafcass.gov.uk/about-cafcass/policies/privacy-data-protection/privacy-notice-service-users/" rel="external" target="_blank">Cafcass</a>,
-            the Children and Family Court Advisory and Support Service, who will carry out safeguarding checks and
-            submit information to the court to help the judge make a decision that is in the best interests of the
-            children. They’re required to do so by law.
-            <a href="https://www.cafcass.gov.uk/about-cafcass/policies/privacy-data-protection/privacy-notice-service-users/" rel="external" target="_blank">Read
-              more about who Cafcass may share your personal data with</a></li>
-        </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#hmcts-privacy-policy" class="govuk-link" rel="external" target="_blank">Her
+          Majesty’s Courts and Tribunals Service (HMCTS)</a>, who will process your application and send it to a
+        judge
+      </li>
+      <li>
+        <a href="https://www.cafcass.gov.uk/about-cafcass/policies/privacy-data-protection/privacy-notice-service-users/" class="govuk-link" rel="external" target="_blank">Cafcass</a>,
+        the Children and Family Court Advisory and Support Service, who will carry out safeguarding checks and
+        submit information to the court to help the judge make a decision that is in the best interests of the
+        children. They’re required to do so by law.
+        <a href="https://www.cafcass.gov.uk/about-cafcass/policies/privacy-data-protection/privacy-notice-service-users/" class="govuk-link" rel="external" target="_blank">Read
+          more about who Cafcass may share your personal data with</a></li>
+    </ul>
 
-        <p>Your personal data will not usually be shared with anyone who is not a party to the case unless this is
-          specifically ordered by the court or permitted by the
-          <a href="https://www.justice.gov.uk/courts/procedure-rules/family/rules_pd_menu" rel="external" target="_blank">Family
-            Procedure Rules 2010</a>. There are strict rules about when information in family cases may be disclosed
-          outside the court proceedings. The
-          <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external" target="_blank">HMCTS
-            privacy policy for family court forms</a> provides general information about the use of your personal data
-          in family court cases.</p>
+    <p class="govuk-body">Your personal data will not usually be shared with anyone who is not a party to the case unless this is
+      specifically ordered by the court or permitted by the
+      <a href="https://www.justice.gov.uk/courts/procedure-rules/family/rules_pd_menu" class="govuk-link" rel="external" target="_blank">Family
+        Procedure Rules 2010</a>. There are strict rules about when information in family cases may be disclosed
+      outside the court proceedings. The
+      <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" class="govuk-link" rel="external" target="_blank">HMCTS
+        privacy policy for family court forms</a> provides general information about the use of your personal data
+      in family court cases.</p>
 
-        <p>We may also use your contact information to ask for feedback on using the service, but only when you have
-          given your consent for us to do so.</p>
+    <p class="govuk-body">We may also use your contact information to ask for feedback on using the service, but only when you have
+      given your consent for us to do so.</p>
 
-        <p>We’ll never share your information with other organisations for marketing, market research or commercial purposes.</p>
-      </div>
-    </section>
+    <p class="govuk-body">We’ll never share your information with other organisations for marketing, market research or commercial purposes.</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Keeping your personal data</h2>
+    <h2 class="govuk-heading-l">Keeping your personal data</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>We delete all the information you enter into the online
-          service <%= Rails.configuration.x.drafts.expire_in_days -%> days after the first date you started your
-          application.</p>
+    <p class="govuk-body">We delete all the information you enter into the online
+      service <%= Rails.configuration.x.drafts.expire_in_days -%> days after the first date you started your
+      application.</p>
 
-        <p>If you create a user account to allow you to save and return to partially completed applications, we delete
-          your user account <%= Rails.configuration.x.users.expire_in_days -%> days after your last login. You can
-          delete your partially completed applications at any time.</p>
+    <p class="govuk-body">If you create a user account to allow you to save and return to partially completed applications, we delete
+      your user account <%= Rails.configuration.x.users.expire_in_days -%> days after your last login. You can
+      delete your partially completed applications at any time.</p>
 
-        <p>For information about what happens once your application has been completed online and your information is
-          submitted to the court, you should read the
-          <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" rel="external" target="_blank">HMCTS
-            privacy policy for family court forms</a>.</p>
-      </div>
-    </section>
+    <p class="govuk-body">For information about what happens once your application has been completed online and your information is
+      submitted to the court, you should read the
+      <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter#privacy-policy-for-family-proceedings" class="govuk-link" rel="external" target="_blank">HMCTS
+        privacy policy for family court forms</a>.</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Your rights</h2>
-      <p>You can ask:</p>
-      <ul class="list list-bullet">
-        <li>to see the personal data that we hold on you</li>
-        <li>to have the personal data corrected</li>
-        <li>to have the personal data removed or deleted (this will depend on the circumstances, for example if you decide not to continue your application)</li>
-      </ul>
-      <p>
-        If you want to see the personal data that we hold on you, you can make a <a href="https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter">subject access request</a>. Write to us at: Disclosure Team, Post point 10.38, 102 Petty France, London, SW1H 9AJ or email: <a href="mailto:data.access@justice.gov.uk">data.access@justice.gov.uk</a>.
-      </p>
-    </section>
+    <h2 class="govuk-heading-l">Your rights</h2>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Getting more information</h2>
+    <p class="govuk-body">You can ask:</p>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>You can get more details on:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>to see the personal data that we hold on you</li>
+      <li>to have the personal data corrected</li>
+      <li>to have the personal data removed or deleted (this will depend on the circumstances, for example if you decide not to continue your application)</li>
+    </ul>
 
-        <ul class="list list-bullet">
-          <li>agreements we have with other organisations for sharing information</li>
-          <li>when we can pass on personal information without telling you, for example, to help with the prevention or
-            detection of crime or to produce anonymised statistics
-          </li>
-          <li>instructions we give to staff on how to collect, use or delete your personal information</li>
-          <li>how we check that the information we have is accurate and up-to-date</li>
-          <li>how to make a complaint</li>
-        </ul>
+    <p class="govuk-body">
+      If you want to see the personal data that we hold on you, you can make a <a href="https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter" class="govuk-link" rel="external" target="_blank">subject access request</a>. Write to us at: Disclosure Team, Post point 10.38, 102 Petty France, London, SW1H 9AJ or email: <a href="mailto:data.access@justice.gov.uk" class="govuk-link ga-clickAction" data-ga-category="privacy" data-ga-action="click" data-ga-label="mailto data access">data.access@justice.gov.uk</a>.
+    </p>
 
-        <p>For more information, please contact the MoJ data protection officer at
-          <a href="mailto:data.compliance@justice.gov.uk" class="ga-clickAction" data-ga-category="privacy"
-             data-ga-action="click" data-ga-label="mailto data compliance">data.compliance@justice.gov.uk</a></p>
-      </div>
-    </section>
+    <h2 class="govuk-heading-l">Getting more information</h2>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Telling us about your experience of
-        using this service</h2>
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>We handle your personal data differently if you choose to be contacted about your experience of using the
-          service.</p>
-        <p>If you have chosen to be contacted
-          <a href="/about/privacy_consent">find out how long we keep your data, your rights and how to contact us.</a>
-        </p>
-      </div>
-    </section>
+    <p class="govuk-body">You can get more details on:</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Making a complaint</h2>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>agreements we have with other organisations for sharing information</li>
+      <li>when we can pass on personal information without telling you, for example, to help with the prevention or
+        detection of crime or to produce anonymised statistics
+      </li>
+      <li>instructions we give to staff on how to collect, use or delete your personal information</li>
+      <li>how we check that the information we have is accurate and up-to-date</li>
+      <li>how to make a complaint</li>
+    </ul>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>When we ask you for information, we will keep to the law. If you think that your information has not
-          been handled correctly, you can contact the Information Commissioner for independent advice about data
-          protection on the address below:</p>
+    <p class="govuk-body">For more information, please contact the MoJ data protection officer at
+      <a href="mailto:data.compliance@justice.gov.uk" class="ga-clickAction govuk-link" data-ga-category="privacy"
+         data-ga-action="click" data-ga-label="mailto data compliance">data.compliance@justice.gov.uk</a></p>
 
-        <div class="panel panel-border-narrow">
-          <address class="adr">
-            <div class="extended-address">Information Commissioner's Office,</div>
-            <span class="extended-address">Wycliffe House,</span>
-            <span class="street-address">Water Lane,</span>
-            <div class="locality">Wilmslow,</div>
-            <span class="region">Cheshire,</span>
-            <span class="postal-code">SK9 5AF</span>
-          </address>
-          <div class="util_mt-medium">
-            <div class="tel">Tel: 0303 123 1113</div>
-            <div>
-              <a href="https://www.ico.org.uk" rel="external" target="_blank">www.ico.org.uk</a>
-            </div>
-          </div>
+    <h2 class="govuk-heading-l">Telling us about your experience of
+      using this service</h2>
+
+    <p class="govuk-body">We handle your personal data differently if you choose to be contacted about your experience of using the
+      service.</p>
+
+    <p class="govuk-body">If you have chosen to be contacted
+      <a href="/about/privacy_consent" class="govuk-link">find out how long we keep your data, your rights and how to contact us.</a>
+    </p>
+
+    <h2 class="govuk-heading-l">Making a complaint</h2>
+
+    <p class="govuk-body">When we ask you for information, we will keep to the law. If you think that your information has not
+      been handled correctly, you can contact the Information Commissioner for independent advice about data
+      protection on the address below:</p>
+
+    <div class="govuk-inset-text">
+      <address class="adr">
+        <div class="extended-address">Information Commissioner's Office</div>
+        <span class="extended-address">Wycliffe House</span>
+        <span class="street-address">Water Lane</span>
+        <div class="locality">Wilmslow</div>
+        <span class="region">Cheshire,</span>
+        <span class="postal-code">SK9 5AF</span>
+      </address>
+
+      <div class="govuk-!-margin-top-5">
+        <div class="tel">Tel: 0303 123 1113</div>
+        <div>
+          <a href="https://www.ico.org.uk" class="govuk-link" rel="external" target="_blank">www.ico.org.uk</a>
         </div>
       </div>
-    </section>
+    </div>
   </div>
 </div>

--- a/app/views/about/privacy_consent.en.html.erb
+++ b/app/views/about/privacy_consent.en.html.erb
@@ -1,108 +1,80 @@
 <% title 'Being contacted about your experience of using this service' %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <div class="grid_content_header">
-      <h1 class="app__heading  heading-xlarge gv-u-heading-xxlarge">
-        Being contacted about your experience of using this service
-      </h1>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Being contacted about your experience of using this service</h1>
 
-    <p>By choosing to be contacted by the Ministry of Justice (MOJ) you agree that your personal details and any
+    <p class="govuk-body">By choosing to be contacted by the Ministry of Justice (MOJ) you agree that your personal details and any
       information you give can be used by MOJ for research purposes.</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">The information we use</h2>
+    <h2 class="govuk-heading-l">The information we use</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>MOJ can use any information you provide, including your name and contact information (such as your email
-          address).</p>
-      </div>
-    </section>
+    <p class="govuk-body">MOJ can use any information you provide, including your name and contact information (such as your email
+      address).</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Why we use this information</h2>
+    <h2 class="govuk-heading-l">Why we use this information</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>To get your thoughts on MOJ services - for example, we might send you satisfaction surveys.</p>
-      </div>
-    </section>
+    <p class="govuk-body">To get your thoughts on MOJ services - for example, we might send you satisfaction surveys.</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">How long we will keep your data</h2>
+    <h2 class="govuk-heading-l">How long we will keep your data</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>If you choose to be contacted by MOJ about your experience of using this service, your personal information
-          will be kept for 2 years.</p>
+    <p class="govuk-body">If you choose to be contacted by MOJ about your experience of using this service, your personal information
+      will be kept for 2 years.</p>
 
-        <p>You can also choose to be contacted for other MOJ research. If you opt in, only your name and contact details
-          will be shared with the MOJ research team.</p>
-      </div>
-    </section>
+    <p class="govuk-body">You can also choose to be contacted for other MOJ research. If you opt in, only your name and contact details
+      will be shared with the MOJ research team.</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Your rights</h2>
+    <h2 class="govuk-heading-l">Your rights</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>You have the right to:</p>
+    <p class="govuk-body">You have the right to:</p>
 
-        <ul class="list list-bullet">
-          <li>access the personal information MOJ holds about you</li>
-          <li>change any incorrect information MOJ holds about you</li>
-          <li>stop MOJ using your personal information</li>
-        </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>access the personal information MOJ holds about you</li>
+      <li>change any incorrect information MOJ holds about you</li>
+      <li>stop MOJ using your personal information</li>
+    </ul>
 
-        <p>If you have chosen to be contacted about your experience of using this service, you have the right to request
-          that your personal information is:</p>
+    <p class="govuk-body">If you have chosen to be contacted about your experience of using this service, you have the right to request
+      that your personal information is:</p>
 
-        <ul class="list list-bullet">
-          <li>deleted (the ‘right to be forgotten’)</li>
-          <li>subject to restricted processing (MOJ can store your personal data, but not use it)</li>
-          <li>transferred to you or another organisation in a commonly structured format (the ‘right to portability’)</li>
-        </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>deleted (the ‘right to be forgotten’)</li>
+      <li>subject to restricted processing (MOJ can store your personal data, but not use it)</li>
+      <li>transferred to you or another organisation in a commonly structured format (the ‘right to portability’)</li>
+    </ul>
 
-        <p>Some of these rights only apply in certain circumstances. Even if you want to exercise them, MOJ may not be
-          required to comply.</p>
-      </div>
-    </section>
+    <p class="govuk-body">Some of these rights only apply in certain circumstances. Even if you want to exercise them, MOJ may not be
+      required to comply.</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Withdrawing your consent to be
-        contacted</h2>
+    <h2 class="govuk-heading-l">Withdrawing your consent to be
+      contacted</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>You have the right to withdraw your consent at any time by emailing your request to
-          <a href="mailto:data.compliance@justice.gov.uk" class="ga-clickAction" data-ga-category="privacy"
-             data-ga-action="click" data-ga-label="mailto data compliance">data.compliance@justice.gov.uk</a>.
-        </p>
+    <p class="govuk-body">You have the right to withdraw your consent at any time by emailing your request to
+      <a href="mailto:data.compliance@justice.gov.uk" class="ga-clickAction govuk-link" data-ga-category="privacy"
+         data-ga-action="click" data-ga-label="mailto data compliance">data.compliance@justice.gov.uk</a>.
+    </p>
 
-        <p>The withdrawal of consent will not affect the lawfulness of processing based on consent before its
-          withdrawal.</p>
-      </div>
-    </section>
+    <p class="govuk-body">The withdrawal of consent will not affect the lawfulness of processing based on consent before its
+      withdrawal.</p>
 
-    <section class="moj-Section about-section">
-      <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Contacting MOJ</h2>
+    <h2 class="govuk-heading-l">Contacting MOJ</h2>
 
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p>You can contact MOJ if you:</p>
+    <p class="govuk-body">You can contact MOJ if you:</p>
 
-        <ul class="list list-bullet">
-          <li>would like to update information MOJ holds about you</li>
-          <li>want to exercise any of your rights</li>
-          <li>have any questions about how MOJ handles your personal information</li>
-        </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>would like to update information MOJ holds about you</li>
+      <li>want to exercise any of your rights</li>
+      <li>have any questions about how MOJ handles your personal information</li>
+    </ul>
 
-        <p>Send your request to MOJ by:</p>
+    <p class="govuk-body">Send your request to MOJ by:</p>
 
-        <ul class="list list-bullet">
-          <li>email at
-            <a href="mailto:data.compliance@justice.gov.uk" class="ga-clickAction" data-ga-category="privacy"
-               data-ga-action="click" data-ga-label="mailto data compliance">data.compliance@justice.gov.uk</a>
-          </li>
-          <li>post to Data Protection Officer, Ministry of Justice, 102 Petty France, London SW1H 9AJ</li>
-        </ul>
-      </div>
-    </section>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>email at
+        <a href="mailto:data.compliance@justice.gov.uk" class="ga-clickAction govuk-link" data-ga-category="privacy"
+           data-ga-action="click" data-ga-label="mailto data compliance">data.compliance@justice.gov.uk</a>
+      </li>
+      <li>post to Data Protection Officer, Ministry of Justice, 102 Petty France, London SW1H 9AJ</li>
+    </ul>
   </div>
 </div>

--- a/app/views/about/terms_and_conditions.en.html.erb
+++ b/app/views/about/terms_and_conditions.en.html.erb
@@ -1,62 +1,42 @@
 <% title 'Terms and conditions' %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <div class="grid_content_header">
-      <h1 class="app__heading  heading-xlarge gv-u-heading-xxlarge">Terms and conditions</h1>
-      <p class="app__lede lede gv-u-text-lede">By using this service you agree to these terms and conditions.</p>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Terms and conditions</h1>
 
-    <div class=" govuk-govspeak gv-s-prose">
-      <section class="moj-Section about-section">
-        <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Responsibility for the service</h2>
+    <p class="govuk-body-l">By using this service you agree to these terms and conditions.</p>
 
-        <div class="Section__content govuk-govspeak gv-s-prose">
-          <p>The Ministry of Justice (MOJ) runs this service.</p>
-          <p>We try to make sure the information we provide is accurate and complete and the service is always available and virus free.</p>
-          <p>The MoJ accepts no liability for:</p>
+    <h2 class="govuk-heading-l">Responsibility for the service</h2>
 
-          <ul class="list list-bullet">
-            <li>you being unable to access the service (for example due to high demand or because we've taken it down for maintenance)</li>
-            <li>indirect damages arising from you using the service or relying on its content</li>
-            <li>the content and availability of external websites that link to the service or which link from it</li>
-          </ul>
-        </div>
-      </section>
+    <p class="govuk-body">The Ministry of Justice (MOJ) runs this service.</p>
+    <p class="govuk-body">We try to make sure the information we provide is accurate and complete and the service is always available and virus free.</p>
+    <p class="govuk-body">The MoJ accepts no liability for:</p>
 
-      <section class="moj-Section about-section" data-block-name="terms-conditions-phase">
-        <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Public alpha</h2>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you being unable to access the service (for example due to high demand or because we've taken it down for maintenance)</li>
+      <li>indirect damages arising from you using the service or relying on its content</li>
+      <li>the content and availability of external websites that link to the service or which link from it</li>
+    </ul>
 
-        <div class="Section__content govuk-govspeak gv-s-prose">
-          <p>This service is currently in ‘public alpha’. This means you’re looking at the first version of it.</p>
-          <p>Something that's in ‘public alpha’ isn’t open to everyone or may not work for everyone. We do this so we
-            can test and make improvements before releasing it to more people.</p>
-        </div>
-      </section>
+    <h2 class="govuk-heading-l">Public alpha</h2>
 
-      <section class="moj-Section about-section" data-block-name="terms-conditions-phase">
-        <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Information about you and your
-          visits</h2>
+    <p class="govuk-body">This service is currently in ‘public alpha’. This means you’re looking at the first version of it.</p>
+    <p class="govuk-body">Something that's in ‘public alpha’ isn’t open to everyone or may not work for everyone. We do this so we
+      can test and make improvements before releasing it to more people.</p>
 
-        <div class="Section__content govuk-govspeak gv-s-prose">
-          <p>We collect information about you in accordance with
-            our <%= link_to 'privacy policy', about_privacy_path, class: 'ga-pageLink', data: {ga_category: 'footer', ga_label: 'privacy'} %>
-            and our <%= link_to 'cookie policy', about_cookies_path, class: 'ga-pageLink', data: {ga_category: 'footer', ga_label: 'cookies'} %>.
-            By using this service you agree to us collecting this information and confirm that any data you provide is accurate.</p>
-        </div>
-      </section>
+    <h2 class="govuk-heading-l">Information about you and your visits</h2>
 
-      <section class="moj-Section about-section" data-block-name="terms-conditions-scope">
-        <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Scotland and Northern Ireland</h2>
+    <p class="govuk-body">We collect information about you in accordance with
+      our <%= link_to 'privacy policy', about_privacy_path, class: 'ga-pageLink govuk-link', data: {ga_category: 'footer', ga_label: 'privacy'} %>
+      and our <%= link_to 'cookie policy', about_cookies_path, class: 'ga-pageLink govuk-link', data: {ga_category: 'footer', ga_label: 'cookies'} %>.
+      By using this service you agree to us collecting this information and confirm that any data you provide is accurate.</p>
 
-        <div class="Section__content govuk-govspeak gv-s-prose">
-          <p>Some parts of this service only apply to England and Wales.</p>
-          <p>For example, if you want to go to court the process is different in
-            <a href="https://www.mygov.scot/crime-justice-and-the-law/courts-and-sentencing" rel="external" target="_blank">Scotland</a> and
-            <a href="https://www.nidirect.gov.uk/articles/solicitors-and-courts" rel="external" target="_blank">Northern Ireland</a>.
-          </p>
-        </div>
-      </section>
-    </div>
+    <h2 class="govuk-heading-l">Scotland and Northern Ireland</h2>
+
+    <p class="govuk-body">Some parts of this service only apply to England and Wales.</p>
+    <p class="govuk-body">For example, if you want to go to court the process is different in
+      <a href="https://www.mygov.scot/crime-justice-and-the-law/courts-and-sentencing" class="govuk-link" rel="external" target="_blank">Scotland</a> and
+      <a href="https://www.nidirect.gov.uk/articles/solicitors-and-courts" class="govuk-link" rel="external" target="_blank">Northern Ireland</a>.
+    </p>
   </div>
 </div>


### PR DESCRIPTION
Migrate all pages linked to from the footer (or header like the "Report a problem" link) to the new desig system.

This is not a search and replace (sadly). It is a time consuming task because we must replace old markup with appropiate new one, as well as classes, but also use headings consistently to create a clear hierarchy throughout the service.

The headings mark up must be semantic as per guidelines here:
https://design-system.service.gov.uk/styles/typography/#headings

Also removed obsolete markup and replaced `strong` tags with either headers or proper font weight classes.