### PR TITLE
Recover missing page title prefix functionality

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,13 @@ module ApplicationHelper
   end
 
   def govuk_error_summary(form_object = @form_object)
+    return unless form_object.try(:errors).present?
+
+    # Prepend page title so screen readers read it out as soon as possible
+    content_for(:page_title, flush: true) do
+      content_for(:page_title).insert(0, t('errors.page_title_prefix'))
+    end
+
     fields_for(form_object, form_object) do |f|
       f.govuk_error_summary t('errors.error_summary.heading')
     end

--- a/features/errors.feature
+++ b/features/errors.feature
@@ -14,4 +14,4 @@ Feature: Errors
 
     Then I click the "Enter a full postcode, with or without a space" link
     And I should see "Enter a full postcode, with or without a space" error in the form
-    And "#steps_screener_postcode_form_children_postcodes" has focus
+    And "steps-screener-postcode-form-children-postcodes-field-error" has focus

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -51,17 +51,17 @@ end
 
 # Errors
 When(/^I should see "([^"]*)" in the error summary$/) do |text|
-  page.find("div.govuk-error-summary > h2").has_content? text
+  expect(page.find("div.govuk-error-summary > h2")).to have_text(text)
 end
 
 When(/^I should see "([^"]*)" error in the form$/) do |text|
-  page.find("span.govuk-error-message").has_content? text
+  expect(page.find("span.govuk-error-message")).to have_text(text)
 end
 
 When(/^Page has title "([^"]*)"/) do |text|
-  page.has_title? text
+  expect(page).to have_title(text)
 end
 
 When(/^"([^"]*)" has focus/) do |text|
-  page.evaluate_script("document.activeElement.id") == text
+  expect(page.evaluate_script("document.activeElement.id")).to eq(text)
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe '#govuk_error_summary' do
+    context 'when no form object is given' do
+      let(:form_object) { nil }
+
+      it 'returns nil' do
+        expect(helper.govuk_error_summary(form_object)).to be_nil
+      end
+    end
+
     context 'when a form object without errors is given' do
       let(:form_object) { BaseForm.new }
 
@@ -72,8 +80,10 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context 'when a form object with errors is given' do
       let(:form_object) { BaseForm.new }
+      let(:title) { helper.content_for(:page_title) }
 
       before do
+        helper.title('A page')
         form_object.errors.add(:base, :blank)
       end
 
@@ -83,6 +93,11 @@ RSpec.describe ApplicationHelper, type: :helper do
         ).to eq(
           '<div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title"><h2 id="error-summary-title" class="govuk-error-summary__title">There is a problem on this page</h2><div class="govuk-error-summary__body"><ul class="govuk-list govuk-error-summary__list"><li><a data-turbolinks="false" href="#base-form-base-field-error">Enter an answer</a></li></ul></div></div>'
         )
+      end
+
+      it 'prepends the page title with an error hint' do
+        helper.govuk_error_summary(form_object)
+        expect(title).to start_with('Error: A page')
       end
     end
   end


### PR DESCRIPTION
As part of a recent cleanup, the code that sets the `Error:` prefix in the page title was removed.

This should have been caught by our feature tests, but to my surprise these were not expecting outcomes, thus never failed. I've fixed this broken cuke definitions to actually `expect` things so we are alerted if this prefix, or something similar, is removed.