### PR TITLE
Change submission type to be before payment type

### DIFF
--- a/app/services/c100_app/attending_court_decision_tree.rb
+++ b/app/services/c100_app/attending_court_decision_tree.rb
@@ -11,7 +11,7 @@ module C100App
       when :special_arrangements
         edit(:special_assistance)
       when :special_assistance
-        edit('/steps/application/payment')
+        edit('/steps/application/submission')
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/spec/services/c100_app/attending_court_decision_tree_spec.rb
+++ b/spec/services/c100_app/attending_court_decision_tree_spec.rb
@@ -27,6 +27,6 @@ RSpec.describe C100App::AttendingCourtDecisionTree do
 
   context 'when the step is `special_assistance`' do
     let(:step_params) { { special_assistance: 'anything' } }
-    it { is_expected.to have_destination('/steps/application/payment', :edit) }
+    it { is_expected.to have_destination('/steps/application/submission', :edit) }
   end
 end


### PR DESCRIPTION
We want to know what type of submission before showing the payment type.

This change was lost during https://github.com/ministryofjustice/c100-application/pull/959

Correct order is:

- steps/attending_court/special_assistance
- steps/application/submission
- steps/application/payment
- steps/application/check_your_answers