### PR TITLE
Add new online payment radio option

### DIFF
--- a/app/forms/steps/application/payment_form.rb
+++ b/app/forms/steps/application/payment_form.rb
@@ -5,12 +5,16 @@ module Steps
       attribute :hwf_reference_number, StrippedString
       attribute :solicitor_account_number, StrippedString
 
-      validates_inclusion_of :payment_type, in: PaymentType.string_values
+      validates_inclusion_of :payment_type, in: :choices, if: :c100_application
 
       validates_presence_of :hwf_reference_number, if: :help_with_fees_payment?
       validates_presence_of :solicitor_account_number, if: :solicitor_payment?
 
       validates :hwf_reference_number, allow_blank: true, help_with_fees_reference: true, if: :help_with_fees_payment?
+
+      def choices
+        @_choices ||= ValidPaymentsArray.new(c100_application)
+      end
 
       private
 

--- a/app/presenters/valid_payments_array.rb
+++ b/app/presenters/valid_payments_array.rb
@@ -1,0 +1,30 @@
+class ValidPaymentsArray < SimpleDelegator
+  COMMON_CHOICES = [
+    PaymentType::HELP_WITH_FEES,
+    PaymentType::SELF_PAYMENT_CARD,
+    PaymentType::SELF_PAYMENT_CHEQUE,
+  ].freeze
+
+  def initialize(c100_application)
+    super(
+      choices_to_present(c100_application)
+    )
+  end
+
+  def include?(other)
+    collection.include?(PaymentType.new(other.to_s))
+  end
+
+  private
+
+  def collection
+    __getobj__
+  end
+
+  def choices_to_present(c100_application)
+    COMMON_CHOICES.dup.tap do |choices|
+      choices.append(PaymentType::SOLICITOR) if c100_application.has_solicitor?
+      choices.append(PaymentType::ONLINE)    if c100_application.online_submission?
+    end
+  end
+end

