### PR TITLE
Add form builder (gem) markup smoke tests

### DIFF
--- a/app/lib/markup_normaliser.rb
+++ b/app/lib/markup_normaliser.rb
@@ -1,0 +1,35 @@
+class MarkupNormaliser
+  attr_reader :markup1, :markup2
+
+  def initialize(markup1, markup2)
+    @markup1 = markup1
+    @markup2 = markup2
+
+    normalise!
+  end
+
+  private
+
+  def normalise!
+    @markup1 = remove_blank_children(
+      Nokogiri::HTML.fragment(markup1)
+    ).to_html
+
+    @markup2 = remove_blank_children(
+      Nokogiri::HTML.fragment(markup2)
+    ).to_html
+  end
+
+  def remove_blank_children(element)
+    element.children.each do |child|
+      if child.children.any?
+        remove_blank_children(child)
+      elsif child.blank?
+        # Remove empty elements, like `#(Text "\n  ")`
+        child.remove
+      end
+    end
+
+    element
+  end
+end

--- a/features/fixtures/README.md
+++ b/features/fixtures/README.md
@@ -1,0 +1,21 @@
+# Markup fixtures
+
+This directory contains HTML fixtures to be used in [markup_smoke_tests.feature](/features/markup_smoke_tests.feature)
+
+The idea is to have a sample of a few representative pages in the service containing form elements that are built using 
+the gem [govuk_design_system_formbuilder](https://github.com/DFE-Digital/govuk_design_system_formbuilder) so we are more 
+confident when upgrading to new versions of the gem and we can detect regressions and bugs in the markup, that otherwise 
+would be difficult to catch.
+
+These pages should be a mixture of simple text inputs, radios, checkboxes and some more elaborated form elements.
+
+To add more fixtures, first render the page in a browser, as a user would see it.  
+Then, inspect the HTML markup of the page and look inside the `<form>` tag for one or more `<div class="govuk-form-group">...</div>` 
+and paste that exact markup (including the div containers) into a new fixture file.  
+If there are more than one `<div>` copy all of them one after another as they appear in the page.
+
+Then edit the cucumber scenario to add a new path and corresponding fixture. Make sure the test passes, and if not, check 
+the fixture for any **unnecessary break lines**, in particular in the **localised copy**.
+
+Repeat these steps, but generating a validation error on the page, so you can create a fixture of the markup containing 
+errors. Not all pages produce errors so choose the ones that do.

--- a/features/fixtures/files/child_protection_cases.html
+++ b/features/fixtures/files/child_protection_cases.html
@@ -1,0 +1,18 @@
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl"><h1 class="govuk-fieldset__heading">Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?</h1></legend>
+    <span class="govuk-hint" id="steps-miam-child-protection-cases-form-child-protection-cases-hint">These will often involve a local authority</span>
+    <div class="govuk-radios" data-module="govuk-radios">
+      <div class="govuk-radios__item"><input
+          id="steps-miam-child-protection-cases-form-child-protection-cases-yes-field" class="govuk-radios__input"
+          type="radio" value="yes" name="steps_miam_child_protection_cases_form[child_protection_cases]"><label
+          for="steps-miam-child-protection-cases-form-child-protection-cases-yes-field"
+          class="govuk-label govuk-radios__label">Yes</label></div>
+      <div class="govuk-radios__item"><input id="steps-miam-child-protection-cases-form-child-protection-cases-no-field"
+                                             class="govuk-radios__input" type="radio" value="no"
+                                             name="steps_miam_child_protection_cases_form[child_protection_cases]"><label
+          for="steps-miam-child-protection-cases-form-child-protection-cases-no-field"
+          class="govuk-label govuk-radios__label">No</label></div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/child_protection_cases_with_errors.html
+++ b/features/fixtures/files/child_protection_cases_with_errors.html
@@ -1,0 +1,21 @@
+<div class="govuk-form-group govuk-form-group--error">
+  <fieldset class="govuk-fieldset"
+            aria-describedby="steps-miam-child-protection-cases-form-child-protection-cases-error">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl"><h1 class="govuk-fieldset__heading">Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?</h1></legend>
+    <span class="govuk-hint" id="steps-miam-child-protection-cases-form-child-protection-cases-hint">These will often involve a local authority</span><span
+      class="govuk-error-message" id="steps-miam-child-protection-cases-form-child-protection-cases-error"><span
+      class="govuk-visually-hidden">Error: </span>Select yes or no</span>
+    <div class="govuk-radios" data-module="govuk-radios">
+      <div class="govuk-radios__item"><input
+          id="steps-miam-child-protection-cases-form-child-protection-cases-field-error" class="govuk-radios__input"
+          type="radio" value="yes" name="steps_miam_child_protection_cases_form[child_protection_cases]"><label
+          for="steps-miam-child-protection-cases-form-child-protection-cases-field-error"
+          class="govuk-label govuk-radios__label">Yes</label></div>
+      <div class="govuk-radios__item"><input id="steps-miam-child-protection-cases-form-child-protection-cases-no-field"
+                                             class="govuk-radios__input" type="radio" value="no"
+                                             name="steps_miam_child_protection_cases_form[child_protection_cases]"><label
+          for="steps-miam-child-protection-cases-form-child-protection-cases-no-field"
+          class="govuk-label govuk-radios__label">No</label></div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/miam_acknowledgement.html
+++ b/features/fixtures/files/miam_acknowledgement.html
@@ -1,0 +1,12 @@
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s"><span class="govuk-fieldset__heading">Attending a MIAM</span></legend>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item"><input id="steps-miam-acknowledgement-form-miam-acknowledgement-true-field"
+                                                 class="govuk-checkboxes__input" type="checkbox" value="true"
+                                                 name="steps_miam_acknowledgement_form[miam_acknowledgement]"><label
+          for="steps-miam-acknowledgement-form-miam-acknowledgement-true-field"
+          class="govuk-label govuk-checkboxes__label">I understand that I have to attend a MIAM or provide a valid reason for not attending.</label></div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/miam_acknowledgement_with_errors.html
+++ b/features/fixtures/files/miam_acknowledgement_with_errors.html
@@ -1,0 +1,14 @@
+<div class="govuk-form-group govuk-form-group--error">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-miam-acknowledgement-form-miam-acknowledgement-error">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s"><span class="govuk-fieldset__heading">Attending a MIAM</span></legend>
+    <span class="govuk-error-message" id="steps-miam-acknowledgement-form-miam-acknowledgement-error"><span
+        class="govuk-visually-hidden">Error: </span>Confirm you understand MIAM attendance requirements</span>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item"><input id="steps-miam-acknowledgement-form-miam-acknowledgement-field-error"
+                                                 class="govuk-checkboxes__input" type="checkbox" value="true"
+                                                 name="steps_miam_acknowledgement_form[miam_acknowledgement]"><label
+          for="steps-miam-acknowledgement-form-miam-acknowledgement-field-error"
+          class="govuk-label govuk-checkboxes__label">I understand that I have to attend a MIAM or provide a valid reason for not attending.</label></div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/miam_certification_date.html
+++ b/features/fixtures/files/miam_certification_date.html
@@ -1,0 +1,37 @@
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset"
+            aria-describedby="steps-miam-certification-date-form-miam-certification-date-supplemental">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl"><h1 class="govuk-fieldset__heading">When did you attend the MIAM?</h1></legend>
+    <div id="steps-miam-certification-date-form-miam-certification-date-supplemental">
+      <p class="govuk-body">You can find the date at the bottom of the document your mediator signed.</p>
+    </div>
+    <span class="govuk-hint"
+          id="steps-miam-certification-date-form-miam-certification-date-hint">For example, 31 3 2020</span>
+    <div class="govuk-date-input">
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label"
+                                             for="steps_miam_certification_date_form_miam_certification_date_3i">Day</label><input
+            id="steps_miam_certification_date_form_miam_certification_date_3i"
+            class="govuk-input govuk-date-input__input govuk-input--width-2"
+            name="steps_miam_certification_date_form[miam_certification_date(3i)]" type="text" pattern="[0-9]*"
+            inputmode="numeric"></div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label"
+                                             for="steps_miam_certification_date_form_miam_certification_date_2i">Month</label><input
+            id="steps_miam_certification_date_form_miam_certification_date_2i"
+            class="govuk-input govuk-date-input__input govuk-input--width-2"
+            name="steps_miam_certification_date_form[miam_certification_date(2i)]" type="text" pattern="[0-9]*"
+            inputmode="numeric"></div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label"
+                                             for="steps_miam_certification_date_form_miam_certification_date_1i">Year</label><input
+            id="steps_miam_certification_date_form_miam_certification_date_1i"
+            class="govuk-input govuk-date-input__input govuk-input--width-4"
+            name="steps_miam_certification_date_form[miam_certification_date(1i)]" type="text" pattern="[0-9]*"
+            inputmode="numeric"></div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/miam_certification_date_with_errors.html
+++ b/features/fixtures/files/miam_certification_date_with_errors.html
@@ -1,0 +1,39 @@
+<div class="govuk-form-group govuk-form-group--error">
+  <fieldset class="govuk-fieldset"
+            aria-describedby="steps-miam-certification-date-form-miam-certification-date-error steps-miam-certification-date-form-miam-certification-date-supplemental">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl"><h1 class="govuk-fieldset__heading">When did you attend the MIAM?</h1></legend>
+    <div id="steps-miam-certification-date-form-miam-certification-date-supplemental">
+      <p class="govuk-body">You can find the date at the bottom of the document your mediator signed.</p>
+    </div>
+    <span class="govuk-hint"
+          id="steps-miam-certification-date-form-miam-certification-date-hint">For example, 31 3 2020</span><span
+      class="govuk-error-message" id="steps-miam-certification-date-form-miam-certification-date-error"><span
+      class="govuk-visually-hidden">Error: </span>Enter the date you attended a MIAM</span>
+    <div class="govuk-date-input">
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label"
+                                             for="steps-miam-certification-date-form-miam-certification-date-field-error">Day</label><input
+            id="steps-miam-certification-date-form-miam-certification-date-field-error"
+            class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error"
+            name="steps_miam_certification_date_form[miam_certification_date(3i)]" type="text" pattern="[0-9]*"
+            inputmode="numeric"></div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label"
+                                             for="steps_miam_certification_date_form_miam_certification_date_2i">Month</label><input
+            id="steps_miam_certification_date_form_miam_certification_date_2i"
+            class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error"
+            name="steps_miam_certification_date_form[miam_certification_date(2i)]" type="text" pattern="[0-9]*"
+            inputmode="numeric"></div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label"
+                                             for="steps_miam_certification_date_form_miam_certification_date_1i">Year</label><input
+            id="steps_miam_certification_date_form_miam_certification_date_1i"
+            class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error"
+            name="steps_miam_certification_date_form[miam_certification_date(1i)]" type="text" pattern="[0-9]*"
+            inputmode="numeric"></div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/nature_of_application.html
+++ b/features/fixtures/files/nature_of_application.html
@@ -1,0 +1,157 @@
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-petition-orders-form-orders-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl"><h1 class="govuk-fieldset__heading">What are you asking the court to decide about the children involved?</h1></legend>
+    <span class="govuk-hint" id="steps-petition-orders-form-orders-hint">Select all that apply</span>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-child-arrangements-home-field"
+                                                 class="govuk-checkboxes__input" type="checkbox"
+                                                 value="child_arrangements_home"
+                                                 name="steps_petition_orders_form[orders][]"><label
+          for="steps-petition-orders-form-orders-child-arrangements-home-field"
+          class="govuk-label govuk-checkboxes__label">Decide who they live with and when</label></div>
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-child-arrangements-time-field"
+                                                 class="govuk-checkboxes__input" type="checkbox"
+                                                 value="child_arrangements_time"
+                                                 name="steps_petition_orders_form[orders][]"><label
+          for="steps-petition-orders-form-orders-child-arrangements-time-field"
+          class="govuk-label govuk-checkboxes__label">Decide how much time they spend with each person</label></div>
+
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-group-prohibited-steps-field"
+                                                 class="govuk-checkboxes__input" type="checkbox"
+                                                 value="group_prohibited_steps"
+                                                 name="steps_petition_orders_form[orders][]"
+                                                 aria-controls="steps-petition-orders-form-orders-group-prohibited-steps-conditional"
+                                                 aria-expanded="false"><label
+          for="steps-petition-orders-form-orders-group-prohibited-steps-field"
+          class="govuk-label govuk-checkboxes__label">Stop the other person doing something</label><span
+          class="govuk-hint govuk-checkboxes__hint" id="steps-petition-orders-form-orders-group-prohibited-steps-hint">For example, moving abroad or abducting the children</span>
+      </div>
+      <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+           id="steps-petition-orders-form-orders-group-prohibited-steps-conditional">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes"><input type="hidden"
+                                                                                name="steps_petition_orders_form[orders_collection][]"
+                                                                                value="">
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-names-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_names"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-names-field"
+                  class="govuk-label govuk-checkboxes__label">Changing their names or surname</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-medical-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_medical"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-medical-field"
+                  class="govuk-label govuk-checkboxes__label">Allowing medical treatment to be carried out on them</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-holiday-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_holiday"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-holiday-field"
+                  class="govuk-label govuk-checkboxes__label">Taking them on holiday</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-moving-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_moving"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-moving-field"
+                  class="govuk-label govuk-checkboxes__label">Relocating the children to a different area in England and Wales</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-moving-abroad-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_moving_abroad"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-moving-abroad-field"
+                  class="govuk-label govuk-checkboxes__label">Relocating the children outside of England and Wales (including Scotland and Northern Ireland)</label></div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-group-specific-issues-field"
+                                                 class="govuk-checkboxes__input" type="checkbox"
+                                                 value="group_specific_issues"
+                                                 name="steps_petition_orders_form[orders][]"
+                                                 aria-controls="steps-petition-orders-form-orders-group-specific-issues-conditional"
+                                                 aria-expanded="false"><label
+          for="steps-petition-orders-form-orders-group-specific-issues-field"
+          class="govuk-label govuk-checkboxes__label">Resolve a specific issue</label><span
+          class="govuk-hint govuk-checkboxes__hint" id="steps-petition-orders-form-orders-group-specific-issues-hint">For example, what school they’ll go to</span>
+      </div>
+      <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+           id="steps-petition-orders-form-orders-group-specific-issues-conditional">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes"><input type="hidden"
+                                                                                name="steps_petition_orders_form[orders_collection][]"
+                                                                                value="">
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-holiday-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_holiday"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-holiday-field"
+                  class="govuk-label govuk-checkboxes__label">A specific holiday or arrangement</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-school-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_school"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-school-field"
+                  class="govuk-label govuk-checkboxes__label">What school they’ll go to</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-religion-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_religion"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-religion-field"
+                  class="govuk-label govuk-checkboxes__label">A religious issue</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-names-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_names"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-names-field"
+                  class="govuk-label govuk-checkboxes__label">Changing their names or surname</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-medical-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_medical"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-medical-field"
+                  class="govuk-label govuk-checkboxes__label">Medical treatment</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-moving-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_moving"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-moving-field"
+                  class="govuk-label govuk-checkboxes__label">Relocating the children to a different area in England and Wales</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-moving-abroad-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_moving_abroad"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-moving-abroad-field"
+                  class="govuk-label govuk-checkboxes__label">Relocating the children outside of England and Wales (including Scotland and Northern Ireland)</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-child-return-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_child_return"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-child-return-field"
+                  class="govuk-label govuk-checkboxes__label">Returning the children to your care</label><span
+                  class="govuk-hint govuk-checkboxes__hint"
+                  id="steps-petition-orders-form-orders-collection-specific-issues-child-return-hint">If the children have been abducted, unlawfully removed or unlawfully retained</span>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-other-issue-field"
+                                                 class="govuk-checkboxes__input" type="checkbox" value="other_issue"
+                                                 name="steps_petition_orders_form[orders][]"
+                                                 aria-controls="steps-petition-orders-form-orders-other-issue-conditional"
+                                                 aria-expanded="false"><label
+          for="steps-petition-orders-form-orders-other-issue-field" class="govuk-label govuk-checkboxes__label">Deal with another issue not listed</label></div>
+      <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+           id="steps-petition-orders-form-orders-other-issue-conditional">
+        <div class="govuk-form-group"><label for="steps-petition-orders-form-orders-additional-details-field"
+                                             class="govuk-label">Briefly provide more details</label><textarea
+            id="steps-petition-orders-form-orders-additional-details-field" class="govuk-textarea" rows="5"
+            name="steps_petition_orders_form[orders_additional_details]"></textarea></div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/nature_of_application_with_errors.html
+++ b/features/fixtures/files/nature_of_application_with_errors.html
@@ -1,0 +1,158 @@
+<div class="govuk-form-group govuk-form-group--error">
+  <fieldset class="govuk-fieldset"
+            aria-describedby="steps-petition-orders-form-orders-error steps-petition-orders-form-orders-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl"><h1 class="govuk-fieldset__heading">What are you asking the court to decide about the children involved?</h1></legend>
+    <span class="govuk-hint" id="steps-petition-orders-form-orders-hint">Select all that apply</span><span
+      class="govuk-error-message" id="steps-petition-orders-form-orders-error"><span class="govuk-visually-hidden">Error: </span>Select what you’re asking the court to decide</span>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-field-error"
+                                                 class="govuk-checkboxes__input" type="checkbox"
+                                                 value="child_arrangements_home"
+                                                 name="steps_petition_orders_form[orders][]"><label
+          for="steps-petition-orders-form-orders-field-error" class="govuk-label govuk-checkboxes__label">Decide who they live with and when</label></div>
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-child-arrangements-time-field"
+                                                 class="govuk-checkboxes__input" type="checkbox"
+                                                 value="child_arrangements_time"
+                                                 name="steps_petition_orders_form[orders][]"><label
+          for="steps-petition-orders-form-orders-child-arrangements-time-field"
+          class="govuk-label govuk-checkboxes__label">Decide how much time they spend with each person</label></div>
+
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-group-prohibited-steps-field"
+                                                 class="govuk-checkboxes__input" type="checkbox"
+                                                 value="group_prohibited_steps"
+                                                 name="steps_petition_orders_form[orders][]"
+                                                 aria-controls="steps-petition-orders-form-orders-group-prohibited-steps-conditional"
+                                                 aria-expanded="false"><label
+          for="steps-petition-orders-form-orders-group-prohibited-steps-field"
+          class="govuk-label govuk-checkboxes__label">Stop the other person doing something</label><span
+          class="govuk-hint govuk-checkboxes__hint" id="steps-petition-orders-form-orders-group-prohibited-steps-hint">For example, moving abroad or abducting the children</span>
+      </div>
+      <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+           id="steps-petition-orders-form-orders-group-prohibited-steps-conditional">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes"><input type="hidden"
+                                                                                name="steps_petition_orders_form[orders_collection][]"
+                                                                                value="">
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-names-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_names"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-names-field"
+                  class="govuk-label govuk-checkboxes__label">Changing their names or surname</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-medical-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_medical"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-medical-field"
+                  class="govuk-label govuk-checkboxes__label">Allowing medical treatment to be carried out on them</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-holiday-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_holiday"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-holiday-field"
+                  class="govuk-label govuk-checkboxes__label">Taking them on holiday</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-moving-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_moving"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-moving-field"
+                  class="govuk-label govuk-checkboxes__label">Relocating the children to a different area in England and Wales</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-prohibited-steps-moving-abroad-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="prohibited_steps_moving_abroad"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-prohibited-steps-moving-abroad-field"
+                  class="govuk-label govuk-checkboxes__label">Relocating the children outside of England and Wales (including Scotland and Northern Ireland)</label></div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-group-specific-issues-field"
+                                                 class="govuk-checkboxes__input" type="checkbox"
+                                                 value="group_specific_issues"
+                                                 name="steps_petition_orders_form[orders][]"
+                                                 aria-controls="steps-petition-orders-form-orders-group-specific-issues-conditional"
+                                                 aria-expanded="false"><label
+          for="steps-petition-orders-form-orders-group-specific-issues-field"
+          class="govuk-label govuk-checkboxes__label">Resolve a specific issue</label><span
+          class="govuk-hint govuk-checkboxes__hint" id="steps-petition-orders-form-orders-group-specific-issues-hint">For example, what school they’ll go to</span>
+      </div>
+      <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+           id="steps-petition-orders-form-orders-group-specific-issues-conditional">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes"><input type="hidden"
+                                                                                name="steps_petition_orders_form[orders_collection][]"
+                                                                                value="">
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-holiday-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_holiday"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-holiday-field"
+                  class="govuk-label govuk-checkboxes__label">A specific holiday or arrangement</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-school-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_school"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-school-field"
+                  class="govuk-label govuk-checkboxes__label">What school they’ll go to</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-religion-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_religion"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-religion-field"
+                  class="govuk-label govuk-checkboxes__label">A religious issue</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-names-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_names"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-names-field"
+                  class="govuk-label govuk-checkboxes__label">Changing their names or surname</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-medical-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_medical"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-medical-field"
+                  class="govuk-label govuk-checkboxes__label">Medical treatment</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-moving-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_moving"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-moving-field"
+                  class="govuk-label govuk-checkboxes__label">Relocating the children to a different area in England and Wales</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-moving-abroad-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_moving_abroad"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-moving-abroad-field"
+                  class="govuk-label govuk-checkboxes__label">Relocating the children outside of England and Wales (including Scotland and Northern Ireland)</label></div>
+              <div class="govuk-checkboxes__item"><input
+                  id="steps-petition-orders-form-orders-collection-specific-issues-child-return-field"
+                  class="govuk-checkboxes__input" type="checkbox" value="specific_issues_child_return"
+                  name="steps_petition_orders_form[orders_collection][]"><label
+                  for="steps-petition-orders-form-orders-collection-specific-issues-child-return-field"
+                  class="govuk-label govuk-checkboxes__label">Returning the children to your care</label><span
+                  class="govuk-hint govuk-checkboxes__hint"
+                  id="steps-petition-orders-form-orders-collection-specific-issues-child-return-hint">If the children have been abducted, unlawfully removed or unlawfully retained</span>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-other-issue-field"
+                                                 class="govuk-checkboxes__input" type="checkbox" value="other_issue"
+                                                 name="steps_petition_orders_form[orders][]"
+                                                 aria-controls="steps-petition-orders-form-orders-other-issue-conditional"
+                                                 aria-expanded="false"><label
+          for="steps-petition-orders-form-orders-other-issue-field" class="govuk-label govuk-checkboxes__label">Deal with another issue not listed</label></div>
+      <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+           id="steps-petition-orders-form-orders-other-issue-conditional">
+        <div class="govuk-form-group"><label for="steps-petition-orders-form-orders-additional-details-field"
+                                             class="govuk-label">Briefly provide more details</label><textarea
+            id="steps-petition-orders-form-orders-additional-details-field" class="govuk-textarea" rows="5"
+            name="steps_petition_orders_form[orders_additional_details]"></textarea></div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/order_jurisdiction.html
+++ b/features/fixtures/files/order_jurisdiction.html
@@ -1,0 +1,28 @@
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset"
+            aria-describedby="steps-international-jurisdiction-form-international-jurisdiction-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl"><h1 class="govuk-fieldset__heading">Do you think another person in this application may be able to apply for a similar order in a country outside England or Wales?</h1></legend>
+    <span class="govuk-hint" id="steps-international-jurisdiction-form-international-jurisdiction-hint">For example, because a court in another country has the power to act (has jurisdiction).</span>
+    <div class="govuk-radios" data-module="govuk-radios">
+      <div class="govuk-radios__item"><input
+          id="steps-international-jurisdiction-form-international-jurisdiction-yes-field" class="govuk-radios__input"
+          type="radio" value="yes" name="steps_international_jurisdiction_form[international_jurisdiction]"
+          aria-controls="steps-international-jurisdiction-form-international-jurisdiction-yes-conditional"
+          aria-expanded="false"><label for="steps-international-jurisdiction-form-international-jurisdiction-yes-field"
+                                       class="govuk-label govuk-radios__label">Yes</label></div>
+      <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+           id="steps-international-jurisdiction-form-international-jurisdiction-yes-conditional">
+        <div class="govuk-form-group"><label
+            for="steps-international-jurisdiction-form-international-jurisdiction-details-field" class="govuk-label">Provide details</label><textarea id="steps-international-jurisdiction-form-international-jurisdiction-details-field"
+                                   class="govuk-textarea" rows="5"
+                                   name="steps_international_jurisdiction_form[international_jurisdiction_details]"></textarea>
+        </div>
+      </div>
+      <div class="govuk-radios__item"><input
+          id="steps-international-jurisdiction-form-international-jurisdiction-no-field" class="govuk-radios__input"
+          type="radio" value="no" name="steps_international_jurisdiction_form[international_jurisdiction]"><label
+          for="steps-international-jurisdiction-form-international-jurisdiction-no-field"
+          class="govuk-label govuk-radios__label">No</label></div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/order_jurisdiction_with_errors.html
+++ b/features/fixtures/files/order_jurisdiction_with_errors.html
@@ -1,0 +1,31 @@
+<div class="govuk-form-group govuk-form-group--error">
+  <fieldset class="govuk-fieldset"
+            aria-describedby="steps-international-jurisdiction-form-international-jurisdiction-error steps-international-jurisdiction-form-international-jurisdiction-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl"><h1 class="govuk-fieldset__heading">Do you think another person in this application may be able to apply for a similar order in a country outside England or Wales?</h1></legend>
+    <span class="govuk-hint" id="steps-international-jurisdiction-form-international-jurisdiction-hint">For example, because a court in another country has the power to act (has jurisdiction).</span><span
+      class="govuk-error-message" id="steps-international-jurisdiction-form-international-jurisdiction-error"><span
+      class="govuk-visually-hidden">Error: </span>Select yes or no</span>
+    <div class="govuk-radios" data-module="govuk-radios">
+      <div class="govuk-radios__item"><input
+          id="steps-international-jurisdiction-form-international-jurisdiction-field-error" class="govuk-radios__input"
+          type="radio" value="yes" name="steps_international_jurisdiction_form[international_jurisdiction]"
+          aria-controls="steps-international-jurisdiction-form-international-jurisdiction-yes-conditional"
+          aria-expanded="false"><label
+          for="steps-international-jurisdiction-form-international-jurisdiction-field-error"
+          class="govuk-label govuk-radios__label">Yes</label></div>
+      <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+           id="steps-international-jurisdiction-form-international-jurisdiction-yes-conditional">
+        <div class="govuk-form-group"><label
+            for="steps-international-jurisdiction-form-international-jurisdiction-details-field" class="govuk-label">Provide details</label><textarea id="steps-international-jurisdiction-form-international-jurisdiction-details-field"
+                                   class="govuk-textarea" rows="5"
+                                   name="steps_international_jurisdiction_form[international_jurisdiction_details]"></textarea>
+        </div>
+      </div>
+      <div class="govuk-radios__item"><input
+          id="steps-international-jurisdiction-form-international-jurisdiction-no-field" class="govuk-radios__input"
+          type="radio" value="no" name="steps_international_jurisdiction_form[international_jurisdiction]"><label
+          for="steps-international-jurisdiction-form-international-jurisdiction-no-field"
+          class="govuk-label govuk-radios__label">No</label></div>
+    </div>
+  </fieldset>
+</div>

--- a/features/markup_smoke_tests.feature
+++ b/features/markup_smoke_tests.feature
@@ -11,3 +11,4 @@ Feature: High level form markup smoke tests
     Examples:
       | step_path                         | fixture_file            | errors_fixture_file                 |
       | steps/miam/child_protection_cases | child_protection_cases  | child_protection_cases_with_errors  |
+      | steps/miam/acknowledgement        | miam_acknowledgement    | miam_acknowledgement_with_errors    |

--- a/features/markup_smoke_tests.feature
+++ b/features/markup_smoke_tests.feature
@@ -14,3 +14,4 @@ Feature: High level form markup smoke tests
       | steps/miam/acknowledgement        | miam_acknowledgement    | miam_acknowledgement_with_errors    |
       | steps/miam/certification_date     | miam_certification_date | miam_certification_date_with_errors |
       | steps/petition/orders             | nature_of_application   | nature_of_application_with_errors   |
+      | steps/international/jurisdiction  | order_jurisdiction      | order_jurisdiction_with_errors      |

--- a/features/markup_smoke_tests.feature
+++ b/features/markup_smoke_tests.feature
@@ -1,0 +1,13 @@
+Feature: High level form markup smoke tests
+  Background:
+    Given I have started an application
+
+  Scenario Outline: Markup in a sample of forms should be correct
+    When I visit "<step_path>"
+
+    Then The form markup should match "<fixture_file>"
+    Then The form markup with errors should match "<errors_fixture_file>"
+
+    Examples:
+      | step_path                         | fixture_file            | errors_fixture_file                 |
+      | steps/miam/child_protection_cases | child_protection_cases  | child_protection_cases_with_errors  |

--- a/features/markup_smoke_tests.feature
+++ b/features/markup_smoke_tests.feature
@@ -12,3 +12,4 @@ Feature: High level form markup smoke tests
       | step_path                         | fixture_file            | errors_fixture_file                 |
       | steps/miam/child_protection_cases | child_protection_cases  | child_protection_cases_with_errors  |
       | steps/miam/acknowledgement        | miam_acknowledgement    | miam_acknowledgement_with_errors    |
+      | steps/miam/certification_date     | miam_certification_date | miam_certification_date_with_errors |

--- a/features/markup_smoke_tests.feature
+++ b/features/markup_smoke_tests.feature
@@ -13,3 +13,4 @@ Feature: High level form markup smoke tests
       | steps/miam/child_protection_cases | child_protection_cases  | child_protection_cases_with_errors  |
       | steps/miam/acknowledgement        | miam_acknowledgement    | miam_acknowledgement_with_errors    |
       | steps/miam/certification_date     | miam_certification_date | miam_certification_date_with_errors |
+      | steps/petition/orders             | nature_of_application   | nature_of_application_with_errors   |

--- a/features/step_definitions/fixtures.rb
+++ b/features/step_definitions/fixtures.rb
@@ -1,0 +1,25 @@
+Then(/^The form markup should match "([^"]*)"$/) do |fixture|
+  raw_markup = page.all(
+    :css, 'form > div.govuk-form-group'
+  ).map { |div| div['outerHTML'] }.join
+
+  raw_fixture = Pathname.new(
+    File.join('features', 'fixtures', 'files', "#{fixture}.html")
+  ).read
+
+  normaliser = MarkupNormaliser.new(raw_markup, raw_fixture)
+
+  expect(
+    normaliser.markup1
+  ).to eq(
+    normaliser.markup2
+  )
+end
+
+Then(/^The form markup with errors should match "([^"]*)"$/) do |fixture|
+  # Click continue without filling anything, to trigger validation errors
+  step %[I click the "Continue" button]
+
+  # Now check the markup with errors using the above step
+  step %[The form markup should match "#{fixture}"]
+end


### PR DESCRIPTION
More details in the `README.md`

These smoke tests are coupled to the actual markup generated by the form builder in the service, meaning if the page or locale change, these tests will need to be updated.

Added 5 for now, with a mixture of check boxes, radios, dates and revealing text areas.

We can easily add more, but I think with these we cover most of the combinations already. In any case this does not replace some manual testing / sanity check when updating the gem.