### PR TITLE
Ensure no tampering with checkbox options

### DIFF
--- a/app/forms/concerns/arrangements_check_boxes_form.rb
+++ b/app/forms/concerns/arrangements_check_boxes_form.rb
@@ -10,6 +10,9 @@ module ArrangementsCheckBoxesForm
     def setup_attributes_for(value_object, attribute_name:)
       attribute attribute_name, Array[String]
 
+      # Ensure no tampering with the option values
+      validates attribute_name, checkbox_options: { valid_values: value_object.string_values }
+
       # Define the query method for each of the attributes
       # rubocop:disable Performance/HashEachMethods
       value_object.values.each do |name|

--- a/app/validators/checkbox_options_validator.rb
+++ b/app/validators/checkbox_options_validator.rb
@@ -1,0 +1,18 @@
+class CheckboxOptionsValidator < ActiveModel::EachValidator
+  def initialize(options)
+    super
+    @_valid_values = options.fetch(:valid_values)
+  end
+
+  def validate_each(record, attribute, value)
+    return unless value.is_a?(Array)
+
+    record.errors.add(attribute, :invalid) unless valid_values?(value)
+  end
+
+  private
+
+  def valid_values?(selected_options)
+    selected_options.all? { |value| @_valid_values.include?(value) }
+  end
+end

--- a/app/views/steps/attending_court/special_arrangements/edit.html.erb
+++ b/app/views/steps/attending_court/special_arrangements/edit.html.erb
@@ -6,15 +6,15 @@
     <%= govuk_error_summary %>
 
     <span class="govuk-caption-xl"><%=t '.section' %></span>
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-
-    <p class="govuk-body-l"><%= t '.lead_text' %></p>
-    <p class="govuk-body"><%= t '.court_contact' %></p>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_check_boxes_fieldset :special_arrangements do %>
-        <% SpecialArrangements.values.each do |name| %>
-          <%= f.govuk_check_box :special_arrangements, name.to_s %>
+      <%= f.govuk_check_boxes_fieldset :special_arrangements, legend: { size: 'xl' } do %>
+
+        <p class="govuk-body-l"><%= t '.lead_text' %></p>
+        <p class="govuk-body"><%= t '.court_contact' %></p>
+
+        <% SpecialArrangements.string_values.each do |name| %>
+          <%= f.govuk_check_box :special_arrangements, name %>
         <% end %>
       <% end %>
 

--- a/app/views/steps/attending_court/special_assistance/edit.html.erb
+++ b/app/views/steps/attending_court/special_assistance/edit.html.erb
@@ -9,8 +9,8 @@
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_check_boxes_fieldset :special_assistance, legend: { size: 'xl' } do %>
-        <% SpecialAssistance.values.each do |name| %>
-          <%= f.govuk_check_box :special_assistance, name.to_s %>
+        <% SpecialAssistance.string_values.each do |name| %>
+          <%= f.govuk_check_box :special_assistance, name %>
         <% end %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -797,7 +797,6 @@ en:
         edit:
           page_title: Special arrangements
           section: *attending_court
-          heading: Do you or the children need specific safety arrangements at court?
           lead_text: Not every court has the facilities listed here, and some need to be agreed by a judge, for example the use of protective screens.
           court_contact: The court will contact you to discuss safety arrangements before your hearing.
       special_assistance:
@@ -1478,6 +1477,8 @@ en:
         intermediary_help: Does anyone in this application need an intermediary to help them in court?
       steps_attending_court_language_form:
         language_options: Does anyone in this application have special language requirements?
+      steps_attending_court_special_arrangements_form:
+        special_arrangements: Do you or the children need specific safety arrangements at court?
       steps_attending_court_special_assistance_form:
         special_assistance: Does anyone in this application need assistance or special facilities when attending court?
 

--- a/spec/forms/steps/attending_court/language_form_spec.rb
+++ b/spec/forms/steps/attending_court/language_form_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe Steps::AttendingCourt::LanguageForm do
     end
 
     context 'validations' do
+      context 'invalid option is selected (tampering)' do
+        let(:language_options) { %w(language_interpreter foobar) }
+        it { expect(subject).to_not be_valid }
+      end
+
       context 'when `language_interpreter` is checked' do
         let(:language_options) { ['language_interpreter'] }
         it { should validate_presence_of(:language_interpreter_details) }

--- a/spec/forms/steps/attending_court/special_arrangements_form_spec.rb
+++ b/spec/forms/steps/attending_court/special_arrangements_form_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 RSpec.describe Steps::AttendingCourt::SpecialArrangementsForm do
   let(:arguments) { {
     c100_application: c100_application,
-    special_arrangements: ['video_link'],
+    special_arrangements: special_arrangements,
     special_arrangements_details: 'details',
   } }
+
+  let(:special_arrangements) { ['video_link'] }
 
   let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
   let(:court_arrangement) { CourtArrangement.new }
@@ -19,6 +21,13 @@ RSpec.describe Steps::AttendingCourt::SpecialArrangementsForm do
 
     it 'returns false if the attribute is not in the list' do
       expect(subject.separate_entrance_exit?).to eq(false)
+    end
+  end
+
+  context 'validations' do
+    context 'invalid option is selected (tampering)' do
+      let(:special_arrangements) { %w(video_link foobar) }
+      it { expect(subject).to_not be_valid }
     end
   end
 

--- a/spec/forms/steps/attending_court/special_assistance_form_spec.rb
+++ b/spec/forms/steps/attending_court/special_assistance_form_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 RSpec.describe Steps::AttendingCourt::SpecialAssistanceForm do
   let(:arguments) { {
     c100_application: c100_application,
-    special_assistance: ['hearing_loop'],
+    special_assistance: special_assistance,
     special_assistance_details: 'details',
   } }
+
+  let(:special_assistance) { ['hearing_loop'] }
 
   let(:c100_application) { instance_double(C100Application, court_arrangement: court_arrangement) }
   let(:court_arrangement) { CourtArrangement.new }
@@ -19,6 +21,13 @@ RSpec.describe Steps::AttendingCourt::SpecialAssistanceForm do
 
     it 'returns false if the attribute is not in the list' do
       expect(subject.braille_documents?).to eq(false)
+    end
+  end
+
+  context 'validations' do
+    context 'invalid option is selected (tampering)' do
+      let(:special_assistance) { %w(hearing_loop foobar) }
+      it { expect(subject).to_not be_valid }
     end
   end
 


### PR DESCRIPTION
In the attending to court steps, after the refactor to use the new design system, it was possible to pass unknown options to the form object, by editing the html of the form (tampering with it).

This PR introduces a simple validation so all selected options are validated against the valid expected values.

Also, updated the markup of the `special_arrangements` step so the heading is part of the legend as we did with the other steps, in line with the recommended design system guidelines.