### PR TITLE
Simplify `additional_permitted_params` for arrays

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -67,12 +67,11 @@ class StepController < ApplicationController
   def form_attribute_names(form_class)
     form_class.attribute_set.map do |attr|
       attr_name = attr.name
-      attr_type = attr.type.to_s
+      primitive = attr.primitive.to_s
 
-      # TODO: to maintain backwards compatibility with old form builder gems
-      # Once we've migrated everything, we can simplify this
-      case attr_type
-      when 'Axiom::Types::Boolean'
+      # Avoid having to declare collection attributes `Array[String]` in permitted params.
+      case primitive
+      when 'Array'
         [attr_name, attr_name => []]
       else
         attr_name

--- a/app/controllers/steps/abduction/passport_details_controller.rb
+++ b/app/controllers/steps/abduction/passport_details_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(PassportDetailsForm, as: :passport_details)
       end
-
-      private
-
-      def additional_permitted_params
-        [passport_possession: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/attending_court/language_controller.rb
+++ b/app/controllers/steps/attending_court/language_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(LanguageForm, as: :language)
       end
-
-      private
-
-      def additional_permitted_params
-        [language_options: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/attending_court/special_arrangements_controller.rb
+++ b/app/controllers/steps/attending_court/special_arrangements_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(SpecialArrangementsForm, as: :special_arrangements)
       end
-
-      private
-
-      def additional_permitted_params
-        [special_arrangements: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/attending_court/special_assistance_controller.rb
+++ b/app/controllers/steps/attending_court/special_assistance_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(SpecialAssistanceForm, as: :special_assistance)
       end
-
-      private
-
-      def additional_permitted_params
-        [special_assistance: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/children/orders_controller.rb
+++ b/app/controllers/steps/children/orders_controller.rb
@@ -24,10 +24,6 @@ module Steps
       def set_petition_orders
         @petition = PetitionPresenter.new(current_c100_application)
       end
-
-      def additional_permitted_params
-        [orders: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/children/residence_controller.rb
+++ b/app/controllers/steps/children/residence_controller.rb
@@ -20,10 +20,6 @@ module Steps
       def residence_record
         current_record.child_residence || current_record.build_child_residence
       end
-
-      def additional_permitted_params
-        [person_ids: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/miam_exemptions/adr_controller.rb
+++ b/app/controllers/steps/miam_exemptions/adr_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(AdrForm, as: :adr)
       end
-
-      private
-
-      def additional_permitted_params
-        [adr: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/miam_exemptions/domestic_controller.rb
+++ b/app/controllers/steps/miam_exemptions/domestic_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(DomesticForm, as: :domestic)
       end
-
-      private
-
-      def additional_permitted_params
-        [domestic: [], exemptions_collection: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/miam_exemptions/misc_controller.rb
+++ b/app/controllers/steps/miam_exemptions/misc_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(MiscForm, as: :misc)
       end
-
-      private
-
-      def additional_permitted_params
-        [misc: [], exemptions_collection: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/miam_exemptions/protection_controller.rb
+++ b/app/controllers/steps/miam_exemptions/protection_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(ProtectionForm, as: :protection)
       end
-
-      private
-
-      def additional_permitted_params
-        [protection: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/miam_exemptions/urgency_controller.rb
+++ b/app/controllers/steps/miam_exemptions/urgency_controller.rb
@@ -10,12 +10,6 @@ module Steps
       def update
         update_and_advance(UrgencyForm, as: :urgency)
       end
-
-      private
-
-      def additional_permitted_params
-        [urgency: []]
-      end
     end
   end
 end

--- a/app/controllers/steps/petition/orders_controller.rb
+++ b/app/controllers/steps/petition/orders_controller.rb
@@ -8,12 +8,6 @@ module Steps
       def update
         update_and_advance(OrdersForm, as: :orders)
       end
-
-      private
-
-      def additional_permitted_params
-        [orders: [], orders_collection: []]
-      end
     end
   end
 end


### PR DESCRIPTION
The main use-case of the `additional_permitted_params` at the moment is to declare a permitted parameter as a collection.

This can be simplified now that all our check boxes are unified by inspecting the form object attributes and identifying the ones that are collections `Array[String]`.