### PR TITLE
Disable the screener email consent step

### DIFF
--- a/app/models/screener_answers.rb
+++ b/app/models/screener_answers.rb
@@ -1,8 +1,9 @@
 class ScreenerAnswers < ApplicationRecord
   belongs_to :c100_application
 
+  # Absolute minimum details needed to consider the screener completed
   def self.attributes_to_validate
-    attribute_names - %w[created_at updated_at email_address]
+    %w[children_postcodes parent written_agreement]
   end.freeze
 
   validates_presence_of attributes_to_validate, on: :completion

--- a/app/services/c100_app/screener_decision_tree.rb
+++ b/app/services/c100_app/screener_decision_tree.rb
@@ -44,11 +44,10 @@ module C100App
     end
 
     def after_written_agreement
-      if question(:written_agreement, c100_application.screener_answers).no?
-        edit(:email_consent)
-      else
-        show(:written_agreement_exit)
-      end
+      return show(:written_agreement_exit) if question(:written_agreement, c100_application.screener_answers).yes?
+      return edit(:email_consent)          if Rails.configuration.x.screener.show_email_consent_step
+
+      show(:done)
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,11 @@ class Application < Rails::Application
     :govuk_notify_templates, env: ENV.fetch('GOVUK_NOTIFY_ENV', 'integration')
   ).with_indifferent_access
 
+  # Toggle on/off the `email consent` screener question (used to gather emails
+  # of users for research purposes).
+  # Disabled by default. Set this ENV variable to enable the question.
+  config.x.screener.show_email_consent_step = ENV.key?('SHOW_EMAIL_CONSENT_STEP')
+
   config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 60).to_i
   config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 

--- a/features/screener.feature
+++ b/features/screener.feature
@@ -17,9 +17,6 @@ Feature: Screener
     Then I should see "Do you have a signed draft court order you want the court to consider making legally binding?"
     And I choose "No"
 
-    Then I should see "Are you willing to be contacted by email about your experience using this service?"
-    And I choose "Yes" and fill in "Email address" with "smoketest@example.com"
-
     Then I should see "You’re eligible to apply online"
 
     And I click the "Continue" link

--- a/spec/models/screener_answers_spec.rb
+++ b/spec/models/screener_answers_spec.rb
@@ -9,15 +9,11 @@ RSpec.describe ScreenerAnswers, type: :model do
     it 'returns only the attributes that should be validated' do
       expect(
         described_class.attributes_to_validate
-      ).to match_array(%w(
-        id
-        c100_application_id
+      ).to match_array(%w[
         children_postcodes
-        local_court
         parent
         written_agreement
-        email_consent
-      ))
+      ])
     end
   end
 

--- a/spec/services/c100_app/screener_decision_tree_spec.rb
+++ b/spec/services/c100_app/screener_decision_tree_spec.rb
@@ -89,7 +89,19 @@ RSpec.describe C100App::ScreenerDecisionTree do
     context 'and written_agreement is "no"' do
       let(:written_agreement){ GenericYesNo::NO }
 
-      it { is_expected.to have_destination(:email_consent, :edit) }
+      before do
+        allow(Rails.configuration.x.screener).to receive(:show_email_consent_step).and_return(show_consent)
+      end
+
+      context 'and the email consent step is enabled' do
+        let(:show_consent) { true }
+        it { is_expected.to have_destination(:email_consent, :edit) }
+      end
+
+      context 'and the email consent step is disabled' do
+        let(:show_consent) { false }
+        it { is_expected.to have_destination(:done, :show) }
+      end
     end
 
     context 'and written_agreement is "yes"' do


### PR DESCRIPTION
Make this feature-flag so it is easy to enable it again in the future if we need to. By default will be disabled.

Updated the `ScreenerAnswers.attributes_to_validate` so only checks the ones we absolute need, specially now that we are disabling the email consent.