### PR TITLE
Bump `govuk_design_system_formbuilder` gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.6.5'
 
 gem 'devise', '~> 4.7.1'
 gem 'email_validator', '< 2.0.0'
-gem 'govuk_design_system_formbuilder', github: 'zheileman/govuk_design_system_formbuilder'
+gem 'govuk_design_system_formbuilder', '~> 1.1.11'
 gem 'govuk_notify_rails', '~> 2.1.0'
 gem 'jquery-rails'
 gem 'omniauth-auth0', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/zheileman/govuk_design_system_formbuilder.git
-  revision: c46e379e9875fce9c544b59c268b1cf2ee3ac2f8
-  specs:
-    govuk_design_system_formbuilder (1.1.10)
-      actionview (>= 5.2)
-      activemodel (>= 5.2)
-      activesupport (>= 5.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -149,6 +140,10 @@ GEM
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    govuk_design_system_formbuilder (1.1.11)
+      actionview (>= 5.2)
+      activemodel (>= 5.2)
+      activesupport (>= 5.2)
     govuk_notify_rails (2.1.2)
       notifications-ruby-client (~> 5.1)
       rails (>= 4.1.0)
@@ -425,7 +420,7 @@ DEPENDENCIES
   devise (~> 4.7.1)
   dotenv-rails
   email_validator (< 2.0.0)
-  govuk_design_system_formbuilder!
+  govuk_design_system_formbuilder (~> 1.1.11)
   govuk_notify_rails (~> 2.1.0)
   i18n-debug
   jquery-rails

--- a/app/views/steps/shared/_existing_names.html.erb
+++ b/app/views/steps/shared/_existing_names.html.erb
@@ -1,13 +1,8 @@
-<%= person.hidden_field :id %>
-
-<fieldset class="govuk-fieldset">
-  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-    <span class="govuk-fieldset__heading"><%= legend %></span>
-  </legend>
-
+<%= names_form.govuk_fieldset legend: { text: legend, tag: 'span', size: 'm' } do %>
+  <%= person.hidden_field :id %>
   <%= person.govuk_text_field :first_name, width: 'one-half' %>
   <%= person.govuk_text_field :last_name, width: 'one-half' %>
 
   <%= person.button t('.remove_name', legend: legend.downcase), type: :submit, name: :remove_name, value: person.object.id,
                     class: %w(govuk-button govuk-button--warning), data: { module: 'govuk-button' } %>
-</fieldset>
+<% end %>

--- a/app/views/steps/shared/_new_name.html.erb
+++ b/app/views/steps/shared/_new_name.html.erb
@@ -1,4 +1,4 @@
-<%= names_form.govuk_fieldset do %>
+<%= names_form.govuk_fieldset legend: { text: t('.fieldset_legend'), tag: 'span', size: 'm' } do %>
   <%= names_form.govuk_text_field :new_first_name, width: 'one-half' %>
   <%= names_form.govuk_text_field :new_last_name, width: 'one-half' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,6 +169,8 @@ en:
           other: "%{count} addresses found"
       existing_names:
         remove_name: "Remove %{legend}"
+      new_name:
+        fieldset_legend: Enter a new name
       children_personal_details:
         heading: "Provide details for %{name}"
     applicant:


### PR DESCRIPTION
The new version of the gem has been released [1] and it contains all the work that we contributed back and needed for this service to work, as well as a fix for the `#govuk_fieldset` helper [2] so now we can get rid of the hardcoded markup and use the helper as intended.

[1] https://github.com/DFE-Digital/govuk_design_system_formbuilder/releases/tag/v1.1.11
[2] https://github.com/DFE-Digital/govuk_design_system_formbuilder/pull/130