### PR TITLE
Migrate reset password page

### DIFF
--- a/app/views/steps/abuse_concerns/details/edit.html.erb
+++ b/app/views/steps/abuse_concerns/details/edit.html.erb
@@ -29,7 +29,7 @@
       <%= f.govuk_radio_buttons_fieldset :behaviour_ongoing, legend: { tag: 'span', size: 'm' } do %>
         <%= f.govuk_radio_button :behaviour_ongoing, GenericYesNo::YES, link_errors: true %>
         <%= f.govuk_radio_button :behaviour_ongoing, GenericYesNo::NO do %>
-          <%= f.govuk_email_field :behaviour_stop, label: { size: 's' } %>
+          <%= f.govuk_text_field :behaviour_stop, label: { size: 's' } %>
         <% end %>
       <% end %>
 

--- a/app/views/users/logins/new.html.erb
+++ b/app/views/users/logins/new.html.erb
@@ -20,14 +20,12 @@
                  html: { class: 'ga-submitForm', data: { ga_category: 'save and return', ga_label: 'login' } },
                  builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
 
-      <%= f.govuk_email_field :email, name: 'user[email]', width: 'one-half', autocomplete: 'email', spellcheck: 'false', autofocus: true %>
-      <%= f.govuk_password_field :password, name: 'user[password]', width: 'one-half', autocomplete: 'current-password', spellcheck: 'false' %>
-
-      <p class="govuk-body govuk-!-margin-bottom-5">
-        <%= link_to t('.forgot_password'), new_user_password_path, class: 'govuk-link' %>
-      </p>
+      <%= f.govuk_email_field :email, name: 'user[email]', width: 'two-thirds', autocomplete: 'email', spellcheck: 'false', autofocus: true %>
+      <%= f.govuk_password_field :password, name: 'user[password]', width: 'two-thirds', autocomplete: 'current-password', spellcheck: 'false' %>
 
       <%= f.govuk_submit t('helpers.submit.sign_in') %>
     <% end %>
+
+    <%= link_to t('.forgot_password'), new_user_password_path, class: 'govuk-link' %>
   </div>
 </div>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,18 +1,20 @@
 <% title t('.page_title') %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= error_summary(resource) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(resource) %>
 
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :patch }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name),
+                 html: { method: :patch }, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+
         <%= f.hidden_field :reset_password_token %>
 
-        <%= f.password_field :password, class: 'js-toggleable-password', autofocus: true, autocomplete: "off" %>
-        <%= f.password_field :password_confirmation, class: 'js-toggleable-password', autocomplete: "off" %>
+        <%= f.govuk_password_field :password, width: 'two-thirds', autocomplete: 'new-password', spellcheck: 'false' %>
+        <%= f.govuk_password_field :password_confirmation, width: 'two-thirds', autocomplete: 'new-password', spellcheck: 'false' %>
 
-        <%= f.submit t('helpers.submit.change_password'), class: 'button' %>
+        <%= f.govuk_submit t('helpers.submit.change_password') %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,21 +1,24 @@
 <% title t('.page_title') %>
+<% step_header(path: url_for(:back)) %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= error_summary(resource) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(resource) %>
 
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <p><%= t '.lead_text' %></p>
+    <p class="govuk-body-l"><%= t '.lead_text' %></p>
 
-    <p><%= t '.account_text', expire_in_days: Rails.configuration.x.users.expire_in_days %></p>
+    <p class="govuk-body"><%= t '.account_text', expire_in_days: Rails.configuration.x.users.expire_in_days %></p>
 
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-      <%= f.email_field :email, autofocus: true %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name),
+                 html: { method: :post }, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
 
-      <p><%= link_to t('.sign_in'), user_session_path %></p>
+      <%= f.govuk_email_field :email, width: 'two-thirds', autocomplete: 'email', spellcheck: 'false', autofocus: true %>
 
-      <%= f.submit t('helpers.submit.reset_password'), class: 'button' %>
+      <%= f.govuk_submit t('helpers.submit.reset_password') %>
     <% end %>
+
+    <%= link_to t('.sign_in'), user_session_path, class: 'govuk-link' %>
   </div>
 </div>

--- a/app/views/users/passwords/reset_confirmation.html.erb
+++ b/app/views/users/passwords/reset_confirmation.html.erb
@@ -1,11 +1,13 @@
 <% title t('.page_title') %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-large"><%= t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
 
