### PR TITLE
Copy and style fixes and tweaks

### DIFF
--- a/app/validators/checkbox_options_validator.rb
+++ b/app/validators/checkbox_options_validator.rb
@@ -13,6 +13,6 @@ class CheckboxOptionsValidator < ActiveModel::EachValidator
   private
 
   def valid_values?(selected_options)
-    selected_options.all? { |value| @_valid_values.include?(value) }
+    selected_options.all? { |value| @_valid_values.include?(value) || value.eql?('') }
   end
 end

--- a/app/views/steps/alternatives/court/edit.en.html.erb
+++ b/app/views/steps/alternatives/court/edit.en.html.erb
@@ -62,7 +62,7 @@
       <a href="https://www.gov.uk/legal-aid/domestic-abuse-or-violence" class="govuk-link" rel="external" target="_blank">
         legal aid and domestic violence or abuse</a>.
     </p>
-    <p class="govuk-body">
+    <p class="govuk-body govuk-!-margin-bottom-8">
       Find out more about
       <a href="https://www.refuge.org.uk/get-help-now/help-for-women/recognising-abuse/" class="govuk-link" rel="external" target="_blank">
         domestic violence or abuse</a>
@@ -73,7 +73,7 @@
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%=
-        f.govuk_check_boxes_fieldset :court_acknowledgement, legend: { tag: 'span', size: 'm' } do
+        f.govuk_check_boxes_fieldset :court_acknowledgement, legend: { tag: 'span', size: 's' } do
           f.govuk_check_box(:court_acknowledgement, true, multiple: false, link_errors: true)
         end
       %>

--- a/app/views/steps/attending_court/special_arrangements/edit.html.erb
+++ b/app/views/steps/attending_court/special_arrangements/edit.html.erb
@@ -8,14 +8,9 @@
     <span class="govuk-caption-xl"><%=t '.section' %></span>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_check_boxes_fieldset :special_arrangements do %>
-
-        <p class="govuk-body-l"><%= t '.lead_text' %></p>
-        <p class="govuk-body"><%= t '.court_contact' %></p>
-
-        <% SpecialArrangements.string_values.each do |name| %>
-          <%= f.govuk_check_box :special_arrangements, name %>
-        <% end %>
+      <%= f.govuk_collection_check_boxes :special_arrangements, SpecialArrangements.values, :to_s, :to_s do %>
+        <p class="govuk-body-l"><%=t '.lead_text' %></p>
+        <p class="govuk-body"><%=t '.court_contact' %></p>
       <% end %>
 
       <%= f.govuk_text_area :special_arrangements_details %>

--- a/app/views/steps/attending_court/special_assistance/edit.html.erb
+++ b/app/views/steps/attending_court/special_assistance/edit.html.erb
@@ -8,12 +8,7 @@
     <span class="govuk-caption-xl"><%=t '.section' %></span>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_check_boxes_fieldset :special_assistance do %>
-        <% SpecialAssistance.string_values.each do |name| %>
-          <%= f.govuk_check_box :special_assistance, name %>
-        <% end %>
-      <% end %>
-
+      <%= f.govuk_collection_check_boxes :special_assistance, SpecialAssistance.values, :to_s, :to_s %>
       <%= f.govuk_text_area :special_assistance_details %>
 
       <%= f.continue_button %>

--- a/app/views/steps/petition/orders/edit.html.erb
+++ b/app/views/steps/petition/orders/edit.html.erb
@@ -5,11 +5,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_check_boxes_fieldset :orders, legend: { tag: 'span', size: 'm' } do %>
-
+      <%= f.govuk_check_boxes_fieldset :orders do %>
         <%= f.govuk_check_box :orders, PetitionOrder::CHILD_ARRANGEMENTS_HOME.to_s, link_errors: true %>
         <%= f.govuk_check_box :orders, PetitionOrder::CHILD_ARRANGEMENTS_TIME.to_s %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -531,7 +531,7 @@ en:
           section: Safety concerns
       address_confidentiality:
         edit:
-          page_title: Address confidentiality
+          page_title: Contact details confidentiality
           section: Safety concerns
           heading: Keeping your contact details private
           lead_text_html: |
@@ -590,7 +590,6 @@ en:
       orders:
         edit:
           page_title: What are you asking the court to decide?
-          heading: What are you asking the court to decide about the children involved?
       other_issue:
         edit:
           page_title: Provide details of the issue
@@ -1564,6 +1563,8 @@ en:
         undertaking_is_current: *order_current
 
       # Petition steps (nature of application)
+      steps_petition_orders_form:
+        orders: What are you asking the court to decide about the children involved?
       steps_petition_protection_form:
         protection_orders: Is there anything else you are asking the court to decide, specifically to protect the safety of you or the children?
 

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -566,6 +566,14 @@ en:
               blank: You must give sign language requirements
             welsh_language_details:
               blank: You must give Welsh language requirements
+        steps/attending_court/special_arrangements_form:
+          attributes:
+            special_arrangements:
+              invalid: Select valid safety arrangements
+        steps/attending_court/special_assistance_form:
+          attributes:
+            special_assistance:
+              invalid: Select valid assistance or special facilities
         steps/attending_court/intermediary_form:
           attributes:
             intermediary_help:


### PR DESCRIPTION
As per Simon accessibility audit.

Mainly: fieldset without legend in the orders page, and wrong hint position in the special arrangements pages.