### PR TITLE
Change some h3 to h2

### DIFF
--- a/app/views/layouts/_timeout_modal.html.erb
+++ b/app/views/layouts/_timeout_modal.html.erb
@@ -8,7 +8,7 @@
                 session_length: Rails.configuration.x.session.expires_in_minutes) %>
       </span>
 
-      <h3 class="govuk-heading-m"><%= t('session.expiring.heading') %></h3>
+      <h2 class="govuk-heading-m"><%= t('session.expiring.heading') %></h2>
 
       <p class="govuk-body">
         <%= t('session.expiring.in') %> <span id="timeout-dialog-remaining"></span>.

--- a/app/views/steps/abuse_concerns/details/edit.html.erb
+++ b/app/views/steps/abuse_concerns/details/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <p class="govuk-caption-xl"><%=t '.section' %></p>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
     <h1 class="govuk-heading-xl"><%=t ".heading.#{@form_object.i18n_key}" %></h1>
 
     <details class="govuk-details" data-module="govuk-details">
@@ -48,7 +48,7 @@
 
   <div class="govuk-grid-column-one-third">
     <div class="app-sidebar-grey govuk-!-padding-3 govuk-!-margin-bottom-5">
-      <h3 class="govuk-heading-m">Report an incident</h3>
+      <h2 class="govuk-heading-m">Report an incident</h2>
 
       <p class="govuk-body">
         Always call 999 if there’s an emergency or if you think a child’s in danger.
@@ -63,15 +63,15 @@
 
     <div class="app-sidebar-blue-bar govuk-!-margin-bottom-3"></div>
 
-    <h3 class="govuk-heading-m">Get support</h3>
+    <h2 class="govuk-heading-m">Get support</h2>
 
-    <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Child safety</h4>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Child safety</h3>
     <ul class="govuk-list">
       <li><a href="https://www.nspcc.org.uk" class="govuk-link" rel="external" target="_blank">NSPCC</a></li>
       <li><a href="https://www.childline.org.uk" class="govuk-link" rel="external" target="_blank">Childline</a></li>
     </ul>
 
-    <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Domestic abuse</h4>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Domestic abuse</h3>
     <ul class="govuk-list">
       <li><a href="http://www.nationaldomesticviolencehelpline.org.uk" class="govuk-link" rel="external" target="_blank">National Domestic Violence Helpline</a></li>
       <li><a href="https://www.womensaid.org.uk" class="govuk-link" rel="external" target="_blank">Women’s Aid</a></li>

--- a/app/views/steps/abuse_concerns/question/edit.html.erb
+++ b/app/views/steps/abuse_concerns/question/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <p class="govuk-caption-xl"><%=t '.section' %></p>
+    <span class="govuk-caption-xl"><%=t '.section' %></span>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.hidden_field :subject %>

--- a/app/views/steps/alternatives/collaborative_law/edit.en.html.erb
+++ b/app/views/steps/alternatives/collaborative_law/edit.en.html.erb
@@ -24,7 +24,7 @@
 
   <div class="govuk-grid-column-one-third">
     <div class="app-sidebar-grey govuk-!-padding-3 govuk-!-margin-bottom-5">
-      <h3 class="govuk-heading-m">Pros</h3>
+      <h2 class="govuk-heading-m">Pros</h2>
       <ul class="govuk-list govuk-list--bullet">
         <li>everyone is committed to not going to court</li>
         <li>quicker and less stressful than court</li>
@@ -33,7 +33,7 @@
         <li>good for the children to see their parents working together</li>
       </ul>
 
-      <h3 class="govuk-heading-m">Cons</h3>
+      <h2 class="govuk-heading-m">Cons</h2>
       <ul class="govuk-list govuk-list--bullet">
         <li>can be an expensive process</li>
         <li>won’t work unless you can trust the other parent and co-operate with them</li>

