### PR TITLE
Bring over GovukComponents code from Disclosure Checker

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,24 +18,28 @@ module ApplicationHelper
 
   # Render a back link pointing to the user's previous step
   def step_header(path: nil)
+    # TODO: remove the error summary from here once we've migrated all the views
+    content_for(:old_error_summary, &method(:error_summary))
+
     capture do
       render partial: 'layouts/step_header', locals: {
         path: path || controller.previous_step_path
       }
-    end + error_summary(@form_object)
+    end
   end
 
-  def error_summary(form_object)
+  def error_summary(form_object = @form_object)
     return unless GovukElementsErrorsHelper.errors_exist?(form_object)
 
     content_for(:page_title, flush: true) do
       content_for(:page_title).insert(0, t('errors.page_title_prefix'))
     end
 
+    # TODO: to be removed once not needed
+    content_for(:old_error_summary, '', flush: true)
+
     GovukElementsErrorsHelper.error_summary(
-      form_object,
-      t('errors.error_summary.heading'),
-      t('errors.error_summary.text')
+      form_object, t('errors.error_summary.heading')
     )
   end
 

--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -1,6 +1,5 @@
 module CustomFormHelpers
-  delegate :t,
-           :current_c100_application,
+  delegate :current_c100_application,
            :user_signed_in?, to: :@template
 
   def continue_button(continue: :continue, save_and_continue: :save_and_continue)

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -77,6 +77,9 @@
       </div>
     <% end %>
 
+    <%# TODO: to be removed once all views are migrated %>
+    <%= yield(:old_error_summary) %>
+
     <%= yield(:content) %>
   </main>
 </div>

--- a/app/views/steps/screener/postcode/edit.html.erb
+++ b/app/views/steps/screener/postcode/edit.html.erb
@@ -1,19 +1,30 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <p><%=t '.lead_text' %></p>
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.text_field :children_postcodes, class: 'narrow' %>
+      <%= f.text_field :children_postcodes,
+                       input_options: { class: 'govuk-input--width-10', autocomplete: 'postal-code' } %>
 
       <%= f.continue_button %>
     <% end %>
 
-    <%=t '.unknown_postcode_html' %>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="explanations" data-ga-label="screener postcode">
+          <%=t '.details.summary' %>
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <%=t '.details.text_html' %>
+      </div>
+    </details>
   </div>
 </div>

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -1,5 +1,26 @@
-ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
+# PLEASE BE AWARE:
+#
+# We are still using the gem `govuk_elements_form_builder` that produces a markup
+# not compatible with the new Design System, as there is no ready to use alternative.
+#
+# To workaround these limitations, we've created our own `FormBuilder` class, which
+# inherits from the old `GovukElementsFormBuilder::FormBuilder` class, to reuse as
+# much as possible from the old gem (mainly locales and error handling, and some other
+# utility methods) but overrides some other methods to produce new markup/styles.
+#
+# This is an interim solution that will speed up the time needed to migrate components
+# to the new design system and also will allow us to continue using the very same
+# interface we've been using up until now.
+#
+# Going forwards, once we have migrated all components and the code cleaned up and
+# refactored, we can consider extracting it to a gem for reuse in other projects.
+#
+require_relative '../../lib/govuk_components/form_builder'
+require_relative '../../lib/govuk_components/error_helpers'
 
+ActionView::Base.default_form_builder = GovukComponents::FormBuilder
+
+# Mix in app-specific form helpers
 ActionView::Base.default_form_builder.class_eval do
   include CustomFormHelpers
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1178,6 +1178,7 @@ en:
         special_arrangements_details: *provide_details
       steps_application_details_form:
         application_details: *provide_details
+        foobar: Virtual attribute used temporarily in tests, to be removed
       steps_application_language_form:
         language_help_details: *provide_details
       steps_application_intermediary_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -912,16 +912,11 @@ en:
           page_title: Where the children live
           heading: Where do the children live?
           lead_text: Please tell us the postcode of the children you’re making this application about.
