### PR TITLE
Change const with var in JS

### DIFF
--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -338,7 +338,7 @@ moj.Modules.gaEvents = {
         // transformed to:
         //      `steps_miam_exemptions_domestic_form[domestic]`
         //
-        const regex = /^steps_miam_exemptions_([a-z]+)_form\[[\D]+\]$/;
+        var regex = /^steps_miam_exemptions_([a-z]+)_form\[[\D]+\]$/;
         normalisedAttr = normalisedAttr.replace(regex, "steps_miam_exemptions_$1_form[$1]");
 
         return normalisedAttr;


### PR DESCRIPTION
Fix for build failing due to:

Uglifier::Error: Unexpected token: keyword (const). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).

Anyways, changing to var as we have all JS with var and feel a bit worried about changing the Uglifier settings at this point.