### PR TITLE
Add online payment details to back office

### DIFF
--- a/app/controllers/backoffice/dashboard_controller.rb
+++ b/app/controllers/backoffice/dashboard_controller.rb
@@ -4,7 +4,9 @@ module Backoffice
 
     def index
       @form = Backoffice::LookupForm.new
-      @report = CompletedApplicationsAudit.unscoped.order(completed_at: :desc).limit(50)
+
+      @report = completed_report
+      @payments_report = payments_report
     end
 
     def lookup
@@ -25,6 +27,18 @@ module Backoffice
 
     def form_params
       params.require(:backoffice_lookup_form).permit(:reference_code)
+    end
+
+    def default_limit
+      50
+    end
+
+    def completed_report
+      CompletedApplicationsAudit.unscoped.order(completed_at: :desc).limit(default_limit)
+    end
+
+    def payments_report
+      PaymentIntent.order(created_at: :desc).limit(default_limit)
     end
   end
 end

--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -22,6 +22,7 @@ class AuditHelper
       payment_type: c100.payment_type,
       signee_capacity: c100.declaration_signee_capacity,
       arrangements: arrangements_metadata,
+      payment_details: payment_metadata,
     }
   end
   # rubocop:enable Metrics/AbcSize
@@ -47,5 +48,14 @@ class AuditHelper
       options << arrangement.special_arrangements
       options << arrangement.special_assistance
     end.flatten
+  end
+
+  def payment_metadata
+    return {} unless c100.online_payment?
+
+    {
+      gbs_code: c100.screener_answers_court.gbs,
+      payment_id: c100.payment_intent.payment_id,
+    }
   end
 end

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -1,7 +1,7 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell"><%= completion.completed_at %></td>
-  <td class="govuk-table__cell"><%= completion.reference_code %></td>
-  <td class="govuk-table__cell"><%= completion.submission_type || 'N/A' %></td>
+  <td class="govuk-table__cell"><%= completion.submission_type %></td>
+  <td class="govuk-table__cell"><%= completion.metadata['payment_type'] %></td>
   <td class="govuk-table__cell"><%= completion.court %></td>
 </tr>
 
@@ -22,14 +22,21 @@
                   <dd><%= completion.metadata['saved_for_later'] %></dd>
                   <dt>Any applicant under 18?</dt>
                   <dd><%= completion.metadata['under_age'] || false %></dd>
-                  <dt>Payment type</dt>
-                  <dd><%= completion.metadata['payment_type'] || 'N/A' %></dd>
                   <dt>Legal representation</dt>
                   <dd><%= completion.metadata['legal_representation'] || 'N/A' %></dd>
                   <dt>Urgent hearing</dt>
                   <dd><%= completion.metadata['urgent_hearing'] || 'N/A' %></dd>
                   <dt>Without notice hearing</dt>
                   <dd><%= completion.metadata['without_notice'] || 'N/A' %></dd>
+
+                  <% if completion.metadata['payment_details'].present? %>
+                    <dt>GBS code</dt>
+                    <dd><%= completion.metadata.dig('payment_details', 'gbs_code') %></dd>
+                    <dt>GOV.UK payment ID</dt>
+                    <dd><%= completion.metadata.dig('payment_details', 'payment_id') %></dd>
+                    <dt>GOV.UK payment reference</dt>
+                    <dd><%= completion.reference_code %></dd>
+                  <% end %>
                 </dl>
             </td>
             <td class="govuk-table__cell no-border">

--- a/app/views/backoffice/dashboard/_payment.en.html.erb
+++ b/app/views/backoffice/dashboard/_payment.en.html.erb
@@ -1,0 +1,6 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell govuk-!-width-one-quarter"><%= payment.created_at %></td>
+  <td class="govuk-table__cell govuk-!-width-one-quarter"><%= payment.updated_at %></td>
+  <td class="govuk-table__cell"><%= payment.c100_application_id.split('-').first %></td>
+  <td class="govuk-table__cell"><%= payment.state %></td>
+</tr>

--- a/app/views/backoffice/dashboard/_payments_table.en.html.erb
+++ b/app/views/backoffice/dashboard/_payments_table.en.html.erb
@@ -1,0 +1,20 @@
+<table class="backoffice-table govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Created at</th>
+      <th class="govuk-table__header">Updated at</th>
+      <th class="govuk-table__header">Parent</th>
+      <th class="govuk-table__header">Current state</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% if report.any? %>
+      <%= render partial: 'payment', collection: report, as: :payment %>
+    <% else %>
+      <tr class="govuk-table__row">
+        <td colspan="4" class="govuk-table__cell">No payments were found</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/backoffice/dashboard/_results_table.en.html.erb
+++ b/app/views/backoffice/dashboard/_results_table.en.html.erb
@@ -2,8 +2,8 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Completed at</th>
-      <th class="govuk-table__header">Reference</th>
-      <th class="govuk-table__header">Type</th>
+      <th class="govuk-table__header">Submission</th>
+      <th class="govuk-table__header">Payment</th>
       <th class="govuk-table__header">Court</th>
     </tr>
   </thead>

