### PR TITLE
Add payments flow

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,0 +1,23 @@
+class PaymentsController < ApplicationController
+  before_action :check_intent_presence
+
+  def validate
+    payment_intent.revoke_nonce!
+
+    redirect_to C100App::PaymentsFlowControl.new(
+      current_c100_application
+    ).next_url
+  end
+
+  private
+
+  def payment_intent
+    @_payment_intent ||= PaymentIntent.not_finished.find_by(
+      id: params.require(:id), nonce: params.require(:nonce), c100_application: current_c100_application
+    )
+  end
+
+  def check_intent_presence
+    raise Errors::InvalidSession unless payment_intent
+  end
+end

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -2,38 +2,37 @@ class PaymentIntent < ApplicationRecord
   include Rails.application.routes.url_helpers
 
   belongs_to :c100_application
-  delegate :online_payment?, to: :c100_application
 
   scope :not_finished, -> { where(finished_at: nil) }
 
   enum status: {
     ready: 'ready',
     created: 'created',
-    finished: 'finished',
-    offline_method: 'offline_method',
+    pending: 'pending',
+    success: 'success',
+    failed: 'failed',
+    offline_type: 'offline_type',
   }
 
   # URLs are one-time use only. Once accessed, they are invalidated.
-  def destination_url
-    destination_payment_url(self, nonce: init_nonce)
-  end
-
-  # Helper method as offline payments are always final
-  def offline_method!
-    super() && touch(:finished_at)
+  def return_url
+    validate_payment_url(self, nonce: init_nonce)
   end
 
   def revoke_nonce!
     update_column(:nonce, nil)
   end
 
+  def finish!(with_status: :success)
+    update(
+      status: with_status,
+      finished_at: Time.current,
+    )
+  end
+
   private
 
   def init_nonce
-    update_column(:nonce, _nonce) && nonce
-  end
-
-  def _nonce
-    SecureRandom.hex(8)
+    update_column(:nonce, SecureRandom.hex(8)) && nonce
   end
 end

--- a/app/services/c100_app/application_decision_tree.rb
+++ b/app/services/c100_app/application_decision_tree.rb
@@ -28,7 +28,7 @@ module C100App
       when :payment
         edit(:check_your_answers)
       when :declaration
-        after_declaration
+        proceed_to_payment
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
@@ -77,20 +77,8 @@ module C100App
       end
     end
 
-    def after_declaration
-      if c100_application.online_submission?
-        #
-        # TODO: dirty proof of concept for online payments.
-        # Pending to clean up and deal with returning users to the service after pay,
-        # processing of confirmation emails and PDF, as well as error handling.
-        #
-        return OnlinePayments.new(c100_application).payment_url if show_me_the_pay_poc?
-
-        OnlineSubmissionQueue.new(c100_application).process
-        show('/steps/completion/confirmation')
-      else
-        show('/steps/completion/what_next')
-      end
+    def proceed_to_payment
+      PaymentsFlowControl.new(c100_application).payment_url
     end
 
     def start_international_journey
@@ -99,15 +87,6 @@ module C100App
 
     def start_attending_court_journey
       edit('/steps/attending_court/intermediary')
-    end
-
-    # TODO: For now, we only show the proof of concept if some criteria is met,
-    # to avoid genuine tests or demos on staging to go to the online journey inadvertently.
-    #
-    def show_me_the_pay_poc?
-      dev_tools_enabled? &&
-        c100_application.payment_type.eql?(PaymentType::SELF_PAYMENT_CARD.to_s) &&
-        c100_application.declaration_signee.eql?('John Doe')
     end
   end
 end

--- a/app/services/c100_app/online_payments.rb
+++ b/app/services/c100_app/online_payments.rb
@@ -1,7 +1,5 @@
 module C100App
   class OnlinePayments
