### PR TITLE
Better handling of CYA on IE

### DIFF
--- a/app/assets/stylesheets/local/check_answers.scss
+++ b/app/assets/stylesheets/local/check_answers.scss
@@ -26,14 +26,16 @@
 
     .govuk-summary-list__row {
       border: none;
+      width: 100%;
+    }
+
+    .govuk-summary-list__key {
+      width: 100%;
     }
 
     .govuk-summary-list__value {
       display: block;
-
-      @include govuk-if-ie8 {
-        width: 100%;
-      }
+      width: 100%;
     }
 
     // Give a sense of hierarchy by adding a bit of inset to sub-questions (only on mobile)


### PR DESCRIPTION
Not specific to IE8 but also other IE versions, so making this generic.

Other browsers render fine even with the width 100%.