### PR TITLE
Migrate nature of application (petition order) view

### DIFF
--- a/app/assets/stylesheets/local/app/pending_migration.scss
+++ b/app/assets/stylesheets/local/app/pending_migration.scss
@@ -6,23 +6,6 @@
 // and once we have completed the migration we can get back to these and
 // refactor/replace with standard styling or remove the ones not needed.
 //
-#new_steps_alternatives_court_form {
-  margin-top: 6rem;
-}
-
-#new_steps_petition_orders_form > .form-group {
-  margin-bottom: 0;
-  & > fieldset {
-    & > .multiple-choice {
-      min-height: 6rem;
-    }
-    & > .panel {
-      margin-top: -2rem;
-      margin-bottom: 3rem;
-    }
-  }
-}
-
 .dont-know {
   margin-top: -5px;
   @media (min-width: 641px) {

--- a/app/controllers/steps/petition/orders_controller.rb
+++ b/app/controllers/steps/petition/orders_controller.rb
@@ -8,6 +8,12 @@ module Steps
       def update
         update_and_advance(OrdersForm, as: :orders)
       end
+
+      private
+
+      def additional_permitted_params
+        [orders: [], orders_collection: []]
+      end
     end
   end
 end

--- a/app/presenters/summary/html_sections/nature_of_application.rb
+++ b/app/presenters/summary/html_sections/nature_of_application.rb
@@ -11,22 +11,22 @@ module Summary
           MultiAnswer.new(:child_arrangements_orders,
                           petition.child_arrangements_orders,
                           change_path: edit_steps_petition_orders_path(
-                            anchor: 'steps_petition_orders_form_group_child_arrangements_home'
+                            anchor: 'steps-petition-orders-form-orders-child-arrangements-home-field'
                           )),
           MultiAnswer.new(:prohibited_steps_orders,
                           petition.prohibited_steps_orders,
                           change_path: edit_steps_petition_orders_path(
-                            anchor: 'steps_petition_orders_form_group_prohibited_steps'
+                            anchor: 'steps-petition-orders-form-orders-group-prohibited-steps-field'
                           )),
           MultiAnswer.new(:specific_issues_orders,
                           petition.specific_issues_orders,
                           change_path: edit_steps_petition_orders_path(
-                            anchor: 'steps_petition_orders_form_group_specific_issues'
+                            anchor: 'steps-petition-orders-form-orders-group-specific-issues-field'
                           )),
           FreeTextAnswer.new(:other_issue_details,
                              petition.other_issue_details,
                              change_path: edit_steps_petition_orders_path(
-                               anchor: 'steps_petition_orders_form_other_issue'
+                               anchor: 'steps-petition-orders-form-orders-other-issue-field'
                              )),
           AnswersGroup.new(
             :protection_orders,

--- a/app/views/steps/petition/orders/edit.html.erb
+++ b/app/views/steps/petition/orders/edit.html.erb
@@ -1,27 +1,30 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <%= step_form @form_object do |f| %>
-      <%=
-        f.check_box_fieldset :orders, :base, legend_options: { class: 'visually-hidden', text: t('.heading') } do |fieldset|
-          fieldset.check_box_input(PetitionOrder::CHILD_ARRANGEMENTS_HOME)
-          fieldset.check_box_input(PetitionOrder::CHILD_ARRANGEMENTS_TIME)
-          fieldset.check_box_input(PetitionOrder::GROUP_PROHIBITED_STEPS) {
-            f.check_box_fieldset :orders_prohibited_steps, PetitionOrder::PROHIBITED_STEPS
-          }
-          fieldset.check_box_input(PetitionOrder::GROUP_SPECIFIC_ISSUES) {
-            f.check_box_fieldset :orders_specific_issues, PetitionOrder::SPECIFIC_ISSUES
-          }
-          fieldset.check_box_input(PetitionOrder::OTHER_ISSUE) {
-            f.text_area :orders_additional_details, size: '40x4', class: 'form-control-3-4'
-          }
-        end
-      %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_check_boxes_fieldset :orders, legend: { tag: 'span', size: 'm' } do %>
+
+        <%= f.govuk_check_box :orders, PetitionOrder::CHILD_ARRANGEMENTS_HOME.to_s, link_errors: true %>
+        <%= f.govuk_check_box :orders, PetitionOrder::CHILD_ARRANGEMENTS_TIME.to_s %>
+
+        <%= f.govuk_check_box :orders, PetitionOrder::GROUP_PROHIBITED_STEPS.to_s do %>
+          <%= f.govuk_collection_check_boxes :orders_collection, PetitionOrder::PROHIBITED_STEPS, :to_s, :to_s %>
+        <% end %>
+
+        <%= f.govuk_check_box :orders, PetitionOrder::GROUP_SPECIFIC_ISSUES.to_s do %>
+          <%= f.govuk_collection_check_boxes :orders_collection, PetitionOrder::SPECIFIC_ISSUES, :to_s, :to_s %>
+        <% end %>
+
+        <%= f.govuk_check_box :orders, PetitionOrder::OTHER_ISSUE.to_s do
+          f.govuk_text_area :orders_additional_details
+        end %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/petition/playback/show.html.erb
+++ b/app/views/steps/petition/playback/show.html.erb
@@ -1,62 +1,61 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <% if @petition.child_arrangements_orders.any? %>
-      <p class="lede"><%=t '.lead_text', count: 0 %></p>
-      <ul class="list list-bullet">
+      <h3 class="govuk-heading-m">
+        <%=t '.petition_header', count: 0 %>
+      </h3>
+      <ul class="govuk-list govuk-list--bullet">
         <% @petition.child_arrangements_orders.each do |order| %>
-          <%= content_tag :li, t(".#{order}_html") %>
+          <%= content_tag :li, t(".orders.#{order}") %>
         <% end %>
       </ul>
-      <p><%= t('.aka.child_arrangements_order') %></p>
+      <p class="govuk-body"><%= t('.aka.child_arrangements_order') %></p>
     <% end %>
 
     <% if @petition.prohibited_steps_orders.any? %>
-      <p class="lede">
-        <%=t '.lead_text_stop', count: @petition.count_for(
+      <h3 class="govuk-heading-m">
+        <%=t '.petition_header_stop', count: @petition.count_for(
           :child_arrangements_orders
         ) %>
-      </p>
-      <ul class="list list-bullet">
+      </h3>
+      <ul class="govuk-list govuk-list--bullet">
         <% @petition.prohibited_steps_orders.each do |order| %>
-          <%= content_tag :li, t(".#{order}_html") %>
+          <%= content_tag :li, t(".orders.#{order}") %>
         <% end %>
       </ul>
-      <p><%= t('.aka.prohibited_steps_order') %></p>
+      <p class="govuk-body"><%= t('.aka.prohibited_steps_order') %></p>
     <% end %>
 
     <% if @petition.specific_issues_orders.any? %>
-        <p class="lede">
-          <%=t '.lead_text_issues', count: @petition.count_for(
-            :child_arrangements_orders, :prohibited_steps_orders
-          ) %>
-        </p>
-        <ul class="list list-bullet">
-          <% @petition.specific_issues_orders.each do |order| %>
-              <%= content_tag :li, t(".#{order}_html") %>
-          <% end %>
-        </ul>
-        <p><%= t('.aka.specific_issues_order') %></p>
+      <h3 class="govuk-heading-m">
+        <%=t '.petition_header_issues', count: @petition.count_for(
+          :child_arrangements_orders, :prohibited_steps_orders
+        ) %>
+      </h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <% @petition.specific_issues_orders.each do |order| %>
+            <%= content_tag :li, t(".orders.#{order}") %>
+        <% end %>
+      </ul>
+      <p class="govuk-body"><%= t('.aka.specific_issues_order') %></p>
     <% end %>
 
     <% if @petition.other_issue? %>
-      <p class="lede">
-        <%=t '.lead_text_other', count: @petition.count_for(
+      <h3 class="govuk-heading-m">
+        <%=t '.petition_header_other', count: @petition.count_for(
           :child_arrangements_orders, :prohibited_steps_orders, :specific_issues_orders
         ) %>
-      </p>
-      <div class="panel">
+      </h3>
+      <div class="govuk-inset-text">
         <%= @petition.other_issue_details %>
       </div>
     <% end %>
 
-    <div class="xform-group form-submit">
-      <%= link_to t('.continue'), @next_step_path, class: 'button', role: 'button' %>
-    </div>
+    <%= link_button t('.continue'), @next_step_path %>
   </div>
 </div>

--- a/app/views/steps/petition/protection/edit.html.erb
+++ b/app/views/steps/petition/protection/edit.html.erb
@@ -1,23 +1,20 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :protection_orders do %>
+        <%=t '.lead_text_html' %>
 
-    <%=t '.lead_text_html' %>
+        <%= f.govuk_radio_button :protection_orders, GenericYesNo::YES, link_errors: true do
+          f.govuk_text_area :protection_orders_details
+        end %>
 
-    <%= step_form @form_object do |f| %>
-      <%=
-        f.radio_button_fieldset :protection_orders, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
-          fieldset.radio_input(GenericYesNo::YES, panel_id: :protection_orders_panel)
-          fieldset.radio_input(GenericYesNo::NO)
-          fieldset.revealing_panel(:protection_orders_panel) do |panel|
-            panel.text_area :protection_orders_details, size: '40x4', class: 'form-control-3-4'
-          end
-        end
-      %>
+        <%= f.govuk_radio_button :protection_orders, GenericYesNo::NO %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -23,8 +23,6 @@ en:
     ARRANGEMENT_ORDERS: &ARRANGEMENT_ORDERS
       child_arrangements_home: Decide who they live with and when
       child_arrangements_time: Decide how much time they spend with each person
-      child_arrangements_contact: Decide how and when the children are involved with each person
-      child_arrangements_access: Allow the children to spend time with you
     PROHIBITED_STEPS_ORDERS: &PROHIBITED_STEPS_ORDERS
       prohibited_steps_moving: Relocating the children to a different area in England and Wales
       prohibited_steps_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,22 +36,24 @@ en:
       other: Other
 
     PETITION_ORDERS: &PETITION_ORDERS
-      child_arrangements_home_html: Decide who they live with and when
-      child_arrangements_time_html: Decide how much time they spend with each person
-      prohibited_steps_moving_html: Relocating the children to a different area in England and Wales
-      prohibited_steps_moving_abroad_html: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
-      prohibited_steps_names_html: Changing their names or surname
-      prohibited_steps_medical_html: Allowing medical treatment to be carried out on them
-      prohibited_steps_holiday_html: Taking them on holiday
-      specific_issues_holiday_html: A specific holiday or arrangement
-      specific_issues_school_html: What school they’ll go to
-      specific_issues_religion_html: A religious issue
-      specific_issues_names_html: Changing their names or surname
-      specific_issues_medical_html: Medical treatment
-      specific_issues_moving_html: Relocating the children to a different area in England and Wales
-      specific_issues_moving_abroad_html: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
-      specific_issues_child_return_html: Returning the children to your care
-      other_issue_html: Deal with another issue not listed
+      child_arrangements_home: Decide who they live with and when
+      child_arrangements_time: Decide how much time they spend with each person
+      group_prohibited_steps: Stop the other person doing something
+      prohibited_steps_moving: Relocating the children to a different area in England and Wales
+      prohibited_steps_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
+      prohibited_steps_names: Changing their names or surname
+      prohibited_steps_medical: Allowing medical treatment to be carried out on them
+      prohibited_steps_holiday: Taking them on holiday
+      group_specific_issues: Resolve a specific issue
+      specific_issues_holiday: A specific holiday or arrangement
+      specific_issues_school: What school they’ll go to
+      specific_issues_religion: A religious issue
+      specific_issues_names: Changing their names or surname
+      specific_issues_medical: Medical treatment
+      specific_issues_moving: Relocating the children to a different area in England and Wales
+      specific_issues_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
+      specific_issues_child_return: Returning the children to your care
+      other_issue: Deal with another issue not listed
 
     # Note: this is duplicated in `locales/summary/en.yml`, due to the way locales work
     # (they don't see each other when they are in different files). If you change copy here,
@@ -575,22 +577,23 @@ en:
         show:
           page_title: What you are asking the court to decide
           heading: What you’re asking the court to decide about the children
-          lead_text:
+          petition_header:
             zero: 'You would like the court to:'
-          lead_text_stop:
+          petition_header_stop:
             zero: 'You would like the court to stop the other person:'
             one: 'You would also like the court to stop the other person:'
             other: 'You would also like the court to stop the other person:'
-          lead_text_issues:
+          petition_header_issues:
             zero: 'You would like the court to resolve an issue about:'
             one: 'You would also like the court to resolve an issue about:'
             other: 'You would also like the court to resolve an issue about:'
-          lead_text_other:
+          petition_header_other:
             zero: "You told us that you need help with this dispute:"
             one: "You also told us that you need help with this dispute:"
             other: "You also told us that you need help with this dispute:"
           continue: Continue
-          <<: *PETITION_ORDERS
+          orders:
+            <<: *PETITION_ORDERS
           aka:
             child_arrangements_order: This is known as a Child Arrangements Order.
             specific_issues_order: This is known as a Specific Issue Order.
@@ -972,10 +975,6 @@ en:
       steps_application_without_notice_details_form:
         without_notice_frustrate_html: Are you asking for a without notice hearing because the other person or people may do something that would obstruct the order you are asking for if they knew about the application?
         without_notice_impossible_html: Are you asking for a without notice hearing because there is literally no time to give notice of the application to the other person or people?
-      steps_petition_orders_form:
-        orders_html: ""
-        orders_prohibited_steps_html: ""
-        orders_specific_issues_html: ""
       steps_applicant_personal_details_form:
         has_previous_name: Have you changed your name?
         gender: Sex
@@ -1247,23 +1246,10 @@ en:
         miam_certification_service_name: Family mediation service name
         miam_certification_sole_trader_name: Sole trader name
       steps_petition_orders_form:
-        <<: *PETITION_ORDERS
-        # We override only those that have hint text or are different to the playback here.
-        child_arrangements_contact_html: |
-          <span class="gv-u-heading-small">Decide how and when the children are involved with each person</span><br>
-          <span class="form-hint">For example, in person, or phone calls and emails</span>
-        child_arrangements_access_html: |
-          <span class="gv-u-heading-small">Allow the children to spend time with you</span><br>
-          <span class="form-hint">If they’re currently not being allowed to</span>
-        specific_issues_child_return_html: |
-          <span class="gv-u-heading-small">Returning the children to your care</span><br>
-          <span class="form-hint">If the children have been abducted, unlawfully removed or unlawfully retained</span>
-        group_prohibited_steps_html: |
-          <span class="gv-u-heading-small">Stop the other person doing something</span><br>
-          <span class="form-hint">For example, moving abroad or abducting the children</span>
-        group_specific_issues_html: |
-          <span class="gv-u-heading-small">Resolve a specific issue</span><br>
-          <span class="form-hint">For example, what school they’ll go to</span>
+        orders_options:
+          <<: *PETITION_ORDERS
+        orders_collection_options:
+          <<: *PETITION_ORDERS
         orders_additional_details: Briefly provide more details
       steps_petition_protection_form:
         protection_orders_details: Please give details
@@ -1399,8 +1385,11 @@ en:
         previous_attempt_agency_involved: Including in the UK or abroad
       steps_petition_orders_form:
         orders: *select_all_that_apply
-        orders_prohibited_steps: *select_all_that_apply
-        orders_specific_issues: *select_all_that_apply
+        orders_options:
+          group_prohibited_steps: For example, moving abroad or abducting the children
+          group_specific_issues: For example, what school they’ll go to
+        orders_collection_options:
+          specific_issues_child_return: If the children have been abducted, unlawfully removed or unlawfully retained
       steps_applicant_personal_details_form:
         has_previous_name: For example, through marriage or adoption or by deed poll. This includes first name, surname and any middle names
         previous_name: *previous_name_hint

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -601,16 +601,13 @@ en:
       protection:
         edit:
           page_title: Protection orders
-          heading: Is there anything else you are asking the court to decide, specifically to protect the safety of you or the children?
           lead_text_html: |
-            <div class="govuk-govspeak gv-s-prose">
-              <p>This can include:</p>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>that the person must not be violent or threaten or harass by any means (Non-Molestation Order)</li>
-                <li>preventing a person doing a particular action (Prohibited Steps Order)</li>
-                <li>making a decision about a specific issue on which you and the other person can’t decide (Specific Issue Order)</li>
-              </ul>
-            </div>
+            <p class="govuk-body govuk-!-margin-top-3">This can include:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>that the person must not be violent or threaten or harass by any means (Non-Molestation Order)</li>
+              <li>preventing a person doing a particular action (Prohibited Steps Order)</li>
+              <li>making a decision about a specific issue on which you and the other person can’t decide (Specific Issue Order)</li>
+            </ul>
     abduction:
       children_have_passport:
         edit:
@@ -1253,6 +1250,8 @@ en:
         orders_additional_details: Briefly provide more details
       steps_petition_protection_form:
         protection_orders_details: Please give details
+        protection_orders_options:
+          <<: *YESNO
       steps_abduction_risk_details_form:
         risk_details: Briefly explain your concerns about abduction
         current_location: Where are the children now?
@@ -1458,16 +1457,6 @@ en:
         special_assistance: *one_of_the_people_needs
 
     legend:
-      steps_alternatives_court_form:
-        court_acknowledgement: Going to court
-      steps_alternatives_collaborative_law_form:
-        alternative_collaborative_law: Have you tried collaborative law?
-      steps_alternatives_lawyer_negotiation_form:
-        alternative_lawyer_negotiation: Have you tried lawyer negotiation?
-      steps_alternatives_mediation_form:
-        alternative_mediation: Have you tried professional mediation?
-      steps_alternatives_negotiation_tools_form:
-        alternative_negotiation_tools: Have you tried any negotiation tools or services?
       # Screener steps
       steps_screener_parent_form:
         parent: Are you a parent of the children or a solicitor representing a parent?
@@ -1547,6 +1536,22 @@ en:
         restraining_is_current: *order_current
         injunctive_is_current: *order_current
         undertaking_is_current: *order_current
+
+      # Petition steps (nature of application)
+      steps_petition_protection_form:
+        protection_orders: Is there anything else you are asking the court to decide, specifically to protect the safety of you or the children?
+
+      # Alternatives to court steps
+      steps_alternatives_court_form:
+        court_acknowledgement: Going to court
+      steps_alternatives_collaborative_law_form:
+        alternative_collaborative_law: Have you tried collaborative law?
+      steps_alternatives_lawyer_negotiation_form:
+        alternative_lawyer_negotiation: Have you tried lawyer negotiation?
+      steps_alternatives_mediation_form:
+        alternative_mediation: Have you tried professional mediation?
+      steps_alternatives_negotiation_tools_form:
+        alternative_negotiation_tools: Have you tried any negotiation tools or services?
 
       # Attending court steps
       steps_attending_court_intermediary_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -312,12 +312,8 @@ en:
 
         steps/petition/orders_form:
           attributes:
-            base:
-              blank_orders: Select what you’re asking the court to decide
-            group_prohibited_steps:
-              blank_orders: Select what you’re asking the court to stop the other person doing
-            group_specific_issues:
-              blank_orders: Select what specific issue you’re asking the court to resolve
+            orders:
+              blank: Select what you’re asking the court to decide
             orders_additional_details:
               blank: *blank_details_error
         steps/children/orders_form:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -27,8 +27,6 @@ en:
     ARRANGEMENT_ORDERS: &ARRANGEMENT_ORDERS
       child_arrangements_home: Decide who they live with and when
       child_arrangements_time: Decide how much time they spend with each person
-      child_arrangements_contact: Decide how and when the children are involved with each person
-      child_arrangements_access: Allow the children to spend time with you
     PROHIBITED_STEPS_ORDERS: &PROHIBITED_STEPS_ORDERS
       prohibited_steps_moving: Relocating the children to a different area in England and Wales
       prohibited_steps_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)

--- a/spec/forms/steps/petition/orders_form_spec.rb
+++ b/spec/forms/steps/petition/orders_form_spec.rb
@@ -3,13 +3,8 @@ require 'spec_helper'
 RSpec.describe Steps::Petition::OrdersForm do
   let(:arguments) { {
     c100_application: c100_application,
-    child_arrangements_home: '1',
-    group_prohibited_steps: '1',
-    prohibited_steps_holiday: '1',
-    group_specific_issues: '1',
-    specific_issues_school: '0',
-    specific_issues_medical: '1',
-    other_issue: other_issue,
+    orders: orders,
+    orders_collection: orders_collection,
     orders_additional_details: orders_additional_details,
   } }
 
@@ -17,98 +12,90 @@ RSpec.describe Steps::Petition::OrdersForm do
     instance_double(C100Application, orders: orders, orders_additional_details: orders_additional_details)
   }
 
-  let(:orders) { [] }
-  let(:other_issue) { nil }
+  let(:orders) { %w(child_arrangements_home group_prohibited_steps group_specific_issues) }
+  let(:orders_collection) { %w(prohibited_steps_holiday specific_issues_medical) }
   let(:orders_additional_details) { nil }
 
   subject { described_class.new(arguments) }
 
-  describe 'custom build, loading of attributes' do
-    subject { described_class.build(c100_application) } # NOTE: Using custom build
-
-    let(:orders) { %w(child_arrangements_home specific_issues_medical) }
-
-    it 'returns true if the order is in the list' do
-      expect(subject.child_arrangements_home).to eq(true)
-    end
-
-    it 'returns false if the order is not in the list' do
-      expect(subject.specific_issues_school).to eq(false)
-    end
-
-    context 'other attributes explicitly set' do
-      let(:orders_additional_details) { 'additional details' }
-
-      it { expect(subject.orders_additional_details).to eq('additional details') }
-      it { expect(subject.c100_application).to eq(c100_application) }
+  describe 'custom getter override' do
+    it 'returns all the orders in all attributes' do
+      expect(
+        subject.orders_collection
+      ).to eq(%w(
+        prohibited_steps_holiday
+        specific_issues_medical
+        child_arrangements_home
+        group_prohibited_steps
+        group_specific_issues)
+      )
     end
   end
 
-  context 'validations' do
-    context 'no orders selected' do
-      let(:arguments) { { c100_application: c100_application } }
+  describe 'validations' do
+    context 'when `other_issue` is checked' do
+      let(:orders) { ['other_issue'] }
+      it { should validate_presence_of(:orders_additional_details) }
+    end
 
-      it 'has a top level validation error' do
+    context 'when `other_issue` is not checked' do
+      let(:orders) { [] }
+      it { should_not validate_presence_of(:orders_additional_details) }
+    end
+
+    # mutant kill
+    context 'when `orders` attribute is not submitted' do
+      let(:arguments) { {
+        c100_application: c100_application,
+        orders_collection: [],
+      } }
+
+      it 'has a validation error' do
         expect(subject).to_not be_valid
-        expect(subject.errors.added?(:base, :blank_orders)).to eq(true)
+        expect(subject.errors.added?(:orders, :blank)).to eq(true)
       end
     end
 
-    context 'only a group checkbox was selected' do
-      context 'group_prohibited_steps' do
-        let(:arguments) { {
-          c100_application: c100_application,
-          group_prohibited_steps: '1',
-          group_specific_issues: '1',
-          specific_issues_school: '1',
-        } }
+    context 'when no checkboxes are selected' do
+      let(:orders) { nil }
+      let(:orders_collection) { nil }
 
-        it 'has a validation error in the group' do
-          expect(subject).to_not be_valid
-
-          expect(subject.errors.added?(:group_prohibited_steps, :blank_orders)).to eq(true)
-          expect(subject.errors.added?(:group_specific_issues, :blank_orders)).to eq(false)
-          expect(subject.errors.added?(:base, :blank_orders)).to eq(false)
-        end
-      end
-
-      context 'group_specific_issues' do
-        let(:arguments) { {
-          c100_application: c100_application,
-          group_specific_issues: '1',
-          group_prohibited_steps: '1',
-          prohibited_steps_medical: '1',
-        } }
-
-        it 'has a validation error in the group' do
-          expect(subject).to_not be_valid
-
-          expect(subject.errors.added?(:group_specific_issues, :blank_orders)).to eq(true)
-          expect(subject.errors.added?(:group_prohibited_steps, :blank_orders)).to eq(false)
-          expect(subject.errors.added?(:base, :blank_orders)).to eq(false)
-        end
-      end
-
-      context 'do not produce multiple errors' do
-        let(:arguments) { { c100_application: c100_application, group_specific_issues: '1' } }
-
-        it 'has only the group error' do
-          expect(subject).to_not be_valid
-
-          expect(subject.errors.size).to eq(1)
-          expect(subject.errors.added?(:group_specific_issues, :blank_orders)).to eq(true)
-        end
+      it 'has a validation error' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.added?(:orders, :blank)).to eq(true)
       end
     end
 
-    context '`other_issue` is checked' do
-      let(:other_issue) { '1' }
-      it { should validate_presence_of(:orders_additional_details, :blank) }
+    context 'when only group checkboxes are selected' do
+      let(:orders) { ['group_prohibited_steps'] }
+      let(:orders_collection) { nil }
+
+      it 'has a validation error' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.added?(:orders, :blank)).to eq(true)
+      end
     end
 
-    context '`other_issue` is not checked' do
-      let(:other_issue) { '0' }
-      it { should_not validate_presence_of(:orders_additional_details, :blank) }
+    context 'when invalid checkbox values are submitted' do
+      context 'in `orders` attribute' do
+        let(:orders) { ['foobar'] }
+        let(:orders_collection) { nil }
+
+        it 'has a validation error' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:orders, :blank)).to eq(true)
+        end
+      end
+
+      context 'in `orders_collection` attribute' do
+        let(:orders) { nil }
+        let(:orders_collection) { ['foobar'] }
+
+        it 'has a validation error' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:orders, :blank)).to eq(true)
+        end
+      end
     end
   end
 
