### PR TITLE
Add payments error handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/govuk-pay-ruby-client.git
-  revision: 32a58b48e4557818b41ffdc91c989691b3693717
+  revision: ad6ecbc9fe5766be11d2bb97664d2290ebfeb46a
   specs:
     govuk-pay-ruby-client (0.1.0)
       faraday (~> 1.0)
@@ -299,7 +299,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.1.4)
-    regexp_parser (1.7.0)
+    regexp_parser (1.7.1)
     request_store (1.5.0)
       rack (>= 1.4)
     responders (3.0.1)

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -12,6 +12,10 @@ module ErrorHandling
         redirect_to application_screening_errors_path
       when Errors::ApplicationCompleted
         redirect_to application_completed_errors_path
+      when Errors::PaymentError
+        # Payment errors are reported to Sentry as it is important to know
+        Raven.capture_exception(exception)
+        redirect_to payment_error_errors_path
       else
         raise if Rails.application.config.consider_all_requests_local
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,9 @@
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :check_c100_application_presence, only: [:application_screening, :application_completed]
+
+  before_action :check_c100_application_presence, only: [
+    :application_screening, :application_completed, :payment_error
+  ]
 
   def invalid_session
     respond_with_status(:not_found)
@@ -19,6 +22,10 @@ class ErrorsController < ApplicationController
   end
 
   def application_completed
+    respond_with_status(:unprocessable_entity)
+  end
+
+  def payment_error
     respond_with_status(:unprocessable_entity)
   end
 

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,6 +1,4 @@
 class PaymentsController < ApplicationController
-  before_action :check_intent_presence
-
   def validate
     payment_intent.revoke_nonce!
 
@@ -11,13 +9,12 @@ class PaymentsController < ApplicationController
 
   private
 
+  # Raises an `ActiveRecord::RecordNotFound` error when there is no intent,
+  # and is captured, reported to Sentry and handled in the superclass.
+  #
   def payment_intent
-    @_payment_intent ||= PaymentIntent.not_finished.find_by(
+    @_payment_intent ||= PaymentIntent.not_finished.find_by!(
       id: params.require(:id), nonce: params.require(:nonce), c100_application: current_c100_application
     )
-  end
-
-  def check_intent_presence
-    raise Errors::InvalidSession unless payment_intent
   end
 end

--- a/app/errors/errors.rb
+++ b/app/errors/errors.rb
@@ -3,4 +3,7 @@ module Errors
   class ApplicationNotFound < StandardError; end
   class ApplicationCompleted < StandardError; end
   class ApplicationScreening < StandardError; end
+
+  class PaymentError < StandardError; end
+  class PaymentUnexpectedError < PaymentError; end
 end

--- a/app/services/c100_app/payments_flow_control.rb
+++ b/app/services/c100_app/payments_flow_control.rb
@@ -17,21 +17,21 @@ module C100App
         payment_intent.finish!(with_status: :offline_type)
         confirmation_url
       end
+    rescue StandardError => exception
+      raise Errors::PaymentUnexpectedError, exception
     end
 
-    # Returning users after paying (or failing/cancelling)
-    # TODO: create specific error pages for different scenarios
-    #
     def next_url
       OnlinePayments.retrieve_payment(payment_intent)
 
-      case payment_intent.status
-      when 'success'
+      if payment_intent.success?
         payment_intent.finish!
         confirmation_url
       else
-        unhandled_errors_path
+        payment_error_errors_path
       end
+    rescue StandardError => exception
+      raise Errors::PaymentUnexpectedError, exception
     end
 
     def confirmation_url

--- a/app/views/errors/payment_error.html.erb
+++ b/app/views/errors/payment_error.html.erb
@@ -1,0 +1,20 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <p class="govuk-body-l">
+      <%=t '.lead_text' %>
+    </p>
+
+    <p class="govuk-body">
+      <%=t '.more_text' %>
+    </p>
+
+    <p class="govuk-body govuk-!-margin-top-8">
+      <%= link_button t('shared.retry_payment'), edit_steps_application_payment_path, class: 'ga-pageLink',
+                      data: { module: 'govuk-button', ga_category: 'online payments', ga_label: 'retry payment' } %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -972,6 +972,11 @@ en:
         <p class="govuk-body">You can also try starting again from the homepage.</p>
         <p class="govuk-body">If the problem continues, you can <a href="https://formfinder.hmctsformfinder.justice.gov.uk/c100-eng.pdf" class="govuk-link" rel="external" target="_blank">download and
         complete a C100 paper application form</a>, print it and send it by post.</p>
+    payment_error:
+      page_title: Payment error
+      heading: There was a problem with your payment
+      lead_text: It seems you attempted to make a payment but the payment did not complete.
+      more_text: No money has been taken from your account. You can retry the payment with the same or other card details, or choose a different payment method.
 
   helpers:
     label:
@@ -1695,6 +1700,7 @@ en:
 
   shared:
     start_again: Start again
+    retry_payment: Try payment again
     finish: Finish
     back_link: Back
     password_toggle:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -297,6 +297,7 @@ Rails.application.routes.draw do
     get :application_not_found
     get :application_screening
     get :application_completed
+    get :payment_error
     get :unhandled
     get :not_found
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ApplicationController do
     def application_not_found; raise Errors::ApplicationNotFound; end
     def application_completed; raise Errors::ApplicationCompleted; end
     def application_screening; raise Errors::ApplicationScreening; end
+    def payment_error; raise Errors::PaymentError; end
     def another_exception; raise Exception; end
   end
 
@@ -143,6 +144,17 @@ RSpec.describe ApplicationController do
 
         get :application_completed
         expect(response).to redirect_to(application_completed_errors_path)
+      end
+    end
+
+    context 'Errors::PaymentError' do
+      it 'should report the exception, and redirect to the payment error page' do
+        routes.draw { get 'payment_error' => 'anonymous#payment_error' }
+
+        expect(Raven).to receive(:capture_exception)
+
+        get :payment_error
+        expect(response).to redirect_to(payment_error_errors_path)
       end
     end
 

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -14,20 +14,22 @@ RSpec.describe PaymentsController, type: :controller do
     context 'when there is no application in the session' do
       let(:c100_application) { nil }
 
-      it 'redirects to the invalid session error page' do
-        get :validate, params: { id: 'uuid', nonce: '123456' }
-        expect(response).to redirect_to(invalid_session_errors_path)
+      it 'raises an exception' do
+        expect {
+          get :validate, params: { id: 'intent-uuid', nonce: '123456' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     context 'when there is an application in the session but details do not match' do
-      it 'redirects to the invalid session error page' do
-        get :validate, params: { id: 'intent-uuid', nonce: '123456' }
-        expect(response).to redirect_to(invalid_session_errors_path)
+      it 'raises an exception' do
+        expect {
+          get :validate, params: { id: 'intent-uuid', nonce: '123456' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
-    context 'for an invalid request' do
+    context 'for a request with missing mandatory params' do
       it 'redirects to the invalid session error page' do
         expect {
           get :validate, params: { id: 'intent-uuid' } # nonce param is omitted
@@ -41,7 +43,7 @@ RSpec.describe PaymentsController, type: :controller do
 
         allow(
           intent_scope
-        ).to receive(:find_by).with(
+        ).to receive(:find_by!).with(
           id: 'intent-uuid', nonce: '123456', c100_application: c100_application
         ).and_return(payment_intent)
 


### PR DESCRIPTION
This is just a high level error handling, mostly for the happy paths.

We will need some more error handling, specially if the user didn't come back to the service after a successful payment, or closed the browser in the card details page.