### PR TITLE
Update accessibility statement page

### DIFF
--- a/app/views/about/accessibility.en.html.erb
+++ b/app/views/about/accessibility.en.html.erb
@@ -17,6 +17,7 @@
       <li>zoom in up to 300% without the text spilling off the screen</li>
       <li>navigate most of the online service using just a keyboard</li>
       <li>navigate most of the online service using speech recognition software</li>
+      <li>listen to most of the online service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
     </ul>
 
     <p class="govuk-body">We’ve also made the text as simple as possible to understand.</p>
@@ -29,14 +30,7 @@
     <h2 class="govuk-heading-l">About the accessibility of this online service</h2>
 
     <p class="govuk-body">
-      We’ve used <a href="https://govuk-elements.herokuapp.com" class="govuk-link" rel="external" target="_blank">GOV.UK
-      Elements</a> to build this service. GOV.UK Elements has now been replaced by the GOV.UK Design System, but we will
-      still carry out major bug fixes and security patches.
-    </p>
-
-    <p class="govuk-body">
-      Basic tests were performed on this online service on 9 October 2019. These tests were carried out by the Ministry
-      of Justice.
+      Basic tests were performed on this online service on 15 May 2020. These tests were carried out by the Ministry of Justice.
     </p>
 
     <p class="govuk-body">
@@ -81,17 +75,12 @@
 
     <h2 class="govuk-heading-l">Non compliance with the accessibility regulations</h2>
 
-    <p class="govuk-body">The content listed below is non-accessible for the following reasons.</p>
+    <p class="govuk-body">
+      Some pages may be non-accessible where further inputs are revealed based on a checkbox or radio selection. We’re
+      working to understand whether these nested inputs are fully accessible.
+    </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>For some browsers, the font size does not increase when changes are made in browser settings. However, zooming
-        works correctly.
-      </li>
-      <li>The focus colour shows low contrast against a grey background in some cases.</li>
-      <li>We’re working to understand whether nested checkboxes are fully accessible to screen readers.</li>
-    </ul>
-
-    <p class="govuk-body">We plan to resolve the issues above by September 2020. </p>
+    <p class="govuk-body">We plan to resolve this issue by September 2020.</p>
 
     <h2 class="govuk-heading-l">PDF content</h2>
 
@@ -106,16 +95,11 @@
     <p class="govuk-body">This online service uses a third-party supplied service to collect feedback.</p>
 
     <p class="govuk-body">
-      This third-party supplied service is ‘skinned' to look like our website, but some parts of it do not meet
+      This third-party supplied service is “skinned” to look like our website, but part of it does not meet
       <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link" rel="external" target="_blank">Web Content
-        Accessibility Guidelines version 2.1</a> standards because:
+        Accessibility Guidelines version 2.1</a> standards because clicking the labels does not move the cursor into the
+      corresponding text area.
     </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>incorrect heading tags are used</li>
-      <li>clicking the labels does not move the cursor into the corresponding text area</li>
-      <li>when using the keyboard, the radio button becomes invisible</li>
-    </ul>
 
     <p class="govuk-body">
       The third-party supplied feedback form is one part of our overall approach to collecting feedback. We'll continue
@@ -142,7 +126,7 @@
     </p>
 
     <p class="govuk-body govuk-!-margin-top-8">
-      This statement was prepared on 19 November 2019.<br/>It was last updated on 19 November 2019.
+      This statement was prepared on 19 November 2019.<br/>It was last updated on 21 May 2020.
     </p>
   </div>
 </div>

--- a/app/views/layouts/_timeout_modal.html.erb
+++ b/app/views/layouts/_timeout_modal.html.erb
@@ -8,7 +8,7 @@
                 session_length: Rails.configuration.x.session.expires_in_minutes) %>
       </span>
 
-      <h2 class="govuk-heading-m"><%= t('session.expiring.heading') %></h2>
+      <h3 class="govuk-heading-m"><%= t('session.expiring.heading') %></h3>
 
       <p class="govuk-body">
         <%= t('session.expiring.in') %> <span id="timeout-dialog-remaining"></span>.


### PR DESCRIPTION
With the release of the new version of CAS using the new design system, some of the offences have been fixed.

Implement the copy changes suggested by content designer.

Also, bit unrelated to this but restored the timeout modal to its glorious splendor.

Before:
<img width="563" alt="Screen Shot 2020-05-21 at 12 04 43" src="https://user-images.githubusercontent.com/687910/82563501-1be6b100-9b6f-11ea-9576-1b54af7bd412.png">

After:
<img width="560" alt="Screen Shot 2020-05-21 at 12 04 56" src="https://user-images.githubusercontent.com/687910/82563512-2143fb80-9b6f-11ea-9a15-19f9c5a0f329.png">
