### PR TITLE
More copy changes related to online payments

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -29,11 +29,11 @@ module Summary
     end
 
     def before_submit_warning
-      ['.submit_warning', submission_type].join('.')
+      ['.submit_warning', locale_key_for_context].join('.')
     end
 
     def submit_button_label
-      ['submit_application', submission_type].join('.')
+      ['submit_application', locale_key_for_context].join('.')
     end
 
     private
@@ -95,8 +95,16 @@ module Summary
       ]
     end
 
-    def submission_type
-      c100_application.submission_type || SubmissionType::PRINT_AND_POST
+    def locale_key_for_context
+      if c100_application.online_submission?
+        if c100_application.online_payment?
+          :online_payment
+        else
+          :online
+        end
+      else
+        :print_and_post
+      end
     end
   end
 end

--- a/app/views/steps/application/check_your_answers/edit.html.erb
+++ b/app/views/steps/application/check_your_answers/edit.html.erb
@@ -43,7 +43,7 @@
       </div>
 
       <div class="govuk-inset-text">
-        <%=t @presenter.before_submit_warning %>
+        <%=t @presenter.before_submit_warning, fee: fee_amount %>
       </div>
 
       <%= f.continue_button(

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -616,11 +616,11 @@ en:
     payment_type:
       question: ''
       answers:
-        online: Online payment
+        online: Online
         help_with_fees: Help with fees
         solicitor: Through a solicitor’s fee account
-        self_payment_card: I am paying myself by credit or debit card
-        self_payment_cheque: I am paying myself by cheque or cash
+        self_payment_card: Over the phone
+        self_payment_cheque: By cheque or cash
     submission_type:
       question: ''
       answers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -729,6 +729,7 @@ en:
           false_information_warning: You could be fined or imprisoned for contempt of court if you deliberately submit false information, or cause false information to be submitted.
           submit_warning:
             online: Once you submit your application, you cannot make any further changes. You can download a copy of your submitted application on the next page.
+            online_payment: Once you submit your application, you cannot make any further changes. You will be able to download a copy of your application after you have paid the %{fee} court fee.
             print_and_post: Once you continue, you cannot make any further changes to your application. You can download a copy of your application on the next page.
         resume:
           page_title: Resume application
@@ -963,9 +964,9 @@ en:
         complete a C100 paper application form</a>, print it and send it by post.</p>
     payment_error:
       page_title: Payment error
-      heading: There was a problem with your payment
-      lead_text: It seems you attempted to make a payment but the payment did not complete.
-      more_text: No money has been taken from your account. You can retry the payment with the same or other card details, or choose a different payment method.
+      heading: Your payment was not completed
+      lead_text: No money has been taken from your account.
+      more_text: There are a few different reasons that payments fail. You can either try again or choose another way to pay.
 
   helpers:
     label:
@@ -1207,11 +1208,11 @@ en:
           other_assistance: Other assistance or facilities
       steps_application_payment_form:
         payment_type_options:
-          online: Online payment
-          help_with_fees: Help with fees
-          solicitor: Through a solicitor’s fee account
-          self_payment_card: I am paying myself by credit or debit card
-          self_payment_cheque: I am paying myself by cheque or cash
+          online: Pay online
+          help_with_fees: Pay with ‘Help with fees’
+          solicitor: Pay through a solicitor’s fee account
+          self_payment_card: Pay over the phone
+          self_payment_cheque: Pay by cheque or cash
         hwf_reference_number: Reference number
         solicitor_account_number: Solicitor’s fee account number
       steps_application_submission_form:
@@ -1378,11 +1379,11 @@ en:
       steps_application_payment_form:
         hwf_reference_number: 'This will be in the format: HWF-XXX-XXX'
         payment_type_options:
-          online: You will pay online securely using your credit or debit card. Copy TBD
+          online: You will pay online securely using your credit or debit card
           help_with_fees_html: |
             You may be able to <a href="https://www.gov.uk/get-help-with-court-fees" class="govuk-link" rel="external" target="_blank">get help paying</a> if you’re on a low income, receive certain benefits or have little or no savings. If you do qualify, you’ll need to provide your reference number
           solicitor: If you have a solicitor representing you, they may pay the court by direct debit. You’ll need to provide their ‘fee account number’
-          self_payment_card: Court staff will contact you within 3 working days to take payment over the phone
+          self_payment_card: Court staff will contact you within 3 working days to take payment
           self_payment_cheque: You can send a cheque or pay in person at the court
       steps_application_submission_form:
         receipt_email: You can also download a copy on the confirmation page.
@@ -1699,6 +1700,7 @@ en:
       confirm_and_finish: Confirm and finish
       submit_application:
         online: Submit application
+        online_payment: Pay and submit application
         print_and_post: Continue
 
   number:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -508,7 +508,7 @@ en:
         online: Online payment
         help_with_fees: Help with fees
         solicitor: Through solicitor
-        self_payment_card: Credit or debit card - contact the applicant within 3 working days of receiving application to take payment
+        self_payment_card: Over the phone - contact the applicant within 3 working days of receiving the application to take payment
         self_payment_cheque: Cheque or cash
     solicitor_account_number:
       question: Fee account number

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -5,40 +5,68 @@ describe Summary::HtmlPresenter do
   subject { described_class.new(c100_application) }
 
   describe '#before_submit_warning' do
-    let(:c100_application) { instance_double(C100Application, submission_type: submission_type) }
+    let(:c100_application) { C100Application.new(submission_type: submission_type, payment_type: payment_type) }
+    let(:submission_type) { nil }
+    let(:payment_type) { nil }
 
     context 'for online submissions' do
-      let(:submission_type) { 'online' }
-      it { expect(subject.before_submit_warning).to eq('.submit_warning.online') }
+      let(:submission_type) { SubmissionType::ONLINE }
+
+      context 'with online payment' do
+        let(:payment_type) { PaymentType::ONLINE }
+        it { expect(subject.before_submit_warning).to eq('.submit_warning.online_payment') }
+      end
+
+      context 'without online payment' do
+        let(:payment_type) { PaymentType::SELF_PAYMENT_CHEQUE }
+        it { expect(subject.before_submit_warning).to eq('.submit_warning.online') }
+      end
+
+      context 'defaults to `online` if `payment_type` is not present' do
+        it { expect(subject.before_submit_warning).to eq('.submit_warning.online') }
+      end
     end
 
     context 'for print and post submissions' do
-      let(:submission_type) { 'print_and_post' }
+      let(:submission_type) { SubmissionType::PRINT_AND_POST }
       it { expect(subject.before_submit_warning).to eq('.submit_warning.print_and_post') }
-    end
 
-    context 'defaults to print and post if `submission_type` is not present' do
-      let(:submission_type) { nil }
-      it { expect(subject.before_submit_warning).to eq('.submit_warning.print_and_post') }
+      context 'defaults to `print_and_post` if `submission_type` is not present' do
+        it { expect(subject.before_submit_warning).to eq('.submit_warning.print_and_post') }
+      end
     end
   end
 
   describe '#submit_button_label' do
-    let(:c100_application) { instance_double(C100Application, submission_type: submission_type) }
+    let(:c100_application) { C100Application.new(submission_type: submission_type, payment_type: payment_type) }
+    let(:submission_type) { nil }
+    let(:payment_type) { nil }
 
     context 'for online submissions' do
-      let(:submission_type) { 'online' }
-      it { expect(subject.submit_button_label).to eq('submit_application.online') }
+      let(:submission_type) { SubmissionType::ONLINE }
+
+      context 'with online payment' do
+        let(:payment_type) { PaymentType::ONLINE }
+        it { expect(subject.submit_button_label).to eq('submit_application.online_payment') }
+      end
+
+      context 'without online payment' do
+        let(:payment_type) { PaymentType::SELF_PAYMENT_CHEQUE }
+        it { expect(subject.submit_button_label).to eq('submit_application.online') }
+      end
+
+      context 'defaults to `online` if `payment_type` is not present' do
+        it { expect(subject.submit_button_label).to eq('submit_application.online') }
+      end
     end
 
     context 'for print and post submissions' do
-      let(:submission_type) { 'print_and_post' }
+      let(:submission_type) { SubmissionType::PRINT_AND_POST }
       it { expect(subject.submit_button_label).to eq('submit_application.print_and_post') }
-    end
 
-    context 'defaults to print and post if `submission_type` is not present' do
-      let(:submission_type) { nil }
-      it { expect(subject.submit_button_label).to eq('submit_application.print_and_post') }
+      context 'defaults to `print_and_post` if `submission_type` is not present' do
+        it { expect(subject.submit_button_label).to eq('submit_application.print_and_post') }
+      end
     end
   end
 


### PR DESCRIPTION
As per content designer suggestions.
Copy changes to the different payment methods, and the payment error page.

Also copy changes to the check your answers page, before submission:

**Print and post:**
<img width="974" alt="Screen Shot 2020-06-30 at 09 25 41" src="https://user-images.githubusercontent.com/687910/86102776-db564d80-bab3-11ea-91d1-f2fb1fc6d686.png">

**Submit electronically:**
<img width="978" alt="Screen Shot 2020-06-30 at 09 26 04" src="https://user-images.githubusercontent.com/687910/86102809-e7420f80-bab3-11ea-9a0b-73fe9612f0d1.png">

**Submit electronically and pay online:**
<img width="979" alt="Screen Shot 2020-06-30 at 09 38 29" src="https://user-images.githubusercontent.com/687910/86104426-f033e080-bab5-11ea-9b7e-24c845a314a6.png">