--- a/app/views/backoffice/dashboard/index.en.html.erb
+++ b/app/views/backoffice/dashboard/index.en.html.erb
@@ -6,8 +6,27 @@
 
     <%= render partial: 'lookup_form' %>
 
-    <h3 class="govuk-heading-m">Last 50 completed applications</h3>
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <h2 class="govuk-tabs__title">Lists</h2>
 
-    <%= render partial: 'results_table', locals: { report: @report } %>
+      <ul class="govuk-tabs__list">
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a class="govuk-tabs__tab" href="#recent-applications">Recent applications</a>
+        </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#recent-payments">Recent payments</a>
+        </li>
+      </ul>
+
+      <div class="govuk-tabs__panel" id="recent-applications">
+        <h3 class="govuk-heading-m">Last 50 completed applications</h3>
+        <%= render partial: 'results_table', locals: { report: @report } %>
+      </div>
+
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="recent-payments">
+        <h3 class="govuk-heading-m">Last 50 online payments</h3>
+        <%= render partial: 'payments_table', locals: { report: @payments_report } %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/backoffice/dashboard/lookup.en.html.erb
+++ b/app/views/backoffice/dashboard/lookup.en.html.erb
@@ -6,10 +6,6 @@
 
     <%= render partial: 'lookup_form' %>
 
-    <h3 class="govuk-heading-m">
-      Results
-    </h3>
-
     <%= render partial: 'results_table', locals: { report: @report } %>
   </div>
 </div>

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -8,21 +8,23 @@ describe AuditHelper do
       reduced_litigation_capacity: 'yes',
       urgent_hearing: 'no',
       without_notice: 'yes',
-      payment_type: 'cash',
       declaration_signee_capacity: 'applicant',
     )
   }
 
   let(:user_id) { nil }
-  let(:screener_answers_court) { instance_double(Court, name: 'Test Court') }
-  let(:screener_answers) { instance_double(ScreenerAnswers, children_postcodes: 'abcd 123') }
-
+  let(:payment_type) { 'cash' }
   let(:court_arrangement) { nil }
+
+  let(:screener_answers_court) { instance_double(Court, name: 'Test Court', gbs: 'X123') }
+  let(:screener_answers) { instance_double(ScreenerAnswers, children_postcodes: 'abcd 123') }
 
   subject { described_class.new(c100_application) }
 
   before do
     allow(c100_application).to receive(:user_id).and_return(user_id)
+    allow(c100_application).to receive(:payment_type).and_return(payment_type)
+
     allow(c100_application).to receive(:screener_answers).and_return(screener_answers)
     allow(c100_application).to receive(:screener_answers_court).and_return(screener_answers_court)
     allow(c100_application).to receive(:court_arrangement).and_return(court_arrangement)
@@ -46,10 +48,10 @@ describe AuditHelper do
         payment_type: 'cash',
         signee_capacity: 'applicant',
         arrangements: [],
+        payment_details: {},
       )
     end
 
-    # TODO we can cleanup this when all applications are using the new table
     context 'when we have court arrangements' do
       let(:court_arrangement) {
         CourtArrangement.new(
@@ -70,6 +72,19 @@ describe AuditHelper do
           protective_screens
           hearing_loop
         ))
+      end
+    end
+
+    context 'when payment is online' do
+      let(:payment_type) { 'online' }
+      let(:payment_intent) { instance_double(PaymentIntent, payment_id: 'foobar') }
+
+      it 'returns the expected information' do
+        expect(c100_application).to receive(:payment_intent).and_return(payment_intent)
+
+        expect(
+          subject.metadata[:payment_details]
+        ).to eq({ gbs_code: 'X123', payment_id: 'foobar' })
       end
     end
 


### PR DESCRIPTION
Added the gbs code and the payment ID to the audit table when an application is completed, if paid online.

Exposed this information in the back office as might be helpful to diagnose problems in the future.

Also added a payments report table, mainly for debug purposes.

<img width="283" alt="Screen Shot 2020-07-01 at 12 26 37" src="https://user-images.githubusercontent.com/687910/86238840-25affb00-bb96-11ea-92a4-b68552f5ec09.png">


<img width="1015" alt="Screen Shot 2020-07-01 at 12 27 07" src="https://user-images.githubusercontent.com/687910/86238865-36f90780-bb96-11ea-9f0d-d7ed79ddab7a.png">