--- a/app/value_objects/payment_type.rb
+++ b/app/value_objects/payment_type.rb
@@ -1,5 +1,6 @@
 class PaymentType < ValueObject
   VALUES = [
+    ONLINE = new(:online),
     HELP_WITH_FEES = new(:help_with_fees),
     SOLICITOR = new(:solicitor),
     SELF_PAYMENT_CARD = new(:self_payment_card),

--- a/app/views/steps/application/payment/edit.html.erb
+++ b/app/views/steps/application/payment/edit.html.erb
@@ -9,15 +9,28 @@
       <%= f.govuk_radio_buttons_fieldset :payment_type do %>
         <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
-        <%= f.govuk_radio_button :payment_type, PaymentType::SELF_PAYMENT_CARD, link_errors: true %>
+        <%# Ugly but we need to set `link_errors: true` only in the first visible radio %>
+        <% online_choice = @form_object.choices.include?(PaymentType::ONLINE) %>
 
-        <%= f.govuk_radio_button :payment_type, PaymentType::SELF_PAYMENT_CHEQUE %>
-
-        <%= f.govuk_radio_button :payment_type, PaymentType::HELP_WITH_FEES do %>
-          <%= f.govuk_text_field :hwf_reference_number, width: 'one-half', label: { size: 's' } %>
+        <% if @form_object.choices.include?(PaymentType::ONLINE) %>
+          <%= f.govuk_radio_button :payment_type, PaymentType::ONLINE, link_errors: online_choice %>
         <% end %>
 
-        <% if current_c100_application.has_solicitor? %>
+        <% if @form_object.choices.include?(PaymentType::SELF_PAYMENT_CARD) %>
+          <%= f.govuk_radio_button :payment_type, PaymentType::SELF_PAYMENT_CARD, link_errors: !online_choice %>
+        <% end %>
+
+        <% if @form_object.choices.include?(PaymentType::SELF_PAYMENT_CHEQUE) %>
+          <%= f.govuk_radio_button :payment_type, PaymentType::SELF_PAYMENT_CHEQUE %>
+        <% end %>
+
+        <% if @form_object.choices.include?(PaymentType::HELP_WITH_FEES) %>
+          <%= f.govuk_radio_button :payment_type, PaymentType::HELP_WITH_FEES do %>
+            <%= f.govuk_text_field :hwf_reference_number, width: 'one-half', label: { size: 's' } %>
+          <% end %>
+        <% end %>
+
+        <% if @form_object.choices.include?(PaymentType::SOLICITOR) %>
           <%= f.govuk_radio_button :payment_type, PaymentType::SOLICITOR do %>
             <%= f.govuk_text_field :solicitor_account_number, width: 'one-half', label: { size: 's' } %>
           <% end %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -616,6 +616,7 @@ en:
     payment_type:
       question: ''
       answers:
+        online: Online payment
         help_with_fees: Help with fees
         solicitor: Through a solicitor’s fee account
         self_payment_card: I am paying myself by credit or debit card

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1218,6 +1218,7 @@ en:
           other_assistance: Other assistance or facilities
       steps_application_payment_form:
         payment_type_options:
+          online: Online payment
           help_with_fees: Help with fees
           solicitor: Through a solicitor’s fee account
           self_payment_card: I am paying myself by credit or debit card
@@ -1388,6 +1389,7 @@ en:
       steps_application_payment_form:
         hwf_reference_number: 'This will be in the format: HWF-XXX-XXX'
         payment_type_options:
+          online: You will pay online securely with your credit or debit card
           help_with_fees_html: |
             You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" class="govuk-link" rel="external" target="_blank">get help paying</a> if you’re on a low income, receive certain benefits or have little or no savings. If you do qualify, you’ll need to provide your reference number
           solicitor: If you have a solicitor representing you, they may pay the court by direct debit. You’ll need to provide their ‘fee account number’

--- a/spec/forms/steps/application/payment_form_spec.rb
+++ b/spec/forms/steps/application/payment_form_spec.rb
@@ -16,12 +16,25 @@ RSpec.describe Steps::Application::PaymentForm do
 
   subject { described_class.new(arguments) }
 
+  before do
+    # We test the `ValidPaymentsArray` separately, so here we don't care,
+    # we return just the choices we will use in the following tests.
+    allow(ValidPaymentsArray).to receive(:new).with(c100_application).and_return(
+      %w(self_payment_card help_with_fees solicitor)
+    )
+  end
+
   describe '#save' do
     context 'validations' do
       it { should validate_presence_of(:payment_type, :inclusion) }
 
       it { should_not validate_presence_of(:hwf_reference_number) }
       it { should_not validate_presence_of(:solicitor_account_number) }
+
+      context 'for an invalid payment type' do
+        let(:payment_type) { 'foobar' }
+        it { expect(subject.valid?).to eq(false) }
+      end
 
       context 'when payment type is `help_with_fees`' do
         let(:payment_type) { PaymentType::HELP_WITH_FEES.to_s }

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+RSpec.describe ValidPaymentsArray do
+  subject { described_class.new(c100_application) }
+
+  let(:c100_application) { C100Application.new(attributes) }
+  let(:attributes) { {
+    has_solicitor: has_solicitor,
+    submission_type: submission_type,
+  } }
+
+  let(:has_solicitor) { nil }
+  let(:submission_type) { nil }
+
+  let(:common_choices) { described_class::COMMON_CHOICES }
+
+  describe '#include?' do
+    context 'for an included string' do
+      it 'returns true' do
+        expect(subject.include?(PaymentType::HELP_WITH_FEES.to_s)).to eq(true)
+      end
+    end
+
+    context 'for an included value-object' do
+      it 'returns true' do
+        expect(subject.include?(PaymentType::HELP_WITH_FEES)).to eq(true)
+      end
+    end
+
+    context 'for an invalid string' do
+      it 'returns true' do
+        expect(subject.include?('foobar')).to eq(false)
+      end
+    end
+
+    context 'for a nil value' do
+      it 'returns false' do
+        expect(subject.include?(nil)).to eq(false)
+      end
+    end
+  end
+
+  context 'for an online submission' do
+    let(:submission_type) { SubmissionType::ONLINE.to_s }
+
+    context 'with solicitor' do
+      let(:has_solicitor) { 'yes' }
+
+      it 'has valid payment choices' do
+        expect(subject).to match_array(common_choices + [PaymentType::SOLICITOR, PaymentType::ONLINE])
+      end
+    end
+
+    context 'without solicitor' do
+      let(:has_solicitor) { 'no' }
+
+      it 'has valid payment choices' do
+        expect(subject).to match_array(common_choices + [PaymentType::ONLINE])
+      end
+    end
+  end
+
+  context 'for a print and post submission' do
+    let(:submission_type) { SubmissionType::PRINT_AND_POST.to_s }
+
+    context 'with solicitor' do
+      let(:has_solicitor) { 'yes' }
+
+      it 'has valid payment choices' do
+        expect(subject).to match_array(common_choices + [PaymentType::SOLICITOR])
+      end
+    end
+
+    context 'without solicitor' do
+      let(:has_solicitor) { 'no' }
+
+      it 'has valid payment choices' do
+        expect(subject).to match_array(common_choices)
+      end
+    end
+  end
+end

--- a/spec/value_objects/payment_type_spec.rb
+++ b/spec/value_objects/payment_type_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PaymentType do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(%w(
+        online
         help_with_fees
         solicitor
         self_payment_card


### PR DESCRIPTION
Ensure depending which submission type the user chose, we show the available payment options for that submission method.

This PR does not include yet confirmation page instructions or email instructions. There are some other changes needed as well, to be done in follow-up PRs.

In a follow-up PR we will make sure to only show the ONLINE method on dev/staging envs, but not production. It must be maintained behind a feature flag for the time being.