### PR TITLE
Attempt to use `govuk_design_system_formbuilder`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.6.5'
 
 gem 'devise', '~> 4.7.1'
 gem 'email_validator', '< 2.0.0'
+gem 'govuk_design_system_formbuilder', '~> 1.1'
 gem 'govuk_elements_form_builder', '~> 1.3.1'
 gem 'govuk_elements_rails', '~> 3.0'
 gem 'govuk_frontend_toolkit', '< 8.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,10 @@ GEM
       activesupport (>= 4.2.0)
     gov_uk_date_fields (3.1.0)
       rails (>= 5.0)
+    govuk_design_system_formbuilder (1.1.5)
+      actionview (>= 5.2)
+      activemodel (>= 5.2)
+      activesupport (>= 5.2)
     govuk_elements_form_builder (1.3.1)
       govuk_elements_rails (>= 3.0.0)
       govuk_frontend_toolkit (< 9.0.0)
@@ -432,6 +436,7 @@ DEPENDENCIES
   dotenv-rails
   email_validator (< 2.0.0)
   gov_uk_date_fields (~> 3.1.0)
+  govuk_design_system_formbuilder (~> 1.1)
   govuk_elements_form_builder (~> 1.3.1)
   govuk_elements_rails (~> 3.0)
   govuk_frontend_toolkit (< 8.0.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,14 +18,16 @@ module ApplicationHelper
 
   # Render a back link pointing to the user's previous step
   def step_header(path: nil)
-    capture do
-      render partial: 'layouts/step_header', locals: {
-        path: path || controller.previous_step_path
-      }
-    end + error_summary(@form_object)
+    # TODO: remove the error summary from here once we've migrated all the views
+    content_for(:old_error_summary, &method(:error_summary))
+
+    render partial: 'layouts/step_header', locals: {
+      path: path || controller.previous_step_path
+    }
   end
 
-  def error_summary(form_object)
+  # Old design system, to be removed once we've migrated all the views
+  def error_summary(form_object = @form_object)
     return unless GovukElementsErrorsHelper.errors_exist?(form_object)
 
     content_for(:page_title, flush: true) do
@@ -37,6 +39,21 @@ module ApplicationHelper
       t('errors.error_summary.heading'),
       t('errors.error_summary.text')
     )
+  end
+
+  # New design error summary
+  def govuk_error_summary(form_object = @form_object)
+    # TODO: to be removed once not needed
+    content_for(:old_error_summary, '', flush: true)
+
+    # TODO: can be removed once we use this builder globally
+    options = {
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    }
+
+    fields_for(form_object, form_object, options) do |f|
+      f.govuk_error_summary t('errors.error_summary.heading')
+    end
   end
 
   def analytics_tracking_id

--- a/app/helpers/custom_form_helpers_v2.rb
+++ b/app/helpers/custom_form_helpers_v2.rb
@@ -1,0 +1,37 @@
+module CustomFormHelpersV2
+  delegate :t,
+           :current_c100_application,
+           :user_signed_in?, to: :@template
+
+  def continue_button(continue: :continue, save_and_continue: :save_and_continue)
+    if save_and_return_disabled?
+      submit_button(continue)
+    elsif user_signed_in?
+      submit_button(save_and_continue)
+    else
+      submit_button(continue) do
+        draft_button(:save_and_come_back_later, secondary: true)
+      end
+    end
+  end
+
+  private
+
+  def save_and_return_disabled?
+    current_c100_application.nil? || current_c100_application.screening?
+  end
+
+  def submit_button(i18n_key, opts = {}, &block)
+    govuk_submit t("helpers.submit.#{i18n_key}"), opts, &block
+  end
+
+  # Kind of hackish but `govuk_submit` does not currently accept `name` attribute
+  def draft_button(i18n_key, opts = {})
+    html = Nokogiri::HTML.fragment(
+      submit_button(i18n_key, opts)
+    ).at(:input)
+
+    html['name'] = 'commit_draft'
+    html.to_html.html_safe
+  end
+end

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -77,6 +77,9 @@
       </div>
     <% end %>
 
+    <%# TODO: to be removed once all views are migrated %>
+    <%= yield(:old_error_summary) %>
+
     <%= yield(:content) %>
   </main>
 </div>

--- a/app/views/steps/screener/postcode/edit.html.erb
+++ b/app/views/steps/screener/postcode/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= error_summary %>
+    <%= govuk_error_summary %>
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 

--- a/app/views/steps/screener/postcode/edit.html.erb
+++ b/app/views/steps/screener/postcode/edit.html.erb
@@ -1,19 +1,29 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <p><%=t '.lead_text' %></p>
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.text_field :children_postcodes, class: 'narrow' %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_text_field :children_postcodes, width: 10, autocomplete: 'postal-code' %>
 
       <%= f.continue_button %>
     <% end %>
 
-    <%=t '.unknown_postcode_html' %>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="explanations" data-ga-label="screener postcode">
+          <%=t '.details.summary' %>
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <%=t '.details.text_html' %>
+      </div>
+    </details>
   </div>
 </div>

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -1,5 +1,18 @@
+# New design system (`govuk_design_system_formbuilder`)
+#
+# For now we use this in an ad hoc basis specifying it as an argument to form_for
+# Once we've migrated all forms, we can set it globally here
+#
+# ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
+
+# Old design system (`govuk_elements_form_builder`)
 ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
 