-    <p class="lede"><%=t '.lead_text' %></p>
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
-    <p><%= link_to t('.sign_in'), user_session_path %></p>
+    <p class="govuk-body">
+      <%= link_to t('.sign_in'), user_session_path, class: 'govuk-link' %>
+    </p>
   </div>
 </div>

--- a/app/views/users/passwords/reset_sent.html.erb
+++ b/app/views/users/passwords/reset_sent.html.erb
@@ -1,15 +1,13 @@
 <% title t('.page_title') %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-large"><%= t '.heading' %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t '.heading' %></h1>
 
-    <p class="lede"><%=t '.lead_text' %></p>
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
-    <p><%=t '.account_purge_info', expire_in_days: Rails.configuration.x.users.expire_in_days %></p>
+    <p class="govuk-body"><%=t '.account_purge_info', expire_in_days: Rails.configuration.x.users.expire_in_days %></p>
 
-    <div class="form-group">
-      <%= link_to t('.start_again'), root_path, class: 'button' %>
-    </div>
+    <%= link_button t('.continue'), root_path %>
   </div>
 </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -19,8 +19,8 @@
                  html: { class: 'verify-password-form ga-submitForm', data: { ga_category: 'save and return', ga_label: 'signup' } },
                  builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
 
-      <%= f.govuk_email_field :email, width: 'one-half', autocomplete: 'email', spellcheck: 'false', autofocus: true %>
-      <%= f.govuk_password_field :password, width: 'one-half', autocomplete: 'new-password', spellcheck: 'false' %>
+      <%= f.govuk_email_field :email, width: 'two-thirds', autocomplete: 'email', spellcheck: 'false', autofocus: true %>
+      <%= f.govuk_password_field :password, width: 'two-thirds', autocomplete: 'new-password', spellcheck: 'false' %>
 
       <%= f.govuk_submit t('helpers.submit.create_account') %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1358,12 +1358,12 @@ en:
         email: Email address
       user:
         email: Your email address
-        password: Choose password
+        password: Create a password
         password_confirmation: Confirm password
         current_password: Old password
       user_signin:
         email: Your email address
-        password: Enter password
+        password: Enter your password
 
     hint:
       user:
@@ -1620,8 +1620,8 @@ en:
       update: Continue
       cancel: Cancel
       save_and_come_back_later: Save and come back later
-      create_account: Save draft
-      sign_in: Sign in
+      create_account: Create account
+      sign_in: Continue
       reset_password: Reset password
       change_password: Change my password
       save_and_continue: Save and continue
@@ -1760,9 +1760,9 @@ en:
         page_title: Password updated
     passwords:
       new:
-        heading: Forgot your password
-        sign_in: Go back and sign in
-        lead_text: Enter your email address and we'll send you a link to reset your password.
+        heading: Forgot your password?
+        sign_in: Sign in to an existing account
+        lead_text: Enter your email address and we’ll send you a link to reset your password.
         account_text: Remember, if you have not signed in for %{expire_in_days} days we delete your account for security reasons.
         page_title: Forgot password
       edit:
@@ -1773,7 +1773,7 @@ en:
         lead_text: We’ve sent you an email with a link to reset your password. Please check your inbox and spam folder.
         account_purge_info: *account_purge_info
         page_title: Reset link sent
-        <<: *START_FINISH
+        continue: Continue
       reset_confirmation:
         heading: Your password has been changed
         lead_text: You have set a new password successfully.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -75,7 +75,7 @@ en:
               blank: Enter the password again
               too_short: Your password must be at least %{count} characters
               too_long: Your password must be no longer than %{count} characters
-              confirmation: The password confirmation doesn't match
+              confirmation: The password confirmation doesn’t match
             current_password:
               blank: Enter your current password
               invalid: The password is not valid


### PR DESCRIPTION
And associated confirmation pages.

Changed inputs width from `one-half` to `two-thirds` to make them slighly bigger, reserving 'one-half' for smaller inputs like reference numbers.

Also I went back to tweak some of the copy and positioning of elements in the sign in and registration pages, as per recommendations here:
https://design-system.service.gov.uk/patterns/create-accounts/

<img width="674" alt="Screen Shot 2020-04-27 at 13 19 22" src="https://user-images.githubusercontent.com/687910/80386245-09929380-889f-11ea-9c6c-979241d6051d.png">
--
<img width="587" alt="Screen Shot 2020-04-27 at 13 19 41" src="https://user-images.githubusercontent.com/687910/80386258-0d261a80-889f-11ea-83d7-9b980b5f1613.png">
