### PR TITLE
Refactor the application status enum

### DIFF
--- a/app/controllers/steps/screener_step_controller.rb
+++ b/app/controllers/steps/screener_step_controller.rb
@@ -9,12 +9,14 @@ module Steps
     end
 
     def in_progress_enough?
-      current_c100_application&.in_progress? &&
-        current_c100_application.navigation_stack.size > 2
+      current_c100_application.navigation_stack.size > 2 &&
+        %w[screening completed].exclude?(current_c100_application.status)
     end
 
     def existing_application_warning
+      return unless current_c100_application
       return unless in_progress_enough? && !params.key?(:new)
+
       redirect_to steps_screener_warning_path
     end
   end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -1,12 +1,17 @@
 class C100Application < ApplicationRecord
+  include ApplicationInquiryMethods
   include ApplicationReference
 
   enum status: {
     screening: 0,
     in_progress: 1,
-    first_reminder_sent: 5,
-    last_reminder_sent: 6,
+    pending_payment: 8,
     completed: 10,
+  }
+
+  enum reminder_status: {
+    first_reminder_sent: 'first_reminder_sent',
+    last_reminder_sent: 'last_reminder_sent',
   }
 
   belongs_to :user, optional: true
@@ -45,32 +50,5 @@ class C100Application < ApplicationRecord
 
   def self.purge!(date)
     where('c100_applications.created_at <= :date', date: date).destroy_all
-  end
-
-  def online_submission?
-    submission_type.eql?(SubmissionType::ONLINE.to_s)
-  end
-
-  # TODO: change when we introduce the 'real' online payment method
-  def online_payment?
-    payment_type.eql?(PaymentType::SELF_PAYMENT_CARD.to_s)
-  end
-
-  def confidentiality_enabled?
-    address_confidentiality.eql?(GenericYesNo::YES.to_s)
-  end
-
-  def has_solicitor?
-    has_solicitor.eql?(GenericYesNo::YES.to_s)
-  end
-
-  def has_safety_concerns?
-    [
-      domestic_abuse,
-      risk_of_abduction,
-      children_abuse,
-      substance_abuse,
-      other_abuse
-    ].any? { |concern| concern.eql?(GenericYesNo::YES.to_s) }
   end
 end

--- a/app/models/concerns/application_inquiry_methods.rb
+++ b/app/models/concerns/application_inquiry_methods.rb
@@ -1,0 +1,28 @@
+module ApplicationInquiryMethods
+  def online_submission?
+    submission_type.eql?(SubmissionType::ONLINE.to_s)
+  end
+
+  # TODO: change when we introduce the 'real' online payment method
+  def online_payment?
+    payment_type.eql?(PaymentType::SELF_PAYMENT_CARD.to_s)
+  end
+
+  def confidentiality_enabled?
+    address_confidentiality.eql?(GenericYesNo::YES.to_s)
+  end
+
+  def has_solicitor?
+    has_solicitor.eql?(GenericYesNo::YES.to_s)
+  end
+
+  def has_safety_concerns?
+    [
+      domestic_abuse,
+      risk_of_abduction,
+      children_abuse,
+      substance_abuse,
+      other_abuse
+    ].any? { |concern| concern.eql?(GenericYesNo::YES.to_s) }
+  end
+end

--- a/app/services/c100_app/reminder_rule_set.rb
+++ b/app/services/c100_app/reminder_rule_set.rb
@@ -17,7 +17,7 @@ module C100App
     def self.first_reminder
       new(
         created_days_ago: 23,
-        status: :in_progress,
+        status: nil,
         status_transition_to: :first_reminder_sent,
         email_template_name: 'draft_first_reminder'
       )
@@ -37,7 +37,8 @@ module C100App
     def rule_query
       C100Application
         .with_owner
-        .where(status: status)
+        .not_completed
+        .where(reminder_status: status)
         .where('created_at <= ?', created_days_ago.days.ago)
     end
   end

--- a/db/migrate/20200610133254_add_reminder_status_to_c100_application.rb
+++ b/db/migrate/20200610133254_add_reminder_status_to_c100_application.rb
@@ -1,0 +1,26 @@
+class AddReminderStatusToC100Application < ActiveRecord::Migration[5.2]
+  def up
+    add_column :c100_applications, :reminder_status, :string
+    migrate_existing_reminders!
+  end
+
+  def down
+    remove_column :c100_applications, :reminder_status
+  end
+
+  private
+
+  def migrate_existing_reminders!
+    C100Application.where(status: 5).find_each(batch_size: 25) do |record|
+      record.update_column(
+        :reminder_status, 'first_reminder_sent'
+      )
+    end
+
+    C100Application.where(status: 6).find_each(batch_size: 25) do |record|
+      record.update_column(
+        :reminder_status, 'last_reminder_sent'
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_05_081246) do
+ActiveRecord::Schema.define(version: 2020_06_10_133254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -142,6 +142,7 @@ ActiveRecord::Schema.define(version: 2020_06_05_081246) do
     t.string "declaration_signee"
     t.string "declaration_signee_capacity"
     t.text "international_resident_details"
+    t.string "reminder_status"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -11,9 +11,19 @@ RSpec.describe C100Application, type: :model do
       ).to eq(
         'screening' => 0,
         'in_progress' => 1,
-        'first_reminder_sent' => 5,
-        'last_reminder_sent' => 6,
+        'pending_payment' => 8,
         'completed' => 10,
+      )
+    end
+  end
+
+  describe 'reminder_status enum' do
+    it 'has the right values' do
+      expect(
+        described_class.reminder_statuses
+      ).to eq(
+        'first_reminder_sent' => 'first_reminder_sent',
+        'last_reminder_sent' => 'last_reminder_sent',
       )
     end
   end

--- a/spec/services/c100_app/reminder_rule_set_spec.rb
+++ b/spec/services/c100_app/reminder_rule_set_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe C100App::ReminderRuleSet do
     subject { described_class.first_reminder }
 
     it { expect(subject.created_days_ago).to eq(23) }
-    it { expect(subject.status).to eq(:in_progress) }
+    it { expect(subject.status).to eq(nil) }
     it { expect(subject.status_transition_to).to eq(:first_reminder_sent) }
     it { expect(subject.email_template_name).to eq('draft_first_reminder') }
   end
@@ -38,7 +38,8 @@ RSpec.describe C100App::ReminderRuleSet do
 
     it 'filters the c100 applications' do
       expect(C100Application).to receive(:with_owner).and_return(finder_double)
-      expect(finder_double).to receive(:where).with(status: :test_status).and_return(finder_double)
+      expect(finder_double).to receive(:not_completed).and_return(finder_double)
+      expect(finder_double).to receive(:where).with(reminder_status: :test_status).and_return(finder_double)
       expect(finder_double).to receive(:where).with('created_at <= ?', 3.days.ago).and_return(finder_double)
       subject.find_each
     end


### PR DESCRIPTION
It turned out mixing application progression statuses with reminder statuses was not a good idea.

The latter are irrespective of the application status (so for example, an application still "in progress") can have, in addition, a "first_reminder_sent".

Unfortunately we merged together in the past these statuses, and now we need to split them into 2 separate enums, one tracking progress, the other tracking reminders.

Otherwise, very pesky edge cases will happen, like for example, an application with the `first_reminder_sent`, user gets back, and try to complete by paying online, which will (in the next PR) leave the application in a `pending_payment`, and then if the the payment payment fails, the following day another `first_reminder_sent` will be sent (as we lost track of that status when we applied the new `pending_payment` one).

With this refactor these issues are solved. I've had to do a migration of existing 'reminder' statuses to the new DB field, so no data is lost.