-          unknown_postcode_html: |
-            <details>
-              <summary>
-                <span class="summary" data-ga-category="explanations" data-ga-label="screener postcode">If you do not know where the children live</span>
-              </summary>
-              <div class="panel panel-border-narrow">
-                <p>You can use <a href="https://www.gov.uk/government/publications/form-c4-application-for-an-order-for-disclosure-of-a-childs-whereabouts" rel="external" target="_blank">form C4</a>
-                to apply for an order for someone to give a court information about where a child is.</p>
-              </div>
-            </details>
+          details:
+            summary: If you do not know where the children live
+            text_html: |
+              You can use <a href="https://www.gov.uk/government/publications/form-c4-application-for-an-order-for-disclosure-of-a-childs-whereabouts"
+              class="govuk-link" rel="external" target="_blank">form C4</a> to apply for an order for someone to give a court information about where a child is.
       error_but_continue:
         show:
           page_title: Where the children live

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -55,7 +55,6 @@ en:
       inclusion: Select an option
     error_summary:
       heading: There is a problem on this page
-      text: ''
     page_title_prefix: 'Error: '
 
   activerecord:

--- a/features/errors.feature
+++ b/features/errors.feature
@@ -8,9 +8,9 @@ Feature: Errors
     Given I click the "Continue" button
     Then I should be on "/steps/screener/postcode"
     And Page has title "Error: Where the children live - Apply to court about child arrangements - GOV.UK"
-    And I should see "There is a problem on this page" in a "h2" element
-    And I should see a "Enter a full postcode, with or without a space" link to "#error_steps_screener_postcode_form_children_postcodes"
-        
+    And I should see "There is a problem on this page" in the error summary
+    And I should see a "Enter a full postcode, with or without a space" link to "#steps_screener_postcode_form_children_postcodes"
+
     Then I click the "Enter a full postcode, with or without a space" link
-    And I should see "Enter a full postcode, with or without a space" in the form label
-    And "#error_steps_screener_postcode_form_children_postcodes" has focus
+    And I should see "Enter a full postcode, with or without a space" error in the form
+    And "#steps_screener_postcode_form_children_postcodes" has focus

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -50,12 +50,12 @@ When(/^I pause for "([^"]*)" seconds$/) do |seconds|
 end
 
 # Errors
-When(/^I should see "([^"]*)" in a "([^"]*)" element/) do |text, element|
-  page.find(".error-summary > #{element}").has_content? text
+When(/^I should see "([^"]*)" in the error summary$/) do |text|
+  page.find("div.govuk-error-summary > h2").has_content? text
 end
 
-When(/^I should see "([^"]*)" in the form label/) do |text|
-  page.find("label > #error_message_steps_screener_postcode_form_children_postcodes").has_content? text
+When(/^I should see "([^"]*)" error in the form$/) do |text|
+  page.find("span.govuk-error-message").has_content? text
 end
 
 When(/^Page has title "([^"]*)"/) do |text|

