### PR TITLE
Update the attribute name for reminder statuses

### DIFF
--- a/app/services/c100_app/draft_reminders.rb
+++ b/app/services/c100_app/draft_reminders.rb
@@ -18,7 +18,7 @@ module C100App
       ).deliver_later
 
       c100_application.update(
-        status: rule_set.status_transition_to
+        reminder_status: rule_set.status_transition_to
       )
     end
   end

--- a/spec/services/c100_app/draft_reminders_spec.rb
+++ b/spec/services/c100_app/draft_reminders_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe C100App::DraftReminders do
       allow(NotifyMailer).to receive(:draft_expire_reminder).with(c100_application, :template_name).and_return(mailer_double)
     end
 
-    it 'should send the email and update the C100 application status' do
+    it 'should send the email and update the `reminder_status` attribute' do
       expect(mailer_double).to receive(:deliver_later)
-      expect(c100_application).to receive(:update).with(status: :another_status)
+      expect(c100_application).to receive(:update).with(reminder_status: :another_status)
       subject.run
     end
   end


### PR DESCRIPTION
We forgot to update the name of this attribute. Now it is call `reminder_status` and is a separate DB column to the previous `status`, that is not used for reminders anymore.