### PR TITLE
Remove unused passport DB fields

### DIFF
--- a/db/migrate/20200522082810_remove_passport_possession_fields.rb
+++ b/db/migrate/20200522082810_remove_passport_possession_fields.rb
@@ -1,0 +1,7 @@
+class RemovePassportPossessionFields < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :abduction_details, :passport_possession_mother, :boolean
+    remove_column :abduction_details, :passport_possession_father, :boolean
+    remove_column :abduction_details, :passport_possession_other,  :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_15_095359) do
+ActiveRecord::Schema.define(version: 2020_05_22_082810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -21,9 +21,6 @@ ActiveRecord::Schema.define(version: 2020_05_15_095359) do
     t.string "children_have_passport"
     t.string "passport_office_notified"
     t.string "children_multiple_passports"
-    t.boolean "passport_possession_mother"
-    t.boolean "passport_possession_father"
-    t.boolean "passport_possession_other"
     t.text "passport_possession_other_details"
     t.string "previous_attempt"
     t.text "previous_attempt_details"


### PR DESCRIPTION
In previous PR #938 we refactor the passport possession checkboxes from individual booleans to an array of string values.

We also migrated the existing values to the array.

Now that we've released all this work, and everything is working fine, we can remove these leftover columns.