### PR TITLE
More payment status work

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/govuk-pay-ruby-client.git
-  revision: ad6ecbc9fe5766be11d2bb97664d2290ebfeb46a
+  revision: 70d5f61e7a0bc168b864e0b9a7b869300f32f3b2
   specs:
     govuk-pay-ruby-client (0.1.0)
       faraday (~> 1.0)

--- a/app/controllers/concerns/savepoint_step.rb
+++ b/app/controllers/concerns/savepoint_step.rb
@@ -26,7 +26,7 @@ module SavepointStep
   def mark_in_progress
     # The step including this concern will mark the current application
     # as `in progress`, meaning it has passed the screening and can be drafted.
-    current_c100_application.in_progress!
+    current_c100_application.in_progress! if current_c100_application.screening?
   end
 
   def save_application_for_later

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -13,7 +13,7 @@ class PaymentsController < ApplicationController
   # and is captured, reported to Sentry and handled in the superclass.
   #
   def payment_intent
-    @_payment_intent ||= PaymentIntent.not_finished.find_by!(
+    @_payment_intent ||= PaymentIntent.find_by!(
       id: params.require(:id), nonce: params.require(:nonce), c100_application: current_c100_application
     )
   end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -5,7 +5,7 @@ class C100Application < ApplicationRecord
   enum status: {
     screening: 0,
     in_progress: 1,
-    pending_payment: 8,
+    payment_in_progress: 8,
     completed: 10,
   }
 

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -3,17 +3,6 @@ class PaymentIntent < ApplicationRecord
 
   belongs_to :c100_application
 
-  # Non-persisted attribute, contains the `state` raw data.
-  attribute :state, :jsonb, default: {}
-
-  enum status: {
-    ready: 'ready',
-    created: 'created',
-    pending: 'pending',
-    success: 'success',
-    failed: 'failed',
-  }
-
   # URLs are one-time use only. Once accessed, they are invalidated.
   def return_url
     validate_payment_url(self, nonce: init_nonce)

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -3,8 +3,6 @@ class PaymentIntent < ApplicationRecord
 
   belongs_to :c100_application
 
-  scope :not_finished, -> { where(finished_at: nil) }
-
   # Non-persisted attribute, contains the `state` raw data.
   attribute :state, :jsonb, default: {}
 
@@ -14,7 +12,6 @@ class PaymentIntent < ApplicationRecord
     pending: 'pending',
     success: 'success',
     failed: 'failed',
-    offline_type: 'offline_type',
   }
 
   # URLs are one-time use only. Once accessed, they are invalidated.
@@ -24,13 +21,6 @@ class PaymentIntent < ApplicationRecord
 
   def revoke_nonce!
     update_column(:nonce, nil)
-  end
-
-  def finish!(with_status: :success)
-    update(
-      status: with_status,
-      finished_at: Time.current,
-    )
   end
 
   private

--- a/app/services/c100_app/online_payments.rb
+++ b/app/services/c100_app/online_payments.rb
@@ -1,12 +1,5 @@
 module C100App
   class OnlinePayments
-    STATUSES_ENUM_MAP = {
-      created: %w[created],
-      pending: %w[started submitted capturable],
-      success: %w[success],
-      failed:  %w[failed cancelled error],
-    }.freeze
-
     # Failure codes that indicate either the user do not want to proceed,
     # or the payments provider is having technical issues.
     NON_RETRYABLE_CODES = %w[
@@ -59,20 +52,8 @@ module C100App
     def update_intent!(response)
       payment_intent.update(
         payment_id: response.payment_id,
-        status: choose_status(response.status),
         state: response.state,
       )
-    end
-
-    def choose_status(status)
-      case status
-      when *STATUSES_ENUM_MAP.fetch(:created) then :created
-      when *STATUSES_ENUM_MAP.fetch(:pending) then :pending
-      when *STATUSES_ENUM_MAP.fetch(:success) then :success
-      when *STATUSES_ENUM_MAP.fetch(:failed)  then :failed
-      else
-        status
-      end
     end
 
     # TODO: hardcoded values to a better place, i.e. constants/config

--- a/app/services/c100_app/payments_flow_control.rb
+++ b/app/services/c100_app/payments_flow_control.rb
@@ -12,9 +12,9 @@ module C100App
       return confirmation_url unless payments_enabled?
 
       if c100_application.online_payment?
+        c100_application.payment_in_progress!
         OnlinePayments.create_payment(payment_intent).payment_url
       else
-        payment_intent.finish!(with_status: :offline_type)
         confirmation_url
       end
     rescue StandardError => exception
@@ -23,10 +23,7 @@ module C100App
 
     # Returning users after paying (or failing/cancelling)
     def next_url
-      OnlinePayments.retrieve_payment(payment_intent)
-
-      if payment_intent.success?
-        payment_intent.finish!
+      if OnlinePayments.retrieve_payment(payment_intent).success?
         return confirmation_url
       end
 

--- a/db/migrate/20200610133254_add_reminder_status_to_c100_application.rb
+++ b/db/migrate/20200610133254_add_reminder_status_to_c100_application.rb
@@ -12,14 +12,14 @@ class AddReminderStatusToC100Application < ActiveRecord::Migration[5.2]
 
   def migrate_existing_reminders!
     C100Application.where(status: 5).find_each(batch_size: 25) do |record|
-      record.update_column(
-        :reminder_status, 'first_reminder_sent'
+      record.update_columns(
+        reminder_status: 'first_reminder_sent', status: 'in_progress'
       )
     end
 
     C100Application.where(status: 6).find_each(batch_size: 25) do |record|
-      record.update_column(
-        :reminder_status, 'last_reminder_sent'
+      record.update_columns(
+        reminder_status: 'last_reminder_sent', status: 'in_progress'
       )
     end
   end

--- a/db/migrate/20200611113210_change_payment_intent_attributes.rb
+++ b/db/migrate/20200611113210_change_payment_intent_attributes.rb
@@ -1,0 +1,8 @@
+class ChangePaymentIntentAttributes < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :payment_intents, :finished_at, :datetime
+    remove_column :payment_intents, :status, :string
+
+    add_column :payment_intents, :state, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_10_133254) do
+ActiveRecord::Schema.define(version: 2020_06_11_113210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -275,9 +275,8 @@ ActiveRecord::Schema.define(version: 2020_06_10_133254) do
     t.datetime "updated_at", null: false
     t.string "nonce"
     t.string "payment_id"
-    t.string "status", default: "ready", null: false
-    t.datetime "finished_at"
     t.uuid "c100_application_id"
+    t.jsonb "state", default: {}, null: false
     t.index ["c100_application_id"], name: "index_payment_intents_on_c100_application_id", unique: true
   end
 

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe PaymentsController, type: :controller do
   let(:c100_application) { instance_double(C100Application) }
-
-  let(:intent_scope) { double(PaymentIntent) }
   let(:payment_intent) { instance_double(PaymentIntent) }
 
   describe '#validate' do
@@ -39,10 +37,8 @@ RSpec.describe PaymentsController, type: :controller do
 
     context 'for a valid request' do
       before do
-        allow(PaymentIntent).to receive(:not_finished).and_return(intent_scope)
-
         allow(
-          intent_scope
+          PaymentIntent
         ).to receive(:find_by!).with(
           id: 'intent-uuid', nonce: '123456', c100_application: c100_application
         ).and_return(payment_intent)

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe C100Application, type: :model do
       ).to eq(
         'screening' => 0,
         'in_progress' => 1,
-        'pending_payment' => 8,
+        'payment_in_progress' => 8,
         'completed' => 10,
       )
     end

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe PaymentIntent, type: :model do
         pending
         success
         failed
-        offline_type
       ))
     end
   end
