### PR TITLE
Migrate fourth page of MIAM exemptions (ADR)

### DIFF
--- a/app/controllers/steps/miam_exemptions/adr_controller.rb
+++ b/app/controllers/steps/miam_exemptions/adr_controller.rb
@@ -10,6 +10,12 @@ module Steps
       def update
         update_and_advance(AdrForm, as: :adr)
       end
+
+      private
+
+      def additional_permitted_params
+        [adr: []]
+      end
     end
   end
 end

--- a/app/forms/steps/miam_exemptions/adr_form.rb
+++ b/app/forms/steps/miam_exemptions/adr_form.rb
@@ -1,9 +1,8 @@
 module Steps
   module MiamExemptions
     class AdrForm < BaseForm
-      include MiamExemptionsForm
-
-      setup_attributes_for AdrExemptions, group_name: :adr
+      include MiamExemptionsCheckBoxesForm
+      setup_attributes_for AdrExemptions, attribute_name: :adr
     end
   end
 end

--- a/app/value_objects/adr_exemptions.rb
+++ b/app/value_objects/adr_exemptions.rb
@@ -1,13 +1,11 @@
 class AdrExemptions < ValueObject
   VALUES = [
-    GROUP_PREVIOUS_ADR = new(:group_previous_adr),
     PREVIOUS_ADR = [
       new(:previous_attendance),
       new(:ongoing_attendance),
       new(:existing_proceedings_attendance),
     ].freeze,
 
-    GROUP_PREVIOUS_MIAM = new(:group_previous_miam),
     PREVIOUS_MIAM = [
       new(:previous_exemption),
       new(:existing_proceedings_exemption),

--- a/app/views/steps/miam_exemptions/adr/edit.html.erb
+++ b/app/views/steps/miam_exemptions/adr/edit.html.erb
@@ -1,34 +1,29 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-    <p class="app__section_heading"><%=t '.section' %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="app__heading heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <div class="miam_exemptions or-block__shift">
-    <%= step_form @form_object do |f| %>
-      <%=
-        f.check_box_fieldset :adr_exemptions, [
-          AdrExemptions::GROUP_PREVIOUS_ADR,
-          AdrExemptions::GROUP_PREVIOUS_MIAM
-        ] do |fieldset|
-          fieldset.check_box_input(AdrExemptions::GROUP_PREVIOUS_ADR) {
-            f.check_box_fieldset :exemptions_group, AdrExemptions::PREVIOUS_ADR
-          }
-          fieldset.check_box_input(AdrExemptions::GROUP_PREVIOUS_MIAM) {
-            f.check_box_fieldset :exemptions_group, AdrExemptions::PREVIOUS_MIAM
-          }
-        end
-      %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_check_boxes_fieldset :adr, legend: { tag: 'span', size: 'm' } do %>
 
-      <p class="form-block or-block"><%=t '.or' %></p>
+        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_ADR[0].to_s, link_errors: true %>
+        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_ADR[1].to_s %>
+        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_ADR[2].to_s %>
 
-      <%= f.single_check_box AdrExemptions::ADR_NONE %>
+        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_MIAM[0].to_s %>
+        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_MIAM[1].to_s %>
+
+        <%= f.govuk_radio_divider %>
+
+        <%= f.govuk_check_box :adr, AdrExemptions::ADR_NONE.to_s %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>
-    </div>
   </div>
 </div>

--- a/app/views/steps/miam_exemptions/adr/edit.html.erb
+++ b/app/views/steps/miam_exemptions/adr/edit.html.erb
@@ -11,12 +11,9 @@
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_check_boxes_fieldset :adr, legend: { tag: 'span', size: 'm' } do %>
 
-        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_ADR[0].to_s, link_errors: true %>
-        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_ADR[1].to_s %>
-        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_ADR[2].to_s %>
-
-        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_MIAM[0].to_s %>
-        <%= f.govuk_check_box :adr, AdrExemptions::PREVIOUS_MIAM[1].to_s %>
+        <% AdrExemptions.values.without(AdrExemptions::ADR_NONE).each.with_index do |value, index| %>
+          <%= f.govuk_check_box :adr, value.to_s, link_errors: index.zero? %>
+        <% end %>
 
         <%= f.govuk_radio_divider %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -986,9 +986,6 @@ en:
       steps_application_without_notice_details_form:
         without_notice_frustrate_html: Are you asking for a without notice hearing because the other person or people may do something that would obstruct the order you are asking for if they knew about the application?
         without_notice_impossible_html: Are you asking for a without notice hearing because there is literally no time to give notice of the application to the other person or people?
-      steps_miam_exemptions_adr_form:
-        adr_exemptions_html: "Do you confirm any of the following reasons for not attending a MIAM?"
-        exemptions_group_html: ""
       steps_miam_exemptions_misc_form:
         misc_exemptions_html: "Do you have any other valid reasons for not attending a MIAM?"
         exemptions_group_html: ""
@@ -1468,8 +1465,6 @@ en:
         restraining_case_number: *order_case_number_hint
         injunctive_case_number: *order_case_number_hint
         undertaking_case_number: *order_case_number_hint
-      steps_miam_exemptions_adr_form:
-        adr_exemptions: *select_all_that_apply_or_none
       steps_miam_exemptions_misc_form:
         misc_exemptions: *select_all_that_apply_or_none
       steps_miam_certification_details_form:
@@ -1516,6 +1511,8 @@ en:
         protection: Do you confirm any of the following child protection concerns?
       steps_miam_exemptions_urgency_form:
         urgency: Do you confirm any of the following urgency reasons?
+      steps_miam_exemptions_adr_form:
+        adr: Do you confirm any of the following reasons for not attending a MIAM?
 
       # Safety questions
       steps_safety_questions_address_confidentiality_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -483,7 +483,7 @@ en:
               blank: *blank_exemptions_error
         steps/miam_exemptions/adr_form:
           attributes:
-            adr_none:
+            adr:
               blank: *blank_exemptions_error
         steps/miam_exemptions/misc_form:
           attributes:

--- a/config/locales/exemptions/en.yml
+++ b/config/locales/exemptions/en.yml
@@ -58,25 +58,11 @@ en:
       urgency_none: *none_of_these
 
     ADR_EXEMPTIONS: &ADR_EXEMPTIONS
-      ## GROUP PREVIOUS ADR ##
-      group_previous_adr_html: |
-        <span class="heading-small gv-u-heading-small">You’ve already been to a MIAM or are taking part in another form of non-court resolution</span>
-        <span class="form-hint">The MIAM must have taken place within the past 4 months (or your attendance at another type of non-court resolution must be ongoing) and have been about the same child arrangements issue.</span>
-      previous_attendance_html: In the 4 months prior to making the application, the person attended a MIAM or participated in another form of non-court dispute resolution relating to the same or a very similar dispute
-      ongoing_attendance_html: At the time of making the application, the person is participating in another form of non-court dispute resolution relating to the same or substantially the same dispute
-      existing_proceedings_attendance_html: The application would be made in existing proceedings which are continuing and the prospective applicant attended a MIAM before initiating those proceedings
-      ## GROUP PREVIOUS MIAM ##
-      group_previous_miam_html:
-        <span class="heading-small gv-u-heading-small">You had a valid reason for not attending a MIAM previously</span>
-        <span class="form-hint">For example:<p></p>
-          <ul class="list list-bullet">
-            <li>you’ve made another court application within the last 4 months about the same or a very similar dispute and you had a confirmed valid reason for not attending a MIAM before making that application</li>
-            <li>you’re involved in other ongoing family court proceedings where the applicant in those proceedings had a confirmed valid reason for not attending a MIAM</li>
-          </ul>
-        </span>
-      previous_exemption_html: In the 4 months prior to making the application, the person filed a relevant family application confirming that a MIAM exemption applied and that application related to the same or substantially the same dispute
-      existing_proceedings_exemption_html: The application would be made in existing proceedings which are continuing and a MIAM exemption applied to the application for those proceedings
-      ## ADR NONE ##
+      previous_attendance: In the 4 months prior to making the application, you attended a MIAM or participated in another form of non-court dispute resolution relating to the same or substantially the same dispute
+      ongoing_attendance: At the time of making the application, you are participating in another form of non-court dispute resolution relating to the same or substantially the same dispute
+      existing_proceedings_attendance: The application would be made in existing proceedings which are continuing and you attended a MIAM before initiating those proceedings
+      previous_exemption: In the 4 months prior to making the application, you filed a relevant family application confirming that a MIAM exemption applied and that application related to the same or substantially the same dispute
+      existing_proceedings_exemption: The application would be made in existing proceedings which are continuing and a MIAM exemption applied to the application for those proceedings
       adr_none: *none_of_these
 
     MISC_EXEMPTIONS: &MISC_EXEMPTIONS
@@ -206,7 +192,8 @@ en:
         urgency_options:
           <<: *URGENCY_EXEMPTIONS
       steps_miam_exemptions_adr_form:
-        <<: *ADR_EXEMPTIONS
+        adr_options:
+          <<: *ADR_EXEMPTIONS
       steps_miam_exemptions_misc_form:
         <<: *MISC_EXEMPTIONS
     hint:
@@ -220,6 +207,8 @@ en:
         protection: *select_all_that_apply_or_none
       steps_miam_exemptions_urgency_form:
         urgency: *select_all_that_apply_or_none
+      steps_miam_exemptions_adr_form:
+        adr: *select_all_that_apply_or_none
 
   playback:
     exemptions_claimed:

--- a/spec/forms/steps/miam_exemptions/adr_form_spec.rb
+++ b/spec/forms/steps/miam_exemptions/adr_form_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 RSpec.describe Steps::MiamExemptions::AdrForm do
   let(:arguments) { {
     c100_application: c100_application,
-    previous_attendance: '1',
-    previous_exemption: '0',
+    adr: ['previous_attendance'],
   } }
 
   let(:c100_application) { instance_double(C100Application, miam_exemption: miam_exemption_record) }
@@ -12,13 +11,9 @@ RSpec.describe Steps::MiamExemptions::AdrForm do
 
   subject { described_class.new(arguments) }
 
-  describe 'custom getters override' do
-    it 'returns true if the exemption is in the list' do
-      expect(subject.previous_attendance).to eq(true)
-    end
-
-    it 'returns false if the exemption is not in the list' do
-      expect(subject.previous_exemption).to eq(false)
+  describe 'custom getter override' do
+    it 'returns all the exemptions in all attributes' do
+      expect(subject.exemptions_collection).to eq(['previous_attendance'])
     end
   end
 
@@ -28,16 +23,6 @@ RSpec.describe Steps::MiamExemptions::AdrForm do
 
       it 'raises an error' do
         expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
-      end
-    end
-
-    context 'when form is valid' do
-      it 'saves the record' do
-        expect(miam_exemption_record).to receive(:update).with(
-          adr: [:previous_attendance],
-        ).and_return(true)
-
-        expect(subject.save).to be(true)
       end
     end
 
@@ -53,7 +38,36 @@ RSpec.describe Steps::MiamExemptions::AdrForm do
 
       it 'has a validation error' do
         expect(subject).to_not be_valid
-        expect(subject.errors[:adr_none]).to_not be_empty
+        expect(subject.errors.added?(:adr, :blank)).to eq(true)
+      end
+    end
+
+    context 'when invalid checkbox values are submitted' do
+      context 'in `adr` attribute' do
+        let(:arguments) { {
+          c100_application: c100_application,
+          adr: ['foobar'],
+        } }
+
+        it 'does not save the record' do
+          expect(miam_exemption_record).not_to receive(:update)
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:adr, :blank)).to eq(true)
+        end
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(miam_exemption_record).to receive(:update).with(
+          adr: %w(previous_attendance),
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
       end
     end
   end

--- a/spec/value_objects/adr_exemptions_spec.rb
+++ b/spec/value_objects/adr_exemptions_spec.rb
@@ -4,38 +4,22 @@ RSpec.describe AdrExemptions do
   let(:value) { :foo }
   subject     { described_class.new(value) }
 
-  describe 'Previous ADR exemptions' do
-    context 'GROUP_PREVIOUS_ADR' do
-      it 'returns the expected values' do
-        expect(described_class::GROUP_PREVIOUS_ADR.to_s).to eq('group_previous_adr')
-      end
-    end
-
-    context 'PREVIOUS_ADR' do
-      it 'returns the expected values' do
-        expect(described_class::PREVIOUS_ADR.map(&:to_s)).to eq(%w(
-          previous_attendance
-          ongoing_attendance
-          existing_proceedings_attendance
-        ))
-      end
+  context 'PREVIOUS_ADR' do
+    it 'returns the expected values' do
+      expect(described_class::PREVIOUS_ADR.map(&:to_s)).to eq(%w(
+        previous_attendance
+        ongoing_attendance
+        existing_proceedings_attendance
+      ))
     end
   end
 
-  describe 'Previous MIAM exemptions' do
-    context 'GROUP_PREVIOUS_MIAM' do
-      it 'returns the expected values' do
-        expect(described_class::GROUP_PREVIOUS_MIAM.to_s).to eq('group_previous_miam')
-      end
-    end
-
-    context 'PREVIOUS_MIAM' do
-      it 'returns the expected values' do
-        expect(described_class::PREVIOUS_MIAM.map(&:to_s)).to eq(%w(
-          previous_exemption
-          existing_proceedings_exemption
-        ))
-      end
+  context 'PREVIOUS_MIAM' do
+    it 'returns the expected values' do
+      expect(described_class::PREVIOUS_MIAM.map(&:to_s)).to eq(%w(
+        previous_exemption
+        existing_proceedings_exemption
+      ))
     end
   end
 


### PR DESCRIPTION
After running this through our service designer, we've simplified the page so instead of 2 check boxes revealing 3 and 2 each more, now it is just a plain list of check boxes, identical to the paper form.

This let's us remove some of the ugly hint text with bullet points, and make the page simpler to read.

![Screen Shot 2020-04-16 at 14 45 24](https://user-images.githubusercontent.com/687910/79464938-a37e5480-7ff2-11ea-9bf3-6dc8b70d4cd2.png)