--- a/lib/govuk_components/error_helpers.rb
+++ b/lib/govuk_components/error_helpers.rb
@@ -1,0 +1,67 @@
+module GovukComponents
+  module ErrorHelpers
+    # rubocop:disable Metrics/BlockLength
+    GovukElementsErrorsHelper.module_eval do
+      def self.error_summary(object, heading)
+        return unless errors_exist? object
+
+        error_summary_div do
+          error_summary_heading(heading) + error_summary_list(object)
+        end
+      end
+
+      def self.error_summary_div(&block)
+        attrs = {
+          class: 'govuk-error-summary',
+          aria: { labelledby: 'error-summary-title' },
+          data: { module: 'govuk-error-summary' },
+          role: 'alert',
+          tabindex: '-1',
+        }.freeze
+
+        content_tag(:div, attrs) do
+          yield block
+        end
+      end
+
+      def self.error_summary_heading(text)
+        content_tag :h2, text,
+                    id: 'error-summary-title',
+                    class: 'govuk-error-summary__title'
+      end
+
+      def self.error_summary_list(object)
+        content_tag(:div, class: 'govuk-error-summary__body') do
+          content_tag(:ul, class: 'govuk-list govuk-error-summary__list') do
+            child_to_parents = child_to_parent(object)
+            messages = error_summary_messages(object, child_to_parents)
+
+            # :nocov:
+            # TODO: This will be removed once we have got child parent relationship
+            messages << children_with_errors(object).map do |child|
+              error_summary_messages(child, child_to_parents)
+            end
+            # :nocov:
+
+            messages.flatten.join('').html_safe
+          end
+        end
+      end
+
+      def self.error_summary_message(object, attribute, child_to_parents)
+        messages = object.errors.full_messages_for attribute
+        messages.map do |message|
+          object_prefixes = object_prefixes object, child_to_parents
+          link = link_to_error(object_prefixes, attribute)
+          message.sub! default_label(attribute), localized_label(object_prefixes, attribute)
+          content_tag(:li, content_tag(:a, message, href: link))
+        end
+      end
+
+      def self.link_to_error(object_prefixes, attribute, suffix = nil)
+        [*object_prefixes, attribute, suffix].reject(&:blank?).join('_').prepend('#')
+      end
+    end
+    # rubocop:enable Metrics/BlockLength
+  end
+end

--- a/lib/govuk_components/form_builder.rb
+++ b/lib/govuk_components/form_builder.rb
@@ -1,0 +1,140 @@
+module GovukComponents
+  class FormBuilder < GovukElementsFormBuilder::FormBuilder
+    delegate :t, :concat, to: :@template
+
+    # Methods below overrides the one from the original gem, and reimplement them
+    # to produce new markup and style class names.
+    # Also a few private methods have been reimplemented for this to work side
+    # by side with the old gem.
+    #
+    def text_field(attribute, options = {})
+      value = object.public_send(attribute)
+
+      content_tag(:div, class: form_group_classes(attribute)) do
+        concat input_label(attribute, options)
+        concat hint(attribute, options)
+        concat error(attribute)
+        concat @template.text_field(@object_name, attribute, input_options(attribute, options).merge(value: value))
+      end
+    end
+
+    private
+
+    def form_group_classes(attribute)
+      classes = ['govuk-form-group']
+      classes << 'govuk-form-group--error' if error_for?(attribute)
+      classes
+    end
+
+    def aria_describes(attribute, options)
+      aria_ids = []
+      aria_ids << id_for(attribute, 'hint')  if hint(attribute, options)
+      aria_ids << id_for(attribute, 'error') if error_for?(attribute)
+
+      # If the array is empty, will return nil
+      aria_ids.presence
+    end
+
+    def input_options(attribute, options)
+      defaults = { class: 'govuk-input' }
+
+      defaults[:class] << ' govuk-input--error' if error_for?(attribute)
+      defaults['aria-describedby'] = aria_describes(attribute, options)
+
+      merge_attributes(
+        options[:input_options],
+        default: defaults
+      )
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def input_label(attribute, options)
+      default_attrs = { class: 'govuk-label' }.freeze
+      default_opts  = { visually_hidden: false, page_heading: false, size: nil }.freeze
+
+      label_options = merge_attributes(
+        options[:label_options],
+        default: default_attrs
+      ).reverse_merge(
+        default_opts
+      )
+
+      opts = label_options.extract!(*default_opts.keys)
+
+      label_options[:class] << " govuk-label--#{opts[:size]}" if opts[:size]
+      label_options[:class] << ' govuk-visually-hidden' if opts[:visually_hidden]
+
+      text = localized_text(
+        'helpers.label', attribute,
+        i18n_attribute: options[:i18n_attribute],
+        default: default_label(attribute)
+      )
+
+      html = Nokogiri::HTML.fragment(
+        label(attribute, text, label_options)
+      )
+
+      # Remove the error span Rails introduce, as we are handling errors
+      # in a different way and with different markup.
+      html.at(:span)&.unlink
+      label_html = html.to_html.html_safe
+
+      # The `page_heading` option can be false to disable "Legends as page headings"
+      # https://design-system.service.gov.uk/get-started/labels-legends-headings/
+      #
+      if opts[:page_heading]
+        content_tag(:h1, label_html, class: 'govuk-label-wrapper')
+      else
+        label_html
+      end
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def hint(attribute, options)
+      text = localized_text(
+        'helpers.hint', attribute,
+        i18n_attribute: options[:i18n_attribute],
+        default: ''
+      )
+
+      return unless text.present?
+
+      content_tag(:span, text, class: 'govuk-hint', id: id_for(attribute, 'hint'))
+    end
+
+    def error(attribute)
+      return unless error_for?(attribute)
+
+      text = error_full_message_for(attribute)
+      content_tag(:span, text, class: 'govuk-error-message', id: id_for(attribute, 'error'))
+    end
+
+    def id_for(attribute, suffix)
+      [attribute_prefix, attribute, suffix].join('_')
+    end
+
+    # If a form view is reused but the attribute doesn't change (for example in
+    # partials) an `i18n_attribute` can be used to lookup the legend or hint locales
+    # based on this, instead of the original attribute.
+    #
+    # We prioritise the `i18n_attribute` if provided, and if no locale is found,
+    # we try the 'real' attribute as a fallback and finally the default value.
+    #
+    def localized_text(scope, attribute, i18n_attribute: nil, default:)
+      found = if i18n_attribute
+                key = "#{@object_name}.#{i18n_attribute}"
+
+                I18n.translate(key, default: '', scope: scope).presence ||
+                  I18n.translate("#{key}_html", default: '', scope: scope).html_safe.presence
+              end
+
+      return found if found
+
+      key = "#{@object_name}.#{attribute}"
+
+      # Passes blank String as default because nil is interpreted as no default
+      I18n.translate(key, default: '', scope: scope).presence ||
+        I18n.translate("#{key}_html", default: default, scope: scope).html_safe.presence
+    end
+  end
+end

