### PR TITLE
Removes "Public Alpha" section from T&C

### DIFF
--- a/app/views/about/terms_and_conditions.en.html.erb
+++ b/app/views/about/terms_and_conditions.en.html.erb
@@ -25,16 +25,6 @@
       </section>
 
       <section class="moj-Section about-section" data-block-name="terms-conditions-phase">
-        <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Public alpha</h2>
-
-        <div class="Section__content govuk-govspeak gv-s-prose">
-          <p>This service is currently in ‘public alpha’. This means you’re looking at the first version of it.</p>
-          <p>Something that's in ‘public alpha’ isn’t open to everyone or may not work for everyone. We do this so we
-            can test and make improvements before releasing it to more people.</p>
-        </div>
-      </section>
-
-      <section class="moj-Section about-section" data-block-name="terms-conditions-phase">
         <h2 class="moj-Section__heading moj-Section__heading--2 gv-u-heading-xlarge">Information about you and your
           visits</h2>
 


### PR DESCRIPTION
There are a few services in public beta, and don't see any mention of what this
means - perhaps because services in public beta are assumed to be closer to a
'ongoing maintenance state'.

In which case there isn't really a clearly defined user need to provide info
about our internal development process.

This commit is just removing the paragraph concerning Public alpha without
replacing it with a correspondent one about public beta.