-    class UnknownPaymentStatus < StandardError; end
-
     STATUSES_ENUM_MAP = {
       created: %w[created],
       pending: %w[started submitted capturable],
@@ -56,16 +54,12 @@ module C100App
 
     def choose_status(status)
       case status
-      when *STATUSES_ENUM_MAP.fetch(:created)
-        :created
-      when *STATUSES_ENUM_MAP.fetch(:pending)
-        :pending
-      when *STATUSES_ENUM_MAP.fetch(:success)
-        :success
-      when *STATUSES_ENUM_MAP.fetch(:failed)
-        :failed
+      when *STATUSES_ENUM_MAP.fetch(:created) then :created
+      when *STATUSES_ENUM_MAP.fetch(:pending) then :pending
+      when *STATUSES_ENUM_MAP.fetch(:success) then :success
+      when *STATUSES_ENUM_MAP.fetch(:failed)  then :failed
       else
-        raise UnknownPaymentStatus, status
+        status
       end
     end
 

--- a/app/services/c100_app/online_payments.rb
+++ b/app/services/c100_app/online_payments.rb
@@ -1,33 +1,91 @@
 module C100App
   class OnlinePayments
-    include Rails.application.routes.url_helpers
+    class UnknownPaymentStatus < StandardError; end
 
-    attr_reader :c100_application
+    STATUSES_ENUM_MAP = {
+      created: %w[created],
+      pending: %w[started submitted capturable],
+      success: %w[success],
+      failed:  %w[failed cancelled error],
+    }.freeze
 
-    def initialize(c100_application)
-      @c100_application = c100_application
+    attr_reader :payment_intent
+    delegate :c100_application, to: :payment_intent
+
+    def initialize(payment_intent)
+      @payment_intent = payment_intent
+    end
+    private_class_method :new
+
+    class << self
+      def create_payment(payment_intent)
+        new(payment_intent).create_payment
+      end
+
+      def retrieve_payment(payment_intent)
+        new(payment_intent).retrieve_payment
+      end
     end
 
-    def payment_url
-      create_payment.payment_url
+    def create_payment
+      response = PaymentsApi::Requests::CreateCardPayment.new(
+        details_payload
+      ).call
+
+      update_intent!(response)
+      response
+    end
+
+    def retrieve_payment
+      response = PaymentsApi::Requests::GetCardPayment.new(
+        payment_id: payment_intent.payment_id
+      ).call
+
+      update_intent!(response)
+      response
     end
 
     private
 
-    def create_payment
-      PaymentsApi::Requests::CreateCardPayment.new(payload).call
+    def update_intent!(response)
+      payment_intent.update(
+        payment_id: response.payment_id,
+        status: choose_status(response.status),
+      )
     end
 
-    # TODO: extract details to a better place/constants/config
-    def payload
+    def choose_status(status)
+      case status
+      when *STATUSES_ENUM_MAP.fetch(:created)
+        :created
+      when *STATUSES_ENUM_MAP.fetch(:pending)
+        :pending
+      when *STATUSES_ENUM_MAP.fetch(:success)
+        :success
+      when *STATUSES_ENUM_MAP.fetch(:failed)
+        :failed
+      else
+        raise UnknownPaymentStatus, status
+      end
+    end
+
+    # TODO: hardcoded values to a better place, i.e. constants/config
+    def details_payload
       {
         amount: 215_00,
-        reference: c100_application.reference_code,               # TODO: maybe append GBS code?
-        return_url: steps_completion_confirmation_url,            # TODO: identify returned users
-        description: 'Court fee for lodging a C100 application',  # TODO: description TBD
+        description: 'Court fee for lodging a C100 application',
+        reference: c100_application.reference_code,
+
+        # One-time return url
+        return_url: payment_intent.return_url,
 
         # Optional details
         email: c100_application.receipt_email,
+        metadata: {
+          court_gbs_code: 'TBD',
+          court_name: c100_application.screener_answers_court.name,
+          court_email: c100_application.screener_answers_court.email,
+        }
       }
     end
   end

--- a/app/services/c100_app/payments_flow_control.rb
+++ b/app/services/c100_app/payments_flow_control.rb
@@ -1,0 +1,61 @@
+module C100App
+  class PaymentsFlowControl
+    include Rails.application.routes.url_helpers
+
+    attr_reader :c100_application
+
+    def initialize(c100_application)
+      @c100_application = c100_application
+    end
+
+    def payment_url
+      return confirmation_url unless payments_enabled?
+
+      if c100_application.online_payment?
+        OnlinePayments.create_payment(payment_intent).payment_url
+      else
+        payment_intent.finish!(with_status: :offline_type)
+        confirmation_url
+      end
+    end
+
+    # Returning users after paying (or failing/cancelling)
+    # TODO: create specific error pages for different scenarios
+    #
+    def next_url
+      OnlinePayments.retrieve_payment(payment_intent)
+
+      case payment_intent.status
+      when 'success'
+        payment_intent.finish!
+        confirmation_url
+      else
+        unhandled_errors_path
+      end
+    end
+
+    def confirmation_url
+      if c100_application.online_submission?
+        OnlineSubmissionQueue.new(c100_application).process
+        steps_completion_confirmation_path
+      else
+        steps_completion_what_next_path
+      end
+    end
+
+    private
+
+    def payment_intent
+      @_payment_intent ||= PaymentIntent.find_or_create_by!(
+        c100_application: c100_application
+      )
+    end
+
+    # TODO: For now, we only run the online payments code if some criteria is met,
+    # to avoid genuine tests or demos on staging while still WIP.
+    #
+    def payments_enabled?
+      c100_application.declaration_signee.eql?('John Doe')
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -289,7 +289,7 @@ Rails.application.routes.draw do
   end
 
   resources :payments, only: [] do
-    get :destination, on: :member
+    get :validate, on: :member
   end
 
   resource :errors, only: [] do

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe PaymentsController, type: :controller do
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:intent_scope) { double(PaymentIntent) }
+  let(:payment_intent) { instance_double(PaymentIntent) }
+
+  describe '#validate' do
+    before do
+      allow(controller).to receive(:current_c100_application).and_return(c100_application)
+    end
+
+    context 'when there is no application in the session' do
+      let(:c100_application) { nil }
+
+      it 'redirects to the invalid session error page' do
+        get :validate, params: { id: 'uuid', nonce: '123456' }
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when there is an application in the session but details do not match' do
+      it 'redirects to the invalid session error page' do
+        get :validate, params: { id: 'intent-uuid', nonce: '123456' }
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'for an invalid request' do
+      it 'redirects to the invalid session error page' do
+        expect {
+          get :validate, params: { id: 'intent-uuid' } # nonce param is omitted
+        }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+
+    context 'for a valid request' do
+      before do
+        allow(PaymentIntent).to receive(:not_finished).and_return(intent_scope)
+
+        allow(
+          intent_scope
+        ).to receive(:find_by).with(
+          id: 'intent-uuid', nonce: '123456', c100_application: c100_application
+        ).and_return(payment_intent)
+
+        allow(
+          C100App::PaymentsFlowControl
+        ).to receive(:new).with(c100_application).and_return(double(next_url: 'https://payments.example.com'))
+      end
+
+      it 'invalidates the current URL to avoid reuse and redirects to the payments vendor' do
+        expect(payment_intent).to receive(:revoke_nonce!)
+
+        get :validate, params: { id: 'intent-uuid', nonce: '123456' }
+        expect(response).to redirect_to('https://payments.example.com')
+      end
+    end
+  end
+end

