### PR TITLE
Tweak description list styles

### DIFF
--- a/app/assets/stylesheets/local/backoffice.scss
+++ b/app/assets/stylesheets/local/backoffice.scss
@@ -12,19 +12,16 @@ table.backoffice-table {
   }
 }
 
-div.application-extra-details {
+div.backoffice-extra-details {
   margin-top: 0;
 
   dl {
     margin-bottom: 0;
   }
   dt {
-    font-weight: bold;
     font-size: 1rem;
   }
   dd {
-    padding-left: 1em;
-    margin-bottom: 0.4em;
     font-size: 1rem;
   }
 }

--- a/app/assets/stylesheets/local/misc.scss
+++ b/app/assets/stylesheets/local/misc.scss
@@ -133,3 +133,20 @@ table.app-saved-drafts {
     }
   }
 }
+
+dl.app-description-list {
+  @extend .govuk-summary-list;
+
+  dt {
+    font-weight: $govuk-font-weight-bold;
+  }
+
+  dd {
+    margin-bottom: govuk-spacing(3);
+    margin-left: govuk-spacing(3);
+  }
+
+  & > :last-child {
+    margin-bottom: 0;
+  }
+}

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -10,11 +10,11 @@
 
   <tr class="govuk-table__row">
     <td colspan="4" class="no-border govuk-table__cell">
-      <div class="govuk-inset-text application-extra-details">
+      <div class="govuk-inset-text backoffice-extra-details">
         <table class="govuk-table">
           <tr class="govuk-table__row">
             <td class="govuk-table__cell no-border">
-                <dl class="govuk-summary-list govuk-summary-list--no-border">
+                <dl class="app-description-list">
                   <dt>Application started at</dt>
                   <dd><%= completion.started_at %> (v:<%= completion.metadata['v'] || '1-3' %>)</dd>
                   <dt>Saved for later?</dt>
@@ -32,7 +32,7 @@
                 </dl>
             </td>
             <td class="govuk-table__cell no-border">
-              <dl class="govuk-summary-list govuk-summary-list--no-border">
+              <dl class="app-description-list">
                 <dt>Postcode</dt>
                 <dd><%= completion.metadata['postcode'] %></dd>
                 <dt>C1A form?</dt>

--- a/app/views/steps/shared/_court_help.en.html.erb
+++ b/app/views/steps/shared/_court_help.en.html.erb
@@ -8,10 +8,10 @@
   you have any issues.
 </p>
 
-<dl>
-  <dt><strong>Email</strong></dt>
+<dl class="app-description-list">
+  <dt>Email</dt>
   <dd><%= mail_to court.email, court.email, class: 'ga-pageLink govuk-link', data: { ga_category: 'completion', ga_label: 'email court' } %></dd>
 
-  <dt class="govuk-!-margin-top-3"><strong>More information</strong></dt>
+  <dt>More information</dt>
   <dd><%= link_to court.name, C100App::CourtfinderAPI.new.court_url(court.slug), class: 'govuk-link', rel: 'external', target: '_blank' %></dd>
 </dl>


### PR DESCRIPTION
Instead of hacking the govuk design system version to fit us, create an app-specific version, to use in those places where we need something different.

These so far include the back office and the completion page (court details).

Before:
<img width="401" alt="Screen Shot 2020-05-11 at 13 39 58" src="https://user-images.githubusercontent.com/687910/81563560-4f1a8a80-938e-11ea-91f5-f7b1582a6d93.png">

After:
<img width="507" alt="Screen Shot 2020-05-11 at 13 39 37" src="https://user-images.githubusercontent.com/687910/81563562-504bb780-938e-11ea-8172-860b7e9163d6.png">
