### PR TITLE
Add consent order to CYA and PDF

### DIFF
--- a/app/presenters/summary/html_sections/miam_requirement.rb
+++ b/app/presenters/summary/html_sections/miam_requirement.rb
@@ -7,6 +7,7 @@ module Summary
 
       def answers
         [
+          Answer.new(:consent_order_application, c100.consent_order, change_path: edit_steps_miam_consent_order_path),
           Answer.new(:child_protection_cases, c100.child_protection_cases, change_path: edit_steps_miam_child_protection_cases_path),
           Answer.new(:miam_attended, c100.miam_attended, change_path: edit_steps_miam_attended_path),
           Answer.new(:miam_certification, c100.miam_certification, change_path: edit_steps_miam_certification_path),

--- a/app/presenters/summary/html_sections/nature_of_application.rb
+++ b/app/presenters/summary/html_sections/nature_of_application.rb
@@ -23,6 +23,11 @@ module Summary
                           change_path: edit_steps_petition_orders_path(
                             anchor: 'steps-petition-orders-form-orders-group-specific-issues-field'
                           )),
+          MultiAnswer.new(:formalise_arrangements,
+                          petition.formalise_arrangements,
+                          change_path: edit_steps_petition_orders_path(
+                            anchor: 'steps-petition-orders-form-orders-consent-order-field'
+                          )),
           FreeTextAnswer.new(:other_issue_details,
                              petition.other_issue_details,
                              change_path: edit_steps_petition_orders_path(

--- a/app/presenters/summary/sections/miam_requirement.rb
+++ b/app/presenters/summary/sections/miam_requirement.rb
@@ -12,6 +12,7 @@ module Summary
       def answers
         [
           Partial.new(:miam_information),
+          Answer.new(:miam_consent_order,        c100.consent_order,          default: default_value),
           Answer.new(:miam_child_protection,     c100.child_protection_cases, default: default_value),
           Answer.new(:miam_exemption_claim,      c100.miam_exemption_claim,   default: default_value),
           Answer.new(:miam_certificate_received, c100.miam_certification,     default: default_value),

--- a/app/presenters/summary/sections/nature_of_application.rb
+++ b/app/presenters/summary/sections/nature_of_application.rb
@@ -10,6 +10,7 @@ module Summary
           MultiAnswer.new(:child_arrangements_orders, petition.child_arrangements_orders),
           MultiAnswer.new(:prohibited_steps_orders, petition.prohibited_steps_orders),
           MultiAnswer.new(:specific_issues_orders, petition.specific_issues_orders),
+          MultiAnswer.new(:formalise_arrangements, petition.formalise_arrangements),
           FreeTextAnswer.new(:other_issue_details, petition.other_issue_details),
         ].select(&:show?)
       end

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -20,6 +20,7 @@ en:
       father: Father
       other: Other
 
+    # Important: maintain these orders in sync with the rest of locale files
     ARRANGEMENT_ORDERS: &ARRANGEMENT_ORDERS
       child_arrangements_home: Decide who they live with and when
       child_arrangements_time: Decide how much time they spend with each person
@@ -38,13 +39,14 @@ en:
       specific_issues_moving: Relocating the children to a different area in England and Wales
       specific_issues_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
       specific_issues_child_return: Returning the children to your care
-    OTHER_ORDER: &OTHER_ORDER
-      other_issue: Deal with another issue not listed
+    FORMALISE_ARRANGEMENTS: &FORMALISE_ARRANGEMENTS
+      consent_order: Consent order
 
     PETITION_ORDER_TYPES: &PETITION_ORDER_TYPES
       child_arrangements: Child Arrangements Order
       prohibited_steps: Prohibited Steps Order
       specific_issues: Specific Issue Order
+      consent_order: Consent order
       other_issue: Other issue
 
     COURT_ORDER_TYPES: &COURT_ORDER_TYPES
@@ -58,7 +60,6 @@ en:
   check_answers_html:
     change_link_html: Change <span class="govuk-visually-hidden">your answer to, %{a11y_question}</span>
     sections:
-      child_protection_cases: Emergency protection, care or supervision proceedings
       miam_requirement: MIAM requirement
       miam_attendance: MIAM attendance
       miam_exemptions: MIAM exemption
@@ -123,6 +124,11 @@ en:
       applicants_details_index_title: Applicant %{index}
       respondents_details_index_title: Respondent %{index}
       other_parties_details_index_title: Other party %{index}
+
+    consent_order_application:
+      question: Do you have a signed draft court order you want the court to consider making legally binding?
+      answers:
+        <<: *YESNO
     child_protection_cases:
       question: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
       answers:
@@ -414,6 +420,10 @@ en:
       question_a11y: What you’re asking the court to stop the other person from doing
       answers:
         <<: *PROHIBITED_STEPS_ORDERS
+    formalise_arrangements:
+      question: Formalise an agreement
+      answers:
+        <<: *FORMALISE_ARRANGEMENTS
     other_issue_details:
       question: 'You told us that you need help with this dispute:'
       question_a11y: You need help with this dispute

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -24,6 +24,7 @@ en:
       father: Father
       other: Other
 
+    # Important: maintain these orders in sync with the rest of locale files
     ARRANGEMENT_ORDERS: &ARRANGEMENT_ORDERS
       child_arrangements_home: Decide who they live with and when
       child_arrangements_time: Decide how much time they spend with each person
@@ -42,13 +43,14 @@ en:
       specific_issues_moving: Relocating the children to a different area in England and Wales
       specific_issues_moving_abroad: Relocating the children outside of England and Wales (including Scotland and Northern Ireland)
       specific_issues_child_return: Returning the children to your care
-    OTHER_ORDER: &OTHER_ORDER
-      other_issue: Deal with another issue not listed
+    FORMALISE_ARRANGEMENTS: &FORMALISE_ARRANGEMENTS
+      consent_order: Consent order
 
     PETITION_ORDER_TYPES: &PETITION_ORDER_TYPES
       child_arrangements: Child Arrangements Order
       prohibited_steps: Prohibited Steps Order
       specific_issues: Specific Issue Order
+      consent_order: Consent order
       other_issue: Other issue
 
     # Note: this is duplicated in `locales/en.yml`, due to the way locales work
@@ -182,6 +184,10 @@ en:
       question: 'Prohibited steps order(s):'
       answers:
         <<: *PROHIBITED_STEPS_ORDERS
+    formalise_arrangements:
+      question: 'Formalise an agreement:'
+      answers:
+        <<: *FORMALISE_ARRANGEMENTS
     other_issue_details:
       question: 'Other issue:'
     domestic_abuse:
@@ -293,10 +299,16 @@ en:
         Applicant: Applicant
         Respondent: Respondent
         OtherParty: Other
+    miam_consent_order:
+      question: Are you applying for a consent order?
+      answers:
+        'yes': Yes - MIAM not required
+        'no': 'No'
     miam_child_protection:
       question: "Current or previous proceedings: are/were any of those cases about an emergency protection, care or supervision order?"
       answers:
-        <<: *YESNO
+        'yes': Yes - MIAM not required
+        'no': 'No'
     miam_exemption_claim:
       question: Are you claiming exemption from the requirement to attend a MIAM?
       answers:

--- a/spec/presenters/summary/html_sections/miam_requirement_spec.rb
+++ b/spec/presenters/summary/html_sections/miam_requirement_spec.rb
@@ -4,6 +4,7 @@ module Summary
   describe HtmlSections::MiamRequirement do
     let(:c100_application) {
       instance_double(C100Application,
+        consent_order: 'no',
         child_protection_cases: 'no',
         miam_attended: 'yes',
         miam_certification: 'yes',
@@ -20,26 +21,30 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(5)
 
         expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:child_protection_cases)
+        expect(answers[0].question).to eq(:consent_order_application)
         expect(answers[0].value).to eq('no')
 
         expect(answers[1]).to be_an_instance_of(Answer)
-        expect(answers[1].question).to eq(:miam_attended)
-        expect(answers[1].change_path).to eq('/steps/miam/attended')
-        expect(answers[1].value).to eq('yes')
+        expect(answers[1].question).to eq(:child_protection_cases)
+        expect(answers[1].value).to eq('no')
 
         expect(answers[2]).to be_an_instance_of(Answer)
-        expect(answers[2].question).to eq(:miam_certification)
-        expect(answers[2].change_path).to eq('/steps/miam/certification')
+        expect(answers[2].question).to eq(:miam_attended)
+        expect(answers[2].change_path).to eq('/steps/miam/attended')
         expect(answers[2].value).to eq('yes')
 
         expect(answers[3]).to be_an_instance_of(Answer)
-        expect(answers[3].question).to eq(:miam_exemption_claim)
-        expect(answers[3].change_path).to eq('/steps/miam/exemption_claim')
-        expect(answers[3].value).to eq('no')
+        expect(answers[3].question).to eq(:miam_certification)
+        expect(answers[3].change_path).to eq('/steps/miam/certification')
+        expect(answers[3].value).to eq('yes')
+
+        expect(answers[4]).to be_an_instance_of(Answer)
+        expect(answers[4].question).to eq(:miam_exemption_claim)
+        expect(answers[4].change_path).to eq('/steps/miam/exemption_claim')
+        expect(answers[4].value).to eq('no')
       end
     end
   end

--- a/spec/presenters/summary/html_sections/nature_of_application_spec.rb
+++ b/spec/presenters/summary/html_sections/nature_of_application_spec.rb
@@ -89,6 +89,19 @@ module Summary
         expect(protection[1].question).to eq(:protection_orders_details)
         expect(protection[1].value).to eq('protection orders details')
       end
+
+      context 'for a consent order' do
+        let(:orders) { ['consent_order'] }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(3)
+
+          expect(answers[0]).to be_an_instance_of(MultiAnswer)
+          expect(answers[0].question).to eq(:formalise_arrangements)
+          expect(answers[0].value).to eq(['consent_order'])
+          expect(answers[0].change_path).to eq('/steps/petition/orders#steps-petition-orders-form-orders-consent-order-field')
+        end
+      end
     end
   end
 end

--- a/spec/presenters/summary/sections/miam_requirement_spec.rb
+++ b/spec/presenters/summary/sections/miam_requirement_spec.rb
@@ -4,6 +4,7 @@ module Summary
   describe Sections::MiamRequirement do
     let(:c100_application) {
       instance_double(C100Application,
+        consent_order: 'no',
         child_protection_cases: 'no',
         miam_exemption_claim: 'no',
         miam_certification: 'yes',
@@ -29,31 +30,36 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(5)
+        expect(answers.count).to eq(6)
 
         expect(answers[0]).to be_an_instance_of(Partial)
         expect(answers[0].name).to eq(:miam_information)
 
         expect(answers[1]).to be_an_instance_of(Answer)
-        expect(answers[1].question).to eq(:miam_child_protection)
+        expect(answers[1].question).to eq(:miam_consent_order)
         expect(answers[1].value).to eq('no')
 
         expect(answers[2]).to be_an_instance_of(Answer)
-        expect(answers[2].question).to eq(:miam_exemption_claim)
+        expect(answers[2].question).to eq(:miam_child_protection)
         expect(answers[2].value).to eq('no')
 
         expect(answers[3]).to be_an_instance_of(Answer)
-        expect(answers[3].question).to eq(:miam_certificate_received)
-        expect(answers[3].value).to eq('yes')
+        expect(answers[3].question).to eq(:miam_exemption_claim)
+        expect(answers[3].value).to eq('no')
 
         expect(answers[4]).to be_an_instance_of(Answer)
-        expect(answers[4].question).to eq(:miam_attended)
+        expect(answers[4].question).to eq(:miam_certificate_received)
         expect(answers[4].value).to eq('yes')
+
+        expect(answers[5]).to be_an_instance_of(Answer)
+        expect(answers[5].question).to eq(:miam_attended)
+        expect(answers[5].value).to eq('yes')
       end
 
       context 'uses the default when value is `nil`' do
         let(:c100_application) {
           instance_double(C100Application,
+            consent_order: nil,
             child_protection_cases: nil,
             miam_exemption_claim: nil,
             miam_certification: nil,
@@ -61,26 +67,30 @@ module Summary
           ) }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(5)
+          expect(answers.count).to eq(6)
 
           expect(answers[0]).to be_an_instance_of(Partial)
           expect(answers[0].name).to eq(:miam_information)
 
           expect(answers[1]).to be_an_instance_of(Answer)
-          expect(answers[1].question).to eq(:miam_child_protection)
+          expect(answers[1].question).to eq(:miam_consent_order)
           expect(answers[1].value).to eq(GenericYesNo::NO)
 
           expect(answers[2]).to be_an_instance_of(Answer)
-          expect(answers[2].question).to eq(:miam_exemption_claim)
+          expect(answers[2].question).to eq(:miam_child_protection)
           expect(answers[2].value).to eq(GenericYesNo::NO)
 
           expect(answers[3]).to be_an_instance_of(Answer)
-          expect(answers[3].question).to eq(:miam_certificate_received)
+          expect(answers[3].question).to eq(:miam_exemption_claim)
           expect(answers[3].value).to eq(GenericYesNo::NO)
 
           expect(answers[4]).to be_an_instance_of(Answer)
-          expect(answers[4].question).to eq(:miam_attended)
+          expect(answers[4].question).to eq(:miam_certificate_received)
           expect(answers[4].value).to eq(GenericYesNo::NO)
+
+          expect(answers[5]).to be_an_instance_of(Answer)
+          expect(answers[5].question).to eq(:miam_attended)
+          expect(answers[5].value).to eq(GenericYesNo::NO)
         end
       end
     end

--- a/spec/presenters/summary/sections/nature_of_application_spec.rb
+++ b/spec/presenters/summary/sections/nature_of_application_spec.rb
@@ -43,5 +43,20 @@ module Summary
         expect(answers[3].question).to eq(:other_issue_details)
       end
     end
+
+    context 'for a consent order' do
+      let(:c100_application) {
+        instance_double(C100Application, orders: %w(consent_order), orders_additional_details: nil)
+      }
+
+      it 'has the correct number of rows' do
+        expect(answers.count).to eq(1)
+      end
+
+      it 'has the correct rows in the right order' do
+        expect(answers[0]).to be_an_instance_of(MultiAnswer)
+        expect(answers[0].question).to eq(:formalise_arrangements)
+      end
+    end
   end
 end


### PR DESCRIPTION
In the CYA this goes in the MIAM requirement section we already have.
Also ensure we show the consent order in the list of orders (nature of application) section.

<img width="1042" alt="Screen Shot 2020-07-20 at 14 30 05" src="https://user-images.githubusercontent.com/687910/87943593-2b627780-ca96-11ea-86c3-81d1b9892f33.png">

Most of it was already present in the PDF.
Just ensure we show the order in the nature of application, as well as in the MIAM section.

<img width="822" alt="Screen Shot 2020-07-20 at 14 31 41" src="https://user-images.githubusercontent.com/687910/87943633-361d0c80-ca96-11ea-9c16-d5ed3b5340bf.png">

<img width="833" alt="Screen Shot 2020-07-20 at 14 31 49" src="https://user-images.githubusercontent.com/687910/87943644-3917fd00-ca96-11ea-8af3-caec52a2bc26.png">
