### PR TITLE
Ensure we have a valid GBS code

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -79,7 +79,7 @@ class SessionsController < ApplicationController
         "name" => "Milton Keynes County Court and Family Court",
         "slug" => "milton-keynes-county-court-and-family-court",
         "email" => "family@miltonkeynes.countycourt.gsi.gov.uk",
-        "gbs" => "X123",
+        "gbs" => "Y610",
       }
     }.merge(screener.attributes.symbolize_keys) do |_key, old_value, new_value|
       new_value || old_value

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -9,7 +9,7 @@ class Court
     @name = data.fetch('name')
     @slug = data.fetch('slug')
     @address = data.fetch('address')
-    # The email, if not already present, comes from a separate API request
+    # Email and GBS code, if not already present, come from a separate API request
     @email = data['email'] || best_enquiries_email
     @gbs = data['gbs'] || retrieve_gbs_from_api
   rescue StandardError => ex
@@ -63,7 +63,7 @@ class Court
   end
 
   def retrieve_gbs_from_api
-    court_data.fetch('gbs')
+    court_data.fetch('gbs') || 'unknown'
   end
 
   def retrieve_emails_from_api

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -101,6 +101,16 @@ describe Court do
           end
         end
 
+        context 'the API returned a `nil` gbs' do
+          let(:api_response) do
+            { 'gbs' => nil }
+          end
+
+          it 'sets the gbs fallback code' do
+            expect(subject.gbs).to eq('unknown')
+          end
+        end
+
         context 'the API failed to return gbs' do
           let(:api_response) { {} }
           it { expect { subject.gbs }.to raise_error(KeyError, 'key not found: "gbs"') }


### PR DESCRIPTION
The API will not accept a `nil` value so we must be careful in case there are courts without the GBS code set.

Instead of falling back to an empty string by doing `to_s`, let's make it super explicit by using `unknown` as the code.

Updated the screener fixture to use the real GBS code for Milton Keynes.