### PR TITLE
Refactor back office forms with form object

### DIFF
--- a/app/controllers/backoffice/dashboard_controller.rb
+++ b/app/controllers/backoffice/dashboard_controller.rb
@@ -3,17 +3,28 @@ module Backoffice
     include Auth0Secured
 
     def index
+      @form = Backoffice::LookupForm.new
       @report = CompletedApplicationsAudit.unscoped.order(completed_at: :desc).limit(50)
     end
 
     def lookup
-      @reference_code = params[:reference_code]&.strip
-      @report = CompletedApplicationsAudit.where(reference_code: @reference_code)
+      @form = Backoffice::LookupForm.new(form_params)
+      @report = []
+
+      render :lookup && return if @form.invalid?
+
+      @report = CompletedApplicationsAudit.where(reference_code: @form.reference_code)
 
       audit!(
         action: :application_lookup,
-        details: { reference_code: @reference_code, found: @report.size }
+        details: { reference_code: @form.reference_code, found: @report.size }
       )
+    end
+
+    private
+
+    def form_params
+      params.require(:backoffice_lookup_form).permit(:reference_code)
     end
   end
 end

--- a/app/controllers/backoffice/emails_controller.rb
+++ b/app/controllers/backoffice/emails_controller.rb
@@ -3,19 +3,22 @@ module Backoffice
     include Auth0Secured
 
     def index
+      @form = Backoffice::LookupForm.new
       @report = Reports::FailedEmailsReport.list
     end
 
     def lookup
-      @reference_code = params[:reference_code]&.strip
-      @email_address  = params[:email_address]&.strip
+      @form = Backoffice::LookupForm.new(form_params)
+      @report = []
 
-      @report = EmailSubmissionsAudit.find_records(@reference_code, @email_address)
-      @submission = C100Application.find_by_reference_code(@reference_code)&.email_submission
+      render :lookup && return if @form.invalid?
+
+      @report = EmailSubmissionsAudit.find_records(@form.reference_code, @form.email_address)
+      @submission = email_submission_details(@form.reference_code, @form.email_address)
 
       audit!(
         action: :email_lookup,
-        details: { reference_code: @reference_code, email_address: @email_address, found: @report.size }
+        details: { reference_code: @form.reference_code, email_address: @form.email_address, found: @report.size }
       )
     end
 
@@ -32,6 +35,24 @@ module Backoffice
     end
 
     private