--- a/app/views/steps/alternatives/lawyer_negotiation/edit.en.html.erb
+++ b/app/views/steps/alternatives/lawyer_negotiation/edit.en.html.erb
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-column-one-third">
     <div class="app-sidebar-grey govuk-!-padding-3 govuk-!-margin-bottom-5">
-      <h3 class="govuk-heading-m">Pros</h3>
+      <h2 class="govuk-heading-m">Pros</h2>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>your lawyer supports you throughout</li>
@@ -37,7 +37,7 @@
         <li>you don’t deal directly with the other parent</li>
       </ul>
 
-      <h3 class="govuk-heading-m">Cons</h3>
+      <h2 class="govuk-heading-m">Cons</h2>
       <ul class="govuk-list govuk-list--bullet">
         <li>can be a more expensive process</li>
         <li>you may feel you’re not in control</li>

--- a/app/views/steps/alternatives/mediation/edit.en.html.erb
+++ b/app/views/steps/alternatives/mediation/edit.en.html.erb
@@ -30,7 +30,7 @@
 
   <div class="govuk-grid-column-one-third">
     <div class="app-sidebar-grey govuk-!-padding-3 govuk-!-margin-bottom-5">
-      <h3 class="govuk-heading-m">Pros</h3>
+      <h2 class="govuk-heading-m">Pros</h2>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>it’s quicker than court in most cases</li>
@@ -40,7 +40,7 @@
         <li>agreements are flexible</li>
       </ul>
 
-      <h3 class="govuk-heading-m">Cons</h3>
+      <h2 class="govuk-heading-m">Cons</h2>
       <ul class="govuk-list govuk-list--bullet">
         <li>you’ll need a consent order to make agreement legally binding</li>
         <li>process won’t work unless parents can co-operate</li>

--- a/app/views/steps/alternatives/negotiation_tools/edit.en.html.erb
+++ b/app/views/steps/alternatives/negotiation_tools/edit.en.html.erb
@@ -36,7 +36,7 @@
 
   <div class="govuk-grid-column-one-third">
     <div class="app-sidebar-grey govuk-!-padding-3 govuk-!-margin-bottom-5">
-      <h3 class="govuk-heading-m">Pros</h3>
+      <h2 class="govuk-heading-m">Pros</h2>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>cheapest and quickest option</li>
@@ -45,7 +45,7 @@
         <li>agreements are flexible</li>
       </ul>
 
-      <h3 class="govuk-heading-m">Cons</h3>
+      <h2 class="govuk-heading-m">Cons</h2>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>you’ll need a consent order to make agreement legally binding</li>

--- a/app/views/steps/miam/consent_order_sought/show.en.html.erb
+++ b/app/views/steps/miam/consent_order_sought/show.en.html.erb
@@ -11,7 +11,7 @@
       You will need to send 3 copies of your proposed agreement along with your application.
     </div>
 
-    <h3 class="govuk-heading-m">Changing or enforcing an order</h3>
+    <h2 class="govuk-heading-m">Changing or enforcing an order</h2>
 
     <p class="govuk-body">A court order isn’t flexible. You’ll need to apply to court again if you want to change it.</p>
     <p class="govuk-body">You or the other person can apply to court to enforce the order if either of you aren’t following the terms.</p>

--- a/app/views/steps/miam_exemptions/shared/_exemption.html.erb
+++ b/app/views/steps/miam_exemptions/shared/_exemption.html.erb
@@ -1,6 +1,6 @@
-<h3 class="govuk-heading-m">
+<h2 class="govuk-heading-m">
   <%=t "playback.exemptions_claimed.#{exemption.group_name}.header" %>
-</h3>
+</h2>
 
 <ul class="govuk-list govuk-list--bullet">
   <% exemption.collection.each do |name| %>

