### PR TITLE
Simplify nature of application for consent orders

### DIFF
--- a/app/forms/steps/petition/orders_form.rb
+++ b/app/forms/steps/petition/orders_form.rb
@@ -26,7 +26,7 @@ module Steps
       end
 
       def selected_options
-        orders_collection & PetitionOrder.string_values
+        (orders_collection + orders) & PetitionOrder.string_values
       end
 
       def at_least_one_order_validation

--- a/app/presenters/petition_presenter.rb
+++ b/app/presenters/petition_presenter.rb
@@ -11,6 +11,10 @@ class PetitionPresenter < SimpleDelegator
     selected_orders_from(PetitionOrder::PROHIBITED_STEPS)
   end
 
+  def formalise_arrangements
+    selected_orders_from(PetitionOrder::FORMALISE_ARRANGEMENTS)
+  end
+
   def all_selected_orders
     selected_orders_from(PetitionOrder.values)
   end

--- a/app/value_objects/petition_order.rb
+++ b/app/value_objects/petition_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PetitionOrder < ValueObject
   VALUES = [
     CHILD_ARRANGEMENTS = [
@@ -26,6 +28,11 @@ class PetitionOrder < ValueObject
       new(:specific_issues_child_return),
     ].freeze,
 
+    # Although there is only one, we use an array for consistency with existing code
+    FORMALISE_ARRANGEMENTS = [
+      CONSENT_ORDER = new(:consent_order),
+    ].freeze,
+
     OTHER_ISSUE = new(:other_issue),
   ].flatten.freeze
 
@@ -36,9 +43,11 @@ class PetitionOrder < ValueObject
   def self.type_for(sub_type)
     case sub_type.to_s
     when /^child_arrangements_.*/ then 'child_arrangements'
-    when /^prohibited_steps_.*/ then 'prohibited_steps'
-    when /^specific_issues_.*/ then 'specific_issues'
-    else 'other_issue'
+    when /^prohibited_steps_.*/   then 'prohibited_steps'
+    when /^specific_issues_.*/    then 'specific_issues'
+    when /^consent_order$/        then 'consent_order'
+    else
+      'other_issue'
     end
   end
 end

--- a/app/views/steps/petition/orders/edit.html.erb
+++ b/app/views/steps/petition/orders/edit.html.erb
@@ -7,15 +7,20 @@
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_check_boxes_fieldset :orders do %>
-        <%= f.govuk_check_box :orders, PetitionOrder::CHILD_ARRANGEMENTS_HOME.to_s, link_errors: true %>
-        <%= f.govuk_check_box :orders, PetitionOrder::CHILD_ARRANGEMENTS_TIME.to_s %>
 
-        <%= f.govuk_check_box :orders, PetitionOrder::GROUP_PROHIBITED_STEPS.to_s do %>
-          <%= f.govuk_collection_check_boxes :orders_collection, PetitionOrder::PROHIBITED_STEPS, :to_s, :to_s %>
-        <% end %>
+        <% if current_c100_application.consent_order? %>
+          <%= f.govuk_check_box :orders, PetitionOrder::CONSENT_ORDER.to_s, link_errors: true %>
+        <% else %>
+          <%= f.govuk_check_box :orders, PetitionOrder::CHILD_ARRANGEMENTS_HOME.to_s, link_errors: true %>
+          <%= f.govuk_check_box :orders, PetitionOrder::CHILD_ARRANGEMENTS_TIME.to_s %>
 
-        <%= f.govuk_check_box :orders, PetitionOrder::GROUP_SPECIFIC_ISSUES.to_s do %>
-          <%= f.govuk_collection_check_boxes :orders_collection, PetitionOrder::SPECIFIC_ISSUES, :to_s, :to_s %>
+          <%= f.govuk_check_box :orders, PetitionOrder::GROUP_PROHIBITED_STEPS.to_s do %>
+            <%= f.govuk_collection_check_boxes :orders_collection, PetitionOrder::PROHIBITED_STEPS, :to_s, :to_s %>
+          <% end %>
+
+          <%= f.govuk_check_box :orders, PetitionOrder::GROUP_SPECIFIC_ISSUES.to_s do %>
+            <%= f.govuk_collection_check_boxes :orders_collection, PetitionOrder::SPECIFIC_ISSUES, :to_s, :to_s %>
+          <% end %>
         <% end %>
 
         <%= f.govuk_check_box :orders, PetitionOrder::OTHER_ISSUE.to_s do

--- a/app/views/steps/petition/playback/show.html.erb
+++ b/app/views/steps/petition/playback/show.html.erb
@@ -45,10 +45,17 @@
       <p class="govuk-body"><%= t('.aka.specific_issues_order') %></p>
     <% end %>
 
+    <% if @petition.formalise_arrangements.any? %>
+      <h2 class="govuk-heading-m">
+        <%=t '.petition_header_formalise_arrangements' %>
+      </h2>
+      <p class="govuk-body"><%= t('.aka.consent_order') %></p>
+    <% end %>
+
     <% if @petition.other_issue? %>
       <h2 class="govuk-heading-m">
         <%=t '.petition_header_other', count: @petition.count_for(
-          :child_arrangements_orders, :prohibited_steps_orders, :specific_issues_orders
+          :child_arrangements_orders, :prohibited_steps_orders, :specific_issues_orders, :formalise_arrangements
         ) %>
       </h2>
       <div class="govuk-inset-text">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
       specific_issues_moving: Relocating the children to a different area in England and Wales
       specific_issues_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
       specific_issues_child_return: Returning the children to your care