--- a/spec/services/c100_app/online_payments_spec.rb
+++ b/spec/services/c100_app/online_payments_spec.rb
@@ -1,7 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe C100App::OnlinePayments do
-  subject { described_class.new(c100_application) }
+  let(:payment_id) { 12345 }
+
+  let(:payment_intent) {
+    instance_double(
+      PaymentIntent,
+      status: 'ready',
+      c100_application: c100_application,
+      payment_id: payment_id,
+      return_url: 'https://c100.justice.uk',
+    )
+  }
 
   let(:c100_application) {
     C100Application.new(
@@ -12,26 +22,122 @@ RSpec.describe C100App::OnlinePayments do
     )
   }
 
-  describe '#payment_url' do
-    let(:response_double) { double(call: double(payment_url: 'http://example.com')) }
+  describe 'STATUSES_ENUM_MAP' do
+    context 'maps API statuses to our internal statuses' do
+      it 'maps success status' do
+        expect(described_class::STATUSES_ENUM_MAP[:success]).to match_array(%w[success])
+      end
+
+      it 'maps pending status' do
+        expect(described_class::STATUSES_ENUM_MAP[:pending]).to match_array(%w[started submitted capturable])
+      end
+
+      it 'maps failed status' do
+        expect(described_class::STATUSES_ENUM_MAP[:failed]).to match_array(%w[failed cancelled error])
+      end
+    end
+  end
+
+  describe '#create_payment' do
+    subject(:do_request) { described_class.create_payment(payment_intent) }
+
+    let(:court_double) { double('Court', name: 'Test court', email: 'court@example.com') }
+    let(:response_double) {
+      double(call: double('Response', payment_id: payment_id, status: 'created', payment_url: 'https://payments.example.com'))
+    }
+
     let(:payload) do
       {
         amount: 215_00,
-        reference: '1970/01/449362AF',
-        return_url: 'https://c100.justice.uk/steps/completion/confirmation',
         description: 'Court fee for lodging a C100 application',
+        return_url: 'https://c100.justice.uk',
+        reference: '1970/01/449362AF',
         email: 'applicant@test.com',
+        metadata: {
+          court_gbs_code: 'TBD',
+          court_name: 'Test court',
+          court_email: 'court@example.com',
+        }
       }
     end
 
     before do