@@ -121,67 +108,43 @@ RSpec.describe Steps::Petition::OrdersForm do
       end
     end
 
-    context 'for valid details' do
-      it 'updates the record' do
+    context 'when form is valid' do
+      it 'saves the record' do
         expect(c100_application).to receive(:update).with(
-          orders: [
-            :child_arrangements_home,
-            :group_prohibited_steps,
-            :prohibited_steps_holiday,
-            :group_specific_issues,
-            :specific_issues_medical
-          ],
+          orders: %w(prohibited_steps_holiday specific_issues_medical child_arrangements_home group_prohibited_steps group_specific_issues),
           orders_additional_details: nil,
         ).and_return(true)
 
         expect(subject.save).to be(true)
       end
 
-      context 'for other issue details' do
-        let(:orders_additional_details) { 'details' }
+      context 'when `another issue` checkbox is selected' do
+        let(:orders) { %w(other_issue) }
+        let(:orders_collection) { nil }
+        let(:orders_additional_details) { 'orders_additional_details' }
 
-        let(:arguments) { {
-          c100_application: c100_application,
-          other_issue: '1',
-          orders_additional_details: orders_additional_details,
-        } }
-
-        it 'updates the record' do
+        it 'saves the record' do
           expect(c100_application).to receive(:update).with(
-            orders: [:other_issue],
-            orders_additional_details: 'details',
+            orders: %w(other_issue),
+            orders_additional_details: 'orders_additional_details',
           ).and_return(true)
 
           expect(subject.save).to be(true)
         end
       end
 