@@ -45,26 +44,6 @@ RSpec.describe PaymentIntent, type: :model do
       expect(
         subject.return_url
       ).to eq("https://c100.justice.uk/payments/#{subject.id}/validate?nonce=#{nonce}")
-    end
-  end
-
-  describe '#finish!' do
-    before do
-      travel_to Time.at(0)
-    end
-
-    context 'when a status is passed' do
-      it 'sets the status and the finished_at' do
-        expect(subject).to receive(:update).with(status: :foobar, finished_at: Time.at(0))
-        subject.finish!(with_status: :foobar)
-      end
-    end
-
-    context 'when no status is passed' do
-      it 'sets the status to the default, and the finished_at' do
-        expect(subject).to receive(:update).with(status: :success, finished_at: Time.at(0))
-        subject.finish!
-      end
     end
   end
 

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -3,24 +3,7 @@ require 'rails_helper'
 RSpec.describe PaymentIntent, type: :model do
   subject { described_class.new(c100_application: c100_application) }
 
-  let(:c100_application) { C100Application.new(payment_type: payment_type) }
-  let(:payment_type) { 'foobar' }
-
-  context 'status enumeration' do
-    it 'maps all the neccessary statuses' do
-      expect(PaymentIntent.statuses.keys).to eq(PaymentIntent.statuses.values)
-
-      expect(
-        PaymentIntent.statuses.keys
-      ).to match_array(%w(
-        ready
-        created
-        pending
-        success
-        failed
-      ))
-    end
-  end
+  let(:c100_application) { C100Application.new }
 
   describe '#return_url' do
     let(:nonce) { '123456' }

--- a/spec/services/c100_app/payments_flow_control_spec.rb
+++ b/spec/services/c100_app/payments_flow_control_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe C100App::PaymentsFlowControl do
   let(:payment_type) { PaymentType::SELF_PAYMENT_CARD }
   let(:declaration_signee) { 'John Doe' }
 
-  let(:payment_intent) { PaymentIntent.new(status: intent_status, payment_id: 'xyz123') }
-  let(:intent_status) { 'ready' }
+  let(:payment_intent) { PaymentIntent.new(payment_id: 'xyz123') }
 
   before do
     allow(

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -236,18 +236,32 @@ RSpec.shared_examples 'a savepoint step controller' do
   end
 
   describe '#update' do
+    let(:status) { 'screening' }
+
     let!(:existing_c100) {
-      C100Application.create(status: :screening, navigation_stack: ['/not', '/empty'], screener_answers: screener_answers)
+      C100Application.create(status: status, navigation_stack: ['/not', '/empty'], screener_answers: screener_answers)
     }
 
     before do
       allow(controller).to receive(:current_c100_application).and_return(existing_c100)
     end
 
-    it 'changes the status to `in_progress`' do
-      expect {
-        put :update, params: {}
-      }.to change { existing_c100.status }.from('screening').to('in_progress')
+    context 'for an application in the screening status' do
+      it 'changes the status to `in_progress`' do
+        expect {
+          put :update, params: {}
+        }.to change { existing_c100.status }.from('screening').to('in_progress')
+      end
+    end
+
+    context 'for an application in any other status' do
+      let(:status) { 'completed' }
+
+      it 'does not change the status to `in_progress`' do
+        expect {
+          put :update, params: {}
+        }.not_to change { existing_c100.status }
+      end
     end
 
     context 'for a not yet completed, or invalid, screener' do


### PR DESCRIPTION
Individual commits for more details, as some changes required justification.

Essentially, we can simplify a lot, even remove completely some of the payment intent statuses, and thus, code around them, as now we have an application-level status `payment_in_progress`.