+      allow(c100_application).to receive(:screener_answers_court).and_return(court_double)
+
       allow(
         PaymentsApi::Requests::CreateCardPayment
       ).to receive(:new).with(payload).and_return(response_double)
+
+      allow(payment_intent).to receive(:update)
     end
 
-    it 'returns the URL where to redirect the user to take payment' do
-      expect(subject.payment_url).to eq('http://example.com')
+    context 'payment intent' do
+      it 'updates the payment intent' do
+        expect(
+          payment_intent
+        ).to receive(:update).with(payment_id: payment_id, status: :created)
+
+        expect(do_request.payment_url).to eq('https://payments.example.com')
+      end
+
+      # mutant killer
+      context 'for statuses other than created' do
+        let(:response_double) {
+          double(call: double('Response', payment_id: nil, status: status))
+        }
+
+        context 'pending statuses' do
+          let(:status) { 'submitted' }
+          it { expect(payment_intent).to receive(:update).with(payment_id: nil, status: :pending); do_request }
+        end
+
+        context 'failed statuses' do
+          let(:status) { 'cancelled' }
+          it { expect(payment_intent).to receive(:update).with(payment_id: nil, status: :failed); do_request }
+        end
+
+        context 'for an unknown status' do
+          let(:status) { 'weird_status' }
+
+          it 'raises an exception' do
+            expect {
+              do_request
+            }.to raise_error(described_class::UnknownPaymentStatus).with_message('weird_status')
+          end
+        end
+      end
+    end
+  end
+
+  describe '#retrieve_payment' do
+    subject { described_class.retrieve_payment(payment_intent) }
+
+    let(:response_double) {
+      double(call: double('Response', payment_id: payment_id, status: 'success'))
+    }
+
+    before do
+      allow(
+        PaymentsApi::Requests::GetCardPayment
+      ).to receive(:new).with(payment_id: payment_id).and_return(response_double)
+
+      allow(payment_intent).to receive(:update)
+    end
+
+    context 'payment details response' do
+      it 'returns the response' do
+        expect(subject.status).to eq('success')
+      end
+    end
+
+    context 'payment intent' do
+      it 'updates the payment intent' do
+        expect(
+          payment_intent
+        ).to receive(:update).with(payment_id: payment_id, status: :success)
+
+        expect(subject).not_to be_nil
+      end
     end
   end
 end

