### PR TITLE
Migrate screener pages and forms to new design system

### DIFF
--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -2,10 +2,6 @@ strong {
   font-weight: bold;
 }
 
-form {
-  padding-bottom: $gutter;
-}
-
 .form-submit + details,
 details + form {
   margin-top: $gutter;
@@ -42,12 +38,6 @@ details + form {
 
 address {
   font-style: normal;
-}
-
-.ellipses {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .actions {

--- a/app/views/steps/screener/done/show.en.html.erb
+++ b/app/views/steps/screener/done/show.en.html.erb
@@ -1,15 +1,12 @@
 <% title 'Screener completed' %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You’re eligible to apply online</h1>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">You're eligible to apply online</h1>
+    <p class="govuk-body-l">Based on your answers, you can use this online service.</p>
 
-    <p class="lede">Based on your answers, you can use this online service.</p>
-
-    <div class="xform-group form-submit">
-      <%= link_to 'Continue', entrypoint_v1_path, class: 'button', role: 'button' %>
-    </div>
+    <%= link_to 'Continue', entrypoint_v1_path, class: 'govuk-button', role: 'button', draggable: false, data: { module: 'govuk-button' } %>
   </div>
 </div>

--- a/app/views/steps/screener/email_consent/edit.html.erb
+++ b/app/views/steps/screener/email_consent/edit.html.erb
@@ -1,27 +1,36 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <div class="govuk-govspeak gv-s-prose">
-      <p><%=t '.lead_text' %></p>
-    </div>
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
-    <%= step_form @form_object do |f| %>
-    <%= f.radio_button_fieldset :email_consent, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
-          fieldset.radio_input(GenericYesNo::YES, panel_id: :email_address_panel)
-          fieldset.radio_input(GenericYesNo::NO)
-          fieldset.revealing_panel(:email_address_panel) do |panel|
-            panel.email_field :email_address
-          end
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%=
+        f.govuk_radio_buttons_fieldset(:email_consent) do
+          f.govuk_radio_button :email_consent, GenericYesNo::YES, label: { text: 'Yes' }, link_errors: true do
+            f.govuk_email_field :email_address, width: 'three-quarters', autocomplete: 'email', spellcheck: false
+          end.concat \
+          f.govuk_radio_button :email_consent, GenericYesNo::NO, label: { text: 'No' }
         end
-    %>
+      %>
 
       <%= f.continue_button %>
     <% end %>
-    <%=t '.consent_html' %>
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="explanations" data-ga-label="screener consent">
+          <%=t '.details.summary' %>
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <%=t '.details.text_html' %>
+      </div>
+    </details>
   </div>
 </div>

--- a/app/views/steps/screener/error_but_continue/show.html.erb
+++ b/app/views/steps/screener/error_but_continue/show.html.erb
@@ -1,12 +1,11 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
-
-    <p class="lede">
+    <p class="govuk-body-l">
       <%- if @courtfinder_ok %>
         <%= t '.lead_text.courtfinder_ok' %>
       <%- else %>
@@ -14,16 +13,11 @@
       <%- end %>
     </p>
 
-    <section id="what-to-do-now" class="moj-Section moj-Section--2" data-block-name="what-to-do-now">
-      <h2 class="gv-u-heading-xlarge"><%= t '.what_to_do_now.heading' %></h2>
-      <div class="Section__content govuk-govspeak gv-s-prose">
-        <p><%= t '.what_to_do_now.copy' %></p>
-      </div>
-    </section>
+    <h2 class="govuk-heading-l"><%= t '.what_to_do_now.heading' %></h2>
 
-    <div class="xform-group form-submit">
-      <%= link_to t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'button ga-pageLink', role: 'button', data: {ga_category: 'postcode error', ga_label: 'paper form'} %>
-      <%= link_to t('.go_back'), '/steps/screener/postcode', class: 'button button-secondary', role: 'button' %>
-    </div>
+    <p class="govuk-body govuk-!-margin-bottom-6"><%= t '.what_to_do_now.copy' %></p>
+
+    <%= link_to t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'govuk-button govuk-!-margin-right-1 ga-pageLink', role: 'button', draggable: false, data: { module: 'govuk-button', ga_category: 'postcode error', ga_label: 'paper form' } %>
+    <%= link_to t('.go_back'), '/steps/screener/postcode', class: 'govuk-button govuk-button--secondary', role: 'button', draggable: false, data: { module: 'govuk-button' } %>
   </div>
 </div>

--- a/app/views/steps/screener/no_court_found/show.en.html.erb
+++ b/app/views/steps/screener/no_court_found/show.en.html.erb
@@ -1,20 +1,20 @@
 <% title 'Not eligible' %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Sorry, you cannot apply online</h1>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">
-      Sorry, you cannot apply online
-    </h1>
+    <p class="govuk-body-l">This service is only available in England and Wales.</p>
 
-    <p class="lede">This service is only available in England and Wales.</p>
+    <p class="govuk-body">
+      If your child or children live in Scotland or Northern Ireland, you will not be able to use this service to submit
+      your application.
+    </p>
 
-    <p>If your child or children live in Scotland or Northern Ireland, you will not be able to use this service to submit your application.</p>
-
-    <p>
+    <p class="govuk-body">
       If you think there’s been an error finding an appropriate court, you
-      can <%= link_to 'report the problem', about_contact_path, class: 'ga-pageLink', data: { ga_category: 'no court found', ga_label: 'contact' } %>.
+      can <%= link_to 'report the problem', about_contact_path, class: 'govuk-link ga-pageLink', data: { ga_category: 'no court found', ga_label: 'contact' } %>.
     </p>
 
     <%= render partial: '/steps/shared/screener_exit_actions' %>

--- a/app/views/steps/screener/parent/edit.html.erb
+++ b/app/views/steps/screener/parent/edit.html.erb
@@ -1,13 +1,12 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
-
-    <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :parent, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_radio_buttons :parent, GenericYesNo.values, :value, :to_s, inline: true, legend: { size: 'xl' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/parent_exit/show.html.erb
+++ b/app/views/steps/screener/parent_exit/show.html.erb
@@ -1,12 +1,11 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
-
-    <p class="lede"><%=t '.lead_text' %></p>
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
     <%= render partial: '/steps/shared/screener_exit_actions' %>
   </div>

--- a/app/views/steps/screener/warning/show.html.erb
+++ b/app/views/steps/screener/warning/show.html.erb
@@ -1,10 +1,10 @@
 <% title t('.page_title') %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <p>
+    <p class="govuk-body-l govuk-!-margin-bottom-6">
       <% if user_signed_in? %>
         <%=t '.lead_signed_in' %>
       <% else %>
@@ -12,9 +12,7 @@
       <% end %>
     </p>
 
-    <div class="form-submit">
-      <%= link_to t('.resume_link'), previous_step_path, class: 'button ga-pageLink', data: {ga_category: 'in progress warning', ga_label: 'resume application'} %>
-      <%= link_to t('.restart_link'), root_path(new: 'y'), class: 'button button-secondary ga-pageLink', data: {ga_category: 'in progress warning', ga_label: 'new application'} %>
-    </div>
+    <%= link_to t('.resume_link'), previous_step_path, class: 'govuk-button govuk-!-margin-right-1 ga-pageLink', role: 'button', draggable: false, data: { module: 'govuk-button', ga_category: 'in progress warning', ga_label: 'resume application' } %>
+    <%= link_to t('.restart_link'), root_path(new: 'y'), class: 'govuk-button govuk-button--secondary ga-pageLink', role: 'button', draggable: false, data: { module: 'govuk-button', ga_category: 'in progress warning', ga_label: 'new application' } %>
   </div>
 </div>

--- a/app/views/steps/screener/written_agreement/edit.html.erb
+++ b/app/views/steps/screener/written_agreement/edit.html.erb
@@ -1,19 +1,20 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <p class="lede gv-u-text-lede"><%=t '.lead_text_html' %></p>
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
-    <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
-      <p><%=t '.info_notice' %></p>
+    <div class="govuk-inset-text">
+      <%=t '.info_notice' %>
     </div>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :written_agreement, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_radio_buttons :written_agreement, GenericYesNo.values, :value, :to_s, inline: true %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/written_agreement_exit/show.html.erb
+++ b/app/views/steps/screener/written_agreement_exit/show.html.erb
@@ -1,12 +1,11 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
-
-    <p class="lede"><%=t '.lead_text' %></p>
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
     <%= render partial: '/steps/shared/screener_exit_actions', locals: { hide_cait_info: true } %>
   </div>

--- a/app/views/steps/shared/_screener_exit_actions.html.erb
+++ b/app/views/steps/shared/_screener_exit_actions.html.erb
@@ -1,14 +1,9 @@
-<section id="what-to-do-now" class="moj-Section moj-Section--2" data-block-name="what-to-do-now">
-  <h2 class="gv-u-heading-xlarge"><%= t '.what_to_do_now.heading' %></h2>
-  <div class="Section__content govuk-govspeak gv-s-prose">
-    <p><%= t '.what_to_do_now.copy' %></p>
-  </div>
-</section>
+<h2 class="govuk-heading-l"><%= t '.what_to_do_now.heading' %></h2>
 
-<div class="xform-group form-submit">
-  <%= link_to t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'button ga-pageLink', role: 'button', data: {ga_category: 'screener kickout', ga_label: 'paper form'} %>
-</div>
+<p class="govuk-body"><%= t '.what_to_do_now.copy' %></p>
+
+<%= link_to t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'govuk-button ga-pageLink', role: 'button', draggable: false, data: { module: 'govuk-button', ga_category: 'screener kickout', ga_label: 'paper form' } %>
 
 <% unless local_assigns.fetch(:hide_cait_info, false) %>
-  <p class="util_mt-large"><%=t '.cait_info_html' %></p>
+  <p class="govuk-body"><%=t '.cait_info_html' %></p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -934,7 +934,6 @@ en:
       parent:
         edit:
           page_title: Are you a parent of the child or children?
-          heading: Are you a parent of the child or children?
       parent_exit:
         show:
           page_title: Sorry, you’re not eligible to apply online
@@ -1498,6 +1497,10 @@ en:
       steps_solicitor_contact_details_form:
         address: Enter the full address including postcode
         dx_number: This is a secure document exchange system used by the legal profession
+
+    legend:
+      steps_screener_parent_form:
+        parent: Are you a parent of the child or children?
 
     submit:
       continue: Continue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -943,11 +943,7 @@ en:
         edit:
           page_title: Consent order
           heading: Do you have a signed draft court order you want the court to consider making legally binding?
-          lead_text_html: |
-            <div class="govuk-govspeak gv-s-prose">
-              <p>If you’ve made a decision about your child arrangements with the other parent (the respondent) you can ask the court to consider making it legally binding.</p>
-              <p>This is known as a consent order.</p>
-            </div>
+          lead_text: If you’ve made a decision about your child arrangements with the other parent (the respondent) you can ask the court to consider making it legally binding. This is known as a consent order.
           info_notice: |
             This question only applies to any new agreement. Do not include any previous agreements or orders the court may have made.
       written_agreement_exit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -956,21 +956,16 @@ en:
           page_title: Contact by email
           heading: Are you willing to be contacted by email about your experience using this service?
           lead_text: This will help us to improve the service, and your answer here will not affect whether or not you can use this service.
-          consent_html: |
-            <details>
-              <summary>
-                <span class="summary" data-ga-category="explanations" data-ga-label="screener consent">What happens if you choose to be contacted</span>
-              </summary>
-              <div class="panel panel-border-narrow">
-                <p>By choosing to be contacted by the Ministry of Justice (MOJ) you agree that your personal details and any information you give can be used by MOJ for research purposes.</p>
-                <h3 class="heading-small">The information we use</h3>
-                <p>MOJ can use any information you provide, including your name and contact information (such as your email address).</p>
-                <h3 class="heading-small">Why we use this information</h3>
-                <p>To get your thoughts on this service - for example, we might send you a satisfaction survey.</p>
-                <h3 class="heading-small">Data and your rights</h3>
-                <p>You can find out how long we keep your data, your rights and how to contact us in our <a href="/about/privacy_consent">privacy policy</a>.</p>
-              </div>
-            </details>
+          details:
+            summary: What happens if you choose to be contacted
+            text_html: |
+              <p class="govuk-body">By choosing to be contacted by the Ministry of Justice (MOJ) you agree that your personal details and any information you give can be used by MOJ for research purposes.</p>
+              <h3 class="govuk-heading-m">The information we use</h3>
+              <p class="govuk-body">MOJ can use any information you provide, including your name and contact information (such as your email address).</p>
+              <h3 class="govuk-heading-m">Why we use this information</h3>
+              <p class="govuk-body">To get your thoughts on this service - for example, we might send you a satisfaction survey.</p>
+              <h3 class="govuk-heading-m">Data and your rights</h3>
+              <p class="govuk-body">You can find out how long we keep your data, your rights and how to contact us in our <a href="/about/privacy_consent" class: "govuk-link">privacy policy</a>.</p>
       warning:
         show:
           page_title: Application in progress

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,7 +131,9 @@ en:
           heading: What to do now
           copy: To submit an application in England or Wales, you’ll need to complete the C100 paper form, print it and send it by post.
         download_c100_link: Download the form (PDF)
-        cait_info_html: Alternatively you can <a href="https://helpwithchildarrangements.service.justice.gov.uk" rel="external" target="_blank">read the child arrangements guide</a> to see if there’s a more suitable option than going to court.
+        cait_info_html: |
+          Alternatively you can <a href="https://helpwithchildarrangements.service.justice.gov.uk" class="govuk-link" rel="external"
+          target="_blank">read the child arrangements guide</a> to see if there’s a more suitable option than going to court.
       existing_names:
         remove_name: "Remove %{legend}"
     applicant:
@@ -996,7 +998,7 @@ en:
       privacy: Privacy
       terms_and_conditions: Terms and conditions
     phase_banner:
-      feedback_contact_html: This is a new service. <a href="/about/contact" class="govuk-link">Report a problem</a> and help improve it for others.
+      feedback_contact_html: This is a new service. <a href="/about/contact" class="govuk-link govuk-link--no-visited-state">Report a problem</a> and help improve it for others.
     current_user_menu:
       logout: Sign out
       change_password: Change password

--- a/features/screener.feature
+++ b/features/screener.feature
@@ -12,15 +12,15 @@ Feature: Screener
     And I click the "Continue" button
 
     Then I should see "Are you a parent of the child or children?"
-    And I choose "Yes"
+    And I choose "yes"
 
     Then I should see "Do you have a signed draft court order you want the court to consider making legally binding?"
-    And I choose "No"
+    And I choose "no"
 
     Then I should see "Are you willing to be contacted by email about your experience using this service?"
     And I choose "Yes" and fill in "Email address" with "smoketest@example.com"
 
-    Then I should see "You're eligible to apply online"
+    Then I should see "You’re eligible to apply online"
 
     And I click the "Continue" link
     Then I should see "Before you start your application"
@@ -66,7 +66,7 @@ Feature: Screener
     And I click the "Continue" button
 
     Then I should see "Are you a parent of the child or children?"
-    And I choose "No"
+    And I choose "no"
 
     Then I should see "Sorry, you’re not eligible to apply online"
     And I should see a "Download the form (PDF)" link to "https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf"


### PR DESCRIPTION
Individual commits for more details.

TODO: the gem does not automatically localise the radio labels. It needs to be passed as `label: { text: 'foobar' }` which is kind of annoying.
Probably we can raise a PR to improve this.

This and other issues will be discovered as we advance with the migration.