### PR TITLE
Improve some copy and styling in back office tables

### DIFF
--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -1,7 +1,7 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell"><%= completion.completed_at %></td>
-  <td class="govuk-table__cell"><%= completion.submission_type %></td>
-  <td class="govuk-table__cell"><%= completion.metadata['payment_type'] %></td>
+  <td class="govuk-table__cell app-util--no-wrap"><%= l(completion.completed_at, format: :short) %></td>
+  <td class="govuk-table__cell app-util--no-wrap"><%= t(completion.submission_type, scope: 'backoffice.submission') %></td>
+  <td class="govuk-table__cell app-util--no-wrap"><%= t(completion.metadata['payment_type'], scope: 'backoffice.payment') %></td>
   <td class="govuk-table__cell"><%= completion.court %></td>
 </tr>
 

--- a/app/views/backoffice/dashboard/_payment.en.html.erb
+++ b/app/views/backoffice/dashboard/_payment.en.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell govuk-!-width-one-quarter"><%= payment.created_at %></td>
-  <td class="govuk-table__cell govuk-!-width-one-quarter"><%= payment.updated_at %></td>
+  <td class="govuk-table__cell app-util--no-wrap"><%= l(payment.created_at, format: :short) %></td>
+  <td class="govuk-table__cell app-util--no-wrap"><%= l(payment.updated_at, format: :short) %></td>
   <td class="govuk-table__cell">
     <strong class="govuk-tag app-tag--<%= payment.state['status'] %>">
       <%= payment.state['status'] %>
@@ -8,7 +8,7 @@
   </td>
   <td class="govuk-table__cell">
     <% if payment.state.key?('code') %>
-      <%= payment.state.slice('code', 'message') %> <em class="app-util--disabled-color">#<%= payment.c100_application_id.split('-').first %></em>
+      <%= payment.state.slice('code', 'message') %> <em class="app-util--disabled-color">Ref. <%= payment.c100_application.reference_code %></em>
     <% end %>
   </td>
 </tr>

--- a/config/locales/backoffice/en.yml
+++ b/config/locales/backoffice/en.yml
@@ -1,0 +1,11 @@
+en:
+  backoffice:
+    submission:
+      online: Online
+      print_and_post: Printed
+    payment:
+      online: Online
+      help_with_fees: HWF
+      solicitor: Fee account
+      self_payment_card: Phone
+      self_payment_cheque: Cheque/cash

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1714,6 +1714,8 @@ en:
       short: '%d/%m/%Y'
       long: '%e %B %Y'
   time:
+    formats:
+      short: '%d %b %H:%M:%S'
     draft_expires_in:
       zero: Today
       one: '%{count} day'


### PR DESCRIPTION
This improve some copy that was not particularly very human-friendly (`self_payment_card ` or `solicitor`) with some more human-friendly versions using locales.

Also reduced some lengthy timestamps so they fit in one line and do not wrap.

Show the complete reference code in the payments error details, if there is an error, instead of just the firt part of the UUID so it is easy to search for the application if needed.

Before:
<img width="1021" alt="Screen Shot 2020-07-14 at 11 49 41" src="https://user-images.githubusercontent.com/687910/87418107-18006980-c5c9-11ea-8d18-dc3457b7b118.png">

After:
<img width="1010" alt="Screen Shot 2020-07-14 at 11 50 38" src="https://user-images.githubusercontent.com/687910/87418114-1b93f080-c5c9-11ea-86ce-3b02af3134a9.png">
