### PR TITLE
Migrated first page of MIAM exemptions (domestic)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/zheileman/govuk_design_system_formbuilder.git
-  revision: 2eb6ed2d3675c7d832735728395f425096f001b1
+  revision: c314f71abc09ce43f9e9798169f96a69c88e4eab
   specs:
     govuk_design_system_formbuilder (1.1.9)
       actionview (>= 5.2)
@@ -185,7 +185,7 @@ GEM
       railties (>= 4)
       request_store (~> 1.0)
     logstash-event (1.2.02)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -16,6 +16,16 @@ div.sentry-error-embed-wrapper p.powered-by {
   padding: 3px;
 }
 
+.app-list--lower-roman {
+  @extend %govuk-list--number;
+  list-style-type: lower-roman;
+}
+
+.app-list--lower-alpha {
+  @extend %govuk-list--number;
+  list-style-type: lower-alpha;
+}
+
 @import 'app/developer_tools';
 @import 'app/pros_cons';
 @import 'app/backoffice';

--- a/app/assets/stylesheets/local/lists.scss
+++ b/app/assets/stylesheets/local/lists.scss
@@ -1,18 +1,3 @@
-ul.buttons {
-  li {
-    margin-bottom: $gutter;
-  }
-}
-
-// Second level lists get circles instead of bullets
-li li {
-  list-style: circle;
-}
-// Third level lists get squares instead of bullets
-li li li {
-  list-style: square;
-}
-
 section.numbered-list h3 {
   margin-top: 0;
 }

--- a/app/controllers/steps/miam_exemptions/domestic_controller.rb
+++ b/app/controllers/steps/miam_exemptions/domestic_controller.rb
@@ -10,6 +10,12 @@ module Steps
       def update
         update_and_advance(DomesticForm, as: :domestic)
       end
+
+      private
+
+      def additional_permitted_params
+        [domestic: [], exemptions_collection: []]
+      end
     end
   end
 end

--- a/app/forms/concerns/miam_exemptions_check_boxes_form.rb
+++ b/app/forms/concerns/miam_exemptions_check_boxes_form.rb
@@ -1,0 +1,58 @@
+module MiamExemptionsCheckBoxesForm
+  extend ActiveSupport::Concern
+  include HasOneAssociationForm
+
+  included do
+    has_one_association :miam_exemption
+    validate :at_least_one_checkbox_validation
+  end
+
+  class_methods do
+    attr_accessor :attribute_name, :allowed_values
+
+    def setup_attributes_for(value_object, attribute_name:)
+      self.attribute_name = attribute_name
+      self.allowed_values = value_object.string_values
+
+      attribute attribute_name, Array[String]
+      attribute :exemptions_collection, Array[String]
+    end
+  end
+
+  # Custom getter and setter so we always have both attributes synced,
+  # as one attribute is the main categories and the other are subcategories.
+  # Needed to make the revealing check boxes work nice with errors, etc.
+  #
+  def exemptions_collection
+    super | public_send(self.class.attribute_name)
+  end
+
+  def exemptions_collection=(values)
+    super(Array(values) | Array(public_send(self.class.attribute_name)))
+  end
+
+  private
+
+  # We filter out `group_xxx` items, as the purpose of these are to present the exemptions
+  # in groups for the user to show/hide them, and are not really an exemption by itself.
+  #
+  def valid_options
+    selected_options.grep_v(/\Agroup_/)
+  end
+
+  def selected_options
+    exemptions_collection & self.class.allowed_values
+  end
+
+  def at_least_one_checkbox_validation
+    errors.add(self.class.attribute_name, :blank) unless valid_options.any?
+  end
+
+  def persist!
+    raise BaseForm::C100ApplicationNotFound unless c100_application
+
+    record_to_persist.update(
+      self.class.attribute_name => selected_options
+    )
+  end
+end

