### PR TITLE
Migrated third page of MIAM exemptions (urgency)

### DIFF
--- a/app/controllers/steps/miam_exemptions/urgency_controller.rb
+++ b/app/controllers/steps/miam_exemptions/urgency_controller.rb
@@ -10,6 +10,12 @@ module Steps
       def update
         update_and_advance(UrgencyForm, as: :urgency)
       end
+
+      private
+
+      def additional_permitted_params
+        [urgency: []]
+      end
     end
   end
 end

--- a/app/forms/steps/miam_exemptions/urgency_form.rb
+++ b/app/forms/steps/miam_exemptions/urgency_form.rb
@@ -1,9 +1,8 @@
 module Steps
   module MiamExemptions
     class UrgencyForm < BaseForm
-      include MiamExemptionsForm
-
-      setup_attributes_for UrgencyExemptions, group_name: :urgency
+      include MiamExemptionsCheckBoxesForm
+      setup_attributes_for UrgencyExemptions, attribute_name: :urgency
     end
   end
 end

--- a/app/views/steps/miam_exemptions/urgency/edit.html.erb
+++ b/app/views/steps/miam_exemptions/urgency/edit.html.erb
@@ -1,32 +1,30 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <div class="miam_exemptions">
-    <%= step_form @form_object do |f| %>
-      <%=
-        f.check_box_fieldset :urgency_exemptions, [
-          UrgencyExemptions::RISK_APPLICANT,
-          UrgencyExemptions::UNREASONABLE_HARDSHIP,
-          UrgencyExemptions::RISK_CHILDREN,
-          UrgencyExemptions::RISK_UNLAWFUL_REMOVAL_RETENTION,
-          UrgencyExemptions::MISCARRIAGE_JUSTICE,
-          UrgencyExemptions::IRRETRIEVABLE_PROBLEMS,
-          UrgencyExemptions::INTERNATIONAL_PROCEEDINGS
-        ]
-      %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_check_boxes_fieldset :urgency, legend: { tag: 'span', size: 'm' } do %>
 
-      <p class="form-block or-block"><%=t '.or' %></p>
+        <%= f.govuk_check_box :urgency, UrgencyExemptions::RISK_APPLICANT.to_s, link_errors: true %>
+        <%= f.govuk_check_box :urgency, UrgencyExemptions::UNREASONABLE_HARDSHIP.to_s %>
+        <%= f.govuk_check_box :urgency, UrgencyExemptions::RISK_CHILDREN.to_s %>
+        <%= f.govuk_check_box :urgency, UrgencyExemptions::RISK_UNLAWFUL_REMOVAL_RETENTION.to_s %>
+        <%= f.govuk_check_box :urgency, UrgencyExemptions::MISCARRIAGE_JUSTICE.to_s %>
+        <%= f.govuk_check_box :urgency, UrgencyExemptions::IRRETRIEVABLE_PROBLEMS.to_s %>
+        <%= f.govuk_check_box :urgency, UrgencyExemptions::INTERNATIONAL_PROCEEDINGS.to_s %>
 
-      <%= f.single_check_box UrgencyExemptions::URGENCY_NONE %>
+        <%= f.govuk_radio_divider %>
+
+        <%= f.govuk_check_box :urgency, UrgencyExemptions::URGENCY_NONE.to_s %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>
-    </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -801,19 +801,16 @@ en:
           section: *miam_exemptions
           heading: Providing evidence of domestic violence or abuse concerns
           lead_text: You’ve told us you have a valid reason for not attending a MIAM. The following questions will ask what evidence you have in support of this.
-          or: or
       protection:
         edit:
           page_title: Child protection concerns
           section: *miam_exemptions
           heading: Confirming child protection concerns
-          or: or
       urgency:
         edit:
           page_title: Urgent application
           section: *miam_exemptions
           heading: Confirming why your application is urgent
-          or: or
       adr:
         edit:
           page_title: Previous valid reason or non-court resolution attendance
