### PR TITLE
Migrate timeout modal dialog

### DIFF
--- a/app/assets/javascripts/modules/session-timeout.js
+++ b/app/assets/javascripts/modules/session-timeout.js
@@ -43,10 +43,10 @@ moj.Modules.sessionTimeout = {
     if(isNaN(moj.Modules.sessionLength) || isNaN(moj.Modules.sessionWarnWhenRemaining)) return;
 
     // Bind buttons in modal
-    $(self.config.$modalContainer + " .extend").click(function() {
+    $(self.config.$modalContainer + " .js-extend").click(function() {
       self.extend();
     });
-    $(self.config.$modalContainer + " .abort").click(function() {
+    $(self.config.$modalContainer + " .js-abort").click(function() {
       self.abort();
     });
 
@@ -57,7 +57,6 @@ moj.Modules.sessionTimeout = {
   showModal: function() {
     this.lastFocus = document.activeElement;
     $(this.config.$modalContainer).show();
-    $(this.config.$modalContainer).find("button.extend").focus();
   },
 
   hideModal: function() {
@@ -67,7 +66,7 @@ moj.Modules.sessionTimeout = {
 
   startTimer: function() {
     var self = this;
-    
+
     var now = new Date();
     self.endOfSessionTime = new Date(now.getTime() + self.config.sessionLength);
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,7 +28,6 @@
 @import 'elements/shame';
 
 @import 'local/buttons';
-@import 'local/timeout_modal';
 @import 'local/js_enabled';
 
 // GOV.UK Frontend

--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -172,6 +172,7 @@ table.app-saved-drafts {
   }
 }
 
+@import 'app/timeout_modal';
 @import 'app/check_answers';
 @import 'app/backoffice';
 @import 'app/pending_migration';

--- a/app/assets/stylesheets/local/app/timeout_modal.scss
+++ b/app/assets/stylesheets/local/app/timeout_modal.scss
@@ -14,10 +14,10 @@
 
 .modal-dialog_box {
   position: absolute;
-  background-color: #fff;
+  background-color: govuk-colour("white");
   width: 100%;
 
-  @include media(desktop) {
+  @include govuk-media-query($from: tablet) {
     top: 50%;
     left: 50%;
     width: 530px;
@@ -25,31 +25,18 @@
     -ms-transform: translate(-50%, -50%);
   }
 
-  h2 {
-    background-color: #df3034;
+  h3 {
+    background-color: govuk-colour("red");
     background-image: image-url('icon-important-red-inverse.png');
     background-position: 15px center;
     background-repeat: no-repeat;
-    color: $white;
-    font-size: 19px;
-    font-weight: bold;
+    color: govuk-colour("white");
     line-height: 60px;
     padding-left: 60px;
-  } 
-
-  p {
-    margin: 15px;
-    font-size: 19px;
-    a {
-      margin-left: 5px;
-      &:focus {
-        background-color: transparent;
-        border: 3px solid $yellow;
-      }
-    }
   }
 
-  .button.abort {
-    @include button($grey-3);
+  p {
+    padding-left: govuk-spacing(3);
+    padding-right: govuk-spacing(3);
   }
 }

--- a/app/views/layouts/_timeout_modal.html.erb
+++ b/app/views/layouts/_timeout_modal.html.erb
@@ -1,20 +1,24 @@
 <div id="timeout-dialog" class="modal-dialog">
   <div class="modal-dialog_container">
     <div class="modal-dialog_box" role="dialog" aria-labelledby="aria-timeout-label">
-      <span class="visuallyhidden" id="aria-timeout-label">
+      <span class="govuk-visually-hidden" id="aria-timeout-label">
         <%= t('session.expiring.aria-warning',
                 passed: Rails.configuration.x.session.expires_in_minutes - Rails.configuration.x.session.warning_when_remaining,
                 remain: Rails.configuration.x.session.warning_when_remaining,
                 session_length: Rails.configuration.x.session.expires_in_minutes) %>
       </span>
-      <h2><%= t('session.expiring.heading') %></h2>
-      <p>
+
+      <h3 class="govuk-heading-m"><%= t('session.expiring.heading') %></h3>
+
+      <p class="govuk-body">
         <%= t('session.expiring.in') %> <span id="timeout-dialog-remaining"></span>.
       </p>
-      <p><%= t('session.expiring.security') %></p>
-      <p>
-        <button class="button secondary extend" id="extend" href="#"><%= t('session.expiring.extend') %></button>
-        <button class="button secondary abort" id="destroy" href="#"><%= t('session.expiring.destroy') %></button>
+
+      <p class="govuk-body"><%= t('session.expiring.security') %></p>
+
+      <p class="govuk-body">
+        <%= link_button t('session.expiring.extend'), '#', class: 'js-extend govuk-!-margin-bottom-1' %>
+        <%= link_button t('session.expiring.destroy'), '#', class: 'js-abort govuk-!-margin-bottom-1 govuk-button--warning' %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
Use as much of the new design system as possible, but we must maintain the custom styling as this modal does not have a direct equivalent in the design system.

<img width="654" alt="Screen Shot 2020-05-05 at 11 29 20" src="https://user-images.githubusercontent.com/687910/81057415-41639180-8ec4-11ea-8248-00cba23377a5.png">