-ActionView::Base.default_form_builder.class_eval do
+# We must maintain backwards compatibility until all forms are migrated
+GovukElementsFormBuilder::FormBuilder.class_eval do
   include CustomFormHelpers
+end
+
+GOVUKDesignSystemFormBuilder::FormBuilder.class_eval do
+  include CustomFormHelpersV2
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -912,16 +912,11 @@ en:
           page_title: Where the children live
           heading: Where do the children live?
           lead_text: Please tell us the postcode of the children you’re making this application about.
-          unknown_postcode_html: |
-            <details>
-              <summary>
-                <span class="summary" data-ga-category="explanations" data-ga-label="screener postcode">If you do not know where the children live</span>
-              </summary>
-              <div class="panel panel-border-narrow">
-                <p>You can use <a href="https://www.gov.uk/government/publications/form-c4-application-for-an-order-for-disclosure-of-a-childs-whereabouts" rel="external" target="_blank">form C4</a>
-                to apply for an order for someone to give a court information about where a child is.</p>
-              </div>
-            </details>
+          details:
+            summary: If you do not know where the children live
+            text_html: |
+              You can use <a href="https://www.gov.uk/government/publications/form-c4-application-for-an-order-for-disclosure-of-a-childs-whereabouts"
+              class="govuk-link" rel="external" target="_blank">form C4</a> to apply for an order for someone to give a court information about where a child is.
       error_but_continue:
         show:
           page_title: Where the children live

--- a/features/errors.feature
+++ b/features/errors.feature
@@ -6,11 +6,12 @@ Feature: Errors
   @happy_path
   Scenario: I don't fill out the postcode field
     Given I click the "Continue" button
+
     Then I should be on "/steps/screener/postcode"
     And Page has title "Error: Where the children live - Apply to court about child arrangements - GOV.UK"
-    And I should see "There is a problem on this page" in a "h2" element
-    And I should see a "Enter a full postcode, with or without a space" link to "#error_steps_screener_postcode_form_children_postcodes"
-        
+    And I should see "There is a problem on this page" in the error summary
+    And I should see a "Enter a full postcode, with or without a space" link to "#steps-screener-postcode-form-children-postcodes-field-error"
+
     Then I click the "Enter a full postcode, with or without a space" link
-    And I should see "Enter a full postcode, with or without a space" in the form label
-    And "#error_steps_screener_postcode_form_children_postcodes" has focus
+    And I should see "Enter a full postcode, with or without a space" error in the form
+    And "#steps_screener_postcode_form_children_postcodes" has focus

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -50,12 +50,12 @@ When(/^I pause for "([^"]*)" seconds$/) do |seconds|
 end
 
 # Errors
-When(/^I should see "([^"]*)" in a "([^"]*)" element/) do |text, element|
-  page.find(".error-summary > #{element}").has_content? text
+When(/^I should see "([^"]*)" in the error summary$/) do |text|
+  page.find("div.govuk-error-summary > h2").has_content? text
 end
 
-When(/^I should see "([^"]*)" in the form label/) do |text|
-  page.find("label > #error_message_steps_screener_postcode_form_children_postcodes").has_content? text
+When(/^I should see "([^"]*)" error in the form$/) do |text|
+  page.find("span.govuk-error-message").has_content? text
 end
 
 When(/^Page has title "([^"]*)"/) do |text|

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -44,21 +44,22 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe '#step_header' do
     let(:form_object) { double('Form object') }
 
-    it 'renders the expected content' do
-      expect(helper).to receive(:render).with(partial: 'layouts/step_header', locals: {path: '/foo/bar'}).and_return('foo')
+    # TODO: to be removed once not needed
+    before do
+      allow(helper).to receive(:content_for).with(:old_error_summary, any_args)
+    end
 
+    it 'renders the expected content' do
+      expect(helper).to receive(:render).with(partial: 'layouts/step_header', locals: {path: '/foo/bar'}).and_return('foobar')
       assign(:form_object, form_object)
-      expect(helper).to receive(:error_summary).with(form_object).and_return('bar')
 
       expect(helper.step_header).to eq('foobar')
     end
 
     context 'a specific path is provided' do
       it 'renders the back link with provided path' do
-        expect(helper).to receive(:render).with(partial: 'layouts/step_header', locals: {path: '/another/step'}).and_return('foo')
-
+        expect(helper).to receive(:render).with(partial: 'layouts/step_header', locals: {path: '/another/step'}).and_return('foobar')
         assign(:form_object, form_object)
-        expect(helper).to receive(:error_summary).with(form_object).and_return('bar')
 
         expect(helper.step_header(path: '/another/step')).to eq('foobar')
       end
@@ -102,6 +103,32 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(GovukElementsErrorsHelper).to receive(:error_summary)
         helper.error_summary(form_object)
         expect(title).to start_with('Error: A page')
