### PR TITLE
Bump Sidekiq to 6.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ gem 'govuk_design_system_formbuilder', '~> 1.2.3'
 gem 'govuk_notify_rails', '~> 2.1.0'
 gem 'govuk-pay-ruby-client', github: 'ministryofjustice/govuk-pay-ruby-client'
 gem 'jquery-rails'
-gem 'omniauth-auth0', '~> 2.2'
-gem 'omniauth-rails_csrf_protection'
 gem 'pg', '~> 1.1'
 gem 'puma'
 gem 'rails', '~> 5.2.4'
@@ -20,6 +18,10 @@ gem 'sentry-raven', '~> 3.0'
 gem 'uglifier'
 gem 'uk_postcode'
 gem 'virtus'
+
+# Back office
+gem 'omniauth-auth0', '~> 2.2'
+gem 'omniauth-rails_csrf_protection'
 
 # Caching and jobs processing
 gem 'redis'
@@ -59,7 +61,6 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec_junit_formatter'
   gem 'rubocop', '~> 0.52.1', require: false
-  gem 'rubocop-rspec', require: false
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
   gem 'simplecov-rcov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    diff-lcs (1.4.2)
+    diff-lcs (1.4.4)
     docile (1.3.2)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
@@ -261,8 +261,6 @@ GEM
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
-    rack-protection (2.0.8.1)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.3)
@@ -331,8 +329,6 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.23.0)
-      rubocop (>= 0.52.1)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     rubyzip (2.3.0)
@@ -353,11 +349,10 @@ GEM
       rubyzip (>= 1.2.2)
     sentry-raven (3.0.0)
       faraday (>= 1.0)
-    sidekiq (6.0.7)
+    sidekiq (6.1.0)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+      redis (>= 4.2.0)
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -449,7 +444,6 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop (~> 0.52.1)
-  rubocop-rspec
   sass-rails (< 6.0.0)
   selenium-webdriver
   sentry-raven (~> 3.0)


### PR DESCRIPTION
This will get rid of a very annoying deprecation warning in the logs as a consequence of a recent redis change:

```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, 
you should use it instead.
```

Removed `rubocop-rspec` gem because it is not actually in use.