### PR TITLE
Add helper to create links with button shape

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,6 +78,25 @@ module ApplicationHelper
     title ''
   end
 
+  def link_button(name, href, options = {})
+    html_options = {
+      class: 'govuk-button',
+      role: 'button',
+      draggable: false,
+      data: { module: 'govuk-button' },
+    }.merge(options) do |_key, old_value, new_value|
+      if new_value.is_a?(String) || new_value.is_a?(Array)
+        # For strings or array attributes, merge (union) both values
+        Array(old_value) | Array(new_value)
+      else
+        # For other attributes do not merge, override (i.e. draggable and data)
+        new_value
+      end
+    end
+
+    link_to name, href, html_options
+  end
+
   # Use this to feature-flag code that should only show in test environments
   def dev_tools_enabled?
     Rails.env.development? || %w[true yes 1].include?(ENV['DEV_TOOLS_ENABLED'])

--- a/app/views/entrypoint/how_long.en.html.erb
+++ b/app/views/entrypoint/how_long.en.html.erb
@@ -23,6 +23,6 @@
       delete any information after this time.
     </p>
 
-    <%= link_to 'Continue', edit_steps_miam_child_protection_cases_path, class: 'govuk-button govuk-!-margin-top-3', role: 'button', draggable: false, data: { module: 'govuk-button' } %>
+    <%= link_button 'Continue', edit_steps_miam_child_protection_cases_path, class: 'govuk-!-margin-top-3' %>
   </div>
 </div>

--- a/app/views/entrypoint/what_is_needed.en.html.erb
+++ b/app/views/entrypoint/what_is_needed.en.html.erb
@@ -37,6 +37,6 @@
       If you do not know all of the details you can still complete your application but it will take longer to process.
     </div>
 
-    <%= link_to 'Continue', entrypoint_how_long_path, class: 'govuk-button govuk-!-margin-top-3', role: 'button', draggable: false, data: { module: 'govuk-button' } %>
+    <%= link_button 'Continue', entrypoint_how_long_path, class: 'govuk-!-margin-top-3' %>
   </div>
 </div>

--- a/app/views/steps/miam/child_protection_info/show.en.html.erb
+++ b/app/views/steps/miam/child_protection_info/show.en.html.erb
@@ -1,18 +1,17 @@
 <% title 'Child protection info' %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You do not have to attend a MIAM</h1>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">You do not have to attend a MIAM</h1>
+    <p class="govuk-body-l">
+      As there are or have been safety concerns about the children, you do not have to attend a
+      <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr>.
+    </p>
 
-    <div class="govuk-govspeak gv-s-prose">
-      <p>As there are or have been safety concerns about the children, you do not have to attend a <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr>.</p>
-      <p>We will ask you about these concerns later in the application.</p>
-    </div>
+    <p class="govuk-body">We will ask you about these concerns later in the application.</p>
 
-    <div class="xform-group form-submit">
-      <%= link_to 'Continue', steps_safety_questions_start_path, class: 'button', role: 'button' %>
-    </div>
+    <%= link_button 'Continue', steps_safety_questions_start_path %>
   </div>
 </div>

--- a/app/views/steps/screener/done/show.en.html.erb
+++ b/app/views/steps/screener/done/show.en.html.erb
@@ -7,6 +7,6 @@
 
     <p class="govuk-body-l">Based on your answers, you can use this online service.</p>
 
-    <%= link_to 'Continue', entrypoint_v1_path, class: 'govuk-button', role: 'button', draggable: false, data: { module: 'govuk-button' } %>
+    <%= link_button 'Continue', entrypoint_v1_path %>
   </div>
 </div>

--- a/app/views/steps/screener/error_but_continue/show.html.erb
+++ b/app/views/steps/screener/error_but_continue/show.html.erb
@@ -17,7 +17,7 @@
 
     <p class="govuk-body govuk-!-margin-bottom-6"><%= t '.what_to_do_now.copy' %></p>
 
