### PR TITLE
Add international resident details text area

### DIFF
--- a/app/forms/steps/international/resident_form.rb
+++ b/app/forms/steps/international/resident_form.rb
@@ -3,7 +3,12 @@ module Steps
     class ResidentForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :international_resident
+      yes_no_attribute :international_resident,
+                       reset_when_no: [:international_resident_details]
+
+      attribute :international_resident_details, String
+
+      validates_presence_of :international_resident_details, if: -> { international_resident&.yes? }
     end
   end
 end

--- a/app/presenters/summary/html_sections/international_element.rb
+++ b/app/presenters/summary/html_sections/international_element.rb
@@ -7,7 +7,14 @@ module Summary
 
       def answers
         [
-          Answer.new(:international_resident, c100.international_resident, change_path: edit_steps_international_resident_path),
+          AnswersGroup.new(
+            :international_resident,
+            [
+              Answer.new(:international_resident, c100.international_resident),
+              FreeTextAnswer.new(:international_resident_details, c100.international_resident_details),
+            ],
+            change_path: edit_steps_international_resident_path
+          ),
           AnswersGroup.new(
             :international_jurisdiction,
             [

--- a/app/presenters/summary/html_sections/international_element.rb
+++ b/app/presenters/summary/html_sections/international_element.rb
@@ -5,6 +5,7 @@ module Summary
         :international_element
       end
 
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def answers
         [
           AnswersGroup.new(
@@ -33,6 +34,7 @@ module Summary
           ),
         ].select(&:show?)
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
     end
   end
 end

--- a/app/presenters/summary/sections/international_element.rb
+++ b/app/presenters/summary/sections/international_element.rb
@@ -12,6 +12,7 @@ module Summary
       def answers
         [
           Answer.new(:international_resident, c100.international_resident, default: GenericYesNo::NO),
+          FreeTextAnswer.new(:international_resident_details, c100.international_resident_details),
           Answer.new(:international_jurisdiction, c100.international_jurisdiction, default: GenericYesNo::NO),
           FreeTextAnswer.new(:international_jurisdiction_details, c100.international_jurisdiction_details),
           Answer.new(:international_request, c100.international_request, default: GenericYesNo::NO),

--- a/app/views/steps/international/resident/edit.html.erb
+++ b/app/views/steps/international/resident/edit.html.erb
@@ -6,8 +6,13 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_collection_radio_buttons :international_resident, GenericYesNo.values, :value, nil do %>
+      <%= f.govuk_radio_buttons_fieldset :international_resident do %>
         <p class="govuk-body-l"><%=t '.lead_text' %></p>
+
+        <%= f.govuk_radio_button :international_resident, GenericYesNo::YES, link_errors: true do %>
+          <%= f.govuk_text_area :international_resident_details %>
+        <% end %>
+        <%= f.govuk_radio_button :international_resident, GenericYesNo::NO %>
       <% end %>
 
       <%= f.continue_button %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -103,6 +103,7 @@ en:
       other_court_cases_details: Other proceedings details
       urgent_hearing_details: Urgent hearing details
       without_notice_hearing_details: Without notice hearing details
+      international_resident: Is the life of the child or children, a parent, or anyone significant to the children mainly based in a country outside England or Wales?
       international_jurisdiction: Do you think another person in this application may be able to apply for a similar order in a country outside England or Wales?
       international_request: Has a request for information or other assistance involving the children been made to or by another country?
       litigation_capacity: Factors affecting ability to participate
@@ -529,9 +530,11 @@ en:
       question: Details
 
     international_resident:
-      question: Is the life of the child or children, a parent, or anyone significant to the children mainly based in a country outside England or Wales?
+      question: ''
       answers:
         <<: *YESNO
+    international_resident_details:
+      question: ''
     international_jurisdiction:
       question: ''
       answers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -802,11 +802,11 @@ en:
       resident:
         edit:
           page_title: International resident
-          lead_text: Including for example, a grandparent or any other close relative. This may include them working, owning property, having children in school or their main family life taking place outside England or Wales
+          lead_text: Including for example, a grandparent or any other close relative. This may include them working, owning property, having children in school or their main family life taking place outside England or Wales.
       jurisdiction:
         edit:
           page_title: International jurisdiction
-          lead_text: For example, because a court in another country has the power to act (has jurisdiction)
+          lead_text: For example, because a court in another country has the power to act (has jurisdiction).
       request:
         edit:
           page_title: International request
@@ -1338,6 +1338,7 @@ en:
       steps_international_resident_form:
         international_resident_options:
           <<: *YESNO
+        international_resident_details: *provide_details
       steps_solicitor_personal_details_form:
         full_name: Full name
         firm_name: Name of firm

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -536,6 +536,8 @@ en:
           attributes:
             international_resident:
               inclusion: *yes_no_error
+            international_resident_details:
+              blank: *blank_details_error
         steps/international/jurisdiction_form:
           attributes:
             international_jurisdiction:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -234,18 +234,21 @@ en:
       question: Do you have any reason to believe that any child, parent or potentially significant adult in the child’s life may be habitually resident in another state?
       answers:
         <<: *YESNO
+    international_resident_details:
+      question: *details
     international_jurisdiction:
       question: Do you have any reason to believe that there may be an issue as to jurisdiction in this case (for example under Brussels 2 revised)?
       answers:
         <<: *YESNO
     international_jurisdiction_details:
-      question: ''
+      question: *details
     international_request:
       question: Has a request been made or should a request be made to a Central Authority or other competent authority in a foreign state or a consular authority in England and Wales?
       answers:
         <<: *YESNO
     international_request_details:
-      question: ''
+      question: *details
+
     child_full_name:
       question: Full name
     child_dob:

--- a/db/migrate/20200511091814_restore_international_resident_details.rb
+++ b/db/migrate/20200511091814_restore_international_resident_details.rb
@@ -1,0 +1,5 @@
+class RestoreInternationalResidentDetails < ActiveRecord::Migration[5.2]
+  def change
+    add_column :c100_applications, :international_resident_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_31_112122) do
+ActiveRecord::Schema.define(version: 2020_05_11_091814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 2020_03_31_112122) do
     t.integer "version", default: 5
     t.string "declaration_signee"
     t.string "declaration_signee_capacity"
+    t.text "international_resident_details"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/forms/steps/international/resident_form_spec.rb
+++ b/spec/forms/steps/international/resident_form_spec.rb
@@ -2,5 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Steps::International::ResidentForm do
   it_behaves_like 'a yes-no question form',
-                  attribute_name:   :international_resident
+                  attribute_name:   :international_resident,
+                  linked_attribute: :international_resident_details,
+                  reset_when_no:   [:international_resident_details]
 end

--- a/spec/presenters/summary/html_sections/international_element_spec.rb
+++ b/spec/presenters/summary/html_sections/international_element_spec.rb
@@ -5,6 +5,7 @@ module Summary
     let(:c100_application) {
       instance_double(C100Application,
         international_resident: 'yes',
+        international_resident_details: 'international resident details',
         international_jurisdiction: 'yes',
         international_jurisdiction_details: 'international jurisdiction details',
         international_request: 'yes',
@@ -26,9 +27,8 @@ module Summary
       end
 
       it 'has the correct rows in the right order' do
-        expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:international_resident)
-        expect(answers[0].value).to eq('yes')
+        expect(answers[0]).to be_an_instance_of(AnswersGroup)
+        expect(answers[0].name).to eq(:international_resident)
         expect(answers[0].change_path).to eq('/steps/international/resident')
 
         expect(answers[1]).to be_an_instance_of(AnswersGroup)
@@ -38,6 +38,20 @@ module Summary
         expect(answers[2]).to be_an_instance_of(AnswersGroup)
         expect(answers[2].name).to eq(:international_request)
         expect(answers[2].change_path).to eq('/steps/international/request')
+      end
+    end
+
+    describe 'the international_resident group' do
+      let(:group){ answers[0] }
+
+      it 'has the right questions in the right order' do
+        expect(group.answers[0]).to be_an_instance_of(Answer)
+        expect(group.answers[0].question).to eq(:international_resident)
+        expect(group.answers[0].value).to eq('yes')
+
+        expect(group.answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(group.answers[1].question).to eq(:international_resident_details)
+        expect(group.answers[1].value).to eq('international resident details')
       end
     end
 

--- a/spec/presenters/summary/sections/international_element_spec.rb
+++ b/spec/presenters/summary/sections/international_element_spec.rb
@@ -5,6 +5,7 @@ module Summary
     let(:c100_application) {
       instance_double(C100Application,
         international_resident: 'yes',
+        international_resident_details: 'international resident details',
         international_jurisdiction: 'yes',
         international_jurisdiction_details: 'international jurisdiction details',
         international_request: 'yes',
@@ -26,7 +27,7 @@ module Summary
 
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(5)
+        expect(answers.count).to eq(6)
       end
 
       it 'has the correct rows in the right order' do
@@ -34,21 +35,25 @@ module Summary
         expect(answers[0].question).to eq(:international_resident)
         expect(answers[0].value).to eq('yes')
 
-        expect(answers[1]).to be_an_instance_of(Answer)
-        expect(answers[1].question).to eq(:international_jurisdiction)
-        expect(answers[1].value).to eq('yes')
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:international_resident_details)
+        expect(answers[1].value).to eq('international resident details')
 
-        expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[2].question).to eq(:international_jurisdiction_details)
-        expect(answers[2].value).to eq('international jurisdiction details')
+        expect(answers[2]).to be_an_instance_of(Answer)
+        expect(answers[2].question).to eq(:international_jurisdiction)
+        expect(answers[2].value).to eq('yes')
 
-        expect(answers[3]).to be_an_instance_of(Answer)
-        expect(answers[3].question).to eq(:international_request)
-        expect(answers[3].value).to eq('yes')
+        expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[3].question).to eq(:international_jurisdiction_details)
+        expect(answers[3].value).to eq('international jurisdiction details')
 
-        expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[4].question).to eq(:international_request_details)
-        expect(answers[4].value).to eq('international request details')
+        expect(answers[4]).to be_an_instance_of(Answer)
+        expect(answers[4].question).to eq(:international_request)
+        expect(answers[4].value).to eq('yes')
+
+        expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[5].question).to eq(:international_request_details)
+        expect(answers[5].value).to eq('international request details')
       end
     end
 


### PR DESCRIPTION
This PR restores a text are in the international journey that was apparently removed by mistake in the past.
It is in line with the other yes-no questions. Show this text area when selecting the YES radio option.

For reference, the PRs where this was removed are #336 and #338.

Updated the CYA and PDF to show the new details.

<img width="551" alt="Screen Shot 2020-05-11 at 11 41 15" src="https://user-images.githubusercontent.com/687910/81552998-59cc2400-937c-11ea-8571-4334fb3efdf6.png">

CYA page:

<img width="1049" alt="Screen Shot 2020-05-11 at 10 42 18" src="https://user-images.githubusercontent.com/687910/81553016-605a9b80-937c-11ea-8f4e-3b04e99e6936.png">