--- a/app/forms/steps/miam_exemptions/domestic_form.rb
+++ b/app/forms/steps/miam_exemptions/domestic_form.rb
@@ -1,9 +1,8 @@
 module Steps
   module MiamExemptions
     class DomesticForm < BaseForm
-      include MiamExemptionsForm
-
-      setup_attributes_for DomesticExemptions, group_name: :domestic
+      include MiamExemptionsCheckBoxesForm
+      setup_attributes_for DomesticExemptions, attribute_name: :domestic
     end
   end
 end

--- a/app/views/steps/miam_exemptions/domestic/edit.html.erb
+++ b/app/views/steps/miam_exemptions/domestic/edit.html.erb
@@ -1,54 +1,47 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <div class="govuk-govspeak gv-s-prose">
-      <p><%= t '.lead_text' %></p>
-    </div>
+    <p class="govuk-body-l"><%= t '.lead_text' %></p>
 
-    <div class="miam_exemptions or-block__shift">
-    <%= step_form @form_object do |f| %>
-      <%=
-        f.check_box_fieldset :domestic_exemptions, [
-          DomesticExemptions::GROUP_POLICE,
-          DomesticExemptions::GROUP_COURT,
-          DomesticExemptions::GROUP_SPECIALIST,
-          DomesticExemptions::GROUP_LOCAL_AUTHORITY,
-          DomesticExemptions::GROUP_DA_SERVICE,
-          DomesticExemptions::RIGHT_TO_REMAIN,
-          DomesticExemptions::FINANCIAL_ABUSE
-        ] do |fieldset|
-          fieldset.check_box_input(DomesticExemptions::GROUP_POLICE) {
-            f.check_box_fieldset :exemptions_group, DomesticExemptions::POLICE
-          }
-          fieldset.check_box_input(DomesticExemptions::GROUP_COURT) {
-            f.check_box_fieldset :exemptions_group, DomesticExemptions::COURT
-          }
-          fieldset.check_box_input(DomesticExemptions::GROUP_SPECIALIST) {
-            f.check_box_fieldset :exemptions_group, DomesticExemptions::SPECIALIST
-          }
-          fieldset.check_box_input(DomesticExemptions::GROUP_LOCAL_AUTHORITY) {
-            f.check_box_fieldset :exemptions_group, DomesticExemptions::LOCAL_AUTHORITY
-          }
-          fieldset.check_box_input(DomesticExemptions::GROUP_DA_SERVICE) {
-            f.check_box_fieldset :exemptions_group, DomesticExemptions::DA_SERVICE
-          }
-          fieldset.check_box_input(DomesticExemptions::RIGHT_TO_REMAIN)
-          fieldset.check_box_input(DomesticExemptions::FINANCIAL_ABUSE)
-        end
-      %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_check_boxes_fieldset :domestic, legend: { tag: 'span', size: 'm' } do %>
 
-      <p class="form-block or-block"><%=t '.or' %></p>
+        <%= f.govuk_check_box :domestic, DomesticExemptions::GROUP_POLICE.to_s, link_errors: true do %>
+          <%= f.govuk_collection_check_boxes :exemptions_collection, DomesticExemptions::POLICE, :to_s, :to_s %>
+        <% end %>
 