-    <%= link_to t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'govuk-button govuk-!-margin-right-1 ga-pageLink', role: 'button', draggable: false, data: { module: 'govuk-button', ga_category: 'postcode error', ga_label: 'paper form' } %>
-    <%= link_to t('.go_back'), '/steps/screener/postcode', class: 'govuk-button govuk-button--secondary', role: 'button', draggable: false, data: { module: 'govuk-button' } %>
+    <%= link_button t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'govuk-!-margin-right-1 ga-pageLink', data: { module: 'govuk-button', ga_category: 'postcode error', ga_label: 'paper form' } %>
+    <%= link_button t('.go_back'), '/steps/screener/postcode', class: 'govuk-button--secondary' %>
   </div>
 </div>

--- a/app/views/steps/screener/start/show.en.html.erb
+++ b/app/views/steps/screener/start/show.en.html.erb
@@ -27,7 +27,7 @@
         <% end %>
       </div>
 
-      <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-column-one-half govuk-!-margin-top-2">
         <%= link_to 'Or return to a saved application', new_user_session_path, class: 'govuk-link govuk-link--no-visited-state' %>
       </div>
     </div>

--- a/app/views/steps/screener/warning/show.html.erb
+++ b/app/views/steps/screener/warning/show.html.erb
@@ -12,7 +12,7 @@
       <% end %>
     </p>
 
-    <%= link_to t('.resume_link'), previous_step_path, class: 'govuk-button govuk-!-margin-right-1 ga-pageLink', role: 'button', draggable: false, data: { module: 'govuk-button', ga_category: 'in progress warning', ga_label: 'resume application' } %>
-    <%= link_to t('.restart_link'), root_path(new: 'y'), class: 'govuk-button govuk-button--secondary ga-pageLink', role: 'button', draggable: false, data: { module: 'govuk-button', ga_category: 'in progress warning', ga_label: 'new application' } %>
+    <%= link_button t('.resume_link'), previous_step_path, class: 'govuk-!-margin-right-1 ga-pageLink', data: { module: 'govuk-button', ga_category: 'in progress warning', ga_label: 'resume application' } %>
+    <%= link_button t('.restart_link'), root_path(new: 'y'), class: 'govuk-button--secondary ga-pageLink', data: { module: 'govuk-button', ga_category: 'in progress warning', ga_label: 'new application' } %>
   </div>
 </div>

--- a/app/views/steps/shared/_screener_exit_actions.html.erb
+++ b/app/views/steps/shared/_screener_exit_actions.html.erb
@@ -2,7 +2,7 @@
 
 <p class="govuk-body"><%= t '.what_to_do_now.copy' %></p>
 
-<%= link_to t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'govuk-button ga-pageLink', role: 'button', draggable: false, data: { module: 'govuk-button', ga_category: 'screener kickout', ga_label: 'paper form' } %>
+<%= link_button t('.download_c100_link'), 'https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf', class: 'ga-pageLink', data: { module: 'govuk-button', ga_category: 'screener kickout', ga_label: 'paper form' } %>
 
 <% unless local_assigns.fetch(:hide_cait_info, false) %>
   <p class="govuk-body"><%=t '.cait_info_html' %></p>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -196,6 +196,20 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#link_button' do
+    it 'builds the link markup styled as a button' do
+      expect(
+        helper.link_button('Continue', root_path)
+      ).to eq('<a class="govuk-button" role="button" draggable="false" data-module="govuk-button" href="/">Continue</a>')
+    end
+
+    it 'appends to the default attributes where possible, otherwise overwrite them' do
+      expect(
+        helper.link_button('Continue', root_path, class: 'ga-pageLink', draggable: true, data: { module: 'govuk-button', ga_category: 'category', ga_label: 'label' })
+      ).to eq('<a class="govuk-button ga-pageLink" role="button" draggable="true" data-module="govuk-button" data-ga-category="category" data-ga-label="label" href="/">Continue</a>')
+    end
+  end
+
   describe 'dev_tools_enabled?' do
     before do
       allow(Rails).to receive_message_chain(:env, :development?).and_return(development_env)


### PR DESCRIPTION
This is a very common use case and we are using it in many places (more to come with the migration).

The helper will output the expected markup and will simplify if we later on need to change the classes or something as ideally there will only be one place to touch.

It tries to be smart about overriding (or not) some attributes, to cope with most common combinations, but later on we could improve it if we need more complex use-cases.

Updated already migrated pages to use this helper.