@@ -989,8 +986,6 @@ en:
       steps_application_without_notice_details_form:
         without_notice_frustrate_html: Are you asking for a without notice hearing because the other person or people may do something that would obstruct the order you are asking for if they knew about the application?
         without_notice_impossible_html: Are you asking for a without notice hearing because there is literally no time to give notice of the application to the other person or people?
-      steps_miam_exemptions_urgency_form:
-        urgency_exemptions_html: "Do you confirm any of the following urgency reasons?"
       steps_miam_exemptions_adr_form:
         adr_exemptions_html: "Do you confirm any of the following reasons for not attending a MIAM?"
         exemptions_group_html: ""
@@ -1473,8 +1468,6 @@ en:
         restraining_case_number: *order_case_number_hint
         injunctive_case_number: *order_case_number_hint
         undertaking_case_number: *order_case_number_hint
-      steps_miam_exemptions_urgency_form:
-        urgency_exemptions: *select_all_that_apply_or_none
       steps_miam_exemptions_adr_form:
         adr_exemptions: *select_all_that_apply_or_none
       steps_miam_exemptions_misc_form:
@@ -1521,6 +1514,8 @@ en:
         domestic: Do you have any of the following evidence of domestic violence or abuse?
       steps_miam_exemptions_protection_form:
         protection: Do you confirm any of the following child protection concerns?
+      steps_miam_exemptions_urgency_form:
+        urgency: Do you confirm any of the following urgency reasons?
 
       # Safety questions
       steps_safety_questions_address_confidentiality_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -479,7 +479,7 @@ en:
               blank: *blank_exemptions_error
         steps/miam_exemptions/urgency_form:
           attributes:
-            urgency_none:
+            urgency:
               blank: *blank_exemptions_error
         steps/miam_exemptions/adr_form:
           attributes:

--- a/config/locales/exemptions/en.yml
+++ b/config/locales/exemptions/en.yml
@@ -1,6 +1,5 @@
 en:
   dictionary:
-    select_all_that_apply: &select_all_that_apply "Select all that apply"
     select_all_that_apply_or_none: &select_all_that_apply_or_none "Select all that apply or ‘None of these’"
     none_of_these: &none_of_these "None of these"
 
@@ -48,13 +47,13 @@ en:
       protection_none: *none_of_these
 
     URGENCY_EXEMPTIONS: &URGENCY_EXEMPTIONS
-      risk_applicant_html: There is risk to the life, liberty or physical safety of you, your family or your home
-      unreasonable_hardship_html: Any delay caused by attending a MIAM would cause unreasonable hardship for you
-      risk_children_html: Any delay caused by attending a MIAM would cause a risk of harm to the children
-      risk_unlawful_removal_retention_html: Any delay caused by attending a MIAM would cause a risk of unlawful removal of a child from the UK, or a risk of unlawful retention of a child who is currently outside England and Wales
-      miscarriage_justice_html: Any delay caused by attending a MIAM would cause a significant risk of a miscarriage of justice
-      irretrievable_problems_html: Any delay caused by attending a MIAM would cause irretrievable problems in dealing with the dispute (including the irretrievable loss of significant evidence)
-      international_proceedings_html: There is a significant risk that in the period necessary to schedule and attend a MIAM, proceedings relating to the dispute will be brought in another state in which a valid claim to jurisdiction may exist, such that a court in that other State would be seized of the dispute before a court in England and Wales
+      risk_applicant: There is risk to the life, liberty or physical safety of you, your family or your home
+      unreasonable_hardship: Any delay caused by attending a MIAM would cause unreasonable hardship for you
+      risk_children: Any delay caused by attending a MIAM would cause a risk of harm to the children
+      risk_unlawful_removal_retention: Any delay caused by attending a MIAM would cause a risk of unlawful removal of a child from the UK, or a risk of unlawful retention of a child who is currently outside England and Wales
+      miscarriage_justice: Any delay caused by attending a MIAM would cause a significant risk of a miscarriage of justice
+      irretrievable_problems: Any delay caused by attending a MIAM would cause irretrievable problems in dealing with the dispute (including the irretrievable loss of significant evidence)
+      international_proceedings: There is a significant risk that in the period necessary to schedule and attend a MIAM, proceedings relating to the dispute will be brought in another state in which a valid claim to jurisdiction may exist, such that a court in that other State would be seized of the dispute before a court in England and Wales
       ## URGENCY NONE ##
       urgency_none: *none_of_these
 