--- a/spec/fixtures/files/govuk_components/error_summary.html
+++ b/spec/fixtures/files/govuk_components/error_summary.html
@@ -1,0 +1,12 @@
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="govuk-error-summary" role="alert" tabindex="-1">
+  <h2 id="error-summary-title" class="govuk-error-summary__title">
+    There is an error
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <a href="#c100_application_has_court_orders">Select an option</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/spec/fixtures/files/govuk_components/text_field.html
+++ b/spec/fixtures/files/govuk_components/text_field.html
@@ -1,0 +1,9 @@
+<div class="govuk-form-group">
+  <label class="govuk-label" for="steps_application_details_form_application_details">
+    Provide details
+  </label>
+  <span class="govuk-hint" id="steps_application_details_form_application_details_hint">
+    You do not have to give a full statement although you may be asked to provide one later.
+  </span>
+  <input class="govuk-input govuk-input--width-10" aria-describedby="steps_application_details_form_application_details_hint" type="text" name="steps_application_details_form[application_details]" id="steps_application_details_form_application_details" />
+</div>

--- a/spec/fixtures/files/govuk_components/text_field_error.html
+++ b/spec/fixtures/files/govuk_components/text_field_error.html
@@ -1,0 +1,10 @@
+<div class="govuk-form-group govuk-form-group--error">
+  <label class="govuk-label" for="steps_application_details_form_application_details">
+    Provide details
+  </label>
+  <span class="govuk-hint" id="steps_application_details_form_application_details_hint">
+    You do not have to give a full statement although you may be asked to provide one later.
+  </span>
+  <span class="govuk-error-message" id="steps_application_details_form_application_details_error">Enter an answer</span>
+  <input class="govuk-input govuk-input--error govuk-input--width-10" aria-describedby="steps_application_details_form_application_details_hint steps_application_details_form_application_details_error" type="text" name="steps_application_details_form[application_details]" id="steps_application_details_form_application_details" />
+</div>

