### PR TITLE
Migrate attending court steps to new design system

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/zheileman/govuk_design_system_formbuilder.git
-  revision: c07008e25f4d21d90c73d759e426d5c973a54f1a
+  revision: ee9ccfd413026095d9b96c981d3bf71d581de7c3
   specs:
-    govuk_design_system_formbuilder (1.1.6)
+    govuk_design_system_formbuilder (1.1.7)
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
@@ -234,7 +234,7 @@ GEM
       mutant (~> 0.8.24)
       rspec-core (>= 3.4.0, < 4.0.0)
     nio4r (2.5.2)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     notifications-ruby-client (5.1.2)
       jwt (>= 1.5, < 3)

--- a/app/controllers/steps/attending_court/language_controller.rb
+++ b/app/controllers/steps/attending_court/language_controller.rb
@@ -10,6 +10,12 @@ module Steps
       def update
         update_and_advance(LanguageForm, as: :language)
       end
+
+      private
+
+      def additional_permitted_params
+        [language_options: []]
+      end
     end
   end
 end

--- a/app/controllers/steps/attending_court/special_arrangements_controller.rb
+++ b/app/controllers/steps/attending_court/special_arrangements_controller.rb
@@ -10,6 +10,12 @@ module Steps
       def update
         update_and_advance(SpecialArrangementsForm, as: :special_arrangements)
       end
+
+      private
+
+      def additional_permitted_params
+        [special_arrangements: []]
+      end
     end
   end
 end

--- a/app/controllers/steps/attending_court/special_assistance_controller.rb
+++ b/app/controllers/steps/attending_court/special_assistance_controller.rb
@@ -10,6 +10,12 @@ module Steps
       def update
         update_and_advance(SpecialAssistanceForm, as: :special_assistance)
       end
+
+      private
+
+      def additional_permitted_params
+        [special_assistance: []]
+      end
     end
   end
 end

--- a/app/forms/steps/attending_court/language_form.rb
+++ b/app/forms/steps/attending_court/language_form.rb
@@ -2,7 +2,7 @@ module Steps
   module AttendingCourt
     class LanguageForm < BaseForm
       include ArrangementsCheckBoxesForm
-      setup_attributes_for LanguageHelp, group_name: :language_options
+      setup_attributes_for LanguageHelp, attribute_name: :language_options
 
       # any other attributes
       attribute :language_interpreter_details, String

--- a/app/forms/steps/attending_court/special_arrangements_form.rb
+++ b/app/forms/steps/attending_court/special_arrangements_form.rb
@@ -2,16 +2,10 @@ module Steps
   module AttendingCourt
     class SpecialArrangementsForm < BaseForm
       include ArrangementsCheckBoxesForm
-      setup_attributes_for SpecialArrangements, group_name: :special_arrangements
+      setup_attributes_for SpecialArrangements, attribute_name: :special_arrangements
 
       # any other attributes
       attribute :special_arrangements_details, String
-
-      private
-
-      def additional_attributes_map
-        { special_arrangements_details: special_arrangements_details }
-      end
     end
   end
 end

--- a/app/forms/steps/attending_court/special_assistance_form.rb
+++ b/app/forms/steps/attending_court/special_assistance_form.rb
@@ -2,16 +2,10 @@ module Steps
   module AttendingCourt
     class SpecialAssistanceForm < BaseForm
       include ArrangementsCheckBoxesForm
-      setup_attributes_for SpecialAssistance, group_name: :special_assistance
+      setup_attributes_for SpecialAssistance, attribute_name: :special_assistance
 
       # any other attributes
       attribute :special_assistance_details, String
-
-      private
-
-      def additional_attributes_map
-        { special_assistance_details: special_assistance_details }
-      end
     end
   end
 end

--- a/app/views/steps/attending_court/intermediary/edit.html.erb
+++ b/app/views/steps/attending_court/intermediary/edit.html.erb
@@ -1,26 +1,22 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <p class="app__section_heading"><%=t '.section' %></p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
 
-    <div class="govuk-govspeak gv-s-prose">
-      <p><%= t '.lead_text' %></p>
-    </div>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_radio_buttons_fieldset(:intermediary_help, legend: { size: 'xl' }) do %>
+        <p class="govuk-body"><%= t('.lead_text') %></p>
 
