### PR TITLE
Improve radios localisation (using forked gem for now)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.6.5'
 
 gem 'devise', '~> 4.7.1'
 gem 'email_validator', '< 2.0.0'
-gem 'govuk_design_system_formbuilder', '~> 1.1'
+gem 'govuk_design_system_formbuilder', github: 'zheileman/govuk_design_system_formbuilder'
 gem 'govuk_elements_form_builder', '~> 1.3.1'
 gem 'govuk_elements_rails', '~> 3.0'
 gem 'govuk_frontend_toolkit', '< 8.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/zheileman/govuk_design_system_formbuilder.git
+  revision: 37a32bac0c4e7c27dc6bbfe2c530f2cc815e04fa
+  specs:
+    govuk_design_system_formbuilder (1.1.5)
+      actionview (>= 5.2)
+      activemodel (>= 5.2)
+      activesupport (>= 5.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -142,10 +151,6 @@ GEM
       activesupport (>= 4.2.0)
     gov_uk_date_fields (3.1.0)
       rails (>= 5.0)
-    govuk_design_system_formbuilder (1.1.5)
-      actionview (>= 5.2)
-      activemodel (>= 5.2)
-      activesupport (>= 5.2)
     govuk_elements_form_builder (1.3.1)
       govuk_elements_rails (>= 3.0.0)
       govuk_frontend_toolkit (< 9.0.0)
@@ -436,7 +441,7 @@ DEPENDENCIES
   dotenv-rails
   email_validator (< 2.0.0)
   gov_uk_date_fields (~> 3.1.0)
-  govuk_design_system_formbuilder (~> 1.1)
+  govuk_design_system_formbuilder!
   govuk_elements_form_builder (~> 1.3.1)
   govuk_elements_rails (~> 3.0)
   govuk_frontend_toolkit (< 8.0.0)

--- a/app/views/steps/screener/email_consent/edit.html.erb
+++ b/app/views/steps/screener/email_consent/edit.html.erb
@@ -12,10 +12,10 @@
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%=
         f.govuk_radio_buttons_fieldset(:email_consent) do
-          f.govuk_radio_button :email_consent, GenericYesNo::YES, label: { text: 'Yes' }, link_errors: true do
+          f.govuk_radio_button :email_consent, GenericYesNo::YES, link_errors: true do
             f.govuk_email_field :email_address, width: 'three-quarters', autocomplete: 'email', spellcheck: false
           end.concat \
-          f.govuk_radio_button :email_consent, GenericYesNo::NO, label: { text: 'No' }
+          f.govuk_radio_button :email_consent, GenericYesNo::NO
         end
       %>
 

--- a/app/views/steps/screener/parent/edit.html.erb
+++ b/app/views/steps/screener/parent/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_collection_radio_buttons :parent, GenericYesNo.values, :value, :to_s, inline: true, legend: { size: 'xl' } %>
+      <%= f.govuk_collection_radio_buttons :parent, GenericYesNo.values, :value, nil, inline: true, legend: { size: 'xl' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/written_agreement/edit.html.erb
+++ b/app/views/steps/screener/written_agreement/edit.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_collection_radio_buttons :written_agreement, GenericYesNo.values, :value, :to_s, inline: true %>
+      <%= f.govuk_collection_radio_buttons :written_agreement, GenericYesNo.values, :value, nil, inline: true %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1133,6 +1133,20 @@ en:
       # attending court redesign -- end
 
     label:
+      # begin screener
+      steps_screener_postcode_form:
+        children_postcodes: Postcode
+      steps_screener_parent_form:
+        parent:
+          <<: *YESNO
+      steps_screener_written_agreement_form:
+        written_agreement:
+          <<: *YESNO
+      steps_screener_email_consent_form:
+        email_address: Email address
+        email_consent:
+          <<: *YESNO
+      # end screener
       steps_shared_under_age_form:
         under_age: I understand I need to be represented by a litigation friend, and that my application won’t be processed until the court receives a certificate of suitability or copy of the court order appointing a litigation friend.
       steps_shared_relationship_form:
@@ -1370,10 +1384,6 @@ en:
         phone_number: Phone number
         fax_number: Fax number
         email: Email address
-      steps_screener_postcode_form:
-        children_postcodes: Postcode
-      steps_screener_email_consent_form:
-        email_address: Email address
       user:
         email: Your email address
         password: Choose password

--- a/features/screener.feature
+++ b/features/screener.feature
@@ -12,10 +12,10 @@ Feature: Screener
     And I click the "Continue" button
 
     Then I should see "Are you a parent of the child or children?"
-    And I choose "yes"
+    And I choose "Yes"
 
     Then I should see "Do you have a signed draft court order you want the court to consider making legally binding?"
-    And I choose "no"
+    And I choose "No"
 
     Then I should see "Are you willing to be contacted by email about your experience using this service?"
     And I choose "Yes" and fill in "Email address" with "smoketest@example.com"
@@ -66,7 +66,7 @@ Feature: Screener
     And I click the "Continue" button
 
     Then I should see "Are you a parent of the child or children?"
-    And I choose "no"
+    And I choose "No"
 
     Then I should see "Sorry, you’re not eligible to apply online"
     And I should see a "Download the form (PDF)" link to "https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf"


### PR DESCRIPTION
The label text for the radio options is now coming from the locales, as it used to be the case with our previous gem.

I've forked the repo and [made the improvement](https://github.com/zheileman/govuk_design_system_formbuilder/pull/1) but not yet raise a PR to the original repo until we advance enough with our migration to be sure it is working as expected and also because we might need to do the same with check boxes once we start using them.