### PR TITLE
Fix header styling

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -16,6 +16,22 @@ div.sentry-error-embed-wrapper p.powered-by {
   padding: 3px;
 }
 
+.app-header__logout-link {
+  // 1. Remove any button styling
+  padding: 0;
+  border: 0;
+  margin: 0;
+  outline: none;
+  box-sizing: unset;
+  background-color: transparent;
+
+  // 2. Apply header link styling
+  @include govuk-font($size: 16, $weight: bold);
+  color: govuk-colour("white");
+  white-space: nowrap;
+  cursor: pointer;
+}
+
 .app-error-summary--alert {
   @include govuk-typography-weight-bold;
   color: $govuk-error-colour;

--- a/app/views/layouts/_current_user_menu.html.erb
+++ b/app/views/layouts/_current_user_menu.html.erb
@@ -2,17 +2,17 @@
   <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
   <nav>
     <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
-      <li class="govuk-header__navigation-item">
+      <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(users_drafts_path) %>">
         <%= link_to t('.your_drafts'), users_drafts_path, class: 'govuk-header__link' %>
       </li>
-      <li class="govuk-header__navigation-item">
+      <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(edit_user_registration_path) %>">
         <%= link_to t('.change_password'), edit_user_registration_path, class: 'govuk-header__link' %>
       </li>
       <li class="govuk-header__navigation-item">
         <%= current_user.email %>
       </li>
       <li class="govuk-header__navigation-item">
-        <%= button_to t('.logout'), destroy_user_session_path, class: 'logout-link govuk-header__link', method: :delete %>
+        <%= button_to t('.logout'), destroy_user_session_path, class: 'govuk-header__link app-header__logout-link', method: :delete %>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
This will now show as it should.

Active link will also be marked in a different colour as per design system.
https://design-system.service.gov.uk/components/header/

<img width="986" alt="Screen Shot 2020-04-28 at 16 29 31" src="https://user-images.githubusercontent.com/687910/80506686-d8cd5f80-896d-11ea-88a0-3d00ecc2a584.png">
