### PR TITLE
Improve logging in some rake tasks

### DIFF
--- a/app/services/reports/failed_emails_report.rb
+++ b/app/services/reports/failed_emails_report.rb
@@ -98,7 +98,7 @@ module Reports
         recipients = BackofficeUser.active.pluck(:email)
         report = failures.map(&:to_csv).join
 
-        puts "[#{Time.now}] Sending failed emails report to #{recipients.size} recipients..."
+        Rails.logger.info "Sending failed emails report to #{recipients.size} recipients..."
 
         recipients.each do |recipient|
           ReportsMailer.failed_emails_report(report, to_address: recipient).deliver_later

--- a/lib/tasks/_logger.rake
+++ b/lib/tasks/_logger.rake
@@ -1,0 +1,9 @@
+# This task is intended to enable log to STDOUT for tasks that are called
+# via cronjobs or workers. Just use it like this:
+#
+#   `task task_name: [:stdout_environment] do ...`
+#
+task :stdout_environment => [:environment] do
+  Rails.logger = Logger.new(STDOUT)
+  Rails.logger.level = Logger::INFO
+end

--- a/lib/tasks/court_refresh.rake
+++ b/lib/tasks/court_refresh.rake
@@ -8,7 +8,7 @@ namespace :court_refresh do
   # Note the criteria will only select applications saved (`with_owner`)
   # and not yet completed. We should never change a completed application.
   #
-  task slug: :environment do
+  task slug: [:stdout_environment] do
     ARGV.shift(2)
 
     slug, email = nil
@@ -33,13 +33,13 @@ namespace :court_refresh do
     ).find_each(batch_size: 25) do |record|
       screener = record.screener_answers
 
-      puts "Enqueuing court refresh for ID #{screener.id}..."
+      Rails.logger.info "Enqueuing court refresh for ID #{screener.id}..."
       ScreenerCourtRefreshJob.perform_later(screener)
 
       count += 1
     end
 
-    puts "Finished. Total: #{count}"
+    Rails.logger.info "Finished. Total: #{count}"
     exit(0)
   end
 end

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -1,4 +1,4 @@
-task daily_tasks: :environment do
+task daily_tasks: [:stdout_environment] do
   log 'Starting daily tasks'
   log "Users count: #{User.count} / Applications count: #{C100Application.count}"
 
@@ -73,5 +73,5 @@ end
 private
 
 def log(message)
-  puts "[#{Time.now}] #{message}"
+  Rails.logger.info message
 end

--- a/lib/tasks/payments_mop_up.rake
+++ b/lib/tasks/payments_mop_up.rake
@@ -3,16 +3,16 @@
 #
 # Refer to `app/jobs/payments_mop_up_job.rb` for more details.
 #
-task payments_mop_up: :environment do
-  puts "Starting payments mop-up for intents older than #{mop_up_minutes_ago.iso8601}"
+task payments_mop_up: [:stdout_environment] do
+  Rails.logger.info "Starting payments mop-up for intents older than #{mop_up_minutes_ago.iso8601}"
 
   PaymentsMopUpJob.run(mop_up_minutes_ago)
 
-  puts "Finished payments mop-up for intents older than #{mop_up_minutes_ago.iso8601}"
+  Rails.logger.info "Finished payments mop-up for intents older than #{mop_up_minutes_ago.iso8601}"
 end
 
 private
 
 def mop_up_minutes_ago
-  @_mop_up_minutes_ago ||= ENV.fetch('GOVUK_PAY_MOP_UP_MINUTES_AGO', 60).to_i.minutes.ago
+  @_mop_up_minutes_ago ||= ENV.fetch('GOVUK_PAY_MOP_UP_MINUTES_AGO', 30).to_i.minutes.ago
 end


### PR DESCRIPTION
Instead of `puts` (in many cases having us to append the timestamp) lets use `Rails.logger.info` that automatically formats and outputs the proper timestamp.

This makes sense for rake tasks running through cronjobs so all log gets output to the STDOUT and is in one place when inspecting the logs through Kibana for example.

Also, reduced from 60 mins to 30 mins the time for a payment intent to be considered as "stale" and we start quering the payments API (every 15 mins) to check their status.