### PR TITLE
Create PaymentIntent model and DB table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.6.5'
 
 gem 'devise', '~> 4.7.1'
 gem 'email_validator', '< 2.0.0'
-gem 'govuk_design_system_formbuilder', '~> 1.1.11'
+gem 'govuk_design_system_formbuilder', '1.1.11'
 gem 'govuk_notify_rails', '~> 2.1.0'
 gem 'govuk-pay-ruby-client', github: 'ministryofjustice/govuk-pay-ruby-client'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/govuk-pay-ruby-client.git
-  revision: dce34532a45ee50f19124c008ea532a43af1e0b9
+  revision: 32a58b48e4557818b41ffdc91c989691b3693717
   specs:
     govuk-pay-ruby-client (0.1.0)
       faraday (~> 1.0)
@@ -156,7 +156,7 @@ GEM
       rails (>= 4.1.0)
     hashdiff (1.0.1)
     hashie (4.1.0)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
       i18n (< 2)
@@ -428,7 +428,7 @@ DEPENDENCIES
   dotenv-rails
   email_validator (< 2.0.0)
   govuk-pay-ruby-client!
-  govuk_design_system_formbuilder (~> 1.1.11)
+  govuk_design_system_formbuilder (= 1.1.11)
   govuk_notify_rails (~> 2.1.0)
   i18n-debug
   jquery-rails

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -19,6 +19,7 @@ class C100Application < ApplicationRecord
   has_one  :miam_exemption,     dependent: :destroy
   has_one  :screener_answers,   dependent: :destroy
   has_one  :email_submission,   dependent: :destroy
+  has_one  :payment_intent,     dependent: :destroy
 
   has_many :abuse_concerns,     dependent: :destroy
   has_many :relationships,      dependent: :destroy
@@ -48,6 +49,11 @@ class C100Application < ApplicationRecord
 
   def online_submission?
     submission_type.eql?(SubmissionType::ONLINE.to_s)
+  end
+
+  # TODO: change when we introduce the 'real' online payment method
+  def online_payment?
+    payment_type.eql?(PaymentType::SELF_PAYMENT_CARD.to_s)
   end
 
   def confidentiality_enabled?

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -1,0 +1,39 @@
+class PaymentIntent < ApplicationRecord
+  include Rails.application.routes.url_helpers
+
+  belongs_to :c100_application
+  delegate :online_payment?, to: :c100_application
+
+  scope :not_finished, -> { where(finished_at: nil) }
+
+  enum status: {
+    ready: 'ready',
+    created: 'created',
+    finished: 'finished',
+    offline_method: 'offline_method',
+  }
+
+  # URLs are one-time use only. Once accessed, they are invalidated.
+  def destination_url
+    destination_payment_url(self, nonce: init_nonce)
+  end
+
+  # Helper method as offline payments are always final
+  def offline_method!
+    super() && touch(:finished_at)
+  end
+
+  def revoke_nonce!
+    update_column(:nonce, nil)
+  end
+
+  private
+
+  def init_nonce
+    update_column(:nonce, _nonce) && nonce
+  end
+
+  def _nonce
+    SecureRandom.hex(8)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,6 +288,10 @@ Rails.application.routes.draw do
     post :notify
   end
 
+  resources :payments, only: [] do
+    get :destination, on: :member
+  end
+
   resource :errors, only: [] do
     get :invalid_session
     get :application_not_found

