### PR TITLE
Move submission before payment

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -20,7 +20,7 @@ module Summary
         HtmlSections::InternationalElement.new(c100_application),
         HtmlSections::ApplicationReasons.new(c100_application),
         *litigation_and_assistance_sections,
-        *payment_and_submission_sections,
+        *submission_and_payment_sections,
       ].flatten.select(&:show?)
     end
 
@@ -88,10 +88,10 @@ module Summary
       ]
     end
 
-    def payment_and_submission_sections
+    def submission_and_payment_sections
       [
-        HtmlSections::Payment.new(c100_application),
         HtmlSections::Submission.new(c100_application),
+        HtmlSections::Payment.new(c100_application),
       ]
     end
 

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -23,10 +23,10 @@ module C100App
         after_litigation_capacity
       when :litigation_capacity_details
         start_attending_court_journey
-      when :payment
-        edit(:submission)
       when :submission
         after_submission_type
+      when :payment
+        edit(:check_your_answers)
       when :declaration
         after_declaration
       else
@@ -73,7 +73,7 @@ module C100App
       if c100_application.receipt_email.present?
         show(:receipt_email_check)
       else
-        edit(:check_your_answers)
+        edit(:payment)
       end
     end
 

--- a/app/views/steps/application/receipt_email_check/show.html.erb
+++ b/app/views/steps/application/receipt_email_check/show.html.erb
@@ -15,7 +15,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <%= link_button t('.continue'), edit_steps_application_check_your_answers_path %>
+        <%= link_button t('.continue'), edit_steps_application_payment_path %>
       </div>
 
       <div class="govuk-grid-column-one-half govuk-!-margin-top-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,9 +130,9 @@ Rails.application.routes.draw do
       edit_step :details
       edit_step :litigation_capacity
       edit_step :litigation_capacity_details
-      edit_step :payment
       edit_step :submission
       show_step :receipt_email_check
+      edit_step :payment
       edit_step :check_your_answers do
         get :resume, action: :resume
       end

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -84,8 +84,8 @@ describe Summary::HtmlPresenter do
         Summary::HtmlSections::ApplicationReasons,
         Summary::HtmlSections::LitigationCapacity,
         Summary::HtmlSections::AttendingCourtV2,
-        Summary::HtmlSections::Payment,
         Summary::HtmlSections::Submission,
+        Summary::HtmlSections::Payment,
       ])
     end
 

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -95,11 +95,6 @@ RSpec.describe C100App::ApplicationDecisionTree do
     it { is_expected.to have_destination('/steps/attending_court/intermediary', :edit) }
   end
 
-  context 'when the step is `payment`' do
-    let(:step_params) { { payment: 'anything' } }
-    it { is_expected.to have_destination(:submission, :edit) }
-  end
-
   context 'when the step is `submission`' do
     let(:step_params) { { submission: 'anything' } }
     let(:c100_application) { instance_double(C100Application, receipt_email: receipt_email) }
@@ -111,13 +106,18 @@ RSpec.describe C100App::ApplicationDecisionTree do
 
     context 'and user left blank the confirmation email' do
       let(:receipt_email) { '' }
-      it { is_expected.to have_destination(:check_your_answers, :edit) }
+      it { is_expected.to have_destination(:payment, :edit) }
     end
 
     context 'and user do not want online submission' do
       let(:receipt_email) { nil }
-      it { is_expected.to have_destination(:check_your_answers, :edit) }
+      it { is_expected.to have_destination(:payment, :edit) }
     end
+  end
+
+  context 'when the step is `payment`' do
+    let(:step_params) { { payment: 'anything' } }
+    it { is_expected.to have_destination(:check_your_answers, :edit) }
   end
 
   context 'when the step is `declaration`' do


### PR DESCRIPTION
Story: https://mojdigital.teamwork.com/#/tasks/20765417

Previously the page order was:

1. Special Assistance
2. Payment
3. Submission

This commit changes the page order to:

1. Special Assistance
2. Submission
3. Payment



![1](https://user-images.githubusercontent.com/136777/83769757-28dbc800-a678-11ea-9dc2-c19d88d269cd.png)
![2](https://user-images.githubusercontent.com/136777/83769775-2bd6b880-a678-11ea-8b60-82219fd9c374.png)
![3](https://user-images.githubusercontent.com/136777/83769780-2d07e580-a678-11ea-8c81-ebdb491d9cf0.png)


### CYA Order changed too

![image](https://user-images.githubusercontent.com/136777/83770028-7b1ce900-a678-11ea-9dc9-182570971255.png)
