### PR TITLE
Migrate postcode lookup to new design system

### DIFF
--- a/app/services/c100_app/address_lookup_service.rb
+++ b/app/services/c100_app/address_lookup_service.rb
@@ -19,6 +19,14 @@ module C100App
       last_exception.nil?
     end
 
+    def self.results_select_option(results)
+      Struct.new(:results_size, :tokenized_value) do
+        def address_lines
+          I18n.translate!(:results, count: results_size, scope: [:steps, :shared, :address_lookup])
+        end
+      end.new(results.size)
+    end
+
     private
 
     def query_params

--- a/app/views/steps/address/lookup/_applicant.html.erb
+++ b/app/views/steps/address/lookup/_applicant.html.erb
@@ -1,9 +1,11 @@
-<%= step_form form_object do |f| %>
-  <%= f.text_field :postcode %>
+<%= step_form form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_text_field :postcode, width: 'one-third', autocomplete: 'postal-code' %>
 
-  <%= link_to t('.manual_address'), {
+  <p class="govuk-body govuk-!-margin-bottom-8">
+    <%= link_to t('.manual_address'), {
       controller: '/steps/applicant/address_details', action: :edit, id: form_object.record
-  }, class: 'ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'applicant manual entry' } %>
+    }, class: 'govuk-link ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'applicant manual entry' } %>
+  </p>
 
   <%= f.continue_button %>
 <% end %>

--- a/app/views/steps/address/lookup/_other_party.html.erb
+++ b/app/views/steps/address/lookup/_other_party.html.erb
@@ -1,13 +1,15 @@
-<div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
-  <p><%=t '.address_for_documents' %></p>
+<div class="govuk-inset-text">
+  <%=t '.address_for_documents' %>
 </div>
 
-<%= step_form form_object do |f| %>
-  <%= f.text_field :postcode %>
+<%= step_form form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_text_field :postcode, width: 'one-third' %>
 
-  <%= link_to t('.manual_address'), {
+  <p class="govuk-body govuk-!-margin-bottom-8">
+    <%= link_to t('.manual_address'), {
       controller: '/steps/other_party/address_details', action: :edit, id: form_object.record
-  }, class: 'ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'other party manual entry' } %>
+    }, class: 'govuk-link ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'other party manual entry' } %>
+  </p>
 
   <%= f.continue_button %>
 <% end %>

--- a/app/views/steps/address/lookup/_respondent.html.erb
+++ b/app/views/steps/address/lookup/_respondent.html.erb
@@ -1,13 +1,15 @@
-<div role="note" aria-label="Information" class="panel panel-border-wide info-notice">
-  <p><%=t '.address_for_documents' %></p>
+<div class="govuk-inset-text">
+  <%=t '.address_for_documents' %>
 </div>
 
-<%= step_form form_object do |f| %>
-  <%= f.text_field :postcode %>
+<%= step_form form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_text_field :postcode, width: 'one-third' %>
 
-  <%= link_to t('.manual_address'), {
+  <p class="govuk-body govuk-!-margin-bottom-8">
+    <%= link_to t('.manual_address'), {
       controller: '/steps/respondent/address_details', action: :edit, id: form_object.record
-  }, class: 'ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'respondent manual entry' } %>
+    }, class: 'govuk-link ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'respondent manual entry' } %>
+  </p>
 
   <%= f.continue_button %>
 <% end %>

--- a/app/views/steps/address/lookup/edit.html.erb
+++ b/app/views/steps/address/lookup/edit.html.erb
@@ -1,10 +1,11 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">
+    <h1 class="govuk-heading-xl">
       <%=t '.heading', name: @form_object.record.full_name %>
     </h1>
 

--- a/app/views/steps/address/results/_no_results.en.html.erb
+++ b/app/views/steps/address/results/_no_results.en.html.erb
@@ -1,28 +1,18 @@
-<% if successful_lookup %>
-
-  <p class="lede">
+<p class="govuk-body-l">
+  <% if successful_lookup %>
     Although the postcode you entered looks like it’s in the right format, no addresses were found. This can happen
     sometimes if it’s a very new or old postcode.
-  </p>
-
-<% else %>
-
-  <p class="lede">
+  <% else %>
     We’re having some trouble connecting to our postcode lookup at the moment - this could be a temporary problem, and
     it might work if you try again.
-  </p>
+  <% end %>
+</p>
 
-<% end %>
+<h3 class="govuk-heading-m">What to do now</h3>
 
-<section id="what-to-do-now" class="moj-Section moj-Section--2" data-block-name="what-to-do-now">
-  <h2 class="gv-u-heading-xlarge">What to do now</h2>
+<p class="govuk-body govuk-!-margin-bottom-6">
+  You can go back and try again, change the postcode, or continue to enter the address manually.
+</p>
 
