### PR TITLE
Migrate abduction journey steps

### DIFF
--- a/app/attributes/checkbox_boolean.rb
+++ b/app/attributes/checkbox_boolean.rb
@@ -1,0 +1,20 @@
+class CheckboxBoolean < Virtus::Attribute::Boolean
+  #
+  # Used to coerce checkboxes created with the new form builder
+  # `govuk_design_system_formbuilder`.
+  #
+  # This is considered a legacy, backwards-compatible workaround and
+  # once we finish migrating the application to the new design system
+  # we should get back to any form object making use of this and
+  # replace the checkbox attributes with a more standard way.
+  #
+  # The only thing it does is, as the attributes are sent wrapped in
+  # an array, extract the (only) element inside and let the original
+  # super class do the rest of the coercion.
+  #
+  def coerce(value)
+    super(
+      Array(value).first || false
+    )
+  end
+end

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -67,10 +67,19 @@ class StepController < ApplicationController
   def form_attribute_names(form_class)
     form_class.attribute_set.map do |attr|
       attr_name = attr.name
-      primitive = attr.primitive
+      attr_type = attr.type.to_s
 
-      primitive.eql?(Date) ? %W[#{attr_name}_dd #{attr_name}_mm #{attr_name}_yyyy] : attr_name
-    end.flatten
+      # TODO: to maintain backwards compatibility with old form builder gems
+      # Once we've migrated everything, we can simplify this
+      case attr_type
+      when 'Axiom::Types::Date'
+        %W[#{attr_name}_dd #{attr_name}_mm #{attr_name}_yyyy]
+      when 'Axiom::Types::Boolean'
+        [attr_name, attr_name => []]
+      else
+        attr_name
+      end
+    end
   end
 
   # Converts multi-param Rails date attributes to an array that can be coerced more easily.

--- a/app/forms/steps/abduction/passport_details_form.rb
+++ b/app/forms/steps/abduction/passport_details_form.rb
@@ -6,9 +6,9 @@ module Steps
       has_one_association :abduction_detail
 
       attribute :children_multiple_passports, YesNo
-      attribute :passport_possession_mother, Boolean
-      attribute :passport_possession_father, Boolean
-      attribute :passport_possession_other, Boolean
+      attribute :passport_possession_mother, CheckboxBoolean
+      attribute :passport_possession_father, CheckboxBoolean
+      attribute :passport_possession_other, CheckboxBoolean
       attribute :passport_possession_other_details, String
 
       validates_inclusion_of :children_multiple_passports, in: GenericYesNo.values

--- a/app/forms/steps/abduction/previous_attempt_details_form.rb
+++ b/app/forms/steps/abduction/previous_attempt_details_form.rb
@@ -20,7 +20,9 @@ module Steps
         raise C100ApplicationNotFound unless c100_application
 
         record_to_persist.update(
-          attributes_map
+          attributes_map.merge(
+            previous_attempt_agency_details: (previous_attempt_agency_details if previous_attempt_agency_involved.yes?)
+          )
         )
       end
     end

--- a/app/views/steps/abduction/children_have_passport/edit.html.erb
+++ b/app/views/steps/abduction/children_have_passport/edit.html.erb
@@ -1,13 +1,14 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :children_have_passport, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_radio_buttons :children_have_passport, GenericYesNo.values, :value, nil %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/abduction/international/edit.html.erb
+++ b/app/views/steps/abduction/international/edit.html.erb
@@ -1,18 +1,18 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :passport_office_notified, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
-
-      <div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
-        <p><%=t '.contact_info_html' %></p>
-      </div>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_radio_buttons :passport_office_notified, GenericYesNo.values, :value, nil do %>
+        <div class="govuk-inset-text">
+          <%=t '.contact_info' %>
+        </div>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/abduction/passport_details/edit.html.erb
+++ b/app/views/steps/abduction/passport_details/edit.html.erb
@@ -1,25 +1,23 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :children_multiple_passports, inline: true, choices: GenericYesNo.values %>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-      <%=
-        f.check_box_fieldset :passport_possesion, [
-          :passport_possession_mother, :passport_possession_father, :passport_possession_other
-        ] do |fieldset|
-          fieldset.check_box_input(:passport_possession_mother)
-          fieldset.check_box_input(:passport_possession_father)
-          fieldset.check_box_input(:passport_possession_other) {
-            f.text_area :passport_possession_other_details, size: '40x4', class: 'form-control-3-4'
-          }
-        end
-      %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_radio_buttons :children_multiple_passports, GenericYesNo.values, :value, nil, legend: { tag: 'span', size: 'm' } %>
+
+      <%= f.govuk_check_boxes_fieldset :passport_possession, legend: { tag: 'span', size: 'm' } do %>
+        <%= f.govuk_check_box :passport_possession_mother, true %>
+        <%= f.govuk_check_box :passport_possession_father, true %>
+        <%= f.govuk_check_box :passport_possession_other, true do
+          f.govuk_text_area :passport_possession_other_details
+        end %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/abduction/previous_attempt/edit.html.erb
+++ b/app/views/steps/abduction/previous_attempt/edit.html.erb
@@ -1,13 +1,14 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :previous_attempt, inline: true, choices: GenericYesNo.values, legend_options: { class: 'visually-hidden', text: t('.heading') } %>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_radio_buttons :previous_attempt, GenericYesNo.values, :value, nil %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/abduction/previous_attempt_details/edit.html.erb
+++ b/app/views/steps/abduction/previous_attempt_details/edit.html.erb
@@ -1,27 +1,23 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <div class="govuk-govspeak gv-s-prose">
-      <p><%=t '.lead_text' %></p>
-    </div>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.text_area :previous_attempt_details, size: '40x4', class: 'form-control-3-4', label_options: { class: 'visually-hidden' } %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_text_area :previous_attempt_details %>
 
-      <%=
-        f.radio_button_fieldset :previous_attempt_agency_involved, inline: true do |fieldset|
-          fieldset.radio_input(GenericYesNo::YES, panel_id: :agency_involved_panel)
-          fieldset.radio_input(GenericYesNo::NO)
-          fieldset.revealing_panel(:agency_involved_panel) do |panel|
-            panel.text_area :previous_attempt_agency_details, size: '40x4', class: 'form-control-3-4'
-          end
-        end
-      %>
+      <%= f.govuk_radio_buttons_fieldset :previous_attempt_agency_involved, legend: { tag: 'span', size: 'm' } do %>
+        <%= f.govuk_radio_button :previous_attempt_agency_involved, GenericYesNo::YES, link_errors: true do
+          f.govuk_text_area :previous_attempt_agency_details
+        end %>
+
+        <%= f.govuk_radio_button :previous_attempt_agency_involved, GenericYesNo::NO %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/abduction/risk_details/edit.html.erb
+++ b/app/views/steps/abduction/risk_details/edit.html.erb
@@ -1,17 +1,18 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <div class=" govuk-govspeak gv-s-prose">
-      <%=t '.info_html' %>
-    </div>
-    <%= step_form @form_object do |f| %>
-      <%= f.text_area :risk_details, size: '40x4', class: 'form-control-3-4', label_options: { class: 'visually-hidden' } %>
-      <%= f.text_area :current_location, size: '40x4', class: 'form-control-3-4' %>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%=t '.info_html' %>
+
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|  %>
+      <%= f.govuk_text_area :risk_details, label: { hidden: true } %>
+      <%= f.govuk_text_area :current_location, label: { size: 's' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,32 +615,28 @@ en:
         edit:
           page_title: Do the children have a passport?
           section: Safety concerns
-          heading: Do any of the children have a passport?
       international:
         edit:
           page_title: Have the police been notified?
           section: Safety concerns
-          heading: Have the police been notified?
-          contact_info_html: If you think the children are at risk of being abducted abroad you should contact the police immediately.
+          contact_info: If you think the children are at risk of being abducted abroad you should contact the police immediately.
       previous_attempt:
         edit:
           page_title: Previous abduction attempts
           section: Safety concerns
-          heading: Have the children been abducted or kept outside the UK without your consent before?
       previous_attempt_details:
         edit:
           page_title: Previous abduction details
           section: Safety concerns
           heading: Provide details of the previous abductions
-          lead_text: Include any previous attempts or threats to abduct them.
       risk_details:
         edit:
           page_title: Abduction risk details
           section: Safety concerns
           heading: Why do you think the children may be abducted or kept outside the UK without your consent?
           info_html: |
-            <p>Briefly explain your concerns, including:</p>
-            <ul class="list list-bullet">
+            <p class="govuk-body">Briefly explain your concerns, including:</p>
+            <ul class="govuk-list govuk-list--bullet">
               <li>who might take them</li>
               <li>where they might be taken or kept</li>
             </ul>
@@ -1015,14 +1011,6 @@ en:
         orders_html: ""
         orders_prohibited_steps_html: ""
         orders_specific_issues_html: ""
-      steps_abduction_passport_details_form:
-        children_multiple_passports_html: "Do the children have more than one passport?"
-        passport_possesion_html: "Who is in possession of the children’s passports?"
-      steps_abduction_international_form:
-        children_multiple_passports_html: "Do the children have more than one passport?"
-        passport_possesion_html: "Who is in possession of the children’s passports?"
-      steps_abduction_previous_attempt_details_form:
-        previous_attempt_agency_involved_html: "Were the police, private investigators or any other organisation involved?"
       steps_abuse_concerns_contact_form:
         concerns_contact_type_html: "Do you agree to the children spending time with the other people in this application?"
         concerns_contact_other_html: "Do you agree to the other people in this application being in touch with the children in other ways?"
@@ -1123,6 +1111,32 @@ en:
           <<: *YESNO
       steps_safety_questions_other_abuse_form:
         other_abuse_options:
+          <<: *YESNO
+
+      # Abduction questions
+      steps_abduction_international_form:
+        passport_office_notified_options:
+          <<: *YESNO
+      steps_abduction_children_have_passport_form:
+        children_have_passport_options:
+          <<: *YESNO
+      steps_abduction_passport_details_form:
+        children_multiple_passports_options:
+          <<: *YESNO
+        passport_possession_mother_options:
+          'true': Mother
+        passport_possession_father_options:
+          'true': Father
+        passport_possession_other_options:
+          'true': Other
+        passport_possession_other_details: Provide more details
+      steps_abduction_previous_attempt_form:
+        previous_attempt_options:
+          <<: *YESNO
+      steps_abduction_previous_attempt_details_form:
+        previous_attempt_details: Give a short description of the previous abductions
+        previous_attempt_agency_details: Provide more details
+        previous_attempt_agency_involved_options:
           <<: *YESNO
 
       steps_shared_under_age_form:
@@ -1227,14 +1241,6 @@ en:
         orders_additional_details: Briefly provide more details
       steps_petition_protection_form:
         protection_orders_details: Please give details
-      steps_abduction_passport_details_form:
-        passport_possession_mother: Mother
-        passport_possession_father: Father
-        passport_possession_other: Other
-        passport_possession_other_details: Provide more details
-      steps_abduction_previous_attempt_details_form:
-        previous_attempt_details: Give a short description of the previous abductions
-        previous_attempt_agency_details: Provide more details
       steps_abduction_risk_details_form:
         risk_details: Briefly explain your concerns about abduction
         current_location: Where are the children now?
@@ -1391,10 +1397,11 @@ en:
       steps_application_submission_form:
         receipt_email: We’ll send a copy of your application to this email address. You can also download a copy on the confirmation page.
       steps_abduction_passport_details_form:
-        passport_possesion: *select_all_that_apply
+        passport_possession: *select_all_that_apply
       steps_abduction_risk_details_form:
         current_location: If they're outside England or Wales, include what country they're in and how long they've been there. You don't need to include any addresses.
       steps_abduction_previous_attempt_details_form:
+        previous_attempt_details: Include any previous attempts or threats to abduct them
         previous_attempt_agency_involved: Including in the UK or abroad
       steps_petition_orders_form:
         orders: *select_all_that_apply
@@ -1511,6 +1518,19 @@ en:
         domestic_abuse: Have you suffered or are you at risk of suffering domestic violence or abuse?
       steps_safety_questions_other_abuse_form:
         other_abuse: Do you have any other safety concerns about you or the children?
+
+      # Abduction questions
+      steps_abduction_international_form:
+        passport_office_notified: Have the police been notified?
+      steps_abduction_children_have_passport_form:
+        children_have_passport: Do any of the children have a passport?
+      steps_abduction_passport_details_form:
+        children_multiple_passports: Do the children have more than one passport?
+        passport_possession: Who is in possession of the children’s passports?
+      steps_abduction_previous_attempt_form:
+        previous_attempt: Have the children been abducted or kept outside the UK without your consent before?
+      steps_abduction_previous_attempt_details_form:
+        previous_attempt_agency_involved: Were the police, private investigators or any other organisation involved?
 
       # Attending court steps
       steps_attending_court_intermediary_form:

--- a/spec/attributes/checkbox_boolean_spec.rb
+++ b/spec/attributes/checkbox_boolean_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe CheckboxBoolean do
+  subject { described_class.build(CheckboxBoolean) }
+
+  let(:coerced_value) { subject.coerce(value) }
+
+  describe 'when value is `nil`' do
+    let(:value) { nil }
+    it { expect(coerced_value).to eq(false) }
+  end
+
+  describe 'when value is a string' do
+    context 'for a blank string' do
+      let(:value) { '' }
+      it { expect(coerced_value).to eq('') }
+    end
+
+    context 'for a `false` string' do
+      let(:value) { 'false' }
+      it { expect(coerced_value).to eq(false) }
+    end
+
+    context 'for a `true` string' do
+      let(:value) { 'true' }
+      it { expect(coerced_value).to eq(true) }
+    end
+
+    context 'for any other string' do
+      let(:value) { 'foobar' }
+      it { expect(coerced_value).to eq('foobar') }
+    end
+  end
+
+  describe 'when value is an array' do
+    let(:value) { ['true'] }
+    it { expect(coerced_value).to eq(true) }
+  end
+end

--- a/spec/forms/steps/abduction/previous_attempt_details_form_spec.rb
+++ b/spec/forms/steps/abduction/previous_attempt_details_form_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe Steps::Abduction::PreviousAttemptDetailsForm do
     c100_application: c100_application,
     previous_attempt_details: 'details',
     previous_attempt_agency_involved: previous_attempt_agency_involved,
-    previous_attempt_agency_details: nil
+    previous_attempt_agency_details: previous_attempt_agency_details,
   } }
 
   let(:c100_application) { instance_double(C100Application) }
-  let(:previous_attempt_agency_involved) { 'no' }
+  let(:previous_attempt_agency_involved) { 'yes' }
+  let(:previous_attempt_agency_details) { 'agency details' }
 
   subject { described_class.new(arguments) }
 
@@ -33,8 +34,22 @@ RSpec.describe Steps::Abduction::PreviousAttemptDetailsForm do
                     association_name: :abduction_detail,
                     expected_attributes: {
                       previous_attempt_details: 'details',
-                      previous_attempt_agency_involved: GenericYesNo::NO,
-                      previous_attempt_agency_details: nil
+                      previous_attempt_agency_involved: GenericYesNo::YES,
+                      previous_attempt_agency_details: 'agency details'
                     }
+
+    # Mutant killer
+    context 'when `previous_attempt_agency_involved` is NO and `previous_attempt_agency_details` is filled' do
+      let(:previous_attempt_agency_involved) { GenericYesNo::NO }
+      let(:previous_attempt_agency_details) { 'blah blah' }
+
+      it_behaves_like 'a has-one-association form',
+                      association_name: :abduction_detail,
+                      expected_attributes: {
+                        previous_attempt_details: 'details',
+                        previous_attempt_agency_involved: GenericYesNo::NO,
+                        previous_attempt_agency_details: nil
+                      }
+    end
   end
 end


### PR DESCRIPTION
This is a sub-journey of the safety questions. If you answer YES to the abduction question, then you enter this set of questions.

Again the way we built the checkboxes originally (with the old gem) is now kicking us back, as the new gem will not POST/PUT single values like true/false but array of values like `["true"]`

In order to workaround this without having to do a big refactor, and also to maintain backwards compatibility with those steps not yet migrated, I've created a new attribute type, named `CheckboxBoolean` that essentially will extract the value from the array and use it to cast a boolean as before.

Once we've migrated all steps we should get back to these checkboxes and refactor to use the same approach we've used in the Attending Court steps (language, special arrangements, etc.)

<img width="604" alt="Screen Shot 2020-04-07 at 11 31 45" src="https://user-images.githubusercontent.com/687910/78659550-a3c87280-78c3-11ea-86ff-73de03ddb440.png">
