### PR TITLE
Migrate submission step

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -15,6 +15,17 @@ strong {
 // App specific custom styles follow. Always prepend `app-` prefix to make
 // it clear this is a custom style not part of the design system.
 //
+@mixin app-button-reset {
+  padding: 0;
+  margin: 0;
+  border: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  box-sizing: unset;
+  background-color: transparent;
+}
+
 .app-sidebar-grey {
   background: govuk-colour("light-grey");
 }
@@ -26,18 +37,11 @@ strong {
 
 .app-header__logout-link {
   // 1. Remove any button styling
-  padding: 0;
-  border: 0;
-  margin: 0;
-  outline: none;
-  box-sizing: unset;
-  background-color: transparent;
+  @include app-button-reset;
 
   // 2. Apply header link styling
   @include govuk-font($size: 16, $weight: bold);
-  color: govuk-colour("white");
   white-space: nowrap;
-  cursor: pointer;
 }
 
 .app-error-summary--alert {

--- a/app/assets/stylesheets/local/buttons.scss
+++ b/app/assets/stylesheets/local/buttons.scss
@@ -1,19 +1,3 @@
-.link-button {
-  background: none;
-  color: $link-colour;
-  border: none;
-  box-shadow: none;
-  text-decoration: underline;
-  padding-right: 50px;
-  margin: 0;
-  font-size: 19px;
-  cursor: pointer;
-}
-
-.button-alternative {
-  @include button($grey-3);
-}
-
 .button-secondary {
   background: transparent;
   color: $link-colour;

--- a/app/views/steps/application/receipt_email_check/show.html.erb
+++ b/app/views/steps/application/receipt_email_check/show.html.erb
@@ -1,24 +1,27 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
-
-    <div class="panel panel-border-narrow">
-      <p class="lede">
-        <strong><%= current_c100_application.receipt_email %></strong>
-      </p>
+    <div class="govuk-inset-text">
+      <span class="govuk-!-font-size-27 govuk-!-font-weight-bold">
+        <%= current_c100_application.receipt_email %>
+      </span>
     </div>
 
-    <p><%=t '.email_info' %></p>
+    <p class="govuk-body govuk-!-margin-bottom-6"><%=t '.email_info' %></p>
 
-    <div class="xform-group form-submit">
-      <%= link_to t('.continue'), edit_steps_application_check_your_answers_path, class: 'button', role: 'button' %>
-      <%= link_to t('.go_back'), edit_steps_application_submission_path,
-                  class: 'link-button link-button-secondary govuk-link--no-visited-state ga-pageLink',
-                  data: { ga_category: 'receipt email address', ga_label: 'change email' } %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <%= link_button t('.continue'), edit_steps_application_check_your_answers_path %>
+      </div>
+
+      <div class="govuk-grid-column-one-half govuk-!-margin-top-2">
+        <%= link_to t('.go_back'), edit_steps_application_submission_path, class: 'govuk-link govuk-link--no-visited-state ga-pageLink',
+                    data: { ga_category: 'receipt email address', ga_label: 'change email' } %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/steps/application/submission/edit.html.erb
+++ b/app/views/steps/application/submission/edit.html.erb
@@ -1,23 +1,20 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
 
-    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%=t '.heading' %></h1>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :submission_type do %>
+        <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
-    <p class="lede gv-u-text-lede"><%=t '.lead_text' %></p>
+        <%= f.govuk_radio_button :submission_type, SubmissionType::ONLINE, link_errors: true do %>
+          <%= f.govuk_email_field :receipt_email, autocomplete: 'email', spellcheck: 'false' %>
+        <% end %>
 
-    <%= step_form @form_object do |f| %>
-      <%=
-        f.radio_button_fieldset :submission_type, legend_options: { class: 'visually-hidden', text: t('.heading') }, inline: true do |fieldset|
-          fieldset.radio_input(SubmissionType::ONLINE, panel_id: :receipt_email_panel)
-          fieldset.radio_input(SubmissionType::PRINT_AND_POST)
-          fieldset.revealing_panel(:receipt_email_panel) do |panel|
-            panel.email_field :receipt_email
-          end
-        end
-      %>
+        <%= f.govuk_radio_button :submission_type, SubmissionType::PRINT_AND_POST %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -721,7 +721,6 @@ en:
       submission:
         edit:
           page_title: How would you submit your application?
-          heading: How would you like to submit your application to court?
           lead_text: Your completed application can be sent straight to the court electronically, or you can print it and send it by post if you prefer.
       receipt_email_check:
         show:
@@ -1222,7 +1221,7 @@ en:
         hwf_reference_number: Reference number
         solicitor_account_number: Solicitor’s fee account number
       steps_application_submission_form:
-        submission_type:
+        submission_type_options:
           online: Submit electronically
           print_and_post: Print and send by post
         receipt_email: Enter an email address if you would like to get a confirmation
@@ -1631,7 +1630,9 @@ en:
       steps_international_resident_form:
         international_resident: Is the life of the child or children, a parent, or anyone significant to the children mainly based in a country outside England or Wales?
 
-      # Payment step
+      # Submission and payment steps
+      steps_application_submission_form:
+        submission_type: How would you like to submit your application to court?
       steps_application_payment_form:
         payment_type: How will you pay the application fee?
 


### PR DESCRIPTION
This is the step where the applicant choose to submit the application online, or print and post.

If online, the next page ask them to confirm the email address is correct, with an option to go back and change it.

Improved the styling for the button reset and cleanup other unused styles.

<img width="701" alt="Screen Shot 2020-04-30 at 15 39 27" src="https://user-images.githubusercontent.com/687910/80793521-40162a00-8b8f-11ea-984f-dfff07e79dee.png">

--

<img width="700" alt="Screen Shot 2020-05-01 at 09 29 15" src="https://user-images.githubusercontent.com/687910/80793529-44424780-8b8f-11ea-9ea9-86865efe83c8.png">
