### PR TITLE
Update Court to receive gbs code

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -79,6 +79,7 @@ class SessionsController < ApplicationController
         "name" => "Milton Keynes County Court and Family Court",
         "slug" => "milton-keynes-county-court-and-family-court",
         "email" => "family@miltonkeynes.countycourt.gsi.gov.uk",
+        "gbs" => "X123",
       }
     }.merge(screener.attributes.symbolize_keys) do |_key, old_value, new_value|
       new_value || old_value

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -1,5 +1,5 @@
 class Court
-  attr_reader :name, :slug, :email, :address
+  attr_reader :name, :slug, :email, :address, :gbs
 
   # Using `fetch` so an exception is raised and we are alerted if the json
   # schema ever changes, instead of silently let the user continue, as all
@@ -11,6 +11,7 @@ class Court
     @address = data.fetch('address')
     # The email, if not already present, comes from a separate API request
     @email = data['email'] || best_enquiries_email
+    @gbs = data['gbs'] || retrieve_gbs_from_api
   rescue StandardError => ex
     log_and_raise(ex, data)
   end
@@ -59,6 +60,10 @@ class Court
 
   def fallback_address(emails)
     emails.find { |e| e['address'] =~ /enquiries/i } || emails.first
+  end
+
+  def retrieve_gbs_from_api
+    court_data.fetch('gbs')
   end
 
   def retrieve_emails_from_api

--- a/app/services/c100_app/online_payments.rb
+++ b/app/services/c100_app/online_payments.rb
@@ -69,7 +69,7 @@ module C100App
         # Optional details
         email: c100_application.receipt_email,
         metadata: {
-          court_gbs_code: 'TBD',
+          court_gbs: c100_application.screener_answers_court.gbs,
           court_name: c100_application.screener_answers_court.name,
           court_email: c100_application.screener_answers_court.email,
         }

--- a/spec/services/c100_app/online_payments_spec.rb
+++ b/spec/services/c100_app/online_payments_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe C100App::OnlinePayments do
   describe '.create_payment' do
     subject(:do_request) { described_class.create_payment(payment_intent) }
 
-    let(:court_double) { double('Court', name: 'Test court', email: 'court@example.com') }
+    let(:court_double) { double('Court', name: 'Test court', email: 'court@example.com', gbs: 'X123') }
     let(:response_double) {
       double(call: double(
         'Response', payment_id: payment_id, state: state, payment_url: 'https://payments.example.com'
@@ -47,7 +47,7 @@ RSpec.describe C100App::OnlinePayments do
         reference: '1970/01/449362AF',
         email: 'applicant@test.com',
         metadata: {
-          court_gbs_code: 'TBD',
+          court_gbs: 'X123',
           court_name: 'Test court',
           court_email: 'court@example.com',
         }


### PR DESCRIPTION
The GBS code is necessary to facilitate HMCTS to know which court to make a credit payment.

Once the user selects their Postcode, a request is made to find the nearest Court, each court should have a GBS code, but currently not all have it, that means it can be nil (null) but the key should be present in all of them.

Story: https://mojdigital.teamwork.com/#/tasks/20809040

