### PR TITLE
Default legend tag is h1 and size xl

### DIFF
--- a/app/views/steps/attending_court/intermediary/edit.html.erb
+++ b/app/views/steps/attending_court/intermediary/edit.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-xl"><%=t '.section' %></span>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_radio_buttons_fieldset(:intermediary_help, legend: { size: 'xl' }) do %>
+      <%= f.govuk_radio_buttons_fieldset :intermediary_help do %>
         <p class="govuk-body"><%= t('.lead_text') %></p>
 
         <%= f.govuk_radio_button :intermediary_help, GenericYesNo::YES, link_errors: true do

--- a/app/views/steps/attending_court/language/edit.html.erb
+++ b/app/views/steps/attending_court/language/edit.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-xl"><%=t '.section' %></span>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_check_boxes_fieldset :language_options, legend: { size: 'xl' } do %>
+      <%= f.govuk_check_boxes_fieldset :language_options do %>
         <%= f.govuk_check_box :language_options, LanguageHelp::LANGUAGE_INTERPRETER.to_s do
           f.govuk_text_area :language_interpreter_details
         end %>

--- a/app/views/steps/attending_court/special_arrangements/edit.html.erb
+++ b/app/views/steps/attending_court/special_arrangements/edit.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-xl"><%=t '.section' %></span>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_check_boxes_fieldset :special_arrangements, legend: { size: 'xl' } do %>
+      <%= f.govuk_check_boxes_fieldset :special_arrangements do %>
 
         <p class="govuk-body-l"><%= t '.lead_text' %></p>
         <p class="govuk-body"><%= t '.court_contact' %></p>

--- a/app/views/steps/attending_court/special_assistance/edit.html.erb
+++ b/app/views/steps/attending_court/special_assistance/edit.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-xl"><%=t '.section' %></span>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_check_boxes_fieldset :special_assistance, legend: { size: 'xl' } do %>
+      <%= f.govuk_check_boxes_fieldset :special_assistance do %>
         <% SpecialAssistance.string_values.each do |name| %>
           <%= f.govuk_check_box :special_assistance, name %>
         <% end %>

--- a/app/views/steps/miam/acknowledgement/edit.en.html.erb
+++ b/app/views/steps/miam/acknowledgement/edit.en.html.erb
@@ -79,7 +79,7 @@
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%=
-        f.govuk_check_boxes_fieldset :miam_acknowledgement, legend: { tag: 'h3' } do
+        f.govuk_check_boxes_fieldset :miam_acknowledgement, legend: { tag: 'h3', size: 's' } do
           f.govuk_check_box(:miam_acknowledgement, true, multiple: false, link_errors: true)
         end
       %>

--- a/app/views/steps/miam/child_protection_cases/edit.html.erb
+++ b/app/views/steps/miam/child_protection_cases/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_collection_radio_buttons :child_protection_cases, GenericYesNo.values, :value, nil, legend: { size: 'xl' } %>
+      <%= f.govuk_collection_radio_buttons :child_protection_cases, GenericYesNo.values, :value, nil %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/email_consent/edit.html.erb
+++ b/app/views/steps/screener/email_consent/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_radio_buttons_fieldset(:email_consent, legend: { size: 'xl' }) do %>
+      <%= f.govuk_radio_buttons_fieldset :email_consent do %>
         <p class="govuk-body-l govuk-!-margin-top-3">
           <%=t '.lead_text' %>
         </p>

--- a/app/views/steps/screener/parent/edit.html.erb
+++ b/app/views/steps/screener/parent/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_collection_radio_buttons :parent, GenericYesNo.values, :value, nil, legend: { size: 'xl' } %>
+      <%= f.govuk_collection_radio_buttons :parent, GenericYesNo.values, :value, nil %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/screener/written_agreement/edit.html.erb
+++ b/app/views/steps/screener/written_agreement/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_collection_radio_buttons :written_agreement, GenericYesNo.values, :value, nil, legend: { size: 'xl' } do %>
+      <%= f.govuk_collection_radio_buttons :written_agreement, GenericYesNo.values, :value, nil do %>
         <p class="govuk-body-l govuk-!-margin-top-3">
           <%=t '.lead_text' %>
         </p>


### PR DESCRIPTION
We do not need to set these manually now as we've defined the default configuration in `config/initializers/form_builder.rb`

For those pages where these defaults don't work we can still set the tag and size manually (like in the MIAM acknowledgement).