-  <div class="Section__content govuk-govspeak gv-s-prose">
-    <p>You can go back and try again, change the postcode, or continue to enter the address manually.</p>
-  </div>
-</section>
-
-<div class="xform-group form-submit">
-  <%= link_to 'Continue', person_url_for(record, step: :address_details), class: 'button ga-pageLink', role: 'button', data: { ga_category: 'address lookup', ga_label: 'no results continue' } %>
-  <%= link_to 'Go back and try again', edit_steps_address_lookup_path(record), class: 'button button-secondary ga-pageLink', role: 'button', data: { ga_category: 'address lookup', ga_label: 'no results retry' } %>
-</div>
+<%= link_button 'Continue', person_url_for(record, step: :address_details), class: 'ga-pageLink', data: { module: 'govuk-button', ga_category: 'address lookup', ga_label: 'no results continue' } %>
+<%= link_button 'Go back and try again', edit_steps_address_lookup_path(record), class: 'govuk-button--secondary ga-pageLink', data: { module: 'govuk-button', ga_category: 'address lookup', ga_label: 'no results retry' } %>

--- a/app/views/steps/address/results/edit.html.erb
+++ b/app/views/steps/address/results/edit.html.erb
@@ -1,31 +1,41 @@
 <% title t('.page_title') %>
+<% step_header %>
 
 <% record = @form_object.record %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge">
+    <h1 class="govuk-heading-xl">
       <%=t '.heading', name: record.full_name %>
     </h1>
 
-    <p class="heading-small bold">
+    <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
       <%=t '.current_postcode' %>
-    </p>
+    </h4>
 
-    <p>
-      <span class="bold-small"><%= record.postcode %></span>
-      <%= link_to t('.change_postcode'), edit_steps_address_lookup_path(record), class: 'util_ml-medium' %>
+    <p class="govuk-body">
+      <span class="govuk-!-font-weight-bold"><%= record.postcode %></span>
+      <%= link_to t('.change_postcode'), edit_steps_address_lookup_path(record), class: 'govuk-link govuk-!-margin-left-6' %>
     </p>
 
     <% if @addresses.any? %>
+      <%
+        # Add the number of results as the first element of the collection. This forces the user
+        # to select something instead of just clicking continue with the first address preselected.
+        @addresses.unshift(
+          C100App::AddressLookupService.results_select_option(@addresses)
+        )
+      %>
 
-      <%= step_form @form_object do |f| %>
-        <%= f.collection_select :selected_address, @addresses, :tokenized_value, :address_lines, include_blank: true %>
+      <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <%= f.govuk_collection_select :selected_address, @addresses, :tokenized_value, :address_lines %>
 
-        <%= link_to t('.address_not_listed'), person_url_for(record, step: :address_details),
-                    class: 'ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'address not listed' } %>
+        <p class="govuk-body govuk-!-margin-bottom-8">
+          <%= link_to t('.address_not_listed'), person_url_for(record, step: :address_details),
+                      class: 'govuk-link ga-pageLink', data: { ga_category: 'address lookup', ga_label: 'address not listed' } %>
+        </p>
 
         <%= f.continue_button %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,6 +151,11 @@ en:
         cait_info_html: |
           Alternatively you can <a href="https://helpwithchildarrangements.service.justice.gov.uk" class="govuk-link" rel="external"
           target="_blank">read the child arrangements guide</a> to see if there’s a more suitable option than going to court.
+      address_lookup:
+        results:
+          zero: "No addresses found"
+          one: "%{count} address found"
+          other: "%{count} addresses found"
       existing_names:
         remove_name: "Remove %{legend}"
       children_personal_details:

--- a/spec/services/c100_app/address_lookup_service_spec.rb
+++ b/spec/services/c100_app/address_lookup_service_spec.rb
@@ -143,4 +143,26 @@ RSpec.describe C100App::AddressLookupService do
       end
     end
   end
+
+  describe '.results_select_option' do
+    subject { described_class.results_select_option(results) }
+
+    context 'when there are no results' do
+      let(:results) { [] }
+      it { expect(subject.address_lines).to eq('No addresses found') }
+      it { expect(subject.tokenized_value).to be_nil }
+    end
+
+    context 'when there is 1 result' do
+      let(:results) { ['result'] }
+      it { expect(subject.address_lines).to eq('1 address found') }
+      it { expect(subject.tokenized_value).to be_nil }
+    end
+
+    context 'when there are more than 1 result' do
+      let(:results) { %w(result1 result2) }
+      it { expect(subject.address_lines).to eq('2 addresses found') }
+      it { expect(subject.tokenized_value).to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
These are a few views, shared between Applicant, Respondent and Other Party.

All behave the same except for some minor copy changes and links pointing to different places.

Had to add a workaround to the dropdown list as the new design system gem does not allow `include_blank: true` to include a blank item in the dropdown as before.

I've seen this is anyways not recommended as cause confusion to the user so I've done what it is recommended that is include as the first element of the dropdown the number of addresses found instead of a blank item as before.

<img width="484" alt="Screen Shot 2020-04-24 at 12 27 12" src="https://user-images.githubusercontent.com/687910/80207926-09885e80-8627-11ea-99ee-6a459e1c8e18.png">
--
<img width="654" alt="Screen Shot 2020-04-24 at 12 27 26" src="https://user-images.githubusercontent.com/687910/80207936-0e4d1280-8627-11ea-871c-9def4496ac60.png">