-      context 'when other issue details are already set' do
-        let(:existing_details){ 'existing details' }
-        let(:c100_application) {
-          instance_double(C100Application,
-            orders: existing_orders,
-            orders_additional_details: existing_details
-          )
-        }
+      context 'when there are additional details but `another issue` checkbox is not selected' do
+        let(:orders) { %w(prohibited_steps_holiday) }
+        let(:orders_collection) { nil }
+        let(:orders_additional_details) { 'orders_additional_details' }
 
-        context 'and the other issue checkbox is un-checked' do
-          let(:existing_orders){ [:other_issue, :group_specific_issues, :specific_issues_medical] }
-          let(:existing_details){ 'existing details' }
-          let(:arguments) { {
-            c100_application: c100_application,
-            group_specific_issues: '1',
-            specific_issues_medical: '1',
-            orders_additional_details: existing_details,
-          } }
+        it 'resets the content `orders_additional_details` attribute' do
+          expect(c100_application).to receive(:update).with(
+            orders: %w(prohibited_steps_holiday),
+            orders_additional_details: nil,
+          ).and_return(true)
 
-          it 'updates the record with orders_additional_details set to nil' do
-            expect(c100_application).to receive(:update).with(
-              orders: [:group_specific_issues, :specific_issues_medical],
-              orders_additional_details: nil,
-            ).and_return(true)
-            subject.save
-          end
+          expect(subject.save).to be(true)
         end
       end
     end

