### PR TITLE
Do not attach the PDF to applicants confirmation email

### DIFF
--- a/app/services/c100_app/applicant_online_submission.rb
+++ b/app/services/c100_app/applicant_online_submission.rb
@@ -1,7 +1,7 @@
 module C100App
   class ApplicantOnlineSubmission < BaseOnlineSubmission
     def process
-      generate_documents && deliver_email && audit_data
+      deliver_email && audit_data
     end
 
     def to_address
@@ -9,12 +9,6 @@ module C100App
     end
 
     private
-
-    def generate_documents
-      documents.store(
-        :bundle, generate_pdf
-      )
-    end
 
     # We use `deliver_now` here, as we want the actions performed in
     # the `process` method to be executed sequentially and the whole job

--- a/app/views/entrypoint/v1.en.html.erb
+++ b/app/views/entrypoint/v1.en.html.erb
@@ -86,8 +86,7 @@
 
     <p class="govuk-body">
       You can submit your completed application straight to the court electronically. If you enter an email address,
-      you’ll get a confirmation that it’s been sent with your application attached. You can also download, print and
-      send your application by post if you prefer.
+      you’ll get a confirmation email. You can also download, print and send your application by post if you prefer.
     </p>
 
     <%= link_to entrypoint_what_is_needed_path, class: 'govuk-button govuk-button--start govuk-!-margin-top-3', data: { module: 'govuk-button' }, role: 'button', draggable: false do %>

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -16,22 +16,21 @@
       Your application has been sent to <%= @court.name %>.
 
       <% if @c100_application.receipt_email? %>
-        We’ve emailed a confirmation of this with a copy of your application to
-        <strong><%= @c100_application.receipt_email %></strong>
+        You’ll receive a confirmation email to <strong><%= @c100_application.receipt_email %></strong>
       <% end %>
     </p>
-
-    <h2 class="govuk-heading-l">Pay the application fee</h2>
-    <%= render partial: 'steps/shared/payment_instructions', locals: {
-      c100_application: @c100_application
-    } %>
-
-    <%= render partial: 'under_age_section' if @c100_application.applicants.under_age? %>
 
     <h2 class="govuk-heading-l">Download a copy of your application</h2>
     <%= render partial: 'steps/shared/download_pdf_copy', locals: {
       callout: 'If you want to keep a copy, you must download it now. You cannot return to a submitted application.'
     } %>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-6">Pay the application fee</h2>
+    <%= render partial: 'steps/shared/payment_instructions', locals: {
+      c100_application: @c100_application
+    } %>
+
+    <%= render partial: 'under_age_section' if @c100_application.applicants.under_age? %>
 
     <%= render partial: 'steps/shared/court_help', locals: {court: @court} %>
 

--- a/app/views/steps/shared/_download_pdf_copy.en.html.erb
+++ b/app/views/steps/shared/_download_pdf_copy.en.html.erb
@@ -3,7 +3,7 @@
   <a href="https://get.adobe.com/uk/reader/" class="govuk-link" rel="external" target="_blank">Adobe Acrobat Reader</a>.
 </p>
 
-<% unless user_signed_in? || @c100_application.receipt_email? %>
+<% unless user_signed_in? %>
   <div class="govuk-inset-text">
     <%= callout %>
   </div>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -627,7 +627,7 @@ en:
         online: Electronically
         print_and_post: Print and post
     submission_receipt_email:
-      question: 'A copy of your application will be sent to:'
+      question: 'A confirmation email will be sent to:'
     has_solicitor:
       question: Do you have a solicitor?
       answers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -722,7 +722,7 @@ en:
         show:
           page_title: Check your email address
           heading: Is this email address correct?
-          email_info: We’ll send a copy of your application to this email address. Please make sure it’s correct and that you can access the email account.
+          email_info: You’ll receive a confirmation email to this address. Please make sure it’s correct and that you can access the email account.
           continue: Yes, continue
           go_back: No, change it
       check_your_answers:
@@ -1396,7 +1396,7 @@ en:
           self_payment_card: Court staff will contact you within 3 working days to take payment over the phone
           self_payment_cheque: You can send a cheque or pay in person at the court
       steps_application_submission_form:
-        receipt_email: We’ll send a copy of your application to this email address. You can also download a copy on the confirmation page.
+        receipt_email: You can also download a copy on the confirmation page.
       steps_safety_questions_substance_abuse_form:
         substance_abuse: For example, you think the children are affected by being in contact with someone who may have a drug, alcohol or substance problem.
       steps_abduction_passport_details_form:

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -83,6 +83,9 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
     end
   end
 
+  # We don't send the bundle PDF to the applicant anymore, but the code to be able
+  # to attach documents is still present if we wanted to attach any other documents.
+  #
   describe '#application_to_user' do
     before do
       allow(c100_application).to receive(:screener_answers_court).and_return(court)

--- a/spec/services/c100_app/applicant_online_submission_spec.rb
+++ b/spec/services/c100_app/applicant_online_submission_spec.rb
@@ -11,31 +11,12 @@ RSpec.describe C100App::ApplicantOnlineSubmission do
   end
 
   describe '#process' do
-    let(:pdf_presenter) { instance_double(Summary::PdfPresenter, generate: true, to_pdf: 'pdf content') }
-
-    before do
-      allow(Summary::PdfPresenter).to receive(:new).with(c100_application).and_return(pdf_presenter)
-    end
-
-    context '#generate_documents' do
-      before do
-        allow(subject).to receive(:deliver_email) # do not care here about the email
-      end
-
-      it 'generates the PDF' do
-        expect(pdf_presenter).to receive(:generate).with(no_args)
-        subject.process
-
-        expect(subject.documents.size).to eq(1)
-      end
-    end
-
     context '#deliver_email' do
       let(:mailer) { spy('mailer') }
 
       before do
         allow(NotifySubmissionMailer).to receive(:with).with(
-          c100_application: c100_application, documents: { bundle: kind_of(StringIO) }
+          c100_application: c100_application, documents: {}
         ).and_return(mailer)
       end
 


### PR DESCRIPTION
Story: https://mojdigital.teamwork.com/#/tasks/20914334

We will not be attaching the application copy in the receipt email that the applicant receives (if they entered their email address, as this is optional).

They can still download the document in the confirmation page or through their user account (save&return).

The code however will very much be ready if we wanted to restore this functionality or attach any other document.