-      <%= f.single_check_box DomesticExemptions::DOMESTIC_NONE %>
+        <%= f.govuk_check_box :domestic, DomesticExemptions::GROUP_COURT.to_s do %>
+          <%= f.govuk_collection_check_boxes :exemptions_collection, DomesticExemptions::COURT, :to_s, :to_s %>
+        <% end %>
+
+        <%= f.govuk_check_box :domestic, DomesticExemptions::GROUP_SPECIALIST.to_s do %>
+          <%= f.govuk_collection_check_boxes :exemptions_collection, DomesticExemptions::SPECIALIST, :to_s, :to_s %>
+        <% end %>
+
+        <%= f.govuk_check_box :domestic, DomesticExemptions::GROUP_LOCAL_AUTHORITY.to_s do %>
+          <%= f.govuk_collection_check_boxes :exemptions_collection, DomesticExemptions::LOCAL_AUTHORITY, :to_s, :to_s %>
+        <% end %>
+
+        <%= f.govuk_check_box :domestic, DomesticExemptions::GROUP_DA_SERVICE.to_s do %>
+          <%= f.govuk_collection_check_boxes :exemptions_collection, DomesticExemptions::DA_SERVICE, :to_s, :to_s %>
+        <% end %>
+
+        <%= f.govuk_check_box :domestic, DomesticExemptions::RIGHT_TO_REMAIN.to_s %>
+        <%= f.govuk_check_box :domestic, DomesticExemptions::FINANCIAL_ABUSE.to_s %>
+
+        <%= f.govuk_radio_divider %>
+
+        <%= f.govuk_check_box :domestic, DomesticExemptions::DOMESTIC_NONE.to_s %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>
-    </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -989,9 +989,6 @@ en:
       steps_application_without_notice_details_form:
         without_notice_frustrate_html: Are you asking for a without notice hearing because the other person or people may do something that would obstruct the order you are asking for if they knew about the application?
         without_notice_impossible_html: Are you asking for a without notice hearing because there is literally no time to give notice of the application to the other person or people?
-      steps_miam_exemptions_domestic_form:
-        domestic_exemptions_html: "Do you have any of the following evidence of domestic violence or abuse?"
-        exemptions_group_html: ""
       steps_miam_exemptions_protection_form:
         protection_exemptions_html: "Do you confirm any of the following child protection concerns?"
       steps_miam_exemptions_urgency_form:
@@ -1478,8 +1475,6 @@ en:
         restraining_case_number: *order_case_number_hint
         injunctive_case_number: *order_case_number_hint
         undertaking_case_number: *order_case_number_hint
-      steps_miam_exemptions_domestic_form:
-        domestic_exemptions: *select_all_that_apply_or_none
       steps_miam_exemptions_protection_form:
         protection_exemptions: *select_all_that_apply_or_none
       steps_miam_exemptions_urgency_form:
@@ -1524,6 +1519,10 @@ en:
         miam_certification_date: When did you attend the MIAM?
       steps_miam_exemption_claim_form:
         miam_exemption_claim: Do you have a valid reason for not attending a MIAM?
+
+      # MIAM exemptions
+      steps_miam_exemptions_domestic_form:
+        domestic: Do you have any of the following evidence of domestic violence or abuse?
 
       # Safety questions
       steps_safety_questions_address_confidentiality_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -471,7 +471,7 @@ en:
 
         steps/miam_exemptions/domestic_form:
           attributes:
-            domestic_none:
+            domestic:
               blank: *blank_exemptions_error
         steps/miam_exemptions/protection_form:
           attributes:

--- a/config/locales/exemptions/en.yml
+++ b/config/locales/exemptions/en.yml
@@ -1,92 +1,44 @@
 en:
   dictionary:
+    select_all_that_apply: &select_all_that_apply "Select all that apply"
+    select_all_that_apply_or_none: &select_all_that_apply_or_none "Select all that apply or ‘None of these’"
     none_of_these: &none_of_these "None of these"
 
+    ### LABELS ###
     DOMESTIC_EXEMPTIONS: &DOMESTIC_EXEMPTIONS
       ## GROUP POLICE ##
