### PR TITLE
Reset payment type when submission changes

### DIFF
--- a/app/forms/steps/applicant/has_solicitor_form.rb
+++ b/app/forms/steps/applicant/has_solicitor_form.rb
@@ -3,8 +3,9 @@ module Steps
     class HasSolicitorForm < BaseForm
       include SingleQuestionForm
 
-      # The reset will delete the row from the `solicitors` table
-      yes_no_attribute :has_solicitor, reset_when_no: [:solicitor]
+      # The reset will delete the row from the `solicitors` table and the `payment_type` attrib,
+      # just in case they got this far and selected fee account (which only works for solicitors).
+      yes_no_attribute :has_solicitor, reset_when_no: [:solicitor, :payment_type]
     end
   end
 end

--- a/app/forms/steps/application/submission_form.rb
+++ b/app/forms/steps/application/submission_form.rb
@@ -9,16 +9,24 @@ module Steps
 
       private
 
+      def changed?
+        !c100_application.submission_type.eql?(submission_type) ||
+          !c100_application.receipt_email.eql?(receipt_email)
+      end
+
       def online_submission?
         submission_type.eql?(SubmissionType::ONLINE.to_s)
       end
 
       def persist!
         raise C100ApplicationNotFound unless c100_application
+        return true unless changed?
 
         c100_application.update(
           submission_type: submission_type,
           receipt_email: (receipt_email if online_submission?),
+          # The following are dependent attributes that need to be reset
+          payment_type: nil,
         )
       end
     end

--- a/spec/forms/steps/applicant/has_solicitor_form_spec.rb
+++ b/spec/forms/steps/applicant/has_solicitor_form_spec.rb
@@ -3,5 +3,5 @@ require 'spec_helper'
 RSpec.describe Steps::Applicant::HasSolicitorForm do
   it_behaves_like 'a yes-no question form',
                   attribute_name: :has_solicitor,
-                  reset_when_no: [:solicitor]
+                  reset_when_no: [:solicitor, :payment_type]
 end


### PR DESCRIPTION
Some payment types are only shown/available for online submission, or when there is a solicitor.

This PR ensures the following:

a) If the applicant answered YES to the "do you have a solicitor?" question, but later on through the edit link in the CYA they change the answer to NO, we will reset the payment as it is very likely they chose `fee account`, which is only available when there is a solicitor.

b) If the applicant changes their submission options (from online to print and post, or viceversa) we do the same and reset the payment method so we force them to select a new payment type.