-    <%= step_form @form_object do |f| %>
-      <%=
-        f.radio_button_fieldset :intermediary_help, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
-          fieldset.radio_input(GenericYesNo::YES, panel_id: :intermediary_help_panel)
-          fieldset.radio_input(GenericYesNo::NO)
-          fieldset.revealing_panel(:intermediary_help_panel) do |panel|
-            panel.text_area :intermediary_help_details, size: '40x4', class: 'form-control-3-4'
-          end
-        end
-      %>
+        <%= f.govuk_radio_button :intermediary_help, GenericYesNo::YES, link_errors: true do
+          f.govuk_text_area :intermediary_help_details
+        end %>
+
+        <%= f.govuk_radio_button :intermediary_help, GenericYesNo::NO %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/attending_court/language/edit.html.erb
+++ b/app/views/steps/attending_court/language/edit.html.erb
@@ -1,26 +1,24 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <p class="app__section_heading"><%=t '.section' %></p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
 
-    <%= step_form @form_object do |f| %>
-      <%=
-        f.check_box_fieldset :help_with_language, LanguageHelp.values do |fieldset|
-          fieldset.check_box_input(:language_interpreter) {
-            f.text_area :language_interpreter_details, size: '40x4', class: 'form-control-3-4'
-          }
-          fieldset.check_box_input(:sign_language_interpreter) {
-            f.text_area :sign_language_interpreter_details, size: '40x4', class: 'form-control-3-4'
-          }
-          fieldset.check_box_input(:welsh_language) {
-            f.text_area :welsh_language_details, size: '40x4', class: 'form-control-3-4'
-          }
-        end
-      %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_check_boxes_fieldset :language_options, legend: { size: 'xl' } do %>
+        <%= f.govuk_check_box :language_options, LanguageHelp::LANGUAGE_INTERPRETER.to_s do
+          f.govuk_text_area :language_interpreter_details
+        end %>
+        <%= f.govuk_check_box :language_options, LanguageHelp::SIGN_LANGUAGE_INTERPRETER.to_s do
+          f.govuk_text_area :sign_language_interpreter_details
+        end %>
+        <%= f.govuk_check_box :language_options, LanguageHelp::WELSH_LANGUAGE.to_s do
+          f.govuk_text_area :welsh_language_details
+        end %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/attending_court/special_arrangements/edit.html.erb
+++ b/app/views/steps/attending_court/special_arrangements/edit.html.erb
@@ -1,20 +1,24 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <p class="app__section_heading"><%=t '.section' %></p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <div class="govuk-govspeak gv-s-prose">
-      <p><%= t '.lead_text' %></p>
-      <p><%= t '.court_contact' %></p>
-    </div>
+    <p class="govuk-body-l"><%= t '.lead_text' %></p>
+    <p class="govuk-body"><%= t '.court_contact' %></p>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.check_box_fieldset :special_arrangements, SpecialArrangements.values %>
-      <%= f.text_area :special_arrangements_details, size: '40x4', class: 'form-control-3-4' %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_check_boxes_fieldset :special_arrangements do %>
+        <% SpecialArrangements.values.each do |name| %>
+          <%= f.govuk_check_box :special_arrangements, name.to_s %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_text_area :special_arrangements_details %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/attending_court/special_assistance/edit.html.erb
+++ b/app/views/steps/attending_court/special_assistance/edit.html.erb
@@ -1,15 +1,20 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <p class="app__section_heading"><%=t '.section' %></p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.check_box_fieldset :special_assistance, SpecialAssistance.values %>
-      <%= f.text_area :special_assistance_details, size: '40x4', class: 'form-control-3-4' %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_check_boxes_fieldset :special_assistance, legend: { size: 'xl' } do %>
+        <% SpecialAssistance.values.each do |name| %>
+          <%= f.govuk_check_box :special_assistance, name.to_s %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_text_area :special_assistance_details %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -813,12 +813,10 @@ en:
         edit:
           page_title: Language help
           section: *attending_court
-          heading: Does anyone in this application have special language requirements?
       intermediary:
         edit:
           page_title: Intermediary help
           section: *attending_court
-          heading: Does anyone in this application need an intermediary to help them in court?
           lead_text: An intermediary is appointed by the court to help people participate in court. For example, you may need an intermediary if you have a learning, mental or physical disability.
       special_arrangements:
         edit:
@@ -831,7 +829,6 @@ en:
         edit:
           page_title: Special assistance
           section: *attending_court
-          heading: Does anyone in this application need assistance or special facilities when attending court?
     # attending court redesign -- end
     international:
       resident:
@@ -1124,14 +1121,6 @@ en:
         dob_unknown_html: ""
       steps_application_declaration_form:
         declaration_signee_capacity_html: ""
-      # attending court redesign -- begin
-      steps_attending_court_language_form:
-        help_with_language: *one_of_the_people_needs
-      steps_attending_court_special_arrangements_form:
-        special_arrangements: *one_of_the_people_needs
-      steps_attending_court_special_assistance_form:
-        special_assistance: *one_of_the_people_needs
-      # attending court redesign -- end
 
     label:
       # begin screener
@@ -1190,29 +1179,32 @@ en:
         intermediary_help:
           <<: *YESNO
       # attending court redesign -- begin
+      steps_attending_court_intermediary_form:
+        intermediary_help_details: *provide_details
+        intermediary_help_options:
+          <<: *YESNO
       steps_attending_court_language_form:
-        language_interpreter: An interpreter
-        sign_language_interpreter: A sign language interpreter
-        welsh_language: To speak Welsh at a court hearing, or read court documents in Welsh
+        language_options_options:
+          language_interpreter: An interpreter
+          sign_language_interpreter: A sign language interpreter
+          welsh_language: To speak Welsh at a court hearing, or read court documents in Welsh
         language_interpreter_details: Give details of who needs an interpreter and the language they require (including dialect, if applicable)
         sign_language_interpreter_details: Give details of who needs a British Sign Language interpreter
         welsh_language_details: Give details of who needs to speak or read in Welsh
-      steps_attending_court_intermediary_form:
-        intermediary_help_details: *provide_details
-        intermediary_help:
-          <<: *YESNO
       steps_attending_court_special_arrangements_form:
-        separate_waiting_rooms: Separate waiting rooms
-        separate_entrance_exit: Separate exits and entrances
-        protective_screens: Protective screens - this needs to be approved by a judge
-        video_link: Video links - this needs to be approved by a judge
         special_arrangements_details: You can add more detail if neccessary
+        special_arrangements_options:
+          separate_waiting_rooms: Separate waiting rooms
+          separate_entrance_exit: Separate exits and entrances
+          protective_screens: Protective screens - this needs to be approved by a judge
+          video_link: Video links - this needs to be approved by a judge
       steps_attending_court_special_assistance_form:
-        hearing_loop: A hearing loop
-        braille_documents: Documents in Braille
-        advance_court_viewing: Advance viewing of the court
-        other_assistance: Other assistance or facilities
         special_assistance_details: You can add more detail if neccessary
+        special_assistance_options:
+          hearing_loop: A hearing loop
+          braille_documents: Documents in Braille
+          advance_court_viewing: Advance viewing of the court
+          other_assistance: Other assistance or facilities
       # attending court redesign -- end
       steps_application_payment_form:
         payment_type:
@@ -1505,12 +1497,24 @@ en:
       steps_solicitor_contact_details_form:
         address: Enter the full address including postcode
         dx_number: This is a secure document exchange system used by the legal profession
+      steps_attending_court_language_form:
+        language_options: *one_of_the_people_needs
+      steps_attending_court_special_arrangements_form:
+        special_arrangements: *one_of_the_people_needs
+      steps_attending_court_special_assistance_form:
+        special_assistance: *one_of_the_people_needs
 
     legend:
       steps_screener_parent_form:
         parent: Are you a parent of the child or children?
       steps_miam_child_protection_cases_form:
         child_protection_cases: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
+      steps_attending_court_intermediary_form:
+        intermediary_help: Does anyone in this application need an intermediary to help them in court?
+      steps_attending_court_language_form:
+        language_options: Does anyone in this application have special language requirements?
+      steps_attending_court_special_assistance_form:
+        special_assistance: Does anyone in this application need assistance or special facilities when attending court?
 
     submit:
       continue: Continue