-      group_police_html: |
-        <span class="heading-small gv-u-heading-small">The police have been involved</span>
-        <span class="form-hint">For example, you or the other people in this application (the respondents) have been arrested, cautioned, charged or convicted for domestic or child abuse offences.</span>
-      police_arrested_html: Evidence that a prospective party has been arrested for a relevant domestic violence offence
-      police_caution_html: Evidence of a relevant police caution for a domestic violence offence
-      police_ongoing_proceedings_html: Evidence of relevant criminal proceedings for a domestic violence offence which have not concluded
-      police_conviction_html: Evidence of a relevant conviction for a domestic violence offence
-      police_dvpn_html: A domestic violence protection notice issued under section 24 of the Crime and Security Act 2010 against a prospective party
+      group_police: The police have been involved
+      police_arrested: Evidence that a prospective party has been arrested for a relevant domestic violence offence
+      police_caution: Evidence of a relevant police caution for a domestic violence offence
+      police_ongoing_proceedings: Evidence of relevant criminal proceedings for a domestic violence offence which have not concluded
+      police_conviction: Evidence of a relevant conviction for a domestic violence offence
+      police_dvpn: A domestic violence protection notice issued under section 24 of the Crime and Security Act 2010 against a prospective party
       ## GROUP COURT ##
-      group_court_html: |
-        <span class="heading-small gv-u-heading-small">A court has already been involved</span>
-        <span class="form-hint">For example, a court has made an order relating to you, the other people in this application (the respondents) or somebody close to you or them in connection with domestic violence or abuse.</span>
-      court_bound_over_html: A court order binding a prospective party over in connection with a domestic violence offence
-      court_protective_injunction_html: A relevant protective injunction
-      court_undertaking_html: An undertaking given in England and Wales under section 46 or 63E of the Family Law Act 1996 (or given in Scotland or Northern Ireland in place of a protective injunction) by a prospective party, provided that a cross-undertaking relating to domestic violence was not given by another prospective party
-      court_finding_of_fact_html: A copy of a finding of fact, made in proceedings in the United Kingdom, that there has been domestic violence by a prospective party
-      court_expert_report_html: An expert report produced as evidence in proceedings in the United Kingdom for the benefit of a court or tribunal confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party
+      group_court: A court has already been involved
+      court_bound_over: A court order binding a prospective party over in connection with a domestic violence offence
+      court_protective_injunction: A relevant protective injunction
+      court_undertaking: An undertaking given in England and Wales under section 46 or 63E of the Family Law Act 1996 (or given in Scotland or Northern Ireland in place of a protective injunction) by a prospective party, provided that a cross-undertaking relating to domestic violence was not given by another prospective party
+      court_finding_of_fact: A copy of a finding of fact, made in proceedings in the United Kingdom, that there has been domestic violence by a prospective party
+      court_expert_report: An expert report produced as evidence in proceedings in the United Kingdom for the benefit of a court or tribunal confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party
       ## GROUP SPECIALIST ##
-      group_specialist_html: |
-        <span class="heading-small gv-u-heading-small">A letter confirms you or the other people in this application (the respondents) are or have been a victim of domestic violence or abuse</span>
-        <span class="form-hint">For example, a health professional or specialist has confirmed injuries that are or were a result of domestic violence or abuse.</span>
-      specialist_examination_html: |
-        <span class="labelLine">A letter or report from an appropriate health professional confirming that-<p></p>
-          <p>(i) that professional, or another appropriate health professional, has examined a prospective party in person; and</p>
-          <p>(ii) in the reasonable professional judgment of the author or the examining appropriate health professional, that prospective party has, or has had, injuries or a condition consistent with being a victim of domestic violence</p>
-        </span>
-      specialist_referral_html: |
-        <span class="labelLine">a letter or report from-<p></p>
-          <p>(i) the appropriate health professional who made the referral described below;</p>
-          <p>(ii) an appropriate health professional who has access to the medical records of the prospective party referred to below; or</p>
-          <p>(iii) the person to whom the referral described below was made; confirming that there was a referral by an appropriate health professional of a prospective party to a person who provides specialist support or assistance for victims of, or those at risk of, domestic violence</p>
-        </span>
+      group_specialist: A letter confirms you or the other people in this application (the respondents) are or have been a victim of domestic violence or abuse
+      specialist_examination: A letter or report from an appropriate health professional
+      specialist_referral: A letter or report confirming that there was a referral by an appropriate health professional of a prospective party to a person who provides specialist support or assistance for victims of, or those at risk of, domestic violence
       ## GROUP LOCAL AUTHORITY ##
