### PR TITLE
Migrate first date form element (MIAM certification date)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/zheileman/govuk_design_system_formbuilder.git
-  revision: ee9ccfd413026095d9b96c981d3bf71d581de7c3
+  revision: f4bc4d3ad4ba1a2babe5f18483ac85e44cc93170
   specs:
     govuk_design_system_formbuilder (1.1.7)
       actionview (>= 5.2)
@@ -387,7 +387,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)

--- a/app/attributes/multi_param_date.rb
+++ b/app/attributes/multi_param_date.rb
@@ -1,0 +1,17 @@
+class MultiParamDate < Virtus::Attribute
+  #
+  # Used to coerce a Rails multi parameter date into a standard date.
+  # Works together with method `#normalise_date_attributes!`
+  # in `controllers/step_controller.rb`
+  #
+  def coerce(value)
+    return value unless value.is_a?(Array)
+
+    set_values = value.values_at(1, 2, 3) # index 0 not in use
+    return if set_values.any? { |num| num.nil? || num.zero? }
+
+    Date.new(*set_values)
+  rescue ArgumentError
+    nil
+  end
+end

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -12,7 +12,7 @@ class StepController < ApplicationController
   private
 
   def update_and_advance(form_class, opts = {})
-    hash = permitted_params(form_class).to_h
+    hash = extract_parameters(form_class)
     record = opts[:record]
 
     @next_step   = params[:next_step].presence
@@ -42,6 +42,12 @@ class StepController < ApplicationController
     end
   end
 
+  def extract_parameters(form_class)
+    normalise_date_attributes!(
+      permitted_params(form_class).to_h
+    )
+  end
+
   def permitted_params(form_class)
     params
       .fetch(form_class.model_name.singular, {})
