### PR TITLE
Bump GOV.UK Frontend v3.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.6.0.tgz",
-      "integrity": "sha512-wTxufdY8vFvKJ2EmmQKmarrQ7n30kzg+vvqgGib2dawl7c5Wst8dffkEJQpy9Zs99TE/yEEFgj0VUO4GRUO22A=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
+      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "^3.6.0"
+    "govuk-frontend": "^3.7.0"
   }
 }


### PR DESCRIPTION
A new version has been released:
https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0

There should not be any breaking changes, and the only noticeable change is the `Back` link styling, as indicated in the changelog.

<img width="234" alt="Screen Shot 2020-06-01 at 16 13 20" src="https://user-images.githubusercontent.com/687910/83423419-d9508e80-a422-11ea-80f7-931eabb47f80.png">
