### PR TITLE
Migrated second page of MIAM exemptions (protection)

### DIFF
--- a/app/controllers/steps/miam_exemptions/protection_controller.rb
+++ b/app/controllers/steps/miam_exemptions/protection_controller.rb
@@ -10,6 +10,12 @@ module Steps
       def update
         update_and_advance(ProtectionForm, as: :protection)
       end
+
+      private
+
+      def additional_permitted_params
+        [protection: []]
+      end
     end
   end
 end

--- a/app/forms/steps/miam_exemptions/protection_form.rb
+++ b/app/forms/steps/miam_exemptions/protection_form.rb
@@ -1,9 +1,8 @@
 module Steps
   module MiamExemptions
     class ProtectionForm < BaseForm
-      include MiamExemptionsForm
-
-      setup_attributes_for ProtectionExemptions, group_name: :protection
+      include MiamExemptionsCheckBoxesForm
+      setup_attributes_for ProtectionExemptions, attribute_name: :protection
     end
   end
 end

--- a/app/views/steps/miam_exemptions/protection/edit.html.erb
+++ b/app/views/steps/miam_exemptions/protection/edit.html.erb
@@ -1,22 +1,25 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <div class="miam_exemptions or-block__shift">
-    <%= step_form @form_object do |f| %>
-      <%= f.check_box_fieldset :protection_exemptions, ProtectionExemptions::AUTHORITY_INVOLVEMENT %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_check_boxes_fieldset :protection, legend: { tag: 'span', size: 'm' } do %>
 
-      <p class="form-block or-block"><%=t '.or' %></p>
+        <%= f.govuk_check_box :protection, ProtectionExemptions::AUTHORITY_INVOLVEMENT[0].to_s, link_errors: true %>
+        <%= f.govuk_check_box :protection, ProtectionExemptions::AUTHORITY_INVOLVEMENT[1].to_s %>
 
-      <%= f.single_check_box ProtectionExemptions::PROTECTION_NONE %>
+        <%= f.govuk_radio_divider %>
+
+        <%= f.govuk_check_box :protection, ProtectionExemptions::PROTECTION_NONE.to_s %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>
-    </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -989,8 +989,6 @@ en:
       steps_application_without_notice_details_form:
         without_notice_frustrate_html: Are you asking for a without notice hearing because the other person or people may do something that would obstruct the order you are asking for if they knew about the application?
         without_notice_impossible_html: Are you asking for a without notice hearing because there is literally no time to give notice of the application to the other person or people?
-      steps_miam_exemptions_protection_form:
-        protection_exemptions_html: "Do you confirm any of the following child protection concerns?"
       steps_miam_exemptions_urgency_form:
         urgency_exemptions_html: "Do you confirm any of the following urgency reasons?"
       steps_miam_exemptions_adr_form:
@@ -1475,8 +1473,6 @@ en:
         restraining_case_number: *order_case_number_hint
         injunctive_case_number: *order_case_number_hint
         undertaking_case_number: *order_case_number_hint
-      steps_miam_exemptions_protection_form:
-        protection_exemptions: *select_all_that_apply_or_none
       steps_miam_exemptions_urgency_form:
         urgency_exemptions: *select_all_that_apply_or_none
       steps_miam_exemptions_adr_form:
@@ -1523,6 +1519,8 @@ en:
       # MIAM exemptions
       steps_miam_exemptions_domestic_form:
         domestic: Do you have any of the following evidence of domestic violence or abuse?
+      steps_miam_exemptions_protection_form:
+        protection: Do you confirm any of the following child protection concerns?
 
       # Safety questions
       steps_safety_questions_address_confidentiality_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -475,7 +475,7 @@ en:
               blank: *blank_exemptions_error
         steps/miam_exemptions/protection_form:
           attributes:
-            protection_none:
+            protection:
               blank: *blank_exemptions_error
         steps/miam_exemptions/urgency_form:
           attributes:

--- a/config/locales/exemptions/en.yml
+++ b/config/locales/exemptions/en.yml
@@ -43,8 +43,8 @@ en:
       domestic_none: *none_of_these
 
     PROTECTION_EXEMPTIONS: &PROTECTION_EXEMPTIONS
