### PR TITLE
Improve bypass to CYA button

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,6 +28,7 @@ class SessionsController < ApplicationController
     raise 'For development use only' unless helpers.dev_tools_enabled?
 
     find_or_create_screener_answers
+    find_or_create_people
     c100_application.update(status: 1)
 
     redirect_to edit_steps_application_check_your_answers_path
@@ -46,6 +47,14 @@ class SessionsController < ApplicationController
       screener.update(
         screener_answers_fixture(screener)
       ) unless screener.valid?(:completion)
+    end
+  end
+
+  def find_or_create_people
+    [Child, Applicant, Respondent].each do |klass|
+      klass.find_or_initialize_by(c100_application_id: c100_application.id).tap do |record|
+        record.update(first_name: record.type, last_name: 'Test') unless record.persisted?
+      end
     end
   end
 

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -27,7 +27,7 @@
                     data: { module: 'govuk-button', confirm: 'Are you sure?' } do; 'Destroy session'; end %>
 
       <h3 class="govuk-heading-m">Bypass steps</h3>
-      <p>Bypass the screener or go to the check your answers page</p>
+      <p>Speed up some common test scenarios by pre-filling some information</p>
 
       <%= button_to bypass_screener_session_path,
                     class: 'govuk-button govuk-!-margin-right-1',


### PR DESCRIPTION
Speed up some common test scenarios by pre-filling some information.

In particular, the bypass to CYA will benefit from having the minimum people pre-filled (just names). Otherwise, it always fail the fullfillment validator when trying to submit.

If there are already people created when the bypass is used, the previously created people remain, will not overwrite nor create new people.