### PR TITLE
Amend some lists makup and styling

### DIFF
--- a/app/views/about/miam_exemptions.en.html.erb
+++ b/app/views/about/miam_exemptions.en.html.erb
@@ -86,17 +86,17 @@
       <div class="govuk-details__text">
         <ul class="govuk-list govuk-list--bullet">
           <li>a letter or report from an appropriate health professional confirming that:
-            <ul class="govuk-list govuk-list--bullet">
-              <li>(i) that professional, or another appropriate health professional, has examined a prospective party in person; and</li>
-              <li>(ii) in the reasonable professional judgment of the author or the examining appropriate health professional, that prospective party has, or has had, injuries or a condition consistent with being a victim of domestic violence</li>
-            </ul>
+            <ol class="govuk-list app-list--lower-roman">
+              <li>that professional, or another appropriate health professional, has examined a prospective party in person; and</li>
+              <li>in the reasonable professional judgment of the author or the examining appropriate health professional, that prospective party has, or has had, injuries or a condition consistent with being a victim of domestic violence</li>
+            </ol>
           </li>
           <li>a letter or report from:
-            <ul class="govuk-list govuk-list--bullet">
-              <li>(i) the appropriate health professional who made the referral described below</li>
-              <li>(ii) an appropriate health professional who has access to the medical records of the prospective party referred to below; or</li>
-              <li>(iii) the person to whom the referral described below was made</li>
-            </ul>
+            <ol class="govuk-list app-list--lower-roman">
+              <li>the appropriate health professional who made the referral described below</li>
+              <li>an appropriate health professional who has access to the medical records of the prospective party referred to below; or</li>
+              <li>the person to whom the referral described below was made</li>
+            </ol>
             <p class="govuk-body">confirming that there was a referral by an appropriate health professional of a prospective party to a person who provides specialist support or assistance for victims of, or those at risk of, domestic violence</p>
           </li>
         </ul>
@@ -118,11 +118,11 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>a letter from any person who is a member of a multi-agency risk assessment conference (or other suitable local safeguarding forum) confirming that a prospective party, or a person with whom that prospective party is in a family relationship, is or has been at risk of harm from domestic violence by another prospective party</li>
           <li>a letter from an officer employed by a local authority or housing association (or their equivalent in Scotland or Northern Ireland) for the purpose of supporting tenants containing:
-            <ul class="govuk-list govuk-list--bullet">
-              <li>(i) a statement to the effect that, in their reasonable professional judgment, a person with whom a prospective party is or has been in a family relationship is, or is at risk of being, a victim of domestic violence by that prospective party</li>
-              <li>(ii) a description of the specific matters relied upon to support that judgment; and</li>
-              <li>(iii) a description of the support they provided to the victim of domestic violence or the person at risk of domestic violence by that prospective party</li>
-            </ul>
+            <ol class="govuk-list app-list--lower-roman">
+              <li>a statement to the effect that, in their reasonable professional judgment, a person with whom a prospective party is or has been in a family relationship is, or is at risk of being, a victim of domestic violence by that prospective party</li>
+              <li>a description of the specific matters relied upon to support that judgment; and</li>
+              <li>a description of the support they provided to the victim of domestic violence or the person at risk of domestic violence by that prospective party</li>
+            </ol>
           </li>
           <li>a letter from a public authority confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party (or a copy of that assessment)</li>
         </ul>
@@ -146,31 +146,31 @@
           <li>a letter from an independent sexual violence advisor confirming that they are providing support to a prospective party relating to sexual violence by another prospective party</li>
           <li>
             a letter which:
-            <p class="govuk-body">
+            <p class="govuk-body govuk-!-margin-top-3">
               (i) is from an organisation providing domestic violence support services, or a registered charity, which letter confirms that it:
             </p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>(a) is situated in England and Wales</li>
-              <li>(b) has been operating for an uninterrupted period of six months or more; and</li>
-              <li>(c) provided a prospective party with support in relation to that person’s needs as a victim, or a person at risk, of domestic violence; and</li>
-            </ul>
+            <ol class="govuk-list app-list--lower-alpha">
+              <li>is situated in England and Wales</li>
+              <li>has been operating for an uninterrupted period of six months or more; and</li>
+              <li>provided a prospective party with support in relation to that person’s needs as a victim, or a person at risk, of domestic violence; and</li>
+            </ol>
             <p class="govuk-body">
-            (ii) contains:
+              (ii) contains:
             </p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>(a) a statement to the effect that, in the reasonable professional judgment of the author of the letter, the prospective party is, or is at risk of being, a victim of domestic violence</li>
-              <li>(b) a description of the specific matters relied upon to support that judgment</li>
-              <li>(c) a description of the support provided to the prospective party; and</li>
-              <li>(d) a statement of the reasons why the prospective party needed that support</li>
-            </ul>
+            <ol class="govuk-list app-list--lower-alpha">
+              <li>a statement to the effect that, in the reasonable professional judgment of the author of the letter, the prospective party is, or is at risk of being, a victim of domestic violence</li>
+              <li>a description of the specific matters relied upon to support that judgment</li>
+              <li>a description of the support provided to the prospective party; and</li>
+              <li>a statement of the reasons why the prospective party needed that support</li>
+            </ol>
           </li>
           <li>
             a letter or report from an organisation providing domestic violence support services in the UK confirming:
-            <ul class="govuk-list govuk-list--bullet">
-              <li>(i) that a person with whom a prospective party is or was in a family relationship was refused admission to a refuge</li>
-              <li>(ii) the date on which they were refused admission to the refuge; and</li>
-              <li>(iii) they sought admission to the refuge because of allegations of domestic violence by the prospective party referred to in paragraph (i)</li>
-            </ul>
+            <ol class="govuk-list app-list--lower-roman">
+              <li>that a person with whom a prospective party is or was in a family relationship was refused admission to a refuge</li>
+              <li>the date on which they were refused admission to the refuge; and</li>
+              <li>they sought admission to the refuge because of allegations of domestic violence by the prospective party referred to in paragraph (i)</li>
+            </ol>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Use more appropriate list styles for some of the lists in the MIAM exemptions page.

Before:
<img width="595" alt="Screen Shot 2020-06-24 at 11 08 21" src="https://user-images.githubusercontent.com/687910/85540910-6d230e00-b60f-11ea-8336-f4341ecc9c7e.png">

After:
<img width="590" alt="Screen Shot 2020-06-24 at 11 21 20" src="https://user-images.githubusercontent.com/687910/85540926-70b69500-b60f-11ea-8410-b65e65cf0421.png">
