### PR TITLE
Amend payment details copy

### DIFF
--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -25,10 +25,12 @@
       callout: 'If you want to keep a copy, you must download it now. You cannot return to a submitted application.'
     } %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-6">Pay the application fee</h2>
-    <%= render partial: 'steps/shared/payment_instructions', locals: {
-      c100_application: @c100_application
-    } %>
+    <% unless @c100_application.online_payment? %>
+      <h2 class="govuk-heading-l govuk-!-margin-top-6">Pay the application fee</h2>
+      <%= render partial: 'steps/shared/payment_instructions', locals: {
+        c100_application: @c100_application
+      } %>
+    <% end %>
 
     <%= render partial: 'under_age_section' if @c100_application.applicants.under_age? %>
 

--- a/app/views/steps/shared/_payment_instructions.en.html.erb
+++ b/app/views/steps/shared/_payment_instructions.en.html.erb
@@ -1,13 +1,8 @@
-<% if c100_application.payment_type.eql?(PaymentType::ONLINE.to_s) %>
-
-  <p class="govuk-body">Online payment copy TBD.</p>
-
-<% elsif c100_application.payment_type.eql?(PaymentType::HELP_WITH_FEES.to_s) %>
+<% if c100_application.payment_type.eql?(PaymentType::HELP_WITH_FEES.to_s) %>
 
   <p class="govuk-body">You may not need to pay the full amount if you have a
     <a href="https://www.gov.uk/get-help-with-court-fees" class="govuk-link" rel="external" target="_blank">‘Help with fees’</a> reference.
     The court will phone you (it may come from a ‘private number’) if they require payment.</p>
-  <p class="govuk-body">The court will not be able to process your application until payment has been received.</p>
 
 <% elsif c100_application.payment_type.eql?(PaymentType::SOLICITOR.to_s) %>
 
@@ -22,7 +17,7 @@
   <p class="govuk-body">Send your cheque or pay in person within 3 working days. The court will not be able to process your application
     until payment has been received.</p>
 
-<% else %>
+<% elsif c100_application.payment_type.eql?(PaymentType::SELF_PAYMENT_CARD.to_s) %>
 
   <p class="govuk-body">You need to pay the £215 court fee. The court will phone you (it may come from a ‘private number’) within 3 working
     days of receiving your application to take payment using a credit or debit card.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1863,19 +1863,28 @@ en:
           Any information will be automatically deleted for your security after this time.
         return_info: You can return to continue your application at any time.
 
+  # Note: empty lines will be honored on Notify emails, to create paragraphs.
   notify_submission_mailer:
     payment_instructions:
       online: |
-        Online payment copy TBD.
+        The court will contact you when a hearing date is set, or if any more information is needed.
       solicitor: |
         Your solicitor will pay the court fee by direct debit, through their fee account.
+
+        The court will not be able to process your application until payment has been received.
       help_with_fees: |
         You may not need to pay the full amount if you have a valid ‘Help with fees’ reference.
+
         The court will phone you (it may look like a ‘private number’) if they require payment.
       self_payment_card: |
         You need to pay the £215 court fee. You’ll either:
         * receive a call from the court in the next 3 working days if you entered your phone number (it may look like a ‘private number’)
         * or you need to contact the court, by phone or in person to make payment
+
+        The court will not be able to process your application until payment has been received.
       self_payment_cheque: |
         You need to pay the £215 court fee. Post a cheque made out to ‘HM Courts and Tribunals Service’. Write your reference code, last name and ‘C100’ on the back of your cheque.
+
         Send your cheque or pay in person within 3 working days.
+
+        The court will not be able to process your application until payment has been received.


### PR DESCRIPTION
As per content designer. This will remove the payment instructions section
in the confirmation page if the payment method was online, and tweak the
copy in the confirmation email as well.

Before we had the paragraph "The court will not be able to process your
application until payment has been received." hardcoded in the Notify email
template, but now we are pushing it from the service, only if needed.