### PR TITLE
Refactor and migrate blue card steps

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -174,5 +174,6 @@ table.app-saved-drafts {
 
 @import 'app/timeout_modal';
 @import 'app/check_answers';
+@import 'app/intro_card';
 @import 'app/backoffice';
 @import 'app/pending_migration';

--- a/app/assets/stylesheets/local/app/intro_card.scss
+++ b/app/assets/stylesheets/local/app/intro_card.scss
@@ -1,0 +1,98 @@
+// Blue card styles - used by masthead and intro slides
+// Inspired by https://github.com/UKGovernmentBEIS/beis-opss-psd
+
+.app-inverted--card {
+  //override govuk-main-wrapper
+  margin-top: -15px;
+
+  // override govuk-grid-row
+  margin-left: 0;
+  margin-right: 0;
+
+  padding: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(7);
+  }
+}
+
+.app-inverted-text {
+  color: govuk-colour("white");
+  background-color: govuk-colour("blue");
+}
+
+.app-inverted-narrow-width {
+  @include govuk-media-query($from: tablet) {
+    width: 82%;
+  }
+}
+
+.app-inset-text--inverted {
+  @extend .app-inverted-text;
+  @include govuk-typography-weight-bold;
+
+  border-left: $govuk-border-width-wide solid govuk-colour("white");
+}
+
+// Inverted button styles from
+// https://github.com/alphagov/govuk-design-system/blob/master/src/stylesheets/components/_inverted-button.scss
+$button-shadow-size: $govuk-border-width-form-element;
+$app-button-inverted-background-colour: govuk-colour("white");
+$app-button-inverted-foreground-colour: govuk-colour("blue");
+$app-button-inverted-shadow-colour: govuk-shade($app-button-inverted-foreground-colour, 30%);
+$app-button-inverted-hover-background-colour: govuk-tint($app-button-inverted-foreground-colour, 90%);
+
+// Larger buttons like govuk-start buttons, but without the chevron
+.app-button--l {
+  // Below styles from govuk-button--start
+  @include govuk-typography-weight-bold;
+  @include govuk-typography-responsive($size: 24, $override-line-height: 1);
+
+  min-height: auto;
+  justify-content: center;
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.app-button--inverted,
+.app-button--inverted:link,
+.app-button--inverted:visited {
+  color: $app-button-inverted-foreground-colour;
+  background-color: $app-button-inverted-background-colour;
+  box-shadow: 0 $button-shadow-size 0 $app-button-inverted-shadow-colour;
+}
+
+.app-button--inverted:hover {
+  color: $app-button-inverted-foreground-colour;
+  background-color: $app-button-inverted-hover-background-colour;
+}
+
+.app-button--inverted:focus:not(:hover) {
+  color: $govuk-focus-text-colour;
+  background-color: $govuk-focus-colour;
+}
+
+.app-button--inverted:active,
+.app-button--inverted:focus {
+  border-color: $govuk-focus-colour;
+  color: $app-button-inverted-foreground-colour;
+  background-color: $app-button-inverted-hover-background-colour;
+  box-shadow: inset 0 0 0 2px $govuk-focus-colour;
+}
+
+.app-link--inverted,
+.app-link--inverted:link,
+.app-link--inverted:active,
+.app-link--inverted:visited {
+  color: govuk-colour("white");
+  font-weight: $govuk-font-weight-bold;
+}
+
+.app-link--inverted:focus,
+.app-link--inverted:hover:focus {
+  color: $govuk-text-colour;
+}
+
+.app-link--inverted:hover {
+  color: $app-button-inverted-hover-background-colour;
+}

--- a/app/views/entrypoint/how_long.en.html.erb
+++ b/app/views/entrypoint/how_long.en.html.erb
@@ -1,28 +1,28 @@
 <% title 'How long it takes' %>
 <% step_header(path: '/entrypoint/what_is_needed') %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl">Before you continue</span>
-    <h1 class="govuk-heading-xl">How long it takes to apply</h1>
+<div class="govuk-grid-row app-inverted--card app-inverted-text">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-xl app-inverted-text">Before you continue</span>
+    <h1 class="govuk-heading-xl app-inverted-text">How long it takes to apply</h1>
 
-    <p class="govuk-body">
+    <p class="govuk-body app-inverted-text app-inverted-narrow-width">
       It usually takes around 45 minutes to complete an application. It may take longer if your situation is more
       complex - for example if you’ve been involved in a previous family court case.
     </p>
 
-    <h2 class="govuk-heading-l">Saving your progress</h2>
+    <h2 class="govuk-heading-l app-inverted-text">Saving your progress</h2>
 
-    <p class="govuk-body">
+    <p class="govuk-body app-inverted-text app-inverted-narrow-width">
       You can save your application and return at any time. You just need your email address and a password of your
       choice.
     </p>
 
-    <p class="govuk-body">
+    <p class="govuk-body app-inverted-text app-inverted-narrow-width">
       We’ll save your draft for <%= Rails.configuration.x.drafts.expire_in_days %> days. For security reasons, we’ll
       delete any information after this time.
     </p>
 
-    <%= link_button 'Continue', edit_steps_miam_child_protection_cases_path, class: 'govuk-!-margin-top-3' %>
+    <%= link_button 'Continue', edit_steps_miam_child_protection_cases_path, class: 'app-button--l app-button--inverted govuk-!-margin-top-3 govuk-!-margin-bottom-1' %>
   </div>
 </div>

--- a/app/views/entrypoint/what_is_needed.en.html.erb
+++ b/app/views/entrypoint/what_is_needed.en.html.erb
@@ -1,14 +1,14 @@
 <% title 'What is required' %>
 <% step_header(path: '/entrypoint/v1') %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl">Before you continue</span>
-    <h1 class="govuk-heading-xl">What you’ll need to complete your application</h1>
+<div class="govuk-grid-row app-inverted--card app-inverted-text">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-xl app-inverted-text">Before you continue</span>
+    <h1 class="govuk-heading-xl app-inverted-text">What you’ll need to complete your application</h1>
 
-    <p class="govuk-body">You will need the following:</p>
+    <p class="govuk-body app-inverted-text">You will need the following:</p>
 
-    <ul class="govuk-list govuk-list--bullet">
+    <ul class="govuk-list govuk-list--bullet app-inverted-text app-inverted-narrow-width">
       <li>details of the other people (the respondents), including their date of birth</li>
       <li>contact details of the respondents, including their current address</li>
       <li>solicitor details (if you have asked one to represent you)</li>
@@ -21,7 +21,7 @@
         <%= link_to(
           'certificate of suitability',
           'https://www.gov.uk/government/publications/form-fp9-certificate-of-suitability-of-litigation-friend',
-          class: 'govuk-link',
+          class: 'govuk-link app-link--inverted',
           target: :_blank,
           rel: :external
           )
@@ -33,10 +33,10 @@
       </li>
     </ul>
 
-    <div class="govuk-inset-text">
+    <div class="govuk-inset-text app-inset-text--inverted app-inverted-narrow-width">
       If you do not know all of the details you can still complete your application but it will take longer to process.
     </div>
 
-    <%= link_button 'Continue', entrypoint_how_long_path, class: 'govuk-!-margin-top-3' %>
+    <%= link_button 'Continue', entrypoint_how_long_path, class: 'app-button--l app-button--inverted govuk-!-margin-top-3 govuk-!-margin-bottom-1' %>
   </div>
 </div>


### PR DESCRIPTION
The previous custom styling was removed as it was not accessible and didn't follow the new design system guidelines.

We are now introducing a refactored version of the custom styling, that is accessible and still use as much as possible from the design system.

The blue cards look almost identical as before.

<img width="776" alt="Screen Shot 2020-05-05 at 13 18 43" src="https://user-images.githubusercontent.com/687910/81065514-8511c780-8ed3-11ea-98c6-5304d8d553ea.png">

--

<img width="768" alt="Screen Shot 2020-05-05 at 13 20 00" src="https://user-images.githubusercontent.com/687910/81065517-8b07a880-8ed3-11ea-81b5-d6b55edbd834.png">