-      authority_enquiring_html: A local authority is carrying out enquiries or assessment about any of the children in this application, or other child in the household
-      authority_protection_order_html: Any of the children in this application, or other child in the household, is the subject of a child protection plan
+      authority_enquiring: A local authority is carrying out enquiries or assessment about any of the children in this application, or other child in the household
+      authority_protection_order: Any of the children in this application, or other child in the household, is the subject of a child protection plan
       protection_none: *none_of_these
 
     URGENCY_EXEMPTIONS: &URGENCY_EXEMPTIONS
@@ -201,7 +201,10 @@ en:
         exemptions_collection_options:
           <<: *DOMESTIC_EXEMPTIONS
       steps_miam_exemptions_protection_form:
-        <<: *PROTECTION_EXEMPTIONS
+        protection_options:
+          <<: *PROTECTION_EXEMPTIONS
+        exemptions_collection_options:
+          <<: *PROTECTION_EXEMPTIONS
       steps_miam_exemptions_urgency_form:
         <<: *URGENCY_EXEMPTIONS
       steps_miam_exemptions_adr_form:
@@ -209,15 +212,14 @@ en:
       steps_miam_exemptions_misc_form:
         <<: *MISC_EXEMPTIONS
     hint:
-      shared:
-        select_all_that_apply: *select_all_that_apply
-        select_all_that_apply_or_none: *select_all_that_apply_or_none
       steps_miam_exemptions_domestic_form:
         domestic: *select_all_that_apply_or_none
         domestic_options:
           <<: *DOMESTIC_EXEMPTIONS_HINTS
         exemptions_collection_options:
           <<: *DOMESTIC_EXEMPTIONS_HINTS
+      steps_miam_exemptions_protection_form:
+        protection: *select_all_that_apply_or_none
 
   playback:
     exemptions_claimed:

--- a/spec/forms/steps/miam_exemptions/protection_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/protection_form_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 RSpec.describe Steps::MiamExemptions::ProtectionForm do
   let(:arguments) { {
     c100_application: c100_application,
-    authority_enquiring: '1',
-    authority_protection_order: '0',
+    protection: ['authority_enquiring'],
   } }
 
   let(:c100_application) { instance_double(C100Application, miam_exemption: miam_exemption_record) }
@@ -12,13 +11,9 @@ RSpec.describe Steps::MiamExemptions::ProtectionForm do
 
   subject { described_class.new(arguments) }
 
-  describe 'custom getters override' do
-    it 'returns true if the exemption is in the list' do
-      expect(subject.authority_enquiring).to eq(true)
-    end
-
-    it 'returns false if the exemption is not in the list' do
-      expect(subject.authority_protection_order).to eq(false)
+  describe 'custom getter override' do
+    it 'returns all the exemptions in all attributes' do
+      expect(subject.exemptions_collection).to eq(['authority_enquiring'])
     end
   end
 
@@ -28,16 +23,6 @@ RSpec.describe Steps::MiamExemptions::ProtectionForm do
 
       it 'raises an error' do
         expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
-      end
-    end
-
-    context 'when form is valid' do
-      it 'saves the record' do
-        expect(miam_exemption_record).to receive(:update).with(
-          protection: [:authority_enquiring],
-        ).and_return(true)
-
-        expect(subject.save).to be(true)
       end
     end
 
@@ -53,7 +38,36 @@ RSpec.describe Steps::MiamExemptions::ProtectionForm do
 
       it 'has a validation error' do
         expect(subject).to_not be_valid
-        expect(subject.errors[:protection_none]).to_not be_empty
+        expect(subject.errors.added?(:protection, :blank)).to eq(true)
+      end
+    end
+
+    context 'when invalid checkbox values are submitted' do
+      context 'in `protection` attribute' do
+        let(:arguments) { {
+          c100_application: c100_application,
+          protection: ['foobar'],
+        } }
+
+        it 'does not save the record' do
+          expect(miam_exemption_record).not_to receive(:update)
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:protection, :blank)).to eq(true)
+        end
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(miam_exemption_record).to receive(:update).with(
+          protection: %w(authority_enquiring),
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
       end
     end
   end


### PR DESCRIPTION
Same as the first page, but much simpler as there are no revealing check boxes or hint text.

In any case, with the first page the concern is now prepared to be used in the rest of pages easily.

<img width="683" alt="Screen Shot 2020-04-15 at 16 42 12" src="https://user-images.githubusercontent.com/687910/79357803-6786b900-7f38-11ea-8d0d-177577dfc213.png">
