### PR TITLE
Handle users returning to a `payment_in_progress` application

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -1,6 +1,8 @@
 class StepController < ApplicationController
   before_action :check_c100_application_presence
+  before_action :check_application_payment_status
   before_action :check_application_not_completed, :check_application_not_screening, except: [:show]
+
   before_action :update_navigation_stack, only: [:show, :edit]
 
   def previous_step_path

--- a/app/services/c100_app/payments_flow_control.rb
+++ b/app/services/c100_app/payments_flow_control.rb
@@ -30,13 +30,10 @@ module C100App
       # For a while, until we are confident, let's log these failures
       log_failure_info
 
-      if OnlinePayments.non_retryable_state?(payment_intent)
-        # Let the user change payment method
-        payment_error_errors_path
-      else
-        # Re-enter the online payment journey
-        payment_url
-      end
+      # Revert to `in_progress` as we are certain at this point payment failed
+      c100_application.in_progress!
+
+      payment_error_errors_path
     rescue StandardError => exception
       raise Errors::PaymentUnexpectedError, exception
     end

--- a/app/views/errors/payment_error.html.erb
+++ b/app/views/errors/payment_error.html.erb
@@ -13,8 +13,11 @@
     </p>
 
     <p class="govuk-body govuk-!-margin-top-8">
-      <%= link_button t('shared.retry_payment'), edit_steps_application_payment_path, class: 'ga-pageLink',
+      <%= link_button t('shared.retry_payment'), edit_steps_application_check_your_answers_path, class: 'ga-pageLink govuk-!-margin-right-1',
                       data: { module: 'govuk-button', ga_category: 'online payments', ga_label: 'retry payment' } %>
+
+      <%= link_button t('shared.change_payment'), edit_steps_application_payment_path, class: 'ga-pageLink govuk-button--secondary',
+                      data: { module: 'govuk-button', ga_category: 'online payments', ga_label: 'change payment' } %>
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1701,6 +1701,7 @@ en:
   shared:
     start_again: Start again
     retry_payment: Try payment again
+    change_payment: Change payment method
     finish: Finish
     back_link: Back
     password_toggle:

--- a/spec/controllers/steps/abuse_concerns/start_controller_spec.rb
+++ b/spec/controllers/steps/abuse_concerns/start_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::AbuseConcerns::StartController, type: :controller do
   it_behaves_like 'a show step controller'
 
   describe '#show' do
-    let(:c100_application) { instance_double(C100Application).as_null_object }
+    let(:c100_application) { instance_double(C100Application) }
 
     before do
       allow(controller).to receive(:current_c100_application).and_return(c100_application)

--- a/spec/controllers/steps/miam/child_protection_cases_controller_spec.rb
+++ b/spec/controllers/steps/miam/child_protection_cases_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Miam::ChildProtectionCasesController, type: :controller do
+  it_behaves_like 'a controller that checks the application payment status', for_action: :edit
   it_behaves_like 'a savepoint step controller'
 
   # Following examples will stub the screener sanity check for simplicity,

--- a/spec/controllers/steps/miam_exemptions/safety_playback_controller_spec.rb
+++ b/spec/controllers/steps/miam_exemptions/safety_playback_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::MiamExemptions::SafetyPlaybackController, type: :controlle
   it_behaves_like 'a show step controller'
 
   describe '#show' do
-    let(:c100_application) { instance_double(C100Application).as_null_object }
+    let(:c100_application) { instance_double(C100Application) }
 
     before do
       allow(controller).to receive(:current_c100_application).and_return(c100_application)

--- a/spec/controllers/steps/screener/start_controller_spec.rb
+++ b/spec/controllers/steps/screener/start_controller_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Screener::StartController, type: :controller do
-  let!(:existing_c100) { C100Application.create(status: status, navigation_stack: navigation_stack) }
+  it_behaves_like 'a controller that checks the application payment status', for_action: :show
 
   describe '#show' do
+    let!(:existing_c100) { C100Application.create(status: status, navigation_stack: navigation_stack) }
+
     context 'when an existing application in progress exists' do
       let(:status) { :in_progress }
 


### PR DESCRIPTION
If the application was left in a `payment_in_progress` status, we need to check if the payment went ahead successfully, or not, for the edge cases where the redirect from payments website failed.

This complements the automated mop-up job running periodically (to be implemented in a follow-up PR).

Essentially it means, any request to almost any url in our website, when there is a `payment_in_progress` application in the session, will trigger the `retrieve_payment` to update its status, and if successful, will just take the user directly to the confirmation page, otherwise they will see the payment error page and they can retry again.

To simplify this user-flow, I've removed for now the `OnlinePayments.non_retryable_state?` condition, as I believe it will not be that useful anymore with this new payment status handling and redirect. But didn't remove the method completely in case we want to reintroduce it again later on.