### PR TITLE
Fix couple of links without govuk-link class

### DIFF
--- a/app/views/steps/completion/shared/_c1a_getting_support.en.pdf.erb
+++ b/app/views/steps/completion/shared/_c1a_getting_support.en.pdf.erb
@@ -5,14 +5,14 @@
   If you have any concerns about your safety and that of the children you can call the
   <strong>National Domestic Violence
     Helpline</strong> on <strong>freephone 0808 2000 247</strong> or you get more information from
-  <a href="https://www.nationaldomesticviolencehelpline.org.uk" rel="external" target="_blank">www.nationaldomesticviolencehelpline.org.uk</a>
+  <a href="https://www.nationaldomesticviolencehelpline.org.uk" class="govuk-link" rel="external" target="_blank">www.nationaldomesticviolencehelpline.org.uk</a>
 </p>
 
 <p>
   If you are a man and have concerns for your safety and that of the children you can call the
   <strong>Men’s Advice Line and
     Enquiry</strong> on <strong>freephone 0808 801 0327</strong> or you get more information from
-  <a href="https://www.mensadviceline.org.uk" rel="external" target="_blank">www.mensadviceline.org.uk</a>
+  <a href="https://www.mensadviceline.org.uk" class="govuk-link" rel="external" target="_blank">www.mensadviceline.org.uk</a>
 </p>
 
 <p>


### PR DESCRIPTION
This is not a critical one as this setting (https://github.com/ministryofjustice/c100-application/commit/4854f2ae304442a6699f4bd734544653cf8b3693#diff-f859e2848b07324f808ce1a5ccd9fcbaR5) has been turned on but I though it should be addressed anyway.