--- a/spec/fixtures/files/govuk_components/text_field_page_heading.html
+++ b/spec/fixtures/files/govuk_components/text_field_page_heading.html
@@ -1,0 +1,11 @@
+<div class="govuk-form-group">
+  <h1 class="govuk-label-wrapper">
+    <label class="govuk-label govuk-label--xl" for="steps_application_details_form_application_details">
+      Provide details
+    </label>
+  </h1>
+  <span class="govuk-hint" id="steps_application_details_form_application_details_hint">
+    You do not have to give a full statement although you may be asked to provide one later.
+  </span>
+  <input class="govuk-input" aria-describedby="steps_application_details_form_application_details_hint" type="text" name="steps_application_details_form[application_details]" id="steps_application_details_form_application_details" />
+</div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -44,21 +44,22 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe '#step_header' do
     let(:form_object) { double('Form object') }
 
-    it 'renders the expected content' do
-      expect(helper).to receive(:render).with(partial: 'layouts/step_header', locals: {path: '/foo/bar'}).and_return('foo')
+    # TODO: to be removed once not needed
+    before do
+      allow(helper).to receive(:content_for).with(:old_error_summary, any_args)
+    end
 
+    it 'renders the expected content' do
+      expect(helper).to receive(:render).with(partial: 'layouts/step_header', locals: {path: '/foo/bar'}).and_return('foobar')
       assign(:form_object, form_object)
-      expect(helper).to receive(:error_summary).with(form_object).and_return('bar')
 
       expect(helper.step_header).to eq('foobar')
     end
 
     context 'a specific path is provided' do
       it 'renders the back link with provided path' do
-        expect(helper).to receive(:render).with(partial: 'layouts/step_header', locals: {path: '/another/step'}).and_return('foo')
-
+        expect(helper).to receive(:render).with(partial: 'layouts/step_header', locals: {path: '/another/step'}).and_return('foobar')
         assign(:form_object, form_object)
-        expect(helper).to receive(:error_summary).with(form_object).and_return('bar')
 
         expect(helper.step_header(path: '/another/step')).to eq('foobar')
       end
@@ -93,7 +94,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it 'delegates to GovukElementsErrorsHelper' do
-        expect(GovukElementsErrorsHelper).to receive(:error_summary).with(form_object, anything, anything).and_return(summary)
+        expect(GovukElementsErrorsHelper).to receive(:error_summary).with(form_object, anything).and_return(summary)
 
         expect(helper.error_summary(form_object)).to eq(summary)
       end

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -7,9 +7,11 @@ class TestHelper < ActionView::Base
 end
 
 # The module `CustomFormHelpers` gets mixed in and extends the helpers already
-# provided by `GovukElementsFormBuilder`. Refer to: `config/initializers/form_builder.rb`
+# provided by `GovukComponents::FormBuilder`. These are app-specific form helpers
+# so can be coupled to application business and logic.
+# Refer to: `config/initializers/form_builder.rb`
 #
-RSpec.describe GovukElementsFormBuilder::FormBuilder do
+RSpec.describe GovukComponents::FormBuilder do
   let(:helper) { TestHelper.new }
 
   describe '#continue_button' do

--- a/spec/lib/govuk_components/error_helpers_spec.rb
+++ b/spec/lib/govuk_components/error_helpers_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe GovukElementsErrorsHelper do
+  def strip_text(text)
+    text = text.strip.split("\n").map(&:strip)
+    text.delete_if { |line| line == '' }
+    text.join
+  end
+
+  # Note: This is just a very broad and `happy path` test.
+  # It is also coupled to current i18n so, if the strings change,
+  # then the HTML fixture will need to also be updated.
+  #
+  # TODO: decouple from app-specific models (`C100Application`)
+  #
+  describe '.error_summary' do
+    subject { C100Application.new }
+
+    context 'yes-no question' do
+      let(:html_output) { GovukElementsErrorsHelper.error_summary(subject, 'There is an error') }
+      let(:html_fixture) { file_fixture('govuk_components/error_summary.html').read }
+
+      it 'outputs the expected markup' do
+        subject.errors.add(:has_court_orders, :inclusion)
+
+        expect(
+          strip_text(html_output)
+        ).to eq(
+          strip_text(html_fixture)
+        )
+      end
+    end
+
+    context 'text box' do
+      let(:html_output) { GovukElementsErrorsHelper.error_summary(form_object, 'There is an error') }
+      let(:form_object) { Steps::Application::DetailsForm.build(subject) }
+
+      it 'links to the expected text field' do
+        form_object.errors.add(:application_details, :blank)
+
+        expect(
+          strip_text(html_output)
+        ).to match(/<a href="#steps_application_details_form_application_details">/)
+      end
+    end
+  end
+end