-      group_local_authority_html: |
-        <span class="heading-small gv-u-heading-small">A letter from a local authority or other agency confirms a risk of harm</span>
-        <span class="form-hint">For example, a local authority or housing association has confirmed there is or has been a risk of domestic violence or abuse.</span>
-      local_authority_marac_html: A letter from any person who is a member of a multi-agency risk assessment conference (or other suitable local safeguarding forum) confirming that a prospective party, or a person with whom that prospective party is in a family relationship, is or has been at risk of harm from domestic violence by another prospective party
-      local_authority_la_ha_html: |
-        <span class="labelLine">A letter from an officer employed by a local authority or housing association (or their equivalent in Scotland or Northern Ireland) for the purpose of supporting tenants containing-<p></p>
-          <p>(i) a statement to the effect that, in their reasonable professional judgment, a person with whom a prospective party is or has been in a family relationship is, or is at risk of being, a victim of domestic violence by that prospective party;</p>
-          <p>(ii) a description of the specific matters relied upon to support that judgment; and</p>
-          <p>(iii) a description of the support they provided to the victim of domestic violence or the person at risk of domestic violence by that prospective party</p>
-        </span>
-      local_authority_public_authority_html: A letter from a public authority confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party (or a copy of that assessment)
+      group_local_authority: A letter from a local authority or other agency confirms a risk of harm
+      local_authority_marac: A letter from any person who is a member of a multi-agency risk assessment conference (or other suitable local safeguarding forum) confirming that a prospective party, or a person with whom that prospective party is in a family relationship, is or has been at risk of harm from domestic violence by another prospective party
+      local_authority_la_ha: A letter from an officer employed by a local authority or housing association (or their equivalent in Scotland or Northern Ireland) for the purpose of supporting tenants
+      local_authority_public_authority: A letter from a public authority confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party (or a copy of that assessment)
       ## GROUP DA SERVICE ##
-      group_da_service_html: |
-        <span class="heading-small gv-u-heading-small">You have a letter from a domestic violence or abuse support service, specialist or organisation</span>
-        <span class="form-hint">For example, an independent domestic violence or abuse adviser has confirmed support to you or the other people in this application (the respondents).</span>
-      da_service_idva_html: A letter from an independent domestic violence advisor confirming that they are providing support to a prospective party
-      da_service_isva_html: A letter from an independent sexual violence advisor confirming that they are providing support to a prospective party relating to sexual violence by another prospective party
-      da_service_organisation_html: |
-        <span class="labelLine">a letter which-<p></p>
-          <p>(i) is from an organisation providing domestic violence support services, or a registered charity, which letter confirms that it-</p>
-          <p>(a) is situated in England and Wales,</p>
-          <p>(b) has been operating for an uninterrupted period of six months or more; and</p>
-          <p>(c) provided a prospective party with support in relation to that person’s needs as a victim, or a person at risk, of domestic violence; and</p>
-          <p>(ii) contains-</p>
-          <p>(a) a statement to the effect that, in the reasonable professional judgment of the author of the letter, the prospective party is, or is at risk of being, a victim of domestic violence;</p>
-          <p>(b) a description of the specific matters relied upon to support that judgment;</p>
-          <p>(c) a description of the support provided to the prospective party; and</p>
-          <p>(d) a statement of the reasons why the prospective party needed that support;</p>
-        </span>
-      da_service_refuge_refusal_html: |
-        <span class="labelLine">A letter or report from an organisation providing domestic violence support services in the United Kingdom confirming-<p></p>
-          <p>(i) that a person with whom a prospective party is or was in a family relationship was refused admission to a refuge;</p>
-          <p>(ii) the date on which they were refused admission to the refuge; and</p>
-          <p>(iii) they sought admission to the refuge because of allegations of domestic violence by the prospective party referred to in paragraph (i)</p>
-        </span>
+      group_da_service: You have a letter from a domestic violence or abuse support service, specialist or organisation
+      da_service_idva: A letter from an independent domestic violence advisor confirming that they are providing support to a prospective party
+      da_service_isva: A letter from an independent sexual violence advisor confirming that they are providing support to a prospective party relating to sexual violence by another prospective party
+      da_service_organisation: A letter from an organisation providing domestic violence support services, or a registered charity
+      da_service_refuge_refusal: A letter or report from an organisation providing domestic violence support services in the United Kingdom
       ## RIGHT TO REMAIN ##
