### PR TITLE
Migrate children personal details page

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -63,6 +63,12 @@ div.sentry-error-embed-wrapper p.powered-by {
   }
 }
 
+.app-fieldset--compact-first-group {
+  div.govuk-form-group:first-of-type {
+    margin-bottom: 0.4em;
+  }
+}
+
 @import 'app/developer_tools';
 @import 'app/backoffice';
 @import 'app/pending_migration';

--- a/app/forms/steps/children/personal_details_form.rb
+++ b/app/forms/steps/children/personal_details_form.rb
@@ -1,17 +1,13 @@
 module Steps
   module Children
     class PersonalDetailsForm < BaseForm
-      include GovUkDateFields::ActsAsGovUkDate
-
       attribute :gender, GenderAttribute
-      attribute :dob, Date
+      attribute :dob, MultiParamDate
       attribute :dob_unknown, Boolean
       attribute :age_estimate, StrippedString
 
-      acts_as_gov_uk_date :dob
-
-      validates_inclusion_of :gender, in: Gender.values
       validates_presence_of :dob, unless: :dob_unknown?
+      validates_inclusion_of :gender, in: Gender.values
 
       validates :dob, sensible_date: true, unless: :dob_unknown?
 

--- a/app/views/steps/children/personal_details/edit.html.erb
+++ b/app/views/steps/children/personal_details/edit.html.erb
@@ -1,24 +1,22 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading', name: @form_object.record.full_name %></h1>
+    <h1 class="govuk-heading-xl"><%=t '.heading', name: @form_object.record.full_name %></h1>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.gov_uk_date_field :dob,
-        placeholders: true,
-        legend_text: t('shared.form_elements.dob'),
-        form_hint_text: t('shared.form_elements.dob_child_hint') %>
+    <%= step_form @form_object, html: { class: 'app-fieldset--compact-first-group'}, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_date_field :dob, legend: { tag: 'span', size: 'm' } %>
 
-      <%=
-        f.check_box_fieldset :dob_unknown, [:dob_unknown] do |fieldset|
-          fieldset.check_box_input(:dob_unknown) { f.text_field :age_estimate }
-        end
-      %>
+      <%= f.govuk_check_boxes_fieldset :dob_unknown, small: true, legend: { tag: 'span', size: 's', hidden: true } do %>
+        <%= f.govuk_check_box :dob_unknown, true, multiple: false do
+          f.govuk_text_field :age_estimate, width: 'one-half'
+        end %>
+      <% end %>
 
-      <%= f.radio_button_fieldset :gender, choices: Gender.values %>
+      <%= f.govuk_collection_radio_buttons :gender, Gender.values, :value, nil, legend: { tag: 'span', size: 'm' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
 
   dictionary:
     dont_know: &dont_know "Don't know"
+    leave_blank_if_unknown: &leave_blank_if_unknown "Leave blank if you don’t know"
     previous_name_hint: &previous_name_hint "This should be the full legal name (including any middle names)"
     birthplace_hint: &birthplace_hint "For example, town or city"
     middle_names_hint: &middle_names_hint "Include all middle names here"
@@ -71,11 +72,19 @@ en:
       has_previous_name:
         <<: *YESNO
       previous_name: Enter their previous name
+      # old version (to be removed once all type of people are migrated)
+      dob_unknown: I don’t know their date of birth
       gender:
         female: Female
         male: Male
         unspecified: Unspecified
-      dob_unknown: I don't know their date of birth
+      # new version
+      dob_unknown_options:
+        'true': I don’t know their date of birth
+      gender_options:
+        female: Female
+        male: Male
+        unspecified: Unspecified
       age_estimate: Approximate age or year born
       birthplace: Place of birth
 
@@ -1356,8 +1365,8 @@ en:
         miam_certification_date: For example, 31 3 2020
       steps_application_court_proceedings_form:
         proceedings_date: Add approximate date if unsure
-        case_number: Leave blank if you don’t know
-        cafcass_details: Leave blank if you don’t know
+        case_number: *leave_blank_if_unknown
+        cafcass_details: *leave_blank_if_unknown
         order_types: For example, an Emergency protection order, Supervision order, Care order or any orders related to child abduction
         previous_details: Try and include as many details as possible, for example case number, date and name of court
       steps_application_urgent_hearing_details_form:
@@ -1418,6 +1427,8 @@ en:
       steps_children_additional_details_form:
         children_protection_plan_html: |
           A child protection plan is prepared by a local authority where a child is thought to be at risk of significant harm. It sets out steps to be taken to protect the child and support the family
+      steps_children_personal_details_form:
+        dob: For example, 31 3 2016
       steps_children_residence_form:
         person_ids_html: *select_all_that_apply
       steps_children_orders_form:
@@ -1443,7 +1454,7 @@ en:
         injunctive_case_number: *order_case_number_hint
         undertaking_case_number: *order_case_number_hint
       steps_miam_certification_details_form:
-        miam_certification_sole_trader_name: Leave blank if you don’t know
+        miam_certification_sole_trader_name: *leave_blank_if_unknown
       steps_solicitor_personal_details_form:
         reference: This is the reference for this case
       steps_solicitor_contact_details_form:
@@ -1552,6 +1563,12 @@ en:
         alternative_mediation: Have you tried professional mediation?
       steps_alternatives_negotiation_tools_form:
         alternative_negotiation_tools: Have you tried any negotiation tools or services?
+
+      # Children steps
+      steps_children_personal_details_form:
+        dob: Date of birth
+        dob_unknown: Date of birth unknown
+        gender: Sex
 
       # Attending court steps
       steps_attending_court_intermediary_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -22,7 +22,7 @@ en:
       dob:
         blank: Enter the date of birth
         invalid: Date of birth is not valid
-        future: Date of birth is in the future
+        future: Date of birth must be in the past
       gender:
         inclusion: Select the sex
       birthplace:


### PR DESCRIPTION
Fortunetely we've already migrated dates before so this was an easy task.

Just made sure the checkbox for "I don’t know their date of birth" was closer together to the actual date of birth input, as before, but as we can't apply classes to form element wrappers directly (`govuk-form-group`) I had to rely to the pseudo class `first-of-type` that will not work on older IE (older than 9 I believe) browser.

Not a big issue, on those browsers the checkbox will be a bit more separated from the date of birth input.

<img width="649" alt="Screen Shot 2020-04-22 at 16 03 01" src="https://user-images.githubusercontent.com/687910/79998616-d02ee200-84b2-11ea-900b-5a55ddd360bc.png">
