### PR TITLE
Implement stale payments mop-up job

### DIFF
--- a/app/jobs/payments_mop_up_job.rb
+++ b/app/jobs/payments_mop_up_job.rb
@@ -1,0 +1,37 @@
+# There are 2 failure cases which affect the integration with GOV.UK Pay:
+#
+# - the user abandons their payment journey before completing it
+# - the user completes their payment successfully, but their network connection
+#   is interrupted before they return to our service
+#
+# In these failure cases, the user will never visit the `return_url`.
+#
+# Instead, we must use an automatic mop-up job as a background process which
+# checks the outcome of incomplete payment journeys.
+#
+class PaymentsMopUpJob < ApplicationJob
+  queue_as :default
+
+  def self.run(date)
+    C100Application.payment_in_progress
+      .joins(:payment_intent)
+      .where("payment_intents.state ->> 'finished' = 'false'")
+      .where("payment_intents.created_at <= :date", date: date)
+      .each do |c100_application|
+        logger.info "Enqueuing payment status refresh for application #{c100_application.id}"
+        perform_later(c100_application)
+      end
+  end
+
+  def perform(c100_application)
+    return unless C100App::OnlinePayments.retrieve_payment(
+      c100_application.payment_intent
+    ).success?
+
+    c100_application.mark_as_completed!
+
+    C100App::OnlineSubmissionQueue.new(
+      c100_application
+    ).process if c100_application.online_submission?
+  end
+end

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -59,7 +59,7 @@ def classes_to_mutate(option)
     when 'all', 'master'
       # Complete coverage (very long run time) or only changed classes
       puts '> running complete mutant testing'
-      form_objects + decision_trees_and_services + models
+      form_objects + decision_trees_and_services + models + jobs
     else
       # Individual class testing, very quick
       # we'll take all arguments after the first (which is 'mutant')
@@ -97,4 +97,11 @@ end
 #
 def decision_trees_and_services
   C100App.constants.map { |symbol| C100App.const_get(symbol) }
+end
+
+# Everything inheriting from `ApplicationJob`
+# i.e. all jobs in `/app/jobs/*`
+#
+def jobs
+  ApplicationJob.descendants
 end

--- a/lib/tasks/payments_mop_up.rake
+++ b/lib/tasks/payments_mop_up.rake
@@ -1,0 +1,18 @@
+# This task runs frequently and calls the GOV.UK Pay API to determine the status
+# of any pending payments.
+#
+# Refer to `app/jobs/payments_mop_up_job.rb` for more details.
+#
+task payments_mop_up: :environment do
+  puts "Starting payments mop-up for intents older than #{mop_up_minutes_ago.iso8601}"
+
+  PaymentsMopUpJob.run(mop_up_minutes_ago)
+
+  puts "Finished payments mop-up for intents older than #{mop_up_minutes_ago.iso8601}"
+end
+
+private
+
+def mop_up_minutes_ago
+  @_mop_up_minutes_ago ||= ENV.fetch('GOVUK_PAY_MOP_UP_MINUTES_AGO', 60).to_i.minutes.ago
+end

--- a/spec/jobs/payments_mop_up_job_spec.rb
+++ b/spec/jobs/payments_mop_up_job_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe PaymentsMopUpJob, type: :job do
+  describe '.run' do
+    let(:c100_application) { C100Application.new(id: '449362af-0bc3-4953-82a7-1363d479b876') }
+
+    let(:finder_double) { double.as_null_object }
+    let(:time_ago) { 15.minutes.ago }
+
+    before do
+      allow(C100Application).to receive(:payment_in_progress).and_return(finder_double)
+    end
+
+    it 'finds any pending payment intents' do
+      expect(finder_double).to receive(:joins).with(:payment_intent).and_return(finder_double)
+      expect(finder_double).to receive(:where).with("payment_intents.state ->> 'finished' = 'false'").and_return(finder_double)
+      expect(finder_double).to receive(:where).with("payment_intents.created_at <= :date", date: time_ago).and_return(finder_double)
+
+      expect(finder_double).to receive(:each)
+      expect(described_class).not_to receive(:perform_later)
+
+      described_class.run(time_ago)
+    end
+
+    it 'enqueues a status refresh for each application found' do
+      expect(finder_double).to receive(:each).and_yield(c100_application)
+      expect(described_class).to receive(:perform_later).with(c100_application)
+
+      # Mutant kill
+      expect(Rails.logger).to receive(:info).with(
+        'Enqueuing payment status refresh for application 449362af-0bc3-4953-82a7-1363d479b876'
+      )
+
+      described_class.run(time_ago)
+    end
+  end
+
+  describe '#perform' do
+    let(:c100_application) { instance_double(C100Application, online_submission?: online_submission, payment_intent: payment_intent) }
+    let(:payment_intent) { instance_double(PaymentIntent) }
+    let(:payment_result) { double(success?: success) }
+
+    before do
+      allow(
+        C100App::OnlinePayments
+      ).to receive(:retrieve_payment).with(payment_intent).and_return(payment_result)
+    end
+
+    context 'for a success payment' do
+      let(:success) { true }
+
+      context 'for an online submission' do
+        let(:online_submission) { true }
+        let(:queue) { double.as_null_object }
+
+        it 'marks the application as completed and process the application online submission' do
+          expect(c100_application).to receive(:mark_as_completed!)
+          expect(C100App::OnlineSubmissionQueue).to receive(:new).with(c100_application).and_return(queue)
+          expect(queue).to receive(:process)
+
+          described_class.perform_now(c100_application)
+        end
+      end
+
+      context 'for an offline submission' do
+        let(:online_submission) { false }
+
+        it 'marks the application as completed' do
+          expect(c100_application).to receive(:mark_as_completed!)
+          expect(C100App::OnlineSubmissionQueue).not_to receive(:new)
+
+          described_class.perform_now(c100_application)
+        end
+      end
+    end
+
+    context 'for a failed payment' do
+      let(:success) { false }
+      let(:online_submission) { true }
+
+      it 'does nothing' do
+        expect(c100_application).not_to receive(:mark_as_completed!)
+        expect(C100App::OnlineSubmissionQueue).not_to receive(:new)
+
+        described_class.perform_now(c100_application)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This task will run periodically, triggered by a cronjob, and will scan stale pending payments in order to refresh their status and make sure we either progress the application to completed, or not.

Added all the jobs to the mutation testing for improved coverage (only when running a complete test).