--- a/spec/forms/steps/attending_court/language_form_spec.rb
+++ b/spec/forms/steps/attending_court/language_form_spec.rb
@@ -3,46 +3,33 @@ require 'spec_helper'
 RSpec.describe Steps::AttendingCourt::LanguageForm do
   let(:arguments) { {
     c100_application: c100_application,
-    language_interpreter: language_interpreter,
-    sign_language_interpreter: sign_language_interpreter,
-    welsh_language: welsh_language,
+    language_options: language_options,
     language_interpreter_details: language_interpreter_details,
     sign_language_interpreter_details: sign_language_interpreter_details,
     welsh_language_details: welsh_language_details,
   } }
 
-  let(:language_interpreter) { '1' }
+  let(:language_options) { ['language_interpreter'] }
   let(:language_interpreter_details) { 'details' }
-
-  let(:sign_language_interpreter) { '0' }
   let(:sign_language_interpreter_details) { 'details' }
-
-  let(:welsh_language) { '0' }
   let(:welsh_language_details) { 'details' }
 
   let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
-  let(:court_arrangement) {
-    CourtArrangement.new(
-      language_options: ['language_interpreter'],
-      language_interpreter_details: 'details',
-      sign_language_interpreter_details: '',
-      welsh_language_details: '',
-    )
-  }
+  let(:court_arrangement) { CourtArrangement.new }
 
   subject { described_class.new(arguments) }
 
-  describe 'custom getters override' do
+  describe 'custom query getter override' do
     it 'returns true if the attribute is in the list' do
-      expect(subject.language_interpreter).to eq(true)
+      expect(subject.language_interpreter?).to eq(true)
     end
 
     it 'returns false if the attribute is not in the list' do
-      expect(subject.sign_language_interpreter).to eq(false)
+      expect(subject.sign_language_interpreter?).to eq(false)
     end
 
     it 'returns false if the attribute is not in the list' do
-      expect(subject.welsh_language).to eq(false)
+      expect(subject.welsh_language?).to eq(false)
     end
   end
 
@@ -57,32 +44,32 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
 
     context 'validations' do
       context 'when `language_interpreter` is checked' do
-        let(:language_interpreter) { true }
+        let(:language_options) { ['language_interpreter'] }
         it { should validate_presence_of(:language_interpreter_details) }
       end
 
       context 'when `language_interpreter` is not checked' do
-        let(:language_interpreter) { false }
+        let(:language_options) { [] }
         it { should_not validate_presence_of(:language_interpreter_details) }
       end
 
       context 'when `sign_language_interpreter` is checked' do
-        let(:sign_language_interpreter) { true }
+        let(:language_options) { ['sign_language_interpreter'] }
         it { should validate_presence_of(:sign_language_interpreter_details) }
       end
 
       context 'when `sign_language_interpreter` is not checked' do
-        let(:sign_language_interpreter) { false }
+        let(:language_options) { [] }
         it { should_not validate_presence_of(:sign_language_interpreter_details) }
       end
 
       context 'when `welsh_language` is checked' do
-        let(:welsh_language) { true }
+        let(:language_options) { ['welsh_language'] }
         it { should validate_presence_of(:welsh_language_details) }
       end
 
       context 'when `welsh_language` is not checked' do
-        let(:welsh_language) { false }
+        let(:language_options) { [] }
         it { should_not validate_presence_of(:welsh_language_details) }
       end
     end