--- a/spec/services/c100_app/payments_flow_control_spec.rb
+++ b/spec/services/c100_app/payments_flow_control_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe C100App::PaymentsFlowControl do
+  subject { described_class.new(c100_application) }
+
+  let(:c100_application) {
+    C100Application.new(
+      submission_type: submission_type,
+      payment_type: payment_type,
+      declaration_signee: declaration_signee,
+    )
+  }
+
+  let(:submission_type) { SubmissionType::ONLINE }
+  let(:payment_type) { PaymentType::SELF_PAYMENT_CARD }
+  let(:declaration_signee) { 'John Doe' }
+
+  let(:payment_intent) {
+    instance_double(PaymentIntent, status: intent_status)
+  }
+  let(:intent_status) { 'ready' }
+
+  before do
+    allow(
+      PaymentIntent
+    ).to receive(:find_or_create_by!).with(
+      c100_application: c100_application
+    ).and_return(payment_intent)
+  end
+
+  describe '#payment_url' do
+    before do
+      # We test the confirmation URL separately
+      allow(subject).to receive(:confirmation_url).and_return('confirmation-page')
+    end
+
+    context 'when feature flag is not enabled' do
+      let(:declaration_signee) { 'John FooBar' }
+
+      it 'skips to confirmation' do
+        expect(subject.payment_url).to eq('confirmation-page')
+      end
+    end
+
+    context 'when feature flag is enabled' do
+      context 'and payment is offline' do
+        let(:payment_type) { PaymentType::HELP_WITH_FEES }
+
+        it 'sets the payment_intent as finished and skips to confirmation' do
+          expect(payment_intent).to receive(:finish!).with(with_status: :offline_type)
+          expect(subject.payment_url).to eq('confirmation-page')
+        end
+      end
+
+      context 'and payment is online' do
+        it 'calls the API to create the payment' do
+          expect(
+            C100App::OnlinePayments
+          ).to receive(:create_payment).with(payment_intent).and_return(
+            double(payment_url: 'https://payments.example.com')
+          )
+
+          expect(subject.payment_url).to eq('https://payments.example.com')
+        end
+      end
+    end
+  end
+
+  describe '#next_url' do
+    before do
+      # We test the confirmation URL separately
+      allow(subject).to receive(:confirmation_url).and_return('confirmation-page')
+
+      # We also test this separately
+      expect(C100App::OnlinePayments).to receive(:retrieve_payment).with(payment_intent)
+    end
+
+    let(:payment_response) { nil }
+
+    context 'for a success payment status' do
+      let(:intent_status) { 'success' }
+
+      it 'sets the payment_intent as finished and continue to confirmation' do
+        expect(payment_intent).to receive(:finish!)
+        expect(subject.next_url).to eq('confirmation-page')
+      end
+    end
+
+    context 'for a failed payment status' do
+      let(:intent_status) { 'failed' }
+
+      it 'returns an error page' do
+        expect(payment_intent).not_to receive(:finish!)
+        expect(subject.next_url).to eq('/errors/unhandled')
+      end
+    end
+  end
+
+  describe '#confirmation_url' do
+    let(:queue) { double.as_null_object }
+
+    context 'for an online submission' do
+      let(:submission_type) { SubmissionType::ONLINE }
+
+      it 'process the application online submission and returns the confirmation page' do
+        expect(C100App::OnlineSubmissionQueue).to receive(:new).with(c100_application).and_return(queue)
+
+        expect(queue).to receive(:process)
+        expect(subject.confirmation_url).to eq('/steps/completion/confirmation')
+      end
+    end
+
+    context 'for a print and post submission' do
+      let(:submission_type) { SubmissionType::PRINT_AND_POST }
+
+      it 'returns the what next page' do
+        expect(queue).not_to receive(:process)
+        expect(subject.confirmation_url).to eq('/steps/completion/what_next')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Individual commits for more details.

Move the payment and confirmation logic out of the decision tree into a little service object `PaymentsFlowControl` to handle the flow of the payments (or skip to confirmation if no online payment is needed).

For "offline" payments we just mark the intent as finished and skip to confirmation page. For online payments it uses the Payments API to create a payment and redirect the user to the card details page.
On returning, it handles the `#next_url` that can be either success or fail.

It also handles, for now, the feature-flagged code. Once we don't need this we can cleanup the code.

**TODO:** proper handling of errors. For now there are no specific error pages or a way to communicate to the user what went wrong and how to "fix it" or restart the payments flow.