### PR TITLE
Mark the application as completed after payment

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -1,12 +1,8 @@
-# The step including this concern will mark the application as `completed`,
-# meaning it can't be drafted anymore, also can't be submitted again by mistake,
-# and we save an audit record of this submission and the court it was sent to.
-#
 module CompletionStep
   extend ActiveSupport::Concern
 
   included do
-    before_action :mark_completed, unless: :completed?
+    before_action :check_application_is_completed
   end
 
   def show
@@ -16,15 +12,9 @@ module CompletionStep
 
   private
 
-  def completed?
-    current_c100_application.completed?
-  end
+  def check_application_is_completed
+    return if current_c100_application.completed?
 
-  def mark_completed
-    current_c100_application.completed!
-
-    CompletedApplicationsAudit.log!(
-      current_c100_application
-    )
+    redirect_to steps_screener_warning_path
   end
 end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -51,4 +51,8 @@ class C100Application < ApplicationRecord
   def self.purge!(date)
     where('c100_applications.created_at <= :date', date: date).destroy_all
   end
+
+  def mark_as_completed!
+    completed! && CompletedApplicationsAudit.log!(self)
+  end
 end

--- a/app/services/c100_app/payments_flow_control.rb
+++ b/app/services/c100_app/payments_flow_control.rb
@@ -42,6 +42,8 @@ module C100App
     end
 
     def confirmation_url
+      c100_application.mark_as_completed!
+
       if c100_application.online_submission?
         OnlineSubmissionQueue.new(c100_application).process
         steps_completion_confirmation_path

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -144,4 +144,13 @@ RSpec.describe C100Application, type: :model do
       subject.screener_answers_court
     end
   end
+
+  describe '#mark_as_completed!' do
+    it 'marks the application as completed and saves the audit record' do
+      expect(subject).to receive(:completed!).and_return(true)
+      expect(CompletedApplicationsAudit).to receive(:log!).with(subject)
+
+      subject.mark_as_completed!
+    end
+  end
 end

--- a/spec/services/c100_app/payments_flow_control_spec.rb
+++ b/spec/services/c100_app/payments_flow_control_spec.rb
@@ -154,6 +154,10 @@ RSpec.describe C100App::PaymentsFlowControl do
   describe '#confirmation_url' do
     let(:queue) { double.as_null_object }
 
+    before do
+      expect(c100_application).to receive(:mark_as_completed!)
+    end
+
     context 'for an online submission' do
       let(:submission_type) { SubmissionType::ONLINE }
 


### PR DESCRIPTION
Move the logic to mark the application completed from the concern in the confirmation pages, to be an explicit method to be called after payment.

This eliminates the possibility of someone hitting (either by editing the URL or by a bookmark) the confirmation page and markin automatically the application as completed, even if it was still in the `payment_in_progress` state.

If this happens, we now show a warning error and let the user go back to the last step they completed.