@@ -65,6 +71,31 @@ class StepController < ApplicationController
 
       primitive.eql?(Date) ? %W[#{attr_name}_dd #{attr_name}_mm #{attr_name}_yyyy] : attr_name
     end.flatten
+  end
+
+  # Converts multi-param Rails date attributes to an array that can be coerced more easily.
+  # Uses the `(1i)` part to know the position in the array (index 0 being nil).
+  #
+  # Example: {'birth_date(1i)' => '2008', 'birth_date(2i)' => '11', 'birth_date(3i)' => '22'}
+  # will be converted to an array attribute named `birth_date` with values: [nil, 2008, 11, 22]
+  #
+  def normalise_date_attributes!(hash)
+    regex = /(?<name>.+)\((?<index>[1-3])i\)$/ # captures the attribute name and index (1 to 3)
+    new_hash = {}
+
+    hash.each do |key, value|
+      next unless key =~ regex
+
+      hash.delete(key)
+
+      name  = Regexp.last_match(:name)
+      index = Regexp.last_match(:index).to_i
+
+      new_hash[name] ||= []
+      new_hash[name][index] = value.to_i
+    end.merge!(
+      new_hash
+    )
   end
 
   def update_navigation_stack

--- a/app/forms/steps/miam/certification_date_form.rb
+++ b/app/forms/steps/miam/certification_date_form.rb
@@ -1,14 +1,9 @@
 module Steps
   module Miam
     class CertificationDateForm < BaseForm
-      include GovUkDateFields::ActsAsGovUkDate
-
-      attribute :miam_certification_date, Date
-
-      acts_as_gov_uk_date :miam_certification_date
+      attribute :miam_certification_date, MultiParamDate
 
       validates_presence_of :miam_certification_date
-
       validates :miam_certification_date, sensible_date: true
 
       private

--- a/app/views/steps/miam/attended/edit.html.erb
+++ b/app/views/steps/miam/attended/edit.html.erb
@@ -1,17 +1,14 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
-
-    <div class="govuk-govspeak gv-s-prose">
-      <%=t '.miam_info_html' %>
-    </div>
-
-    <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :miam_attended, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_radio_buttons :miam_attended, GenericYesNo.values, :value, nil do %>
+        <%=t '.miam_info_html' %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam/certification/edit.html.erb
+++ b/app/views/steps/miam/certification/edit.html.erb
@@ -1,15 +1,14 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
-
-    <div class="govuk-govspeak gv-s-prose"><%=t '.body_html' %></div>
-
-    <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :miam_certification, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_radio_buttons :miam_certification, GenericYesNo.values, :value, nil do %>
+        <p class="govuk-body"><%=t '.lead_text' %></p>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/miam/certification_date/edit.html.erb
+++ b/app/views/steps/miam/certification_date/edit.html.erb
@@ -1,20 +1,14 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
-
-    <div class="govuk-govspeak gv-s-prose">
-      <%=t '.body_html' %>
-    </div>
-
-    <%= step_form @form_object do |f| %>
-      <%= f.gov_uk_date_field :miam_certification_date,
-                              placeholders: true,
-                              legend_text: t('.heading'),
-                              form_hint_text: t('shared.form_elements.certification_date_hint') %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_date_field :miam_certification_date do %>
+        <p class="govuk-body"><%=t '.lead_text' %></p>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -8,6 +8,11 @@
 # Old design system (`govuk_elements_form_builder`)
 ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
 
+GOVUKDesignSystemFormBuilder.configure do |config|
+  config.default_legend_tag  = 'h1'
+  config.default_legend_size = 'xl'
+end
+
 # We must maintain backwards compatibility until all forms are migrated
 GovukElementsFormBuilder::FormBuilder.class_eval do
   include CustomFormHelpers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -522,10 +522,9 @@ en:
       attended:
         edit:
           page_title: MIAM attended
-          heading: Have you attended a MIAM?
           miam_info_html: |
-            <p>The <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> must have:</p>
-            <ul class="list list-bullet">
+            <p class="govuk-body">The <abbr title="Mediation Information and Assessment Meeting">MIAM</abbr> must have:</p>
+            <ul class="govuk-list govuk-list--bullet">
               <li>taken place within the past 4 months</li>
               <li>been about the same or a very similar issue about the children</li>
             </ul>
@@ -544,15 +543,11 @@ en:
       certification:
         edit:
           page_title: MIAM certification
-          heading: Have you got a document signed by the mediator?
-          body_html: |
-            <p>Your mediator should have signed a document confirming your MIAM attendance.
-            You may need to go back to the mediator and ask for a signed document if you don't have one.</p>
+          lead_text: Your mediator should have signed a document confirming your MIAM attendance. You may need to go back to the mediator and ask for a signed document if you don't have one.
       certification_date:
         edit:
           page_title: MIAM certification date
-          heading: When did you attend the MIAM?
-          body_html: <p>You can find the date at the bottom of the document your mediator signed.</p>
+          lead_text: You can find the date at the bottom of the document your mediator signed.
       certification_details:
         edit:
           page_title: MIAM certification details
@@ -935,7 +930,7 @@ en:
               <h3 class="govuk-heading-m">Why we use this information</h3>
               <p class="govuk-body">To get your thoughts on this service - for example, we might send you a satisfaction survey.</p>
               <h3 class="govuk-heading-m">Data and your rights</h3>
-              <p class="govuk-body">You can find out how long we keep your data, your rights and how to contact us in our <a href="/about/privacy_consent" class: "govuk-link">privacy policy</a>.</p>
+              <p class="govuk-body">You can find out how long we keep your data, your rights and how to contact us in our <a href="/about/privacy_consent" class="govuk-link">privacy policy</a>.</p>
       warning:
         show:
           page_title: Application in progress
@@ -1095,7 +1090,7 @@ en:
         declaration_signee_capacity_html: ""
 
     label:
-      # begin screener
+      # Screener steps
       steps_screener_postcode_form:
         children_postcodes: Postcode
       steps_screener_parent_form:
@@ -1108,10 +1103,18 @@ en:
         email_address: Email address
         email_consent_options:
           <<: *YESNO
-      # end screener
+
+      # MIAM steps
       steps_miam_child_protection_cases_form:
         child_protection_cases_options:
           <<: *YESNO
+      steps_miam_attended_form:
+        miam_attended_options:
+          <<: *YESNO
+      steps_miam_certification_form:
+        miam_certification_options:
+          <<: *YESNO
+
       steps_shared_under_age_form:
         under_age: I understand I need to be represented by a litigation friend, and that my application won’t be processed until the court receives a certificate of suitability or copy of the court order appointing a litigation friend.
       steps_shared_relationship_form:
@@ -1356,6 +1359,8 @@ en:
         current_password: We need your current password to confirm your changes
       steps_miam_child_protection_cases_form:
         child_protection_cases: These will often involve a local authority
+      steps_miam_certification_date_form:
+        miam_certification_date: For example, 31 3 2020
       steps_application_court_proceedings_form:
         proceedings_date: Add approximate date if unsure
         case_number: Leave blank if you don’t know
@@ -1463,16 +1468,27 @@ en:
         special_assistance: *one_of_the_people_needs
 
     legend:
+      # Screener steps
       steps_screener_parent_form:
         parent: Are you a parent of the child or children?
       steps_screener_written_agreement_form:
         written_agreement: Do you have a signed draft court order you want the court to consider making legally binding?
       steps_screener_email_consent_form:
         email_consent: Are you willing to be contacted by email about your experience using this service?
+
+      # MIAM steps
       steps_miam_child_protection_cases_form:
         child_protection_cases: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
       steps_miam_acknowledgement_form:
         miam_acknowledgement: Attending a MIAM
+      steps_miam_attended_form:
+        miam_attended: Have you attended a MIAM?
+      steps_miam_certification_form:
+        miam_certification: Have you got a document signed by the mediator?
+      steps_miam_certification_date_form:
+        miam_certification_date: When did you attend the MIAM?
+
+      # Attending court steps
       steps_attending_court_intermediary_form:
         intermediary_help: Does anyone in this application need an intermediary to help them in court?
       steps_attending_court_language_form:
@@ -1527,7 +1543,6 @@ en:
       dob_child_hint: For example, 31 3 2010
       order_issue: What date was it made?
       order_issue_hint: For example, 31 3 2015
-      certification_date_hint: For example, 25 9 2018
     cafcass:
       safety_title: Why do we need this information and what will we do with it?
       safety_content_html: |

--- a/spec/attributes/multi_param_date_spec.rb
+++ b/spec/attributes/multi_param_date_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe MultiParamDate do
+  subject { described_class.build(MultiParamDate) }
+
+  let(:coerced_value) { subject.coerce(value) }
+
+  describe 'when value is already a date' do
+    let(:value) { Date.yesterday }
+    it { expect(coerced_value).to eq(value) }
+  end
+
+  describe 'when value is `nil`' do
+    let(:value) { nil }
+    it { expect(coerced_value).to be_nil }
+  end
+
+  describe 'when value is an array' do
+    let(:date) { Date.new(2008, 11, 22) }
+
+    context 'and contains all needed parts' do
+      let(:value) { [nil, date.year, date.month, date.day] }
+      it { expect(coerced_value).to eq(date) }
+    end
+
+    context 'the parts do not represent a valid date (invalid month)' do
+      let(:value) { [nil, date.year, 13, date.day] }
+      it { expect(coerced_value).to be_nil }
+    end
+
+    context 'the parts do not represent a valid date (invalid day)' do
+      let(:value) { [nil, date.year, date.month, 32] }
+      it { expect(coerced_value).to be_nil }
+    end
+
+    context 'any part is missing (zero)' do
+      let(:value) { [nil, date.year, 0, date.day] }
+      it { expect(coerced_value).to be_nil }
+    end
+
+    context 'any part is missing (nil)' do
+      let(:value) { [nil, date.year, date.month, nil] }
+      it { expect(coerced_value).to be_nil }
+    end
+  end
+end

--- a/spec/controllers/step_controller_spec.rb
+++ b/spec/controllers/step_controller_spec.rb
@@ -75,4 +75,62 @@ RSpec.describe DummyStepController, type: :controller do
       end
     end
   end
+
+  # Note this method is private as it is used via another method but as the logic
+  # is quite self contained it makes sense to test it in isolation.
+  #
+  describe '#normalise_date_attributes!' do
+    let(:normalised_attributes) { subject.send(:normalise_date_attributes!, parameters) }
+    let(:extra_parameters) { { foo: 'bar', another: 'attribute' } }
+
+    context 'when there are not multi param dates' do
+      let(:parameters) { extra_parameters }
+
+      it 'returns the parameters as usual' do
+        expect(
+          normalised_attributes
+        ).to eq(extra_parameters)
+      end
+    end
+
+    context 'when there is a multi param date' do
+      let(:parameters) {
+        {'birth_date(1i)' => '2008', 'birth_date(2i)' => '11', 'birth_date(3i)' => '22'}.merge(extra_parameters)
+      }
+
+      it 'converts the date parts to an array' do
+        expect(
+          normalised_attributes
+        ).to eq({ 'birth_date' => [nil, 2008, 11, 22] }.merge(extra_parameters))
+      end
+    end
+
+    context 'when there is more than one multi param date and different part orders' do
+      let(:parameters) {
+        {
+          'birth_date(1i)' => '2008', 'birth_date(2i)' => '11', 'birth_date(3i)' => '22'
+        }.merge(
+          'miam_certification_date(3i)' => '25', 'miam_certification_date(2i)' => '12', 'miam_certification_date(1i)' => '2018'
+        ).merge(extra_parameters)
+      }
+
+      it 'converts the date parts to an array' do
+        expect(
+          normalised_attributes
+        ).to eq({ 'birth_date' => [nil, 2008, 11, 22], 'miam_certification_date' => [nil, 2018, 12, 25] }.merge(extra_parameters))
+      end
+    end
+
+    context 'when some part of the date is missing or not a number' do
+      let(:parameters) {
+        {'birth_date(1i)' => '', 'birth_date(2i)' => 'foobar', 'birth_date(3i)' => '22'}.merge(extra_parameters)
+      }
+
+      it 'converts the date parts to an array' do
+        expect(
+          normalised_attributes
+        ).to eq({ 'birth_date' => [nil, 0, 0, 22] }.merge(extra_parameters))
+      end
+    end
+  end
 end

--- a/spec/forms/steps/miam/certification_date_form_spec.rb
+++ b/spec/forms/steps/miam/certification_date_form_spec.rb
@@ -60,6 +60,23 @@ RSpec.describe Steps::Miam::CertificationDateForm do
           expect(subject.errors.added?(:miam_certification_date, :future)).to eq(true)
         end
       end
+
+      context 'casting the date from multi parameters' do
+        context 'when date is valid' do
+          let(:miam_certification_date) { [nil, 2008, 11, 22] }
+          it { expect(subject).to be_valid }
+        end
+
+        context 'when date is not valid' do
+          let(:miam_certification_date) { [nil, 18, 11, 22] } # 2-digits year (18)
+          it { expect(subject).not_to be_valid }
+        end
+
+        context 'when a part is missing (nil or zero)' do
+          let(:miam_certification_date) { [nil, 2008, 0, 22] }
+          it { expect(subject).not_to be_valid }
+        end
+      end
     end
 
     context 'when form is valid' do


### PR DESCRIPTION
This PR introduces the migration of the first date element found in the application, MIAM certification date (a couple other pages have been migrated to get there but it was just radio options and copy).

For the dates previously we were using a custom date gem `gov_uk_date_fields` that had the ability not only to produce the markup but also to send parameters and process this parameters.

Now, the new gem does not provide that functionality, it only renders the view element, so anything in the backend is up to us. Also, it sends the parameter in the Rails way for multi params (appending a suffix to the parameter name).

Still we are going to leave the old gem because the steps not yet migrated will continue using it but once we've migrated all the dates in the application we can remove the gem and some other code.

<img width="693" alt="Screen Shot 2020-04-03 at 11 53 30" src="https://user-images.githubusercontent.com/687910/78353320-c3992700-75a1-11ea-9d0b-7e18dcab22eb.png">

With errors:
<img width="686" alt="Screen Shot 2020-04-03 at 11 42 32" src="https://user-images.githubusercontent.com/687910/78353343-cbf16200-75a1-11ea-9e9f-cb05f55bd019.png">
