### PR TITLE
Add a short grace period to the applications purge

### DIFF
--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -48,8 +48,15 @@ class C100Application < ApplicationRecord
   #
   validates_with ApplicationFulfilmentValidator, on: :completion
 
+  # There is a 20 minute grace period, in case an application is being updated
+  # by the time the purge kicks off. If so, will be purged in the next daily run.
+  #
   def self.purge!(date)
-    where('c100_applications.created_at <= :date', date: date).destroy_all
+    where(
+      'c100_applications.created_at <= :date', date: date
+    ).where(
+      'c100_applications.updated_at <= :date', date: 20.minutes.ago
+    ).destroy_all
   end
 
   def mark_as_completed!

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe C100Application, type: :model do
       described_class.purge!(28.days.ago)
     end
 
+    it 'picks records that have not been updated for the past 20 minutes' do
+      expect(described_class).to receive(:where).and_return(finder_double)
+
+      expect(finder_double).to receive(:where).with(
+        'c100_applications.updated_at <= :date', date: 20.minutes.ago
+      ).and_return(finder_double)
+
+      described_class.purge!(28.days.ago)
+    end
+
     it 'calls #destroy_all on the records it finds' do
       allow(described_class).to receive(:where).and_return(finder_double)
       expect(finder_double).to receive(:destroy_all)


### PR DESCRIPTION
There is a theoretical edge case scenario where an application older than 28 days (and thus, candidate to be purged in the automated daily maintenance task) is being updated by the user right at that very same moment.

Example: a user gets the "1 day left reminder" telling them their application is about to expire, and they decide to submit the application right before the purge kicks off over night.

This could cause the application record and data to be purged right when we need it to generate the PDF and submit the application.

Or perhaps the user just started the payment and was entering the payment details when their application was purged meaning when they are redirected back, there is no application.

Admittedly this is a very rare scenario but it is easy to protect from it by giving these applications a short grace period so we can see if they've been "touched/updated" short before the purge is due.