### PR TITLE
Ensure error pages respond with appropriate status code

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -37,8 +37,8 @@ class ErrorsController < ApplicationController
 
   def respond_with_status(status)
     respond_to do |format|
-      format.html
-      format.all { head status }
+      format.html { render status: status }
+      format.all  { head status }
     end
   end
 end

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -14,7 +14,7 @@ class StatusController < BareApplicationController
   #
   def index
     check = C100App::Status.new
-    status_code = check.success? ? :ok : :service_unavailable
+    status_code = check.success? ? :ok : :internal_server_error
 
     respond_with(check.response, status: status_code)
   end

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe StatusController, type: :controller do
     context 'for a non healthy service' do
       let(:success) { false }
 
-      it 'has a 503 response code' do
+      it 'has a 500 response code' do
         get :index, format: :json
-        expect(response.status).to eq(503)
+        expect(response.status).to eq(500)
       end
 
       it 'returns json' do


### PR DESCRIPTION
The custom error pages we have were not setting the status code when serving html (it was working only for any other formats, like JSON).

For example, the `not found` custom error page, should go along with a `404` status code.

The `unhandled` error page, shoud go along with a `500` status code.

Also changed the status code returned by the `status` (health check) endpoint, from 503 to 500 to better indicate it is not the service (as a whole) being unavailable, as the proof is it is responding to the request, but just some part of it (like the database or redis). To avoid confusion.