@@ -203,10 +202,9 @@ en:
       steps_miam_exemptions_protection_form:
         protection_options:
           <<: *PROTECTION_EXEMPTIONS
-        exemptions_collection_options:
-          <<: *PROTECTION_EXEMPTIONS
       steps_miam_exemptions_urgency_form:
-        <<: *URGENCY_EXEMPTIONS
+        urgency_options:
+          <<: *URGENCY_EXEMPTIONS
       steps_miam_exemptions_adr_form:
         <<: *ADR_EXEMPTIONS
       steps_miam_exemptions_misc_form:
@@ -220,6 +218,8 @@ en:
           <<: *DOMESTIC_EXEMPTIONS_HINTS
       steps_miam_exemptions_protection_form:
         protection: *select_all_that_apply_or_none
+      steps_miam_exemptions_urgency_form:
+        urgency: *select_all_that_apply_or_none
 
   playback:
     exemptions_claimed:

--- a/spec/forms/steps/miam_exemptions/urgency_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/urgency_form_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 RSpec.describe Steps::MiamExemptions::UrgencyForm do
   let(:arguments) { {
     c100_application: c100_application,
-    risk_applicant: '1',
-    risk_children: '0',
+    urgency: ['risk_applicant'],
   } }
 
   let(:c100_application) { instance_double(C100Application, miam_exemption: miam_exemption_record) }
@@ -12,13 +11,9 @@ RSpec.describe Steps::MiamExemptions::UrgencyForm do
 
   subject { described_class.new(arguments) }
 
-  describe 'custom getters override' do
-    it 'returns true if the exemption is in the list' do
-      expect(subject.risk_applicant).to eq(true)
-    end
-
-    it 'returns false if the exemption is not in the list' do
-      expect(subject.risk_children).to eq(false)
+  describe 'custom getter override' do
+    it 'returns all the exemptions in all attributes' do
+      expect(subject.exemptions_collection).to eq(['risk_applicant'])
     end
   end
 
@@ -28,16 +23,6 @@ RSpec.describe Steps::MiamExemptions::UrgencyForm do
 
       it 'raises an error' do
         expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
-      end
-    end
-
-    context 'when form is valid' do
-      it 'saves the record' do
-        expect(miam_exemption_record).to receive(:update).with(
-          urgency: [:risk_applicant],
-        ).and_return(true)
-
-        expect(subject.save).to be(true)
       end
     end
 
@@ -53,7 +38,36 @@ RSpec.describe Steps::MiamExemptions::UrgencyForm do
 
       it 'has a validation error' do
         expect(subject).to_not be_valid
-        expect(subject.errors[:urgency_none]).to_not be_empty
+        expect(subject.errors.added?(:urgency, :blank)).to eq(true)
+      end
+    end
+
+    context 'when invalid checkbox values are submitted' do
+      context 'in `urgency` attribute' do
+        let(:arguments) { {
+          c100_application: c100_application,
+          urgency: ['foobar'],
+        } }
+
+        it 'does not save the record' do
+          expect(miam_exemption_record).not_to receive(:update)
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:urgency, :blank)).to eq(true)
+        end
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(miam_exemption_record).to receive(:update).with(
+          urgency: %w(risk_applicant),
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
       end
     end
   end


### PR DESCRIPTION
Same as the first page, but much simpler as there are no revealing check boxes or hint text. Like protection page.

<img width="541" alt="Screen Shot 2020-04-16 at 12 14 00" src="https://user-images.githubusercontent.com/687910/79449820-ccdfb600-7fdb-11ea-9bc7-50547f9e974c.png">
