### PR TITLE
Add some extra error handling

### DIFF
--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -5,6 +5,9 @@ class PaymentIntent < ApplicationRecord
 
   scope :not_finished, -> { where(finished_at: nil) }
 
+  # Non-persisted attribute, contains the `state` raw data.
+  attribute :state, :jsonb, default: {}
+
   enum status: {
     ready: 'ready',
     created: 'created',

--- a/app/services/c100_app/online_payments.rb
+++ b/app/services/c100_app/online_payments.rb
@@ -7,6 +7,13 @@ module C100App
       failed:  %w[failed cancelled error],
     }.freeze
 
+    # Failure codes that indicate either the user do not want to proceed,
+    # or the payments provider is having technical issues.
+    NON_RETRYABLE_CODES = %w[
+      P0030
+      P0050
+    ].freeze
+
     attr_reader :payment_intent
     delegate :c100_application, to: :payment_intent
 
@@ -22,6 +29,10 @@ module C100App
 
       def retrieve_payment(payment_intent)
         new(payment_intent).retrieve_payment
+      end
+
+      def non_retryable_state?(payment_intent)
+        NON_RETRYABLE_CODES.include?(payment_intent.state['code'])
       end
     end
 
@@ -49,6 +60,7 @@ module C100App
       payment_intent.update(
         payment_id: response.payment_id,
         status: choose_status(response.status),
+        state: response.state,
       )
     end
 


### PR DESCRIPTION
Some errors on the payment card details page can make the user re-enter the journey, but there are others that not.

For example, a user cancelling the payment, by clicking the "cancel payment" link in the card details (code `P0030`), should not make the user re-enter the payment card details, but instead, give the user our custom error page, so they can go back to change the payment method if they want.

Same for technical error issues with the payment provider (code `P0050`), there is no point in returning the user to the card details page as it will probably fail again, so better to show them our custom error and let them decide if they want to retry or change the payment method.

I've identified these 2 codes, but we could add some more, or remove some.

As part of this, I'm also sending to Sentry some debug information when the payment intent returns unsuccessfully, to know better why payments fail.