### PR TITLE
Extract hardcoded fee details to configuration

### DIFF
--- a/app/helpers/fees_helper.rb
+++ b/app/helpers/fees_helper.rb
@@ -1,0 +1,7 @@
+module FeesHelper
+  def fee_amount
+    ActionController::Base.helpers.number_to_currency(
+      Rails.configuration.x.court_fee.amount_in_pence / 100
+    )
+  end
+end

--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -1,5 +1,6 @@
 class NotifySubmissionMailer < NotifyMailer
-  #
+  include FeesHelper
+
   # Notify doesn't care about the `from` address, but we use it in the interceptor.
   #
   # It can be `nil`, as the interceptor will then make Notify fail email validation,
@@ -63,7 +64,8 @@ class NotifySubmissionMailer < NotifyMailer
   def payment_instructions
     I18n.translate!(
       @c100_application.payment_type,
-      scope: [:notify_submission_mailer, :payment_instructions]
+      scope: [:notify_submission_mailer, :payment_instructions],
+      fee: fee_amount,
     )
   end
 

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -1,8 +1,6 @@
 class BaseDecisionTree
   class InvalidStep < RuntimeError; end
 
-  include ApplicationHelper
-
   attr_reader :c100_application, :record, :step_params, :as, :next_step
 
   def initialize(c100_application:, record: nil, step_params: {}, as: nil, next_step: nil)

--- a/app/services/c100_app/online_payments.rb
+++ b/app/services/c100_app/online_payments.rb
@@ -56,11 +56,10 @@ module C100App
       )
     end
 
