### PR TITLE
Customise applicant email for consent orders

### DIFF
--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -45,6 +45,7 @@ class NotifySubmissionMailer < NotifyMailer
         court_email: court.email,
         court_url: C100App::CourtfinderAPI.new.court_url(court.slug),
         is_under_age: notify_boolean(@c100_application.applicants.under_age?),
+        is_consent_order: @c100_application.consent_order || 'no',
         payment_instructions: payment_instructions,
       )
     )

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
       id: '4a362e1c-48eb-40e3-9458-a31ead3f30a4',
       created_at: Time.at(0),
       receipt_email: 'receipt@example.com',
+      consent_order: 'yes',
       urgent_hearing: 'yes',
       address_confidentiality: address_confidentiality,
       payment_type: 'foobar_payment',
@@ -119,6 +120,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         court_email: 'court@example.com',
         court_url: 'https://courttribunalfinder.service.gov.uk/courts/test-court',
         is_under_age: 'no',
+        is_consent_order: 'yes',
         payment_instructions: 'payment instructions from locales',
       })
     end


### PR DESCRIPTION
Send yes/no to Notify to be able to show/hide the instructions in the confirmation email, when the application is for a consent order.

As Notify will fail if we add the variable to the template but we don't pass it, we are NOT changing the Notify template on production yet, until the day of the release of this work.

Parent ticket: https://mojdigital.teamwork.com/#/tasks/19965720
Subtask: https://mojdigital.teamwork.com/#/tasks/21212958