### PR TITLE
Styling tweaks to the payments table

### DIFF
--- a/app/assets/stylesheets/local/backoffice.scss
+++ b/app/assets/stylesheets/local/backoffice.scss
@@ -25,3 +25,23 @@ div.backoffice-extra-details {
     font-size: 1rem;
   }
 }
+
+// Used to tag with colors the different payment statuses
+.app-tag--created,
+.app-tag--started {
+  @extend .govuk-tag--grey;
+}
+
+.app-tag--submitted {
+  @extend .govuk-tag--yellow;
+}
+
+.app-tag--success {
+  @extend .govuk-tag--green;
+}
+
+.app-tag--failed,
+.app-tag--cancelled,
+.app-tag--error {
+  @extend .govuk-tag--red;
+}

--- a/app/views/backoffice/audit/_record.en.html.erb
+++ b/app/views/backoffice/audit/_record.en.html.erb
@@ -6,7 +6,7 @@
 
 <% if record.details.present? %>
   <tr class="govuk-table__row">
-    <td class="govuk-table__cell xsmall no-border" colspan="3">
+    <td class="govuk-table__cell no-border" colspan="3">
       <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">

--- a/app/views/backoffice/dashboard/_payment.en.html.erb
+++ b/app/views/backoffice/dashboard/_payment.en.html.erb
@@ -1,6 +1,14 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell govuk-!-width-one-quarter"><%= payment.created_at %></td>
   <td class="govuk-table__cell govuk-!-width-one-quarter"><%= payment.updated_at %></td>
-  <td class="govuk-table__cell"><%= payment.c100_application_id.split('-').first %></td>
-  <td class="govuk-table__cell"><%= payment.state %></td>
+  <td class="govuk-table__cell">
+    <strong class="govuk-tag app-tag--<%= payment.state['status'] %>">
+      <%= payment.state['status'] %>
+    </strong>
+  </td>
+  <td class="govuk-table__cell">
+    <% if payment.state.key?('code') %>
+      <%= payment.state.slice('code', 'message') %> <em class="app-util--disabled-color">#<%= payment.c100_application_id.split('-').first %></em>
+    <% end %>
+  </td>
 </tr>

--- a/app/views/backoffice/dashboard/_payments_table.en.html.erb
+++ b/app/views/backoffice/dashboard/_payments_table.en.html.erb
@@ -3,8 +3,8 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Created at</th>
       <th class="govuk-table__header">Updated at</th>
-      <th class="govuk-table__header">Parent</th>
-      <th class="govuk-table__header">Current state</th>
+      <th class="govuk-table__header">Status</th>
+      <th class="govuk-table__header">Error details</th>
     </tr>
   </thead>
 


### PR DESCRIPTION
Make it a bit nicer with coloured tags and only add extra details if they are interesting (on failures), not on success.

<img width="1016" alt="Screen Shot 2020-07-01 at 15 38 43" src="https://user-images.githubusercontent.com/687910/86257513-8dc00a80-bbb1-11ea-8220-3db3ef0434a4.png">
