### PR TITLE
Convert inline radios to stacked radios

### DIFF
--- a/app/forms/steps/screener/email_consent_form.rb
+++ b/app/forms/steps/screener/email_consent_form.rb
@@ -8,17 +8,6 @@ module Steps
       yes_no_attribute      :email_consent, reset_when_no: [:email_address]
       attribute             :email_address, NormalisedEmail
       validates             :email_address, email: true, if: -> { email_consent&.yes? }
-
-      private
-
-      def persist!
-        raise C100ApplicationNotFound unless c100_application
-
-        record_to_persist.update(
-          email_consent: email_consent,
-          email_address: email_address
-        )
-      end
     end
   end
 end

--- a/app/views/steps/miam/acknowledgement/edit.en.html.erb
+++ b/app/views/steps/miam/acknowledgement/edit.en.html.erb
@@ -79,7 +79,7 @@
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%=
-        f.govuk_check_boxes_fieldset :miam_acknowledgement do
+        f.govuk_check_boxes_fieldset :miam_acknowledgement, legend: { tag: 'h3' } do
           f.govuk_check_box(:miam_acknowledgement, true, multiple: false, link_errors: true)
         end
       %>

--- a/app/views/steps/miam/child_protection_cases/edit.html.erb
+++ b/app/views/steps/miam/child_protection_cases/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_collection_radio_buttons :child_protection_cases, GenericYesNo.values, :value, nil, inline: true, legend: { size: 'xl' } %>
+      <%= f.govuk_collection_radio_buttons :child_protection_cases, GenericYesNo.values, :value, nil, legend: { size: 'xl' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/email_consent/edit.html.erb
+++ b/app/views/steps/screener/email_consent/edit.html.erb
@@ -5,19 +5,17 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-
-    <p class="govuk-body-l"><%=t '.lead_text' %></p>
-
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%=
-        f.govuk_radio_buttons_fieldset(:email_consent) do
-          f.govuk_radio_button :email_consent, GenericYesNo::YES, link_errors: true do
-            f.govuk_email_field :email_address, width: 'three-quarters', autocomplete: 'email', spellcheck: false
-          end.concat \
-          f.govuk_radio_button :email_consent, GenericYesNo::NO
-        end
-      %>
+      <%= f.govuk_radio_buttons_fieldset(:email_consent, legend: { size: 'xl' }) do %>
+        <p class="govuk-body-l govuk-!-margin-top-3">
+          <%=t '.lead_text' %>
+        </p>
+
+        <%= f.govuk_radio_button :email_consent, GenericYesNo::YES, link_errors: true do %>
+          <%= f.govuk_email_field :email_address, width: 'three-quarters', autocomplete: 'email', spellcheck: false %>
+        <% end  %>
+        <%= f.govuk_radio_button :email_consent, GenericYesNo::NO %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/parent/edit.html.erb
+++ b/app/views/steps/screener/parent/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_collection_radio_buttons :parent, GenericYesNo.values, :value, nil, inline: true, legend: { size: 'xl' } %>
+      <%= f.govuk_collection_radio_buttons :parent, GenericYesNo.values, :value, nil, legend: { size: 'xl' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/written_agreement/edit.html.erb
+++ b/app/views/steps/screener/written_agreement/edit.html.erb
@@ -5,16 +5,16 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-
-    <p class="govuk-body-l"><%=t '.lead_text' %></p>
-
-    <div class="govuk-inset-text">
-      <%=t '.info_notice' %>
-    </div>
-
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_collection_radio_buttons :written_agreement, GenericYesNo.values, :value, nil, inline: true %>
+      <%= f.govuk_collection_radio_buttons :written_agreement, GenericYesNo.values, :value, nil, legend: { size: 'xl' } do %>
+        <p class="govuk-body-l govuk-!-margin-top-3">
+          <%=t '.lead_text' %>
+        </p>
+
+        <div class="govuk-inset-text">
+          <%=t '.info_notice' %>
+        </div>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/court_slugs.yml
+++ b/config/court_slugs.yml
@@ -36,7 +36,7 @@
 - barnsley-law-courts
 - lincoln-county-court-and-family-court
 - york-county-court-and-family-court
-- harrogate-magistrates-court-and-family-court
+- harrogate-justice-centre
 - scarborough-justice-centre
 - skipton-county-court-and-family-court
 - central-family-court
@@ -75,7 +75,7 @@
 - basingstoke-county-court-and-family-court
 - aldershot-justice-centre
 - bournemouth-and-poole-county-court-and-family-court
-- weymouth-magistrates-court
+- weymouth-combined-court
 - brighton-county-court
 - hastings-county-court-and-family-court
 - horsham-county-court-and-family-court

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -915,7 +915,6 @@ en:
       written_agreement:
         edit:
           page_title: Consent order
-          heading: Do you have a signed draft court order you want the court to consider making legally binding?
           lead_text: If you’ve made a decision about your child arrangements with the other parent (the respondent) you can ask the court to consider making it legally binding. This is known as a consent order.
           info_notice: |
             This question only applies to any new agreement. Do not include any previous agreements or orders the court may have made.
@@ -927,7 +926,6 @@ en:
       email_consent:
         edit:
           page_title: Contact by email
-          heading: Are you willing to be contacted by email about your experience using this service?
           lead_text: This will help us to improve the service, and your answer here will not affect whether or not you can use this service.
           details:
             summary: What happens if you choose to be contacted
@@ -1468,8 +1466,14 @@ en:
     legend:
       steps_screener_parent_form:
         parent: Are you a parent of the child or children?
+      steps_screener_written_agreement_form:
+        written_agreement: Do you have a signed draft court order you want the court to consider making legally binding?
+      steps_screener_email_consent_form:
+        email_consent: Are you willing to be contacted by email about your experience using this service?
       steps_miam_child_protection_cases_form:
         child_protection_cases: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
+      steps_miam_acknowledgement_form:
+        miam_acknowledgement: Attending a MIAM
       steps_attending_court_intermediary_form:
         intermediary_help: Does anyone in this application need an intermediary to help them in court?
       steps_attending_court_language_form:

--- a/spec/forms/steps/screener/email_consent_form_spec.rb
+++ b/spec/forms/steps/screener/email_consent_form_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Screener::EmailConsentForm do
-  let(:email_consent){ GenericYesNo::NO }
+  let(:email_consent){ GenericYesNo::YES }
   let(:email_address){ 'my.email@example.com' }
   let(:arguments) { {
     c100_application: c100_application,
@@ -45,12 +45,27 @@ RSpec.describe Steps::Screener::EmailConsentForm do
         end
       end
     end
-    it_behaves_like 'a has-one-association form',
-                    association_name: :screener_answers,
-                    expected_attributes: {
-                      email_consent: GenericYesNo::NO,
-                      email_address: 'my.email@example.com'
-                    }
 
+    context 'when answer is yes' do
+      let(:email_consent){ GenericYesNo::YES }
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :screener_answers,
+                      expected_attributes: {
+                        email_consent: GenericYesNo::YES,
+                        email_address: 'my.email@example.com'
+                      }
+    end
+
+    context 'when answer is no' do
+      let(:email_consent){ GenericYesNo::NO }
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :screener_answers,
+                      expected_attributes: {
+                        email_consent: GenericYesNo::NO,
+                        email_address: nil
+                      }
+    end
   end
 end


### PR DESCRIPTION
Radios that reveal content should never be inline, and instead must be stacked, as per issue clarification here:
https://github.com/DFE-Digital/govuk_design_system_formbuilder/issues/104

As having mixed inline and stacked radios for Yes-No question will be negative for users, from now on we will be using only stacked radios even if they don't reveal content, so there is consistency. We could re-evaluate this decision later on if design system introduces inline revealing elements.

<img width="677" alt="Screen Shot 2020-04-01 at 12 07 12" src="https://user-images.githubusercontent.com/687910/78130509-59517c80-7411-11ea-8b2b-c74d8590f9e6.png">

Some other minor amendments to comply with design system guidelines, like trying to incorporate the header into the fieldset legend where possible, and if not, provide a legend even if it is visually hidden.

For now we are not using visually hidden but in the MIAM acknowledgement I've made sure we have a legend in the fieldset (set to h3 as the default is h1).

A bit unrelated to this but I realised in the email consent form object we don't need the `#persist` method anymore as we are using the SingleQuestionForm and HasOneAssociationForm that provide this functionality for us automatically. Made sure the specs cover this as well.