### PR TITLE
Migrate each individual CYA partial

### DIFF
--- a/app/assets/stylesheets/local/app/check_answers.scss
+++ b/app/assets/stylesheets/local/app/check_answers.scss
@@ -107,3 +107,48 @@
   margin-top: govuk-spacing(8);
   background-color: #ddd;
 }
+
+// Custom styles for groups of question-answer, partial `_answers_group.html.erb`
+//
+.app-cya--answers-group {
+  dl {
+    // This is the secondary (embedded) definition list
+    dt, dd {
+      width: unset !important;
+      padding-right: unset;
+      display: unset;
+      border: none;
+    }
+
+    .govuk-summary-list__row {
+      border: none;
+    }
+
+    .govuk-summary-list__value {
+      display: block;
+    }
+
+    // Give a sense of hierarchy by adding a bit of inset to sub-questions (only on mobile)
+    @include govuk-media-query($until: tablet) {
+      margin-left: govuk-spacing(4);
+    }
+  }
+
+  @include govuk-media-query($until: tablet) {
+    .app-cya--answers-group__key {
+      margin-bottom: govuk-spacing(3);
+    }
+  }
+}
+
+// BEGIN -- Overrides for design system styles. Use with caution.
+//
+.govuk-summary-list {
+  table-layout: unset;
+}
+
+.govuk-summary-list__actions {
+  // Reduce the column width of the 'Change' link in CYA to give more space to the answers
+  width: 10%;
+}
+// END -- Overrides for design system.

--- a/app/presenters/summary/html_sections/children_further_information.rb
+++ b/app/presenters/summary/html_sections/children_further_information.rb
@@ -5,6 +5,7 @@ module Summary
         :children_further_information
       end
 
+      # rubocop:disable Metrics/MethodLength
       def answers
         [
           Answer.new(
@@ -22,8 +23,14 @@ module Summary
             c100.children_protection_plan,
             change_path: edit_steps_children_additional_details_path
           ),
+          Answer.new(
+            :has_other_children,
+            c100.has_other_children,
+            change_path: edit_steps_children_has_other_children_path
+          ),
         ].select(&:show?)
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/presenters/summary/html_sections/other_children_details.rb
+++ b/app/presenters/summary/html_sections/other_children_details.rb
@@ -9,17 +9,6 @@ module Summary
         c100.other_children
       end
 
-      def answers
-        [
-          Answer.new(
-            :has_other_children,
-            c100.has_other_children,
-            change_path: edit_steps_children_has_other_children_path
-          ),
-          super,
-        ].flatten.select(&:show?)
-      end
-
       protected
 
       def names_path

--- a/app/views/steps/completion/shared/_answers_group.html.erb
+++ b/app/views/steps/completion/shared/_answers_group.html.erb
@@ -1,13 +1,13 @@
-<dl class="answers-group" id="<%= answers_group.name %>">
-  <dt class="question">
+<div class="govuk-summary-list__row app-cya--answers-group" id="<%= answers_group.name %>">
+  <dt class="govuk-summary-list__key app-cya--answers-group__key">
     <%=t "check_answers_html.groups.#{answers_group.name}" %>
   </dt>
-  <dd class="answer">
-    <dl class="answers-group-inner">
+  <dd class="govuk-summary-list__value">
+    <dl class="govuk-summary-list">
       <%= render answers_group.answers %>
     </dl>
   </dd>
-  <dd class="change">
+  <dd class="govuk-summary-list__actions">
     <%= render partial: 'steps/completion/shared/change_link', locals: { question: answers_group } %>
   </dd>
-</dl>
+</div>

--- a/app/views/steps/completion/shared/_change_link.html.erb
+++ b/app/views/steps/completion/shared/_change_link.html.erb
@@ -13,7 +13,7 @@
                     end
   %>
 
-  <%= link_to question.change_path, class: 'ga-pageLink', data: { ga_category: 'check your answers', ga_label: 'change link' } do %>
+  <%= link_to question.change_path, class: 'govuk-link govuk-link--no-visited-state ga-pageLink', data: { ga_category: 'check your answers', ga_label: 'change link' } do %>
     <%= t('check_answers_html.change_link_html', a11y_question: a11y_question) %>
   <% end %>
 <% end %>

