### PR TITLE
Migrate user sign in page

### DIFF
--- a/app/assets/javascripts/modules/password-toggle.js
+++ b/app/assets/javascripts/modules/password-toggle.js
@@ -1,12 +1,12 @@
 'use strict';
 
 moj.Modules.passwordToggle = {
-  element_class: 'js-toggleable-password',
-  link_class: 'js-toggle-password',
+  password_element: 'input[name="user[password]"]',
+  link_class: 'app-js--toggle-password',
 
   init: function() {
     var self = this,
-        $toggleablePasswords = $('.' + self.element_class);
+        $toggleablePasswords = $(self.password_element);
 
     if($toggleablePasswords.length) {
       self.injectLinks($toggleablePasswords);
@@ -25,7 +25,7 @@ moj.Modules.passwordToggle = {
         $el = $el.closest('p');
       }
       e.preventDefault();
-      $el.find('.toggle').toggleClass('js-hidden');
+      $el.find('.toggle').toggleClass('govuk-!-display-none');
       self.togglePassword($el);
     });
   },
@@ -33,12 +33,17 @@ moj.Modules.passwordToggle = {
   injectLinks: function($els) {
     var self = this;
 
-    $els.after('<p class="' + self.link_class + '"><a href="#" class="show toggle">' + moj.Modules.showPasswordText + '</a><a href="#" class="hide toggle js-hidden">' + moj.Modules.hidePasswordText + '</a></p>');
+    $els.after(
+        '<p class="' + self.link_class + '">' +
+        '<a href="#" class="show toggle">' + moj.Modules.showPasswordText + '</a>' +
+        '<a href="#" class="govuk-!-display-none hide toggle">' + moj.Modules.hidePasswordText + '</a>' +
+        '</p>'
+    );
   },
 
   togglePassword: function($link) {
     var self = this,
-        $el = $link.siblings('.' + self.element_class),
+        $el = $link.siblings(self.password_element),
         elType = $el.attr('type'),
         newType = (elType === 'password' ? 'text' : 'password');
 

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -74,6 +74,13 @@ div.sentry-error-embed-wrapper p.powered-by {
   }
 }
 
+// Used in `javascripts/modules/password-toggle.js`
+.app-js--toggle-password {
+  a {
+    @extend %govuk-link;
+  }
+}
+
 @import 'app/developer_tools';
 @import 'app/backoffice';
 @import 'app/pending_migration';

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -16,6 +16,11 @@ div.sentry-error-embed-wrapper p.powered-by {
   padding: 3px;
 }
 
+.app-error-summary--alert {
+  @include govuk-typography-weight-bold;
+  color: $govuk-error-colour;
+}
+
 .app-list--lower-roman {
   @extend %govuk-list--number;
   list-style-type: lower-roman;

--- a/app/assets/stylesheets/local/inputs.scss
+++ b/app/assets/stylesheets/local/inputs.scss
@@ -27,9 +27,3 @@
   float: none;
   display: table;
 }
-
-// Maintain the width when toggling between input password and input text.
-// Otherwise the input text override the width, making it bigger.
-.js-toggleable-password {
-  width: $full-width;
-}

--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -58,14 +58,6 @@ address {
   }
 }
 
-.js-toggle-password {
-  cursor: pointer;
-  color: $link-colour;
-  text-decoration: underline;
-  margin-bottom: 0;
-  width: 200px;
-}
-
 .govuk-box-highlight {
   p {
     @include core-24;

--- a/app/views/layouts/_flash_alert.html.erb
+++ b/app/views/layouts/_flash_alert.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+      <h2 id="error-summary-title" class="govuk-error-summary__title">
+        <%=t 'errors.error_summary.heading' %>
+      </h2>
+
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <li class="app-error-summary--alert"><%= flash[:alert] %></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,10 @@
   <%= render partial: 'layouts/phase_banner' %>
 <% end %>
 
+<% content_for(:flash_alert) do %>
+  <%= render partial: 'layouts/flash_alert' if flash[:alert].present? %>
+<% end %>
+
 <% content_for(:content) do %>
   <%= yield %>
 <% end %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -67,15 +67,7 @@
   <%= yield(:back_link) %>
 
   <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
-    <% if flash[:alert].present? %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <li><%= flash[:alert] %></li>
-          </ul>
-        </div>
-      </div>
-    <% end %>
+    <%= yield(:flash_alert) %>
 
     <%# TODO: to be removed once all views are migrated %>
     <%= yield(:old_error_summary) %>

--- a/app/views/users/logins/new.html.erb
+++ b/app/views/users/logins/new.html.erb
@@ -1,23 +1,33 @@
 <% title t('.page_title') %>
+<% step_header(path: url_for(:back)) %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <!-- Not using `govuk_error_summary` here. This view uses flash[:alert] from Devise -->
 
-    <p><%=t '.account_purge_info', expire_in_days: Rails.configuration.x.users.expire_in_days %></p>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <p class="govuk-body-l">
+      <%=t '.account_purge_info', expire_in_days: Rails.configuration.x.users.expire_in_days %>
+    </p>
 
     <%#
       Using `as: 'user_signin'` so we can customise the i18n labels (and password hint),
       to be different in this form. Because of this, we also need to specify the `name`,
       otherwise it would become `user_signin[email] and user_signin[password]`
     %>
-    <%= form_for(resource, as: 'user_signin', url: user_session_path, html: {class: 'ga-submitForm', data: {ga_category: 'save and return', ga_label: 'login'}}) do |f| %>
-      <%= f.email_field :email, name: 'user[email]', autofocus: true %>
-      <%= f.password_field :password, name: 'user[password]', class: 'js-toggleable-password', autocomplete: 'off' %>
+    <%= form_for(resource, as: 'user_signin', url: user_session_path,
+                 html: { class: 'ga-submitForm', data: { ga_category: 'save and return', ga_label: 'login' } },
+                 builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
 
-      <p><%= link_to t('.forgot_password'), new_user_password_path %></p>
+      <%= f.govuk_email_field :email, name: 'user[email]', width: 'one-half', autocomplete: 'email', spellcheck: 'false', autofocus: true %>
+      <%= f.govuk_password_field :password, name: 'user[password]', width: 'one-half', autocomplete: 'current-password', spellcheck: 'false' %>
 
-      <%= f.submit t('helpers.submit.sign_in'), class: 'button' %>
+      <p class="govuk-body govuk-!-margin-bottom-5">
+        <%= link_to t('.forgot_password'), new_user_password_path, class: 'govuk-link' %>
+      </p>
+
+      <%= f.govuk_submit t('helpers.submit.sign_in') %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1691,10 +1691,10 @@ en:
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
-      invalid: "There's an error. Please enter a valid email and password."
+      invalid: "Please enter a valid email and password"
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "There's an error. Please enter a valid email and password."
+      not_found_in_database: "Please enter a valid email and password"
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in before continuing."
       unconfirmed: "You have to confirm your email address before continuing."


### PR DESCRIPTION
* Refactored flash alert and styling

The flash alert will be used in some places of the `views/users/*` due to how Devise works.

In order to make it behave more like the rest of errors, we can style and make sure the flash alert is identical to the other errors.

* Adapted the javascript to show/hide the password to work with new markup and styles

<img width="685" alt="Screen Shot 2020-04-27 at 09 43 15" src="https://user-images.githubusercontent.com/687910/80352509-e69abc00-886b-11ea-98f4-30917cfd6d5f.png">