### PR TITLE
Do not use 404 codes for invalid session errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,7 +6,7 @@ class ErrorsController < ApplicationController
   ]
 
   def invalid_session
-    respond_with_status(:not_found)
+    respond_with_status(:ok)
   end
 
   def not_found


### PR DESCRIPTION
These technically are not 404 (as the page/route exists, it is just the current session to access that page is invalid).

The side effect is we are getting an increased number of alerts, as bots scanning the website will trigger plenty of these errors.

Instead of returning them as 404, let's return a 200. This does not affect users as they will continue seeing the usual error page.