+      end
+    end
+  end
+
+  describe '#govuk_error_summary' do
+    context 'when a form object without errors is given' do
+      let(:form_object) { BaseForm.new }
+
+      it 'returns nil' do
+        expect(helper.govuk_error_summary(form_object)).to be_nil
+      end
+    end
+
+    context 'when a form object with errors is given' do
+      let(:form_object) { BaseForm.new }
+
+      before do
+        form_object.errors.add(:base, :blank)
+      end
+
+      it 'returns the summary' do
+        expect(
+          helper.govuk_error_summary(form_object)
+        ).to eq(
+          '<div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title"><h2 id="error-summary-title" class="govuk-error-summary__title">There is a problem on this page</h2><div class="govuk-error-summary__body"><ul class="govuk-list govuk-error-summary__list"><li><a data-turbolinks="false" href="#base-form-base-field-error">Enter an answer</a></li></ul></div></div>'
+        )
       end
     end
   end

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -1,13 +1,18 @@
 require 'rails_helper'
 
 class TestHelper < ActionView::Base
+  #:nocov:
   def user_signed_in?
     false
   end
+  #:nocov:
 end
 
 # The module `CustomFormHelpers` gets mixed in and extends the helpers already
-# provided by `GovukElementsFormBuilder`. Refer to: `config/initializers/form_builder.rb`
+# provided by `GovukElementsFormBuilder::FormBuilder`. These are app-specific
+# form helpers so can be coupled to application business and logic.
+#
+# Refer to: `config/initializers/form_builder.rb`
 #
 RSpec.describe GovukElementsFormBuilder::FormBuilder do
   let(:helper) { TestHelper.new }

--- a/spec/helpers/custom_form_helpers_v2_spec.rb
+++ b/spec/helpers/custom_form_helpers_v2_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+class TestHelper < ActionView::Base
+  #:nocov:
+  def user_signed_in?
+    false
+  end
+  #:nocov:
+end
+
+# The module `CustomFormHelpersV2` gets mixed in and extends the helpers already
+# provided by `GOVUKDesignSystemFormBuilder::FormBuilder`. These are app-specific
+# form helpers so can be coupled to application business and logic.
+#
+# Refer to: `config/initializers/form_builder.rb`
+#
+RSpec.describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  let(:helper) { TestHelper.new }
+
+  describe '#continue_button' do
+    let(:c100_application) { C100Application.new(status: :in_progress) }
+    let(:builder) { described_class.new :applicant, Applicant.new, helper, {} }
+    let(:html_output) { builder.continue_button }
+
+    before do
+      allow(helper).to receive(:current_c100_application).and_return(c100_application)
+    end
+
+    context 'no c100 application yet' do
+      let(:c100_application) { nil }
+
+      it 'outputs the continue button' do
+        expect(
+          html_output
+        ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" /></div>')
+      end
+    end
+
+    context 'for an application in screening' do
+      let(:c100_application) { C100Application.new(status: :screening) }
+
+      it 'outputs the continue button' do
+        expect(
+          html_output
+        ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" /></div>')
+      end
+    end
+
+    context 'for a logged in user' do
+      before do
+        allow(helper).to receive(:user_signed_in?).and_return(true)
+      end
+
+      it 'outputs the save and continue button' do
+        expect(
+          html_output
+        ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Save and continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Save and continue" /></div>')
+      end
+
+      context 'with button value customised' do
+        let(:html_output) { builder.continue_button save_and_continue: :confirm_and_finish }
+
+        it 'outputs the custom value' do
+          expect(
+            html_output
+          ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Confirm and finish" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Confirm and finish" /></div>')
+        end
+      end
+    end
+
+    context 'for a logged out user' do
+      it 'outputs the continue button together with a save draft button' do
+        expect(
+          html_output
+        ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Continue" class="govuk-button govuk-!-margin-right-1" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" /><input type="submit" name="commit_draft" value="Save and come back later" class="govuk-button govuk-button--secondary" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Save and come back later"></div>')
+      end
+
+      context 'with button value customised' do
+        let(:html_output) { builder.continue_button continue: :confirm_and_finish }
+
+        it 'outputs the custom value' do
+          expect(
+            html_output
+          ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Confirm and finish" class="govuk-button govuk-!-margin-right-1" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Confirm and finish" /><input type="submit" name="commit_draft" value="Save and come back later" class="govuk-button govuk-button--secondary" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Save and come back later"></div>')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a first attempt to try to use DFE new design system form builder ([govuk_design_system_formbuilder](https://github.com/DFE-Digital/govuk_design_system_formbuilder)) to output form elements with new markup and classes.

First form migrated (children's postcode). As well as the continue buttons.

**Individual commits with more details.**

This is an alternative solution to the one tried in PR #837. I believe, it is early to say but we will be probably better using this builder as it contains all the basic elements and also revealing elements. It is yet to be seen if it will work just "out of the box" for some of our most complex forms/steps.

<img width="698" alt="Screen Shot 2020-03-24 at 16 09 31" src="https://user-images.githubusercontent.com/687910/77449672-26dcc980-6dea-11ea-946a-038471dea8a5.png">