@@ -90,7 +77,7 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
     context 'when form is valid' do
       it 'saves the record' do
         expect(court_arrangement).to receive(:update).with(
-          language_options: [:language_interpreter],
+          language_options: ['language_interpreter'],
           language_interpreter_details: 'details',
           sign_language_interpreter_details: nil,
           welsh_language_details: nil,
@@ -101,22 +88,18 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
     end
 
     context 'ensure leftovers are deleted when deselecting a checkbox' do
-      let(:language_interpreter) { '0' }
-      let(:sign_language_interpreter) { '0' }
-      let(:welsh_language) { '0' }
       let(:language_interpreter_details) { nil }
       let(:sign_language_interpreter_details) { nil }
       let(:welsh_language_details) { nil }
 
       context '`language_interpreter` is not checked and `language_interpreter_details` is filled' do
-        let(:language_interpreter) { '0' }
+        let(:language_options) { ['sign_language_interpreter'] }
         let(:language_interpreter_details) { 'language_interpreter_details' }
-        let(:sign_language_interpreter) { '1' }
         let(:sign_language_interpreter_details) { 'sign_language_interpreter_details' }
 
         it 'saves the record' do
           expect(court_arrangement).to receive(:update).with(
-            language_options: [:sign_language_interpreter],
+            language_options: ['sign_language_interpreter'],
             language_interpreter_details: nil,
             sign_language_interpreter_details: 'sign_language_interpreter_details',
             welsh_language_details: nil,
@@ -127,14 +110,13 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
       end
 
       context '`sign_language_interpreter` is not checked and `sign_language_interpreter_details` is filled' do
-        let(:sign_language_interpreter) { '0' }
+        let(:language_options) { ['welsh_language'] }
         let(:sign_language_interpreter_details) { 'sign_language_interpreter_details' }
-        let(:welsh_language) { '1' }
         let(:welsh_language_details) { 'welsh_language_details' }
 
         it 'saves the record' do
           expect(court_arrangement).to receive(:update).with(
-            language_options: [:welsh_language],
+            language_options: ['welsh_language'],
             language_interpreter_details: nil,
             sign_language_interpreter_details: nil,
             welsh_language_details: 'welsh_language_details',
@@ -145,14 +127,13 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
       end
 
       context '`welsh_language` is not checked and `welsh_language_details` is filled' do
-        let(:welsh_language) { '0' }
+        let(:language_options) { ['language_interpreter'] }
         let(:welsh_language_details) { 'welsh_language_details' }
-        let(:language_interpreter) { '1' }
         let(:language_interpreter_details) { 'language_interpreter_details' }
 
         it 'saves the record' do
           expect(court_arrangement).to receive(:update).with(
-            language_options: [:language_interpreter],
+            language_options: ['language_interpreter'],
             language_interpreter_details: 'language_interpreter_details',
             sign_language_interpreter_details: nil,
             welsh_language_details: nil,

--- a/spec/forms/steps/attending_court/special_arrangements_form_spec.rb
+++ b/spec/forms/steps/attending_court/special_arrangements_form_spec.rb
@@ -3,23 +3,22 @@ require 'spec_helper'
 RSpec.describe Steps::AttendingCourt::SpecialArrangementsForm do
   let(:arguments) { {
     c100_application: c100_application,
-    video_link: '1',
-    separate_entrance_exit: '0',
+    special_arrangements: ['video_link'],
     special_arrangements_details: 'details',
   } }
 
   let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
-  let(:court_arrangement) { CourtArrangement.new(special_arrangements: ['video_link'], special_arrangements_details: 'details') }
+  let(:court_arrangement) { CourtArrangement.new }
 
   subject { described_class.new(arguments) }
 
-  describe 'custom getters override' do
+  describe 'custom query getter override' do
     it 'returns true if the attribute is in the list' do
-      expect(subject.video_link).to eq(true)
+      expect(subject.video_link?).to eq(true)
     end
 
     it 'returns false if the attribute is not in the list' do
-      expect(subject.separate_entrance_exit).to eq(false)
+      expect(subject.separate_entrance_exit?).to eq(false)
     end
   end
 
@@ -35,7 +34,7 @@ RSpec.describe Steps::AttendingCourt::SpecialArrangementsForm do
     context 'when form is valid' do
       it 'saves the record' do
         expect(court_arrangement).to receive(:update).with(
-          special_arrangements: [:video_link],
+          special_arrangements: ['video_link'],
           special_arrangements_details: 'details'
         ).and_return(true)
 

--- a/spec/forms/steps/attending_court/special_assistance_form_spec.rb
+++ b/spec/forms/steps/attending_court/special_assistance_form_spec.rb
@@ -3,23 +3,22 @@ require 'spec_helper'
 RSpec.describe Steps::AttendingCourt::SpecialAssistanceForm do
   let(:arguments) { {
     c100_application: c100_application,
-    hearing_loop: '1',
-    braille_documents: '0',
+    special_assistance: ['hearing_loop'],
     special_assistance_details: 'details',
   } }
 
   let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
-  let(:court_arrangement) { CourtArrangement.new(special_assistance: ['hearing_loop'], special_assistance_details: 'details') }
+  let(:court_arrangement) { CourtArrangement.new }
 
   subject { described_class.new(arguments) }
 
-  describe 'custom getters override' do
+  describe 'custom query getter override' do
     it 'returns true if the attribute is in the list' do
-      expect(subject.hearing_loop).to eq(true)
+      expect(subject.hearing_loop?).to eq(true)
     end
 
     it 'returns false if the attribute is not in the list' do
-      expect(subject.braille_documents).to eq(false)
+      expect(subject.braille_documents?).to eq(false)
     end
   end
 
@@ -35,7 +34,7 @@ RSpec.describe Steps::AttendingCourt::SpecialAssistanceForm do
     context 'when form is valid' do
       it 'saves the record' do
         expect(court_arrangement).to receive(:update).with(
-          special_assistance: [:hearing_loop],
+          special_assistance: ['hearing_loop'],
           special_assistance_details: 'details',
         ).and_return(true)
 

--- a/spec/helpers/custom_form_helpers_v2_spec.rb
+++ b/spec/helpers/custom_form_helpers_v2_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe GOVUKDesignSystemFormBuilder::FormBuilder do
       it 'outputs the continue button' do
         expect(
           html_output
-        ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" /></div>')
+        ).to eq('<input type="submit" name="commit" value="Continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" />')
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe GOVUKDesignSystemFormBuilder::FormBuilder do
       it 'outputs the continue button' do
         expect(
           html_output
-        ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" /></div>')
+        ).to eq('<input type="submit" name="commit" value="Continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" />')
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe GOVUKDesignSystemFormBuilder::FormBuilder do
       it 'outputs the save and continue button' do
         expect(
           html_output
-        ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Save and continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Save and continue" /></div>')
+        ).to eq('<input type="submit" name="commit" value="Save and continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Save and continue" />')
       end
 
       context 'with button value customised' do
@@ -63,7 +63,7 @@ RSpec.describe GOVUKDesignSystemFormBuilder::FormBuilder do
         it 'outputs the custom value' do
           expect(
             html_output
-          ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Confirm and finish" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Confirm and finish" /></div>')
+          ).to eq('<input type="submit" name="commit" value="Confirm and finish" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Confirm and finish" />')
         end
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe GOVUKDesignSystemFormBuilder::FormBuilder do
       it 'outputs the continue button together with a save draft button' do
         expect(
           html_output
-        ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Continue" class="govuk-button govuk-!-margin-right-1" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" /><input type="submit" name="commit_draft" value="Save and come back later" class="govuk-button govuk-button--secondary" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Save and come back later"></div>')
+        ).to eq('<input type="submit" name="commit" value="Continue" class="govuk-button govuk-!-margin-right-1" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" /><input type="submit" name="commit_draft" value="Save and come back later" class="govuk-button govuk-button--secondary" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Save and come back later">')
       end
 
       context 'with button value customised' do
@@ -81,7 +81,7 @@ RSpec.describe GOVUKDesignSystemFormBuilder::FormBuilder do
         it 'outputs the custom value' do
           expect(
             html_output
-          ).to eq('<div class="govuk-form-group"><input type="submit" name="commit" value="Confirm and finish" class="govuk-button govuk-!-margin-right-1" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Confirm and finish" /><input type="submit" name="commit_draft" value="Save and come back later" class="govuk-button govuk-button--secondary" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Save and come back later"></div>')
+          ).to eq('<input type="submit" name="commit" value="Confirm and finish" class="govuk-button govuk-!-margin-right-1" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Confirm and finish" /><input type="submit" name="commit_draft" value="Save and come back later" class="govuk-button govuk-button--secondary" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Save and come back later">')
         end
       end
     end


### PR DESCRIPTION
I've jumped ahead to almost the end of the journey in order to migrate this whole block of 4 questions involving mostly check boxes, as this let us test the gem in this scenario, with some check boxes revealing text areas.

Dramatically simplified the `ArrangementsCheckBoxesForm` concern as instead of separate attributes for each check box, we now use a single attribute to contain the selected check boxes.
This is so it works better with the new gem too.

<img width="715" alt="Screen Shot 2020-03-30 at 16 14 31" src="https://user-images.githubusercontent.com/687910/77929443-939c0c00-72a1-11ea-8532-45796ae39b56.png">