--- a/app/views/steps/petition/playback/show.html.erb
+++ b/app/views/steps/petition/playback/show.html.erb
@@ -6,9 +6,9 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <% if @petition.child_arrangements_orders.any? %>
-      <h3 class="govuk-heading-m">
+      <h2 class="govuk-heading-m">
         <%=t '.petition_header', count: 0 %>
-      </h3>
+      </h2>
       <ul class="govuk-list govuk-list--bullet">
         <% @petition.child_arrangements_orders.each do |order| %>
           <%= content_tag :li, t(".orders.#{order}") %>
@@ -18,11 +18,11 @@
     <% end %>
 
     <% if @petition.prohibited_steps_orders.any? %>
-      <h3 class="govuk-heading-m">
+      <h2 class="govuk-heading-m">
         <%=t '.petition_header_stop', count: @petition.count_for(
           :child_arrangements_orders
         ) %>
-      </h3>
+      </h2>
       <ul class="govuk-list govuk-list--bullet">
         <% @petition.prohibited_steps_orders.each do |order| %>
           <%= content_tag :li, t(".orders.#{order}") %>
@@ -32,11 +32,11 @@
     <% end %>
 
     <% if @petition.specific_issues_orders.any? %>
-      <h3 class="govuk-heading-m">
+      <h2 class="govuk-heading-m">
         <%=t '.petition_header_issues', count: @petition.count_for(
           :child_arrangements_orders, :prohibited_steps_orders
         ) %>
-      </h3>
+      </h2>
       <ul class="govuk-list govuk-list--bullet">
         <% @petition.specific_issues_orders.each do |order| %>
             <%= content_tag :li, t(".orders.#{order}") %>
@@ -46,11 +46,11 @@
     <% end %>
 
     <% if @petition.other_issue? %>
-      <h3 class="govuk-heading-m">
+      <h2 class="govuk-heading-m">
         <%=t '.petition_header_other', count: @petition.count_for(
           :child_arrangements_orders, :prohibited_steps_orders, :specific_issues_orders
         ) %>
-      </h3>
+      </h2>
       <div class="govuk-inset-text">
         <%= simple_format(@petition.other_issue_details, { class: 'govuk-body' }) %>
       </div>

--- a/app/views/steps/shared/_kickout_survey.html.erb
+++ b/app/views/steps/shared/_kickout_survey.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-m govuk-!-margin-top-6">We’d like your feedback</h3>
+<h2 class="govuk-heading-m govuk-!-margin-top-6">We’d like your feedback</h2>
 
 <p class="govuk-body">
   Would you like

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -904,11 +904,11 @@ en:
             summary: What happens if you choose to be contacted
             text_html: |
               <p class="govuk-body">By choosing to be contacted by the Ministry of Justice (MOJ) you agree that your personal details and any information you give can be used by MOJ for research purposes.</p>
-              <h3 class="govuk-heading-m">The information we use</h3>
+              <h2 class="govuk-heading-m">The information we use</h2>
               <p class="govuk-body">MOJ can use any information you provide, including your name and contact information (such as your email address).</p>
-              <h3 class="govuk-heading-m">Why we use this information</h3>
+              <h2 class="govuk-heading-m">Why we use this information</h2>
               <p class="govuk-body">To get your thoughts on this service - for example, we might send you a satisfaction survey.</p>
-              <h3 class="govuk-heading-m">Data and your rights</h3>
+              <h2 class="govuk-heading-m">Data and your rights</h2>
               <p class="govuk-body">You can find out how long we keep your data, your rights and how to contact us in our <a href="/about/privacy_consent" class="govuk-link">privacy policy</a>.</p>
       warning:
         show:


### PR DESCRIPTION
There were some pages with unnecessary heading jumps from h1 to h3.

The class is what makes the font change its size so we don't need an h3 to make the header smaller, an h2 will do as long as it has the proper class (for example `govuk-heading-m`)

There might be other places but I think I found all of them.
We also need to do the same in some places with h4.

In addition, change a couple instances of `<p class="govuk-caption-xl">` to be a span element.