### PR TITLE
Better handling of errors when creating payment

### DIFF
--- a/spec/services/c100_app/payments_flow_control_spec.rb
+++ b/spec/services/c100_app/payments_flow_control_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe C100App::PaymentsFlowControl do
           subject.payment_url
         }.to raise_error(Errors::PaymentUnexpectedError).with_message('boom!')
       end
+
+      it 'reverts the application status to `in_progress`' do
+        expect(c100_application).to receive(:payment_in_progress!).ordered
+        expect(c100_application).to receive(:in_progress!).ordered
+
+        expect { subject.payment_url }.to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
If the creation of the payment failes for whatever reason (maybe a connection timeout, or some weird argument is passed to the API) we don't want to be left with the `payment_in_progress` status, as it is pointless.

Revert back to `in_progress` (as the user is shown an error message) so they can retry payment or change method.

Move all the status-related "movements" to an explicit method to be easier to maintain and read.