### PR TITLE
Bump `govuk_design_system_formbuilder`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.6.5'
 
 gem 'devise', '~> 4.7.1'
 gem 'email_validator', '< 2.0.0'
-gem 'govuk_design_system_formbuilder', '~> 1.2.3'
+gem 'govuk_design_system_formbuilder', '~> 1.2.5'
 gem 'govuk_notify_rails', '~> 2.1.0'
 gem 'govuk-pay-ruby-client', '~> 1.0.2'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       activesupport (>= 4.2.0)
     govuk-pay-ruby-client (1.0.2)
       faraday (~> 1.0)
-    govuk_design_system_formbuilder (1.2.3)
+    govuk_design_system_formbuilder (1.2.5)
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
@@ -193,7 +193,7 @@ GEM
       equalizer (~> 0.0.9)
       ice_nine (~> 0.11.0)
       procto (~> 0.0.2)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     multi_test (0.1.2)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -394,7 +394,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.2)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     wicked_pdf (1.4.0)
@@ -418,7 +418,7 @@ DEPENDENCIES
   dotenv-rails
   email_validator (< 2.0.0)
   govuk-pay-ruby-client (~> 1.0.2)
-  govuk_design_system_formbuilder (~> 1.2.3)
+  govuk_design_system_formbuilder (~> 1.2.5)
   govuk_notify_rails (~> 2.1.0)
   i18n-debug
   jquery-rails

--- a/app/assets/stylesheets/local/util.scss
+++ b/app/assets/stylesheets/local/util.scss
@@ -27,9 +27,7 @@ strong {
 }
 
 .app-util--compact-form-group {
-  div.govuk-form-group {
-    margin-bottom: 0.4em;
-  }
+  margin-bottom: 0.4em;
 }
 
 .app-util--border-box {

--- a/app/views/steps/applicant/personal_details/edit.html.erb
+++ b/app/views/steps/applicant/personal_details/edit.html.erb
@@ -19,7 +19,7 @@
 
       <%= render partial: 'steps/shared/dob_form_element', locals: { form_object: f } %>
 
-      <%= f.govuk_text_field :birthplace, label: { size: 'm' } %>
+      <%= f.govuk_text_field :birthplace, width: 'two-thirds', label: { size: 'm' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/respondent/personal_details/edit.html.erb
+++ b/app/views/steps/respondent/personal_details/edit.html.erb
@@ -20,7 +20,7 @@
 
       <%= render partial: 'steps/shared/dob_form_element', locals: { form_object: f } %>
 
-      <%= f.govuk_text_field :birthplace, label: { size: 'm' } %>
+      <%= f.govuk_text_field :birthplace, width: 'two-thirds', label: { size: 'm' } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/shared/_dob_form_element.html.erb
+++ b/app/views/steps/shared/_dob_form_element.html.erb
@@ -1,8 +1,7 @@
 <% if form_object.object.respond_to?(:dob_unknown) %>
 
-  <div class="app-util--compact-form-group">
-    <%= form_object.govuk_date_field :dob, legend: { tag: 'span', size: 'm' } %>
-  </div>
+  <%= form_object.govuk_date_field :dob, legend: { tag: 'span', size: 'm' },
+                                   form_group_classes: 'app-util--compact-form-group' %>
 
   <%= form_object.govuk_check_boxes_fieldset :dob_unknown, small: true, legend: { tag: 'span', size: 's', hidden: true } do %>
     <%= form_object.govuk_check_box :dob_unknown, true, multiple: false do


### PR DESCRIPTION
Latest version allows to set `form_group_classes` so we can use this instead of having to wrap the element with an external div like we did before.

Reduced size of the `birthplace` text inputs to be in line with other element width sizes.