+      consent_order: Formalise an agreement (consent order)
       other_issue: Deal with another issue not listed
 
     # Note: this is duplicated in `locales/summary/en.yml`, due to the way locales work
@@ -610,6 +611,7 @@ en:
             zero: "You told us that you need help with this dispute:"
             one: "You also told us that you need help with this dispute:"
             other: "You also told us that you need help with this dispute:"
+          petition_header_formalise_arrangements: Formalise an agreement (consent order)
           continue: Continue
           orders:
             <<: *PETITION_ORDERS
@@ -617,6 +619,7 @@ en:
             child_arrangements_order: This is known as a Child Arrangements Order.
             specific_issues_order: This is known as a Specific Issue Order.
             prohibited_steps_order: This is known as a Prohibited Steps Order.
+            consent_order: You will need to send your proposed agreement along with your application.
       protection:
         edit:
           page_title: Protection orders

--- a/spec/forms/steps/petition/orders_form_spec.rb
+++ b/spec/forms/steps/petition/orders_form_spec.rb
@@ -22,13 +22,29 @@ RSpec.describe Steps::Petition::OrdersForm do
     it 'returns all the orders in all attributes' do
       expect(
         subject.orders_collection
-      ).to eq(%w(
-        prohibited_steps_holiday
-        specific_issues_medical
-        child_arrangements_home
-        group_prohibited_steps
-        group_specific_issues)
-      )
+      ).to eq(orders_collection + orders)
+    end
+
+    # mutant kill
+    context 'when `orders_collection` is nil' do
+      let(:orders_collection) { nil }
+
+      it 'returns all the orders in all attributes' do
+        expect(
+          subject.orders_collection
+        ).to eq(orders)
+      end
+    end
+
+    # mutant kill
+    context 'when `orders` is nil' do
+      let(:orders) { nil }
+
+      it 'returns all the orders in all attributes' do
+        expect(
+          subject.orders_collection
+        ).to eq(orders_collection)
+      end
     end
   end
 
@@ -141,6 +157,23 @@ RSpec.describe Steps::Petition::OrdersForm do
         it 'resets the content `orders_additional_details` attribute' do
           expect(c100_application).to receive(:update).with(
             orders: %w(prohibited_steps_holiday),
+            orders_additional_details: nil,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'for a consent order' do
+        let(:arguments) { {
+          c100_application: c100_application,
+          orders: %w(consent_order),
+          orders_additional_details: '',
+        } }
+
+        it 'saves the record' do
+          expect(c100_application).to receive(:update).with(
+            orders: %w(consent_order),
             orders_additional_details: nil,
           ).and_return(true)
 

--- a/spec/presenters/petition_presenter_spec.rb
+++ b/spec/presenters/petition_presenter_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe PetitionPresenter do
     end
   end
 
+  describe '#formalise_arrangements' do
+    it 'only returns the orders set to true' do
+      expect(subject.formalise_arrangements).to eq(%w(
+        consent_order
+      ))
+    end
+  end
+
   describe '#all_selected_orders' do
     it 'only returns the orders set to true' do
       expect(subject.all_selected_orders).to eq(%w(
@@ -64,6 +72,7 @@ RSpec.describe PetitionPresenter do
         specific_issues_moving
         specific_issues_moving_abroad
         specific_issues_child_return
+        consent_order
         other_issue
       ))
     end

--- a/spec/value_objects/petition_order_spec.rb
+++ b/spec/value_objects/petition_order_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe PetitionOrder do
         specific_issues_moving
         specific_issues_moving_abroad
         specific_issues_child_return
+        consent_order
         other_issue
       ))
     end
@@ -77,6 +78,14 @@ RSpec.describe PetitionOrder do
     end
   end
 
+  describe 'FORMALISE_ARRANGEMENTS' do
+    it 'returns the expected values' do
+      expect(described_class::FORMALISE_ARRANGEMENTS.map(&:to_s)).to eq(%w(
+        consent_order
+      ))
+    end
+  end
+
   describe 'OTHER_ISSUE' do
     it 'returns the expected values' do
       expect(described_class::OTHER_ISSUE.to_s).to eq('other_issue')
@@ -100,6 +109,12 @@ RSpec.describe PetitionOrder do
       context 'starting with specific_issues_' do
         it 'returns "specific_issues"' do
           expect(described_class.type_for('specific_issues_foo')).to eq("specific_issues")
+        end
+      end
+
+      context 'exactly matching consent order' do
+        it 'returns "consent_order"' do
+          expect(described_class.type_for('consent_order')).to eq("consent_order")
         end
       end
 


### PR DESCRIPTION
If the application is for a consent order, then we can remove all the other orders from the nature of application and just expose a check box for Consent order (along with the other issue just in case, as it offers a free text area).

Copy still TBD.

Note, as part of a follow-up PR, the CYA and PDF will be implemented. At the moment, if you go all the way to the end, and you've selected the Consent order check box, it will blow up.

<img width="625" alt="Screen Shot 2020-07-20 at 11 17 59" src="https://user-images.githubusercontent.com/687910/87927145-a7e75d00-ca7a-11ea-916f-77bf0e687853.png">

Playback:

<img width="698" alt="Screen Shot 2020-07-20 at 11 18 19" src="https://user-images.githubusercontent.com/687910/87927183-b46bb580-ca7a-11ea-85db-8e5b7589b188.png">


Parent ticket: https://mojdigital.teamwork.com/#/tasks/19965720
Subtask: https://mojdigital.teamwork.com/#/tasks/21245693

