### PR TITLE
Do not propagate the exception on dup audit record

### DIFF
--- a/app/models/completed_applications_audit.rb
+++ b/app/models/completed_applications_audit.rb
@@ -13,6 +13,10 @@ class CompletedApplicationsAudit < ApplicationRecord
       court: c100_application.screener_answers_court.name,
       metadata: metadata(c100_application),
     )
+  rescue ActiveRecord::RecordNotUnique => ex
+    # Do nothing really, this tends to happen sporadically if the user sent two
+    # server requests quickly in succession. Only one will create the record.
+    logger.warn ex.message
   end
 
   def self.metadata(c100_application)

--- a/spec/models/completed_applications_audit_spec.rb
+++ b/spec/models/completed_applications_audit_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
 
       described_class.log!(c100_application)
     end
+
+    context 'when the record already exists' do
+      before do
+        allow(described_class).to receive(:create).and_raise(ActiveRecord::RecordNotUnique, 'not unique!')
+      end
+
+      it 'rescues and log the exception but does not blow up' do
+        expect(Rails.logger).to receive(:warn).with('not unique!')
+
+        expect {
+          described_class.log!(c100_application)
+        }.not_to raise_error
+      end
+    end
   end
 
   describe '#c100_application' do


### PR DESCRIPTION
If the user sends two server requests quickly in succession on the check your answers page, there is a race condition where only one of the requests will be able to create the audit record.

The other request will try and fail because (on purpose) there is unique key constrain in the table.

This happens rarely and usually has no effect on the user, although depending on wich request "won" the race, they might end up with a standard error page.

In order to avoid this, instead of blowing up we will log the failure and do nothing as this is not harmful.