--- a/app/views/steps/completion/shared/_date_row.html.erb
+++ b/app/views/steps/completion/shared/_date_row.html.erb
@@ -1,11 +1,11 @@
-<dl id="<%= date_row.question %>">
-  <dt class="question">
+<div class="govuk-summary-list__row" id="<%= date_row.question %>">
+  <dt class="govuk-summary-list__key govuk-!-width-one-third">
     <%=t "check_answers_html.#{date_row.question}.question" %>
   </dt>
-  <dd class="answer">
+  <dd class="govuk-summary-list__value">
     <%= l(date_row.value) %>
   </dd>
-  <dd class="change">
+  <dd class="govuk-summary-list__actions">
     <%= render partial: 'steps/completion/shared/change_link', locals: { question: date_row } %>
   </dd>
-</dl>
+</div>

--- a/app/views/steps/completion/shared/_free_text_row.html.erb
+++ b/app/views/steps/completion/shared/_free_text_row.html.erb
@@ -1,13 +1,13 @@
-<dl id="<%= free_text_row.question %>">
-  <dt class="question">
+<div class="govuk-summary-list__row" id="<%= free_text_row.question %>">
+  <dt class="govuk-summary-list__key govuk-!-width-one-third">
     <%=t "check_answers_html.#{free_text_row.question}.question", free_text_row.i18n_opts %>
   </dt>
-  <dd class="answer">
+  <dd class="govuk-summary-list__value">
     <%= simple_format(
-      free_text_row.value.presence || t("check_answers_html.#{free_text_row.question}.absence_answer"), { class: 'user-free-text' }
+      free_text_row.value.presence || t("check_answers_html.#{free_text_row.question}.absence_answer"), { class: 'govuk-body' }
     ) %>
   </dd>
-  <dd class="change">
+  <dd class="govuk-summary-list__actions">
     <%= render partial: 'steps/completion/shared/change_link', locals: { question: free_text_row } %>
   </dd>
-</dl>
+</div>

--- a/app/views/steps/completion/shared/_horizontal_rule.html.erb
+++ b/app/views/steps/completion/shared/_horizontal_rule.html.erb
@@ -1,1 +1,1 @@
-<hr/>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/app/views/steps/completion/shared/_multi_answer_row.html.erb
+++ b/app/views/steps/completion/shared/_multi_answer_row.html.erb
@@ -1,10 +1,10 @@
-<dl id="<%= multi_answer_row.question %>">
-  <dt class="question">
+<div class="govuk-summary-list__row" id="<%= multi_answer_row.question %>">
+  <dt class="govuk-summary-list__key govuk-!-width-one-third">
     <%=t "check_answers_html.#{multi_answer_row.question}.question" %>
   </dt>
-  <dd class="answer">
+  <dd class="govuk-summary-list__value">
     <% if Array(multi_answer_row.value).any? %>
-      <ul class="list list-bullet">
+      <ul class="govuk-list govuk-list--bullet">
         <% multi_answer_row.value.each do |value| %>
           <li>
             <%= t("check_answers_html.#{multi_answer_row.question}.answers.#{value}") %>
@@ -16,7 +16,7 @@
       <%=t "check_answers_html.#{multi_answer_row.question}.absence_answer" %>
     <% end %>
   </dd>
-  <dd class="change">
+  <dd class="govuk-summary-list__actions">
     <%= render partial: 'steps/completion/shared/change_link', locals: { question: multi_answer_row } %>
   </dd>
-</dl>
+</div>

--- a/app/views/steps/completion/shared/_row.html.erb
+++ b/app/views/steps/completion/shared/_row.html.erb
@@ -1,11 +1,11 @@
-<dl id="<%= row.question %>">
-  <dt class="question">
+<div class="govuk-summary-list__row" id="<%= row.question %>">
+  <dt class="govuk-summary-list__key govuk-!-width-one-third">
     <%=t "check_answers_html.#{row.question}.question", row.i18n_opts %>
   </dt>