--- a/spec/presenters/summary/html_sections/nature_of_application_spec.rb
+++ b/spec/presenters/summary/html_sections/nature_of_application_spec.rb
@@ -46,7 +46,7 @@ module Summary
         expect(answers[0].value).to eq(
           ['child_arrangements_home', 'child_arrangements_time']
         )
-        expect(answers[0].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_group_child_arrangements_home')
+        expect(answers[0].change_path).to eq('/steps/petition/orders#steps-petition-orders-form-orders-child-arrangements-home-field')
 
         expect(answers[1]).to be_an_instance_of(MultiAnswer)
         expect(answers[1].question).to eq(:prohibited_steps_orders)
@@ -57,7 +57,7 @@ module Summary
             'prohibited_steps_moving'
           ]
         )
-        expect(answers[1].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_group_prohibited_steps')
+        expect(answers[1].change_path).to eq('/steps/petition/orders#steps-petition-orders-form-orders-group-prohibited-steps-field')
 
         expect(answers[2]).to be_an_instance_of(MultiAnswer)
         expect(answers[2].question).to eq(:specific_issues_orders)
@@ -66,12 +66,12 @@ module Summary
           'specific_issues_religion',
           'specific_issues_names'
         ])
-        expect(answers[2].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_group_specific_issues')
+        expect(answers[2].change_path).to eq('/steps/petition/orders#steps-petition-orders-form-orders-group-specific-issues-field')
 
         expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
         expect(answers[3].question).to eq(:other_issue_details)
         expect(answers[3].value).to eq('orders detail')
-        expect(answers[3].change_path).to eq('/steps/petition/orders#steps_petition_orders_form_other_issue')
+        expect(answers[3].change_path).to eq('/steps/petition/orders#steps-petition-orders-form-orders-other-issue-field')
 
         expect(answers[4]).to be_an_instance_of(AnswersGroup)
         expect(answers[4].name).to eq(:protection_orders)


### PR DESCRIPTION
Migrate this step and its playback to new design system.

This is very similar to what was done for MIAM Exemptions, but it has a few particular differences so it is not worth trying to adapt the concern just for this (it has a revealing text area, for once), so I've opted for leaving the logic as it was, inside the form object itself, but updated to work with the new check boxes.

![Screen Shot 2020-04-20 at 16 15 43](https://user-images.githubusercontent.com/687910/79768196-59fb7580-8322-11ea-8173-6b95c8a7501b.png)