-    # TODO: hardcoded values to a better place, i.e. constants/config
     def details_payload
       {
-        amount: 215_00,
-        description: 'Court fee for lodging a C100 application',
+        amount: Rails.configuration.x.court_fee.amount_in_pence,
+        description: Rails.configuration.x.court_fee.description,
         reference: c100_application.reference_code,
 
         # One-time return url

--- a/app/views/entrypoint/v1.en.html.erb
+++ b/app/views/entrypoint/v1.en.html.erb
@@ -23,7 +23,7 @@
     <h2 class="govuk-heading-l">Fees</h2>
 
     <p class="govuk-body">
-      The court fee is £215. Only the person applying to court (the applicant) or their solicitor needs to pay. Check if
+      The court fee is <%= fee_amount %>. Only the person applying to court (the applicant) or their solicitor needs to pay. Check if
       you can
       <a href="https://www.gov.uk/get-help-with-court-fees" class="govuk-link" rel="external" target="_blank">get help
         paying the court fee</a>.

--- a/app/views/steps/application/payment/edit.html.erb
+++ b/app/views/steps/application/payment/edit.html.erb
@@ -7,7 +7,7 @@
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_radio_buttons_fieldset :payment_type do %>
-        <p class="govuk-body-l"><%=t '.lead_text' %></p>
+        <p class="govuk-body-l"><%=t '.lead_text', fee: fee_amount %></p>
 
         <%# Ugly but we need to set `link_errors: true` only in the first visible radio %>
         <% online_choice = @form_object.choices.include?(PaymentType::ONLINE) %>

--- a/app/views/steps/shared/_payment_instructions.en.html.erb
+++ b/app/views/steps/shared/_payment_instructions.en.html.erb
@@ -11,7 +11,7 @@
 
 <% elsif c100_application.payment_type.eql?(PaymentType::SELF_PAYMENT_CHEQUE.to_s) %>
 
-  <p class="govuk-body">You need to pay the £215 court fee. Post a cheque made out to ‘HM Courts and Tribunals Service’. Write your
+  <p class="govuk-body">You need to pay the <%= fee_amount %> court fee. Post a cheque made out to ‘HM Courts and Tribunals Service’. Write your
     reference code (<%= c100_application.reference_code -%>), last name and ‘C100’ on the back of your cheque.</p>
   <p class="govuk-body">You may also pay in person at the court by cheque or cash.</p>
   <p class="govuk-body">Send your cheque or pay in person within 3 working days. The court will not be able to process your application
@@ -19,7 +19,7 @@
 
 <% elsif c100_application.payment_type.eql?(PaymentType::SELF_PAYMENT_CARD.to_s) %>
 
-  <p class="govuk-body">You need to pay the £215 court fee. The court will phone you (it may come from a ‘private number’) within 3 working
+  <p class="govuk-body">You need to pay the <%= fee_amount %> court fee. The court will phone you (it may come from a ‘private number’) within 3 working
     days of receiving your application to take payment using a credit or debit card.</p>
   <p class="govuk-body">If you did not enter a telephone number or you do not get a call, please contact the court to pay. You may also pay
     in person at the court.</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 require "rails"
@@ -80,4 +82,9 @@ class Application < Rails::Application
   # very limited retention period. We maintain an audit (with no personal details) of the
   # delivery result of these emails for diagnostic and debug purposes.
   config.x.email_submissions_audit.expire_in_days = 90
+
+  # Court fee configuration.
+  # Not using Fee Register for now as we only have 1 fee, but might be used in the future.
+  config.x.court_fee.amount_in_pence = 215_00
+  config.x.court_fee.description = 'Court fee for a child arrangements application (C100)'
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -713,7 +713,7 @@ en:
       payment:
         edit:
           page_title: Payment type
-          lead_text: The court fee is £215. Only the person applying to court (the applicant) or their solicitor needs to pay.
+          lead_text: The court fee is %{fee}. Only the person applying to court (the applicant) or their solicitor needs to pay.
       submission:
         edit:
           page_title: How would you submit your application?
@@ -1877,13 +1877,13 @@ en:
 
         The court will phone you (it may look like a ‘private number’) if they require payment.
       self_payment_card: |
-        You need to pay the £215 court fee. You’ll either:
+        You need to pay the %{fee} court fee. You’ll either:
         * receive a call from the court in the next 3 working days if you entered your phone number (it may look like a ‘private number’)
         * or you need to contact the court, by phone or in person to make payment
 
         The court will not be able to process your application until payment has been received.
       self_payment_cheque: |
-        You need to pay the £215 court fee. Post a cheque made out to ‘HM Courts and Tribunals Service’. Write your reference code, last name and ‘C100’ on the back of your cheque.
+        You need to pay the %{fee} court fee. Post a cheque made out to ‘HM Courts and Tribunals Service’. Write your reference code, last name and ‘C100’ on the back of your cheque.
 
         Send your cheque or pay in person within 3 working days.
 

--- a/features/screener.feature
+++ b/features/screener.feature
@@ -19,6 +19,7 @@ Feature: Screener
     Then I should see "You’re eligible to apply online"
 
     And I click the "Continue" link
+    Then I should see "The court fee is £215"
     Then I should see "Before you start your application"
 
     And I click the "Start application" link

--- a/spec/helpers/fees_helper_spec.rb
+++ b/spec/helpers/fees_helper_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe FeesHelper, type: :helper do
+  describe '#fee_amount' do
+    it 'returns the localised version of the court fee' do
+      expect(helper.fee_amount).to eq('£215')
+    end
+  end
+end

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       allow(c100_application).to receive(:screener_answers_court).and_return(court)
 
       allow(I18n).to receive(:translate!).with(
-        'foobar_payment', scope: [:notify_submission_mailer, :payment_instructions]
+        'foobar_payment', scope: [:notify_submission_mailer, :payment_instructions], fee: '£215'
       ).and_return('payment instructions from locales')
     end
 

--- a/spec/services/c100_app/online_payments_spec.rb
+++ b/spec/services/c100_app/online_payments_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe C100App::OnlinePayments do
     let(:payload) do
       {
         amount: 215_00,
-        description: 'Court fee for lodging a C100 application',
+        description: 'Court fee for a child arrangements application (C100)',
         return_url: 'https://c100.justice.uk',
         reference: '1970/01/449362AF',
         email: 'applicant@test.com',


### PR DESCRIPTION
Description of the fee as per content designer suggestion but we might have to change it later on based on any HMCTS feedback.

Replaced the hardcoded instances of the `£215` fee with a helper.