-  <dd class="answer">
+  <dd class="govuk-summary-list__value">
     <%=t "check_answers_html.#{row.question}.answers.#{row.value}" %>
   </dd>
-  <dd class="change">
+  <dd class="govuk-summary-list__actions">
     <%= render partial: 'steps/completion/shared/change_link', locals: { question: row } %>
   </dd>
-</dl>
+</div>

--- a/app/views/steps/completion/shared/_section.html.erb
+++ b/app/views/steps/completion/shared/_section.html.erb
@@ -1,7 +1,9 @@
 <% if section.show_header? %>
-  <h2 class="heading-medium heading-bottom-border section-header"><%=t "check_answers_html.sections.#{section.name}" %></h2>
+  <h2 class="govuk-heading-m">
+    <%=t "check_answers_html.sections.#{section.name}" %>
+  </h2>
 <% end %>
 
-<div class="check-your-answers multiple-sections" id="<%= section.name %>">
+<dl class="govuk-summary-list" id="<%= section.name %>">
   <%= render section.answers %>
-</div>
+</dl>

--- a/app/views/steps/completion/shared/_separator.html.erb
+++ b/app/views/steps/completion/shared/_separator.html.erb
@@ -1,4 +1,5 @@
-<span class="display-block-important util_mb-medium"></span>
-<h3 class="heading-medium heading-bottom-border subsection-header">
-  <%=t "check_answers_html.separators.#{separator.title}", separator.i18n_opts %>
-</h3>
+<div class="govuk-summary-list__row">
+  <h3 class="govuk-heading-m">
+    <%=t "check_answers_html.separators.#{separator.title}", separator.i18n_opts %>
+  </h3>
+</div>

--- a/app/views/steps/petition/playback/show.html.erb
+++ b/app/views/steps/petition/playback/show.html.erb
@@ -52,7 +52,7 @@
         ) %>
       </h3>
       <div class="govuk-inset-text">
-        <%= @petition.other_issue_details %>
+        <%= simple_format(@petition.other_issue_details, { class: 'govuk-body' }) %>
       </div>
     <% end %>
 

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -186,7 +186,7 @@ en:
       question_a11y: Who %{child_name} lives with
 
     miam_exemptions_domestic:
-      question: Evidence of domestic abuse and violence
+      question: Domestic abuse and violence
       answers:
         police_arrested: Evidence that a prospective party has been arrested for a relevant domestic violence offence
         police_caution: Evidence of a relevant police caution for a domestic violence offence
@@ -231,7 +231,7 @@ en:
         urgency_none: *none_selected
 
     miam_exemptions_adr:
-      question: Previously attended a MIAM or had a valid reason for not attending
+      question: Previous MIAM attendance or MIAM exemption
       answers:
         previous_attendance: In the 4 months prior to making the application, the person attended a MIAM or participated in another form of non-court dispute resolution relating to the same or a very similar dispute
         ongoing_attendance: At the time of making the application, the person is participating in another form of non-court dispute resolution relating to the same or substantially the same dispute
@@ -241,7 +241,7 @@ en:
         adr_none: *none_selected
 
     miam_exemptions_misc:
-      question: Other reasons
+      question: Other exemptions
       answers:
         no_respondent_address: You don’t have sufficient contact details for the other people in this application (the respondents)
         without_notice: You’re applying for a without notice hearing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -732,7 +732,7 @@ en:
         edit:
           page_title: Check your answers
           heading: Check your answers
-          lead_text: Please review your answers before you finish your application
+          lead_text: Please review your answers before you finish your application.
           declaration_heading: Declaration
           declaration_lead_text: By entering your full name, you confirm that the facts stated in this application are true.
           warning_title: Warning

--- a/spec/presenters/summary/html_sections/children_further_information_spec.rb
+++ b/spec/presenters/summary/html_sections/children_further_information_spec.rb
@@ -7,6 +7,7 @@ module Summary
         children_known_to_authorities: 'yes',
         children_known_to_authorities_details: 'details',
         children_protection_plan: 'no',
+        has_other_children: 'yes',
       )
     }
 
