### PR TITLE
Restore the flash alert in the back office

### DIFF
--- a/app/assets/stylesheets/local/app.scss
+++ b/app/assets/stylesheets/local/app.scss
@@ -172,6 +172,12 @@ table.app-saved-drafts {
   }
 }
 
+.app-util--border-box {
+  border: 2px solid govuk-colour("black");
+  padding: govuk-spacing(3);
+  margin-bottom: govuk-spacing(5);
+}
+
 @import 'app/timeout_modal';
 @import 'app/check_answers';
 @import 'app/intro_card';

--- a/app/views/backoffice/shared/_flash_alert.en.html.erb
+++ b/app/views/backoffice/shared/_flash_alert.en.html.erb
@@ -1,0 +1,9 @@
+<div class="app-util--border-box">
+  <div class="govuk-warning-text govuk-!-margin-bottom-0">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      <%= flash[:alert] %>
+    </strong>
+  </div>
+</div>

--- a/app/views/backoffice/shared/_menu.en.html.erb
+++ b/app/views/backoffice/shared/_menu.en.html.erb
@@ -2,20 +2,23 @@
   <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
   <nav>
     <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
-      <li class="govuk-header__navigation-item">
-        <%= link_to_unless_current 'Applications', backoffice_dashboard_index_path, class: 'govuk-header__link' %>
+      <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(backoffice_dashboard_index_path) %>">
+        <%= link_to 'Applications', backoffice_dashboard_index_path, class: 'govuk-header__link' %>
+      </li>
+      <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(backoffice_emails_path) %>">
+        <%= link_to 'Emails', backoffice_emails_path, class: 'govuk-header__link' %>
+      </li>
+      <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(backoffice_audit_index_path) %>">
+        <%= link_to 'Audit', backoffice_audit_index_path, class: 'govuk-header__link' %>
+      </li>
+      <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(backoffice_users_path) %>">
+        <%= link_to 'Users', backoffice_users_path, class: 'govuk-header__link' %>
       </li>
       <li class="govuk-header__navigation-item">
-        <%= link_to_unless_current 'Emails', backoffice_emails_path, class: 'govuk-header__link' %>
+        <%= button_to 'Logout', backoffice_auth0_logout_path, class: 'govuk-header__link app-header__logout-link', method: :delete %>
       </li>
       <li class="govuk-header__navigation-item">
-        <%= link_to_unless_current 'Audit', backoffice_audit_index_path, class: 'govuk-header__link' %>
-      </li>
-      <li class="govuk-header__navigation-item">
-        <%= link_to_unless_current 'Users', backoffice_users_path, class: 'govuk-header__link' %>
-      </li>
-      <li class="govuk-header__navigation-item util_ml-medium">
-        <%= link_to 'Logout', backoffice_auth0_logout_path, class: 'govuk-header__link', method: :delete %> (<%= admin_name %>)
+        (<%= admin_name %>)
       </li>
     </ul>
   </nav>

--- a/app/views/layouts/backoffice.html.erb
+++ b/app/views/layouts/backoffice.html.erb
@@ -12,6 +12,10 @@
   <%= render partial: 'backoffice/shared/menu' %>
 <% end %>
 
+<% content_for(:flash_alert) do %>
+  <%= render partial: 'backoffice/shared/flash_alert' if flash[:alert].present? %>
+<% end %>
+
 <% content_for(:content) do %>
   <%= yield %>
 <% end %>


### PR DESCRIPTION
This was refactored for the main layout but was not done in the back office layout.

However not using the same partial as the main layout as that one is for errors, and this is more for giving information.

Fixed the back office user menu as it was also done with the main user menu.

<img width="1056" alt="Screen Shot 2020-05-06 at 12 34 04" src="https://user-images.githubusercontent.com/687910/81172634-8526cb80-8f96-11ea-953d-ad8d3f6ae332.png">
