### PR TITLE
Make mailer documents code more clear

### DIFF
--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -28,6 +28,7 @@ class NotifySubmissionMailer < NotifyMailer
         urgent: @c100_application.urgent_hearing || 'no',
         c8_included: @c100_application.address_confidentiality || 'no',
         link_to_c8_pdf: prepare_upload(@documents[:c8_form]),
+        link_to_pdf: prepare_upload(@documents[:bundle]),
       )
     )
 
@@ -57,7 +58,6 @@ class NotifySubmissionMailer < NotifyMailer
     {
       applicant_name: @c100_application.declaration_signee,
       reference_code: @c100_application.reference_code,
-      link_to_pdf: prepare_upload(@documents[:bundle]),
     }
   end
 

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -83,9 +83,6 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
     end
   end
 
-  # We don't send the bundle PDF to the applicant anymore, but the code to be able
-  # to attach documents is still present if we wanted to attach any other documents.
-  #
   describe '#application_to_user' do
     before do
       allow(c100_application).to receive(:screener_answers_court).and_return(court)
@@ -95,7 +92,8 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       ).and_return('payment instructions from locales')
     end
 
-    let(:documents) { {bundle: StringIO.new('bundle pdf')} }
+    # We don't send the PDF to the applicant anymore, so this hash is empty
+    let(:documents) { {} }
 
     let(:mail) {
       described_class.with(
@@ -122,7 +120,6 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         court_url: 'https://courttribunalfinder.service.gov.uk/courts/test-court',
         is_under_age: 'no',
         payment_instructions: 'payment instructions from locales',
-        link_to_pdf: { file: 'YnVuZGxlIHBkZg==' },
       })
     end
 


### PR DESCRIPTION
We removed the PDF in the emails to the applicant some time ago, but the `link_to_pdf` was a shared personalisation param because before, both emails (court and applicant) used it. But not anymore.

Move this out of the `shared_personalisation` method and into the `application_to_court` method so it is more clear what is going on, and thus we stop sending an (empty) `link_to_pdf` param in the applicant emails.

Updated tests.