--- a/db/migrate/20200605081246_create_payment_intents_table.rb
+++ b/db/migrate/20200605081246_create_payment_intents_table.rb
@@ -1,0 +1,15 @@
+class CreatePaymentIntentsTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :payment_intents, id: :uuid do |t|
+      t.timestamps
+
+      t.string :nonce
+      t.string :payment_id
+      t.string :status, null: false, default: 'ready'
+
+      t.datetime :finished_at
+    end
+
+    add_reference :payment_intents, :c100_application, type: :uuid, foreign_key: true, index: { unique: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_22_082810) do
+ActiveRecord::Schema.define(version: 2020_06_05_081246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -269,6 +269,17 @@ ActiveRecord::Schema.define(version: 2020_05_22_082810) do
     t.index ["c100_application_id"], name: "index_miam_exemptions_on_c100_application_id", unique: true
   end
 
+  create_table "payment_intents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "nonce"
+    t.string "payment_id"
+    t.string "status", default: "ready", null: false
+    t.datetime "finished_at"
+    t.uuid "c100_application_id"
+    t.index ["c100_application_id"], name: "index_payment_intents_on_c100_application_id", unique: true
+  end
+
   create_table "people", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -374,6 +385,7 @@ ActiveRecord::Schema.define(version: 2020_05_22_082810) do
   add_foreign_key "court_proceedings", "c100_applications"
   add_foreign_key "email_submissions", "c100_applications"
   add_foreign_key "miam_exemptions", "c100_applications"
+  add_foreign_key "payment_intents", "c100_applications"
   add_foreign_key "people", "c100_applications"
   add_foreign_key "relationships", "c100_applications"
   add_foreign_key "relationships", "people"

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -80,6 +80,7 @@ def models
     User
     Court
     Person
+    PaymentIntent
     CompletedApplicationsAudit
   ).freeze
 end

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe C100Application, type: :model do
     end
   end
 
+  describe '#online_payment?' do
+    context 'for `online` values' do
+      let(:attributes) { {payment_type: 'self_payment_card'} }
+      it { expect(subject.online_payment?).to eq(true) }
+    end
+
+    context 'for other values' do
+      let(:attributes) { {payment_type: 'whatever'} }
+      it { expect(subject.online_payment?).to eq(false) }
+    end
+  end
+
   describe '#confidentiality_enabled?' do
     context 'for `yes` values' do
       let(:attributes) { {address_confidentiality: 'yes'} }

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe PaymentIntent, type: :model do
+  subject { described_class.new(c100_application: c100_application) }
+
+  let(:c100_application) { C100Application.new(payment_type: payment_type) }
+  let(:payment_type) { 'foobar' }
+
+  context 'status enumeration' do
+    it 'maps all the neccessary statuses' do
+      expect(PaymentIntent.statuses.keys).to eq(PaymentIntent.statuses.values)
+
+      expect(
+        PaymentIntent.statuses.keys
+      ).to match_array(%w(
+        ready
+        created
+        finished
+        offline_method
+      ))
+    end
+  end
+
+  describe '#online_payment?' do
+    it 'delegates method to the c100_application' do
+      expect(c100_application).to receive(:online_payment?)
+      subject.online_payment?
+    end
+  end
+
+  describe '#destination_url' do
+    let(:nonce) { '123456' }
+
+    before do
+      subject.save
+      allow(SecureRandom).to receive(:hex).with(8).and_return(nonce)
+    end
+
+    after do
+      subject.destroy
+    end
+
+    it 'sets the nonce' do
+      expect {
+        subject.destination_url
+      }.to change { subject.nonce }.from(nil).to(nonce)
+    end
+
+    it 'returns the destination url with the nonce parameter' do
+      expect(
+        subject.destination_url
+      ).to eq("https://c100.justice.uk/payments/#{subject.id}/destination?nonce=#{nonce}")
+    end
+  end
+
+  describe '#offline_method!' do
+    before do
+      travel_to Time.at(0)
+      subject.save
+    end
+
+    after do
+      subject.destroy
+    end
+
+    it 'changes the status' do
+      expect {
+        subject.offline_method!
+      }.to change { subject.status }.from('ready').to('offline_method')
+    end
+
+    it 'changes the finished_at' do
+      expect {
+        subject.offline_method!
+      }.to change { subject.finished_at }.from(nil).to(Time.at(0))
+    end
+  end
+
+  describe '#revoke_nonce!' do
+    it 'sets to nil the nonce, invalidating it' do
+      expect(subject).to receive(:update_column).with(:nonce, nil)
+      subject.revoke_nonce!
+    end
+  end
+end


### PR DESCRIPTION
This will be another neccessary piece to tie together the online payments journey.

The idea is, when an applicant finish their application (after the check your answers) we register a "payment intent" and redirects the user to an URL derived from this intent (with a nonce to avoid replay attacks).

For now, this does nothing, but in a follow-up PR, the payments controller will be created to handle the payment intent and redirect the user to the appropiate destination page (either the what next for print and post, the payment page to take card details, or the final confirmation page once paid, or for offline payment methods like HWF or cheque).