@@ -22,7 +23,7 @@ module Summary
 
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(3)
+        expect(answers.count).to eq(4)
       end
 
       it 'has the correct rows in the right order' do
@@ -40,6 +41,11 @@ module Summary
         expect(answers[2].question).to eq(:children_protection_plan)
         expect(answers[2].change_path).to eq('/steps/children/additional_details')
         expect(answers[2].value).to eq('no')
+
+        expect(answers[3]).to be_an_instance_of(Answer)
+        expect(answers[3].question).to eq(:has_other_children)
+        expect(answers[3].change_path).to eq('/steps/children/has_other_children')
+        expect(answers[3].value).to eq('yes')
       end
     end
   end

--- a/spec/presenters/summary/html_sections/other_children_details_spec.rb
+++ b/spec/presenters/summary/html_sections/other_children_details_spec.rb
@@ -4,7 +4,6 @@ module Summary
   describe HtmlSections::OtherChildrenDetails do
     let(:c100_application) {
       instance_double(C100Application,
-        has_other_children: 'yes',
         other_children: [other_child],
       )
     }
@@ -36,31 +35,26 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(3)
       end
 
       it 'has the correct rows in the right order' do
-        expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:has_other_children)
-        expect(answers[0].change_path).to eq('/steps/children/has_other_children')
-        expect(answers[0].value).to eq('yes')
+        expect(answers[0]).to be_an_instance_of(Separator)
+        expect(answers[0].title).to eq('other_children_details_index_title')
+        expect(answers[0].i18n_opts).to eq({index: 1})
 
-        expect(answers[1]).to be_an_instance_of(Separator)
-        expect(answers[1].title).to eq('other_children_details_index_title')
-        expect(answers[1].i18n_opts).to eq({index: 1})
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:person_full_name)
+        expect(answers[1].value).to eq('name')
+        expect(answers[1].change_path).to eq('/steps/other_children/names/')
 
-        expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[2].question).to eq(:person_full_name)
-        expect(answers[2].value).to eq('name')
-        expect(answers[2].change_path).to eq('/steps/other_children/names/')
-
-        expect(answers[3]).to be_an_instance_of(AnswersGroup)
-        expect(answers[3].name).to eq(:person_personal_details)
-        expect(answers[3].change_path).to eq('/steps/other_children/personal_details/uuid-123')
-        expect(answers[3].answers.count).to eq(2)
+        expect(answers[2]).to be_an_instance_of(AnswersGroup)
+        expect(answers[2].name).to eq(:person_personal_details)
+        expect(answers[2].change_path).to eq('/steps/other_children/personal_details/uuid-123')
+        expect(answers[2].answers.count).to eq(2)
 
           # personal_details group answers ###
-          details = answers[3].answers
+          details = answers[2].answers
 
           expect(details[0]).to be_an_instance_of(DateAnswer)
           expect(details[0].question).to eq(:person_dob)


### PR DESCRIPTION
The CYA page is composed of many small partials each producing the different sections.

Migrate all these partials to use the new design system markup and styles.

Add some custom markup for the more complicated sections so these render find on desktop but also on mobile devices.

In another follow-up PR I will do the cleaning of the old CYA styles making sure we are not using these in any other place (specially the PDF!)

As this page can be huge, adding here only a few screenshots of some sections for reference:

<img width="1042" alt="Screen Shot 2020-05-04 at 12 46 43" src="https://user-images.githubusercontent.com/687910/80962707-70ff9480-8e05-11ea-93a9-b72071e75564.png">

--

<img width="1034" alt="Screen Shot 2020-05-04 at 12 46 52" src="https://user-images.githubusercontent.com/687910/80962722-765cdf00-8e05-11ea-81c8-81924bee19d8.png">

--

<img width="1027" alt="Screen Shot 2020-05-04 at 12 47 04" src="https://user-images.githubusercontent.com/687910/80962728-7957cf80-8e05-11ea-975d-7ace5feb4f18.png">

--

<img width="384" alt="Screen Shot 2020-05-04 at 12 47 34" src="https://user-images.githubusercontent.com/687910/80962732-7c52c000-8e05-11ea-8899-02b5b4a3ba1a.png">