-      right_to_remain_html: |
-        <span class="heading-small gv-u-heading-small">You or any of the other people in this application (the respondents) have been granted indefinite leave to remain in the UK as a victim of domestic violence or abuse</span>
-        <span class="form-hint">A letter from the Home Office will have confirmed that the leave was granted under paragraph 289B of the Immigration Rules.</span>
+      right_to_remain: You or any of the other people in this application (the respondents) have been granted indefinite leave to remain in the UK as a victim of domestic violence or abuse
       ## FINANCIAL ABUSE ##
-      financial_abuse_html: |
-        <span class="heading-small gv-u-heading-small">You have evidence that you or the other people in this application (the respondents) have been, or are at risk of being, financially abused by the other</span>
-        <span class="form-hint">Financial abuse is a way of controlling someone being able to earn, spend or keep their own money. For example, preventing someone going to work, withholding money, or putting debts in someone else’s name.<p></p>
-        <p>Evidence could include:</p>
-        <ul class="list list-bullet">
-          <li>a copy of a credit card account, loan document or bank statements</li>
-          <li>a letter from a domestic violence support organisation</li>
-          <li>emails, text messages or a diary kept by the victim</li>
-        </ul>
-        </span>
+      financial_abuse: You have evidence that you or the other people in this application (the respondents) have been, or are at risk of being, financially abused by the other
       ## DOMESTIC NONE ##
       domestic_none: *none_of_these
 
@@ -180,10 +132,74 @@ en:
       ## MISC NONE ##
       misc_none: *none_of_these
 