+
+    def form_params
+      params.require(:backoffice_lookup_form).permit(
+        :reference_code,
+        :email_address,
+      )
+    end
+
+    def email_submission_details(reference, email = nil)
+      email_submission = C100Application.find_by_reference_code(reference).try(:email_submission)
+      return if email_submission.nil?
+
+      email_submission if [
+        email_submission.to_address,
+        email_submission.email_copy_to,
+        nil
+      ].include?(email.presence)
+    end
 
     def audit_resend(email, resend_type:)
       details = {

--- a/app/forms/backoffice/lookup_form.rb
+++ b/app/forms/backoffice/lookup_form.rb
@@ -1,0 +1,32 @@
+module Backoffice
+  class LookupForm
+    include ActiveModel::Model
+
+    attr_accessor :reference_code, :email_address
+
+    validates_presence_of :reference_code
+    validate :reference_code_format
+
+    # Email is optional, and in some places we don't even ask for it
+    validates :email_address, email: true, allow_blank: true
+
+    def initialize(*args)
+      super
+
+      # It is very common to copy&paste, introducing some extraneous spacing.
+      # In order to reduce this silly mistake, we pro-actively remove blanks,
+      # instead of returning no results or even worse, an error.
+      #
+      @reference_code.try(:strip!)
+      @email_address.try(:strip!)
+    end
+
+    private
+
+    def reference_code_format
+      # Very high level format validation for now, as the reference codes
+      # might need to change soon with online payments.
+      errors.add(:reference_code, :invalid) unless reference_code.count('/') > 1
+    end
+  end
+end

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -5,7 +5,8 @@
   <td class="govuk-table__cell"><%= completion.court %></td>
 </tr>
 
-<% if defined?(@reference_code) %>
+<%# Only show extra details when a specific reference code is searched %>
+<% if controller.action_name == 'lookup' %>
   <% c100 = completion.c100_application %>
 
   <tr class="govuk-table__row">

--- a/app/views/backoffice/dashboard/_lookup_form.en.html.erb
+++ b/app/views/backoffice/dashboard/_lookup_form.en.html.erb
@@ -6,7 +6,7 @@
   This will search the given reference in the historical audit table, no matter how old the application is.
 </p>
 
-<%= form_with(url: lookup_backoffice_dashboard_index_path, local: true, class: 'govuk-!-margin-bottom-3', builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
-  <%= f.govuk_text_field :reference_code, width: 'one-half', value: @reference_code, label: { text: 'Reference code'} %>
+<%= form_for(@form, url: lookup_backoffice_dashboard_index_path, html: { class: 'govuk-!-margin-bottom-5' }) do |f| %>
+  <%= f.govuk_text_field :reference_code, width: 'one-half', label: { text: 'Reference code'} %>
   <%= f.govuk_submit 'Lookup application' %>
 <% end %>

--- a/app/views/backoffice/dashboard/lookup.en.html.erb
+++ b/app/views/backoffice/dashboard/lookup.en.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Back office: applications</h1>
 
-    <%= render partial: 'lookup_form', locals: { reference_code: @reference_code } %>
+    <%= render partial: 'lookup_form' %>
 
     <h3 class="govuk-heading-m">
       Results

--- a/app/views/backoffice/emails/_lookup_form.en.html.erb
+++ b/app/views/backoffice/emails/_lookup_form.en.html.erb
@@ -6,8 +6,8 @@
 </p>
 
 
-<%= form_with(url: lookup_backoffice_emails_path, local: true, class: 'govuk-!-margin-bottom-3', builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
-  <%= f.govuk_text_field :reference_code, width: 'one-half', value: @reference_code, label: { text: 'Reference code' } %>
-  <%= f.govuk_text_field :email_address, width: 'one-half', value: @email_address, label: { text: 'Email address' } %>
+<%= form_for(@form, url: lookup_backoffice_emails_path, html: { class: 'govuk-!-margin-bottom-5' }) do |f| %>
+  <%= f.govuk_text_field :reference_code, width: 'one-half', label: { text: 'Reference code' } %>
+  <%= f.govuk_text_field :email_address, width: 'one-half', label: { text: 'Email address (optional)' } %>
   <%= f.govuk_submit 'Lookup emails'%>
 <% end %>

--- a/app/views/backoffice/emails/lookup.en.html.erb
+++ b/app/views/backoffice/emails/lookup.en.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Back office: emails</h1>
 
-    <%= render partial: 'lookup_form', locals: { reference_code: @reference_code, email_address: @email_address } %>
+    <%= render partial: 'lookup_form' %>
 
     <table class="govuk-table backoffice-table">
       <thead class="govuk-table__head">

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -96,6 +96,13 @@ en:
   activemodel:
     errors:
       models:
+        # Back office
+        backoffice/lookup_form:
+          attributes:
+            reference_code:
+              blank: Enter a reference code
+              invalid: The reference code format is invalid
+
         # Begin screener
         steps/screener/parent_form:
           attributes:


### PR DESCRIPTION
There is some technical debt in the back office as a consequence of the rapid development back then. Still there are some missing things, TODO when time allows: back office tests.

Added a form object to hold the (currently) 2 fields we use in the back office lookup functionality: reference code, and email address.
Do some high level validation of these fields as well as some pre-processing stripping blanks to minimise errors.

Individual commits for more context.

<img width="888" alt="Screen Shot 2020-05-29 at 15 19 54" src="https://user-images.githubusercontent.com/687910/83270473-6f38af00-a1c0-11ea-8834-9f2151606976.png">

<img width="1003" alt="Screen Shot 2020-05-29 at 15 20 09" src="https://user-images.githubusercontent.com/687910/83270478-72339f80-a1c0-11ea-93ed-6bc5dc1eb58d.png">
