### PR TITLE
Consent orders will bypass alternatives to court

### DIFF
--- a/app/models/concerns/application_inquiry_methods.rb
+++ b/app/models/concerns/application_inquiry_methods.rb
@@ -1,4 +1,6 @@
 module ApplicationInquiryMethods
+  YES_ANSWER = GenericYesNo::YES.to_s
+
   def online_submission?
     submission_type.eql?(SubmissionType::ONLINE.to_s)
   end
@@ -7,12 +9,20 @@ module ApplicationInquiryMethods
     payment_type.eql?(PaymentType::ONLINE.to_s)
   end
 
+  def consent_order?
+    consent_order.eql?(YES_ANSWER)
+  end
+
+  def child_protection_cases?
+    child_protection_cases.eql?(YES_ANSWER)
+  end
+
   def confidentiality_enabled?
-    address_confidentiality.eql?(GenericYesNo::YES.to_s)
+    address_confidentiality.eql?(YES_ANSWER)
   end
 
   def has_solicitor?
-    has_solicitor.eql?(GenericYesNo::YES.to_s)
+    has_solicitor.eql?(YES_ANSWER)
   end
 
   def has_safety_concerns?
@@ -22,6 +32,6 @@ module ApplicationInquiryMethods
       children_abuse,
       substance_abuse,
       other_abuse
-    ].any? { |concern| concern.eql?(GenericYesNo::YES.to_s) }
+    ].any? { |concern| concern.eql?(YES_ANSWER) }
   end
 end

--- a/app/services/c100_app/alternatives_decision_tree.rb
+++ b/app/services/c100_app/alternatives_decision_tree.rb
@@ -22,7 +22,7 @@ module C100App
     private
 
     def after_court_acknowledgement
-      if c100_application.has_safety_concerns?
+      if c100_application.consent_order? || c100_application.has_safety_concerns?
         start_children_journey
       else
         show(:start)

--- a/app/services/c100_app/miam_exemptions_decision_tree.rb
+++ b/app/services/c100_app/miam_exemptions_decision_tree.rb
@@ -20,7 +20,7 @@ module C100App
     end
 
     def playback_destination
-      if has_child_protection_cases? || has_mediator_details?
+      if miam_not_required? || has_mediator_details?
         edit('/steps/petition/orders')
       elsif has_miam_exemptions?
         show('/steps/miam_exemptions/reasons_playback')
@@ -43,12 +43,12 @@ module C100App
       c100_application.has_safety_concerns?
     end
 
-    def has_child_protection_cases?
-      c100_application.child_protection_cases.eql?(GenericYesNo::YES.to_s)
+    def has_mediator_details?
+      c100_application.miam_certification_number?
     end
 
-    def has_mediator_details?
-      c100_application.miam_certification_number
+    def miam_not_required?
+      c100_application.consent_order? || c100_application.child_protection_cases?
     end
   end
 end

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -85,6 +85,40 @@ RSpec.describe C100Application, type: :model do
     end
   end
 
+  describe '#consent_order?' do
+    context 'for a `nil` value' do
+      let(:attributes) { {consent_order: nil} }
+      it { expect(subject.consent_order?).to eq(false) }
+    end
+
+    context 'for a `no` value' do
+      let(:attributes) { {consent_order: 'no'} }
+      it { expect(subject.consent_order?).to eq(false) }
+    end
+
+    context 'for a `yes` value' do
+      let(:attributes) { {consent_order: 'yes'} }
+      it { expect(subject.consent_order?).to eq(true) }
+    end
+  end
+
+  describe '#child_protection_cases?' do
+    context 'for a `nil` value' do
+      let(:attributes) { {child_protection_cases: nil} }
+      it { expect(subject.child_protection_cases?).to eq(false) }
+    end
+
+    context 'for a `no` value' do
+      let(:attributes) { {child_protection_cases: 'no'} }
+      it { expect(subject.child_protection_cases?).to eq(false) }
+    end
+
+    context 'for a `yes` value' do
+      let(:attributes) { {child_protection_cases: 'yes'} }
+      it { expect(subject.child_protection_cases?).to eq(true) }
+    end
+  end
+
   describe '#confidentiality_enabled?' do
     context 'for `yes` values' do
       let(:attributes) { {address_confidentiality: 'yes'} }

--- a/spec/services/c100_app/alternatives_decision_tree_spec.rb
+++ b/spec/services/c100_app/alternatives_decision_tree_spec.rb
@@ -14,8 +14,20 @@ RSpec.describe C100App::AlternativesDecisionTree do
   context 'when the step is `court_acknowledgement`' do
     let(:step_params) {{court_acknowledgement: 'anything'}}
 
-    before do
-      allow(c100_application).to receive(:has_safety_concerns?).and_return(safety_concerns)
+    let(:c100_application) {
+      instance_double(
+        C100Application,
+        consent_order?: consent_order,
+        has_safety_concerns?: safety_concerns,
+      )
+    }
+
+    let(:consent_order) { false }
+    let(:safety_concerns) { false }
+
+    context 'and it is a consent order application' do
+      let(:consent_order) { true }
+      it { is_expected.to have_destination('/steps/children/names', :edit) }
     end
 
     context 'and there are safety concerns' do
@@ -23,8 +35,7 @@ RSpec.describe C100App::AlternativesDecisionTree do
       it { is_expected.to have_destination('/steps/children/names', :edit) }
     end
 
-    context 'and there are no safety concerns' do
-      let(:safety_concerns) { false }
+    context 'and it is not a consent order and there are no safety concerns' do
       it { is_expected.to have_destination(:start, :show) }
     end
   end

--- a/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
+++ b/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
@@ -39,12 +39,23 @@ RSpec.describe C100App::MiamExemptionsDecisionTree do
     let(:c100_application) { C100Application.new(attributes) }
     let(:attributes) {
       {
+        consent_order: 'no',
         child_protection_cases: 'no',
         miam_certification_number: nil,
         substance_abuse: 'no',
         miam_exemption: nil,
       }
     }
+
+    context 'when asking for a consent order' do
+      let(:attributes) { super().merge(consent_order: 'yes') }
+
+      it {
+        expect(
+          subject.playback_destination
+        ).to eq(controller: '/steps/petition/orders', action: :edit)
+      }
+    end
 
     context 'when children have been involved in court cases' do
       let(:attributes) { super().merge(child_protection_cases: 'yes') }


### PR DESCRIPTION
As well as not showing the MIAM exemptions playback pages same as we already did with child protection cases.

This is a follow-up to PR #1006 