+    ### HINTS ###
+    DOMESTIC_EXEMPTIONS_HINTS: &DOMESTIC_EXEMPTIONS_HINTS
+      group_police: For example, you or the other people in this application (the respondents) have been arrested, cautioned, charged or convicted for domestic or child abuse offences
+      group_court: For example, a court has made an order relating to you, the other people in this application (the respondents) or somebody close to you or them in connection with domestic violence or abuse
+      group_specialist: For example, a health professional or specialist has confirmed injuries that are or were a result of domestic violence or abuse
+      group_local_authority: For example, a local authority or housing association has confirmed there is or has been a risk of domestic violence or abuse
+      group_da_service: For example, an independent domestic violence or abuse adviser has confirmed support to you or the other people in this application (the respondents)
+      right_to_remain: A letter from the Home Office will have confirmed that the leave was granted under paragraph 289B of the Immigration Rules
+      financial_abuse_html: |
+        Financial abuse is a way of controlling someone being able to earn, spend or keep their own money. For example, preventing someone going to work, withholding money, or putting debts in someone else’s name. Evidence could include:
+        <ul class="govuk-list govuk-list--bullet govuk-hint govuk-!-margin-top-2">
+          <li>a copy of a credit card account, loan document or bank statements</li>
+          <li>a letter from a domestic violence support organisation</li>
+          <li>emails, text messages or a diary kept by the victim</li>
+        </ul>
+      specialist_examination_html: |
+        The letter or report must confirm:
+        <ol class="govuk-list app-list--lower-roman govuk-hint govuk-!-margin-top-2">
+          <li>that professional, or another appropriate health professional, has examined a prospective party in person; and</li>
+          <li>in the reasonable professional judgment of the author or the examining appropriate health professional, that prospective party has, or has had, injuries or a condition consistent with being a victim of domestic violence</li>
+        </ol>
+      specialist_referral_html: |
+        The letter or report must be from:
+        <ol class="govuk-list app-list--lower-roman govuk-hint govuk-!-margin-top-2">
+          <li>the appropriate health professional who made the referral;</li>
+          <li>an appropriate health professional who has access to the medical records of the prospective party referred to; or</li>
+          <li>the person to whom the referral was made</li>
+        </ol>
+      local_authority_la_ha_html: |
+        The letter must contain:
+        <ol class="govuk-list app-list--lower-roman govuk-hint govuk-!-margin-top-2">
+          <li>a statement to the effect that, in their reasonable professional judgment, a person with whom a prospective party is or has been in a family relationship is, or is at risk of being, a victim of domestic violence by that prospective party;</li>
+          <li>a description of the specific matters relied upon to support that judgment; and</li>
+          <li>a description of the support they provided to the victim of domestic violence or the person at risk of domestic violence by that prospective party</li>
+        </ol>
+      da_service_organisation_html: |
+        <ol class="govuk-list app-list--lower-roman govuk-hint govuk-!-margin-top-2">
+          <li>The letter confirms that it-
+            <ol class="govuk-list app-list--lower-alpha govuk-hint">
+              <li>is situated in England and Wales;</li>
+              <li>has been operating for an uninterrupted period of six months or more; and</li>
+              <li>provided a prospective party with support in relation to that person’s needs as a victim, or a person at risk, of domestic violence; and</li>
+            </ol>
+          </li>
+          <li>The letter contains-
+            <ol class="govuk-list app-list--lower-alpha govuk-hint">
+              <li>a statement to the effect that, in the reasonable professional judgment of the author of the letter, the prospective party is, or is at risk of being, a victim of domestic violence;</li>
+              <li>a description of the specific matters relied upon to support that judgment;</li>
+              <li>a description of the support provided to the prospective party; and</li>
+              <li>a statement of the reasons why the prospective party needed that support</li>
+            </ol>
+          </li>
+        </ol>
+      da_service_refuge_refusal_html: |
+        The letter or report must confirm:
+        <ol class="govuk-list app-list--lower-roman govuk-hint govuk-!-margin-top-2">
+          <li>that a person with whom a prospective party is or was in a family relationship was refused admission to a refuge;</li>
+          <li>the date on which they were refused admission to the refuge; and</li>
+          <li>they sought admission to the refuge because of allegations of domestic violence by the prospective party referred to in paragraph (i)</li>
+        </ol>
+
   helpers:
     label:
       steps_miam_exemptions_domestic_form:
-        <<: *DOMESTIC_EXEMPTIONS
+        domestic_options:
+          <<: *DOMESTIC_EXEMPTIONS
+        exemptions_collection_options:
+          <<: *DOMESTIC_EXEMPTIONS
       steps_miam_exemptions_protection_form:
         <<: *PROTECTION_EXEMPTIONS
       steps_miam_exemptions_urgency_form:
@@ -192,6 +208,16 @@ en:
         <<: *ADR_EXEMPTIONS
       steps_miam_exemptions_misc_form:
         <<: *MISC_EXEMPTIONS
+    hint:
+      shared:
+        select_all_that_apply: *select_all_that_apply
+        select_all_that_apply_or_none: *select_all_that_apply_or_none
+      steps_miam_exemptions_domestic_form:
+        domestic: *select_all_that_apply_or_none
+        domestic_options:
+          <<: *DOMESTIC_EXEMPTIONS_HINTS
+        exemptions_collection_options:
+          <<: *DOMESTIC_EXEMPTIONS_HINTS
 
   playback:
     exemptions_claimed:

