### PR TITLE
Migrate children decisions step

### DIFF
--- a/app/controllers/steps/children/orders_controller.rb
+++ b/app/controllers/steps/children/orders_controller.rb
@@ -6,7 +6,8 @@ module Steps
       def edit
         @form_object = OrdersForm.new(
           c100_application: current_c100_application,
-          record: current_record
+          orders: current_record.child_order.try(:orders),
+          record: current_record,
         )
       end
 
@@ -22,6 +23,10 @@ module Steps
 
       def set_petition_orders
         @petition = PetitionPresenter.new(current_c100_application)
+      end
+
+      def additional_permitted_params
+        [orders: []]
       end
     end
   end

--- a/app/forms/form_attribute_methods.rb
+++ b/app/forms/form_attribute_methods.rb
@@ -19,12 +19,6 @@ module FormAttributeMethods
     def attributes_map
       self.class.attributes_map(self)
     end
-
-    # Returns an array of attributes with a `true` value (this is meant to
-    # be used to return an array of selected checkboxes, for example).
-    def selected_options
-      attributes_map.select { |_name, selected| selected.is_a?(TrueClass) }.keys
-    end
   end
 
   module ClassMethods

--- a/app/forms/steps/children/orders_form.rb
+++ b/app/forms/steps/children/orders_form.rb
@@ -1,20 +1,18 @@
 module Steps
   module Children
     class OrdersForm < BaseForm
-      attributes PetitionOrder.values, Boolean
+      attribute :orders, Array[String]
 
-      # We override the getter methods for each of the order attributes so we
-      # can retrieve their state (checked/unchecked) from the DB array column.
-      attribute_names.each do |name|
-        define_method(name) { child_order.orders.include?(name.to_s) }
-      end
-
-      validate :at_least_one_checkbox_validation
+      validate :at_least_one_order_validation
 
       private
 
-      def at_least_one_checkbox_validation
-        errors.add(:base, :blank_orders) unless selected_options.any?
+      def selected_options
+        self[:orders] & PetitionOrder.string_values
+      end
+
+      def at_least_one_order_validation
+        errors.add(:orders, :blank) unless selected_options.any?
       end
 
       def persist!

--- a/app/views/steps/children/orders/edit.html.erb
+++ b/app/views/steps/children/orders/edit.html.erb
@@ -1,15 +1,13 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<% heading = t '.heading', name: @form_object.record.full_name %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
-
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%= heading %></h1>
-
-    <%= step_form @form_object do |f| %>
-      <%= f.check_box_fieldset :orders, @petition.all_selected_orders, legend_options: {class: "visually-hidden", text: heading} %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_check_boxes :orders, @petition.all_selected_orders, :to_s, :to_s,
+                                         legend: { text: t('.heading', name: @form_object.record.full_name) } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1316,7 +1316,8 @@ en:
         <<: *PERSONAL_DETAILS_FIELDS
         age_estimate: Approximate age or year child was born
       steps_children_orders_form:
-        <<: *PETITION_ORDERS
+        orders_options:
+          <<: *PETITION_ORDERS
       steps_children_additional_details_form:
         children_known_to_authorities:
           <<: *YESNO

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -318,8 +318,8 @@ en:
               blank: *blank_details_error
         steps/children/orders_form:
           attributes:
-            base:
-              blank_orders: Select a decision
+            orders:
+              blank: Select at least a decision
         steps/petition/protection_form:
           attributes:
             protection_orders:


### PR DESCRIPTION
This step is shown for each child and the list of checkboxes comes from the step where we ask what the applicant want to apply for, so the list is dynamic.

Complication is, the record is a child, but we are reading/writing the orders attribute in a `child_order` association (has_one).

Removed the method `selected_options` from the `FormAttributeMethods` module because we don't use it anymore in any other places.

<img width="665" alt="Screen Shot 2020-04-23 at 11 29 08" src="https://user-images.githubusercontent.com/687910/80089388-c0b4a500-8555-11ea-8680-90addae27531.png">
