### PR TITLE
Use new payment option to trigger the online journey

### DIFF
--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -62,7 +62,7 @@ class NotifySubmissionMailer < NotifyMailer
 
   def payment_instructions
     I18n.translate!(
-      @c100_application.payment_type || PaymentType::SELF_PAYMENT_CARD,
+      @c100_application.payment_type,
       scope: [:notify_submission_mailer, :payment_instructions]
     )
   end

--- a/app/models/concerns/application_inquiry_methods.rb
+++ b/app/models/concerns/application_inquiry_methods.rb
@@ -3,9 +3,8 @@ module ApplicationInquiryMethods
     submission_type.eql?(SubmissionType::ONLINE.to_s)
   end
 
-  # TODO: change when we introduce the 'real' online payment method
   def online_payment?
-    payment_type.eql?(PaymentType::SELF_PAYMENT_CARD.to_s)
+    payment_type.eql?(PaymentType::ONLINE.to_s)
   end
 
   def confidentiality_enabled?

--- a/app/presenters/valid_payments_array.rb
+++ b/app/presenters/valid_payments_array.rb
@@ -24,7 +24,12 @@ class ValidPaymentsArray < SimpleDelegator
   def choices_to_present(c100_application)
     COMMON_CHOICES.dup.tap do |choices|
       choices.append(PaymentType::SOLICITOR) if c100_application.has_solicitor?
-      choices.append(PaymentType::ONLINE)    if c100_application.online_submission?
+      choices.append(PaymentType::ONLINE)    if c100_application.online_submission? && govuk_pay_enabled?
     end
+  end
+
+  # TODO: For now we hide the online payment option in production
+  def govuk_pay_enabled?
+    ENV.key?('GOVUK_PAY_API_KEY')
   end
 end

--- a/app/services/c100_app/payments_flow_control.rb
+++ b/app/services/c100_app/payments_flow_control.rb
@@ -9,8 +9,6 @@ module C100App
     end
 
     def payment_url
-      return confirmation_url unless payments_enabled?
-
       if c100_application.online_payment?
         c100_application.payment_in_progress!
         OnlinePayments.create_payment(payment_intent).payment_url
@@ -62,13 +60,6 @@ module C100App
         Errors::PaymentError.new(payment_intent.state),
         level: 'info', tags: { payment_id: payment_intent.payment_id }
       )
-    end
-
-    # TODO: For now, we only run the online payments code if some criteria is met,
-    # to avoid genuine tests or demos on staging while still WIP.
-    #
-    def payments_enabled?
-      c100_application.declaration_signee.eql?('John Doe')
     end
   end
 end

--- a/app/views/steps/shared/_payment_instructions.en.html.erb
+++ b/app/views/steps/shared/_payment_instructions.en.html.erb
@@ -1,4 +1,8 @@
-<% if c100_application.payment_type.eql?(PaymentType::HELP_WITH_FEES.to_s) %>
+<% if c100_application.payment_type.eql?(PaymentType::ONLINE.to_s) %>
+
+  <p class="govuk-body">Online payment copy TBD.</p>
+
+<% elsif c100_application.payment_type.eql?(PaymentType::HELP_WITH_FEES.to_s) %>
 
   <p class="govuk-body">You may not need to pay the full amount if you have a
     <a href="https://www.gov.uk/get-help-with-court-fees" class="govuk-link" rel="external" target="_blank">‘Help with fees’</a> reference.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1389,7 +1389,7 @@ en:
       steps_application_payment_form:
         hwf_reference_number: 'This will be in the format: HWF-XXX-XXX'
         payment_type_options:
-          online: You will pay online securely with your credit or debit card
+          online: You will pay online securely using your credit or debit card. Copy TBD
           help_with_fees_html: |
             You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" class="govuk-link" rel="external" target="_blank">get help paying</a> if you’re on a low income, receive certain benefits or have little or no savings. If you do qualify, you’ll need to provide your reference number
           solicitor: If you have a solicitor representing you, they may pay the court by direct debit. You’ll need to provide their ‘fee account number’
@@ -1865,6 +1865,8 @@ en:
 
   notify_submission_mailer:
     payment_instructions:
+      online: |
+        Online payment copy TBD.
       solicitor: |
         Your solicitor will pay the court fee by direct debit, through their fee account.
       help_with_fees: |

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -505,6 +505,7 @@ en:
     payment_type:
       question: Payment option selected
       answers:
+        online: Online payment
         help_with_fees: Help with fees
         solicitor: Through solicitor
         self_payment_card: Credit or debit card - contact the applicant within 3 working days of receiving application to take payment

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -8,12 +8,11 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       receipt_email: 'receipt@example.com',
       urgent_hearing: 'yes',
       address_confidentiality: address_confidentiality,
-      payment_type: payment_type,
+      payment_type: 'foobar_payment',
       declaration_signee: 'John Doe',
     )
   }
 
-  let(:payment_type) { nil }
   let(:address_confidentiality) { 'no' }
 
   let(:court) {
@@ -89,7 +88,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       allow(c100_application).to receive(:screener_answers_court).and_return(court)
 
       allow(I18n).to receive(:translate!).with(
-        PaymentType::SELF_PAYMENT_CARD, scope: [:notify_submission_mailer, :payment_instructions]
+        'foobar_payment', scope: [:notify_submission_mailer, :payment_instructions]
       ).and_return('payment instructions from locales')
     end
 
@@ -122,22 +121,6 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         payment_instructions: 'payment instructions from locales',
         link_to_pdf: { file: 'YnVuZGxlIHBkZg==' },
       })
-    end
-
-    context 'for a specific payment type' do
-      before do
-        allow(I18n).to receive(:translate!).with(
-          'help_with_fees', scope: [:notify_submission_mailer, :payment_instructions]
-        ).and_return('hwf payment instructions')
-      end
-
-      let(:payment_type) { 'help_with_fees' }
-
-      it 'has the right personalisation' do
-        expect(
-          mail.govuk_notify_personalisation
-        ).to include(payment_instructions: 'hwf payment instructions')
-      end
     end
 
     context 'when at least one applicant is under age' do

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe C100Application, type: :model do
 
   describe '#online_payment?' do
     context 'for `online` values' do
-      let(:attributes) { {payment_type: 'self_payment_card'} }
+      let(:attributes) { {payment_type: 'online'} }
       it { expect(subject.online_payment?).to eq(true) }
     end
 

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe ValidPaymentsArray do
 
   context 'for an online submission' do
     let(:submission_type) { SubmissionType::ONLINE.to_s }
+    let(:pay_enabled) { true }
+
+    before do
+      allow(ENV).to receive(:key?).with('GOVUK_PAY_API_KEY').and_return(pay_enabled)
+    end
+
+    # TODO: temporary feature flag until we release online payments
+    context 'without govuk pay enabled' do
+      let(:pay_enabled) { false }
+
+      it 'does not include the online option' do
+        expect(subject).not_to include(PaymentType::ONLINE)
+      end
+    end
 
     context 'with solicitor' do
       let(:has_solicitor) { 'yes' }


### PR DESCRIPTION
Now we have the new "online payment" radio option exposed, let's use this one to trigger the online payment journey, instead of using `self_payment_card` like we did until now.

Also, hide this radio option behind a feature flag so we don't show it accidentally on production just yet.
No need for signing the declaration as 'John Doe' either.

Some more copy placeholders in preparation for when we have it available.