--- a/spec/forms/steps/miam_exemptions/domestic_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/domestic_form_spec.rb
@@ -3,22 +3,18 @@ require 'spec_helper'
 RSpec.describe Steps::MiamExemptions::DomesticForm do
   let(:arguments) { {
     c100_application: c100_application,
-    police_conviction: '1',
-    specialist_examination: '0',
+    domestic: ['police_conviction'],
+    exemptions_collection: ['group_police'],
   } }
 
   let(:c100_application) { instance_double(C100Application, miam_exemption: miam_exemption_record) }
-  let(:miam_exemption_record) { MiamExemption.new(domestic: ['police_conviction']) }
+  let(:miam_exemption_record) { MiamExemption.new(domestic: %w(group_police police_conviction)) }
 
   subject { described_class.new(arguments) }
 
-  describe 'custom getters override' do
-    it 'returns true if the exemption is in the list' do
-      expect(subject.police_conviction).to eq(true)
-    end
-
-    it 'returns false if the exemption is not in the list' do
-      expect(subject.specialist_examination).to eq(false)
+  describe 'custom getter override' do
+    it 'returns all the exemptions in all attributes' do
+      expect(subject.exemptions_collection).to eq(%w(group_police police_conviction))
     end
   end
 
@@ -28,16 +24,6 @@ RSpec.describe Steps::MiamExemptions::DomesticForm do
 
       it 'raises an error' do
         expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
-      end
-    end
-
-    context 'when form is valid' do
-      it 'saves the record' do
-        expect(miam_exemption_record).to receive(:update).with(
-          domestic: [:police_conviction],
-        ).and_return(true)
-
-        expect(subject.save).to be(true)
       end
     end
 
@@ -53,7 +39,53 @@ RSpec.describe Steps::MiamExemptions::DomesticForm do
 
       it 'has a validation error' do
         expect(subject).to_not be_valid
-        expect(subject.errors[:domestic_none]).to_not be_empty
+        expect(subject.errors.added?(:domestic, :blank)).to eq(true)
+      end
+    end
+
+    context 'when invalid checkbox values are submitted' do
+      context 'in `domestic` attribute' do
+        let(:arguments) { {
+          c100_application: c100_application,
+          domestic: ['foobar'],
+        } }
+
+        it 'does not save the record' do
+          expect(miam_exemption_record).not_to receive(:update)
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:domestic, :blank)).to eq(true)
+        end
+      end
+
+      context 'in `exemptions_collection` attribute' do
+        let(:arguments) { {
+          c100_application: c100_application,
+          exemptions_collection: ['foobar'],
+        } }
+
+        it 'does not save the record' do
+          expect(miam_exemption_record).not_to receive(:update)
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:domestic, :blank)).to eq(true)
+        end
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(miam_exemption_record).to receive(:update).with(
+          domestic: %w(group_police police_conviction),
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
       end
     end
   end


### PR DESCRIPTION
This is a first attempt to migrate the MIAM exemptions.

It is in a working state although there is a refinement we should do at some point so if you select some exemptions inside a group (a checkbox revealing more check boxes) and then deselect the whole group and submit, the selected options inside said group should also be automatically de-selected and not saved to the database to avoid confusion to the user. **Note**: this is happening also in production, so any improvement is welcomed but not a regression per se.

In any case, other than that, I believe it is totally functional but a big refactor to the locales was needed. As well as another improvement to the gem here https://github.com/zheileman/govuk_design_system_formbuilder/pull/4

Problem with locales is, up until now we used the sames locales in the check boxes also for the MIAM playback page, and the check your answers and the PDF generation. We will need to adapt also this.

<img width="524" alt="Screen Shot 2020-04-15 at 13 14 02" src="https://user-images.githubusercontent.com/687910/79336101-0c929900-7f1b-11ea-9bcd-70e3e88329ae.png">