--- a/spec/lib/govuk_components/form_builder_spec.rb
+++ b/spec/lib/govuk_components/form_builder_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+class TestHelper < ActionView::Base
+end
+
+RSpec.describe GovukComponents::FormBuilder do
+  def strip_text(text)
+    text = text.strip.split("\n").map(&:strip)
+    text.delete_if { |line| line == '' }
+    text.join
+  end
+
+  let(:c100_application) { C100Application.new }
+  let(:helper) { TestHelper.new }
+
+  # Note: This is just a very broad and `happy path` test.
+  # It is also coupled to current i18n so, if the strings change,
+  # then the HTML fixture will need to also be updated.
+  #
+  describe '#text_field' do
+    let(:builder) { described_class.new form.to_sym, c100_application, helper, {} }
+
+    let(:form) { 'steps_application_details_form' }
+    let(:attribute) { :application_details }
+
+    let(:options) do
+      { input_options: { class: 'govuk-input--width-10' } }
+    end
+
+    let(:html_output) { builder.text_field attribute, options }
+
+    context 'no errors' do
+      let(:html_fixture) { file_fixture('govuk_components/text_field.html').read }
+
+      it 'outputs the expected markup' do
+        expect(
+          strip_text(html_output)
+        ).to eq(
+          strip_text(html_fixture)
+        )
+      end
+    end
+
+    context 'with errors' do
+      let(:html_fixture) { file_fixture('govuk_components/text_field_error.html').read }
+
+      before do
+        c100_application.errors.add(attribute, :blank)
+      end
+
+      it 'outputs the expected markup' do
+        expect(
+          strip_text(html_output)
+        ).to eq(
+          strip_text(html_fixture)
+        )
+      end
+    end
+
+    context 'page_heading set to true' do
+      let(:html_fixture) { file_fixture('govuk_components/text_field_page_heading.html').read }
+
+      let(:options) do
+        { label_options: { page_heading: true, size: 'xl' } }
+      end
+
+      it 'outputs the expected markup' do
+        expect(
+          strip_text(html_output)
+        ).to eq(
+          strip_text(html_fixture)
+        )
+      end
+    end
+
+    # TODO: decouple from i18n once extracted to gem or similar
+    context 'label with a virtual attribute' do
+      let(:options) { super().merge(i18n_attribute: :foobar) }
+
+      it 'outputs the expected markup' do
+        expect(
+          strip_text(html_output)
+        ).to match(/<label class="govuk-label" for="steps_application_details_form_application_details">Virtual attribute used temporarily in tests, to be removed<\/label>/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For the Disclosure Checker service we already managed to migrate some components although in a quite hacky way. For reference:

ministryofjustice/disclosure-checker#4

Although it is not the best of the code and it is a bit convoluted, it will be a great way to kick off the migration of components for C100 and speed up the process.

Also, as opposite to Disclosure Checker were we have "simple" components, here we make use of more complex components like revealing radios, etc. so that will need to be adapted too.

The idea is once we have a more clear understanding of the complexity of this, we can organise the components into individual classes and reuse as much as possible as well as eventually extract all the code to a gem that could also be used by Disclosure Checker.

For now, only the error summary and the text field have been migrated.

Migrated the first step (children's postcode) (refer to individual commit):

<img width="687" alt="Screen Shot 2020-03-24 at 09 53 12" src="https://user-images.githubusercontent.com/687910/77412079-4c9bab80-6db5-11ea-8068-ae0afc54279c.png">
