### PR TITLE
Updated Aldershot court

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ tags
 .env
 .env.test
 
+node_modules/
 public/assets/
 .DS_Store

--- a/config/court_slugs.yml
+++ b/config/court_slugs.yml
@@ -73,7 +73,7 @@
 - barrow-in-furness-county-court-and-family-court
 - birmingham-civil-and-family-justice-centre
 - basingstoke-county-court-and-family-court
-- aldershot-magistrates-court
+- aldershot-justice-centre
 - bournemouth-and-poole-county-court-and-family-court
 - weymouth-magistrates-court
 - brighton-county-court


### PR DESCRIPTION
The old page is no longer valid but there is a new slug for this court, so adding it to the service.

This fixes the failing smoke test.

Note: I've added to the .gitignore the `node_modules` as we are now using it (on develop branch) and could be commited by mistake when switching between branches.