### PR TITLE
Add consent order text for online and print and post

### DIFF
--- a/app/views/steps/completion/confirmation/_consent_order_section.html.erb
+++ b/app/views/steps/completion/confirmation/_consent_order_section.html.erb
@@ -1,0 +1,10 @@
+<h3 class="govuk-heading-m">Send your proposed agreement for the consent order</h3>
+
+<p class="govuk-body">
+  As you are applying for a consent order, you need to send your agreement to the court.
+  You can do this by email or post. If you post it, please send 3 copies.
+</p>
+
+<p class="govuk-body">
+  Remember to include your application reference code.
+</p>

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -34,6 +34,8 @@
 
     <%= render partial: 'under_age_section' if @c100_application.applicants.under_age? %>
 
+    <%= render partial: 'consent_order_section' if @c100_application.consent_order? %>
+
     <%= render partial: 'steps/shared/court_help', locals: {court: @court} %>
 
     <%= render partial: 'steps/shared/feedback' %>

--- a/app/views/steps/completion/what_next/_with_consent_order.html.erb
+++ b/app/views/steps/completion/what_next/_with_consent_order.html.erb
@@ -1,0 +1,9 @@
+<h3 class="govuk-heading-m">Print your application and proposed agreement for the consent order</h3>
+<p class="govuk-body">
+  Print 3 copies of your whole application on A4 paper, single sided. The court will send one copy to the other
+  person, keep one copy, and return one copy to you.
+</p>
+
+<p class="govuk-body">
+  You must also send 3 copies of your proposed agreement for the consent order.
+</p>

--- a/app/views/steps/completion/what_next/_without_consent_order.html.erb
+++ b/app/views/steps/completion/what_next/_without_consent_order.html.erb
@@ -1,0 +1,5 @@
+<h3 class="govuk-heading-m">Print your application</h3>
+<p class="govuk-body">
+  Print 3 copies of your whole application on A4 paper, single sided. The court will send one copy to the other
+  person, keep one copy, and return one copy to you.
+</p>

--- a/app/views/steps/completion/what_next/show.en.html.erb
+++ b/app/views/steps/completion/what_next/show.en.html.erb
@@ -23,11 +23,11 @@
       </li>
 
       <li>
-        <h3 class="govuk-heading-m">Print your application</h3>
-        <p class="govuk-body">
-          Print 3 copies of your whole application on A4 paper, single sided. The court will send one copy to the other
-          person, keep one copy, and return one copy to you.
-        </p>
+
+        <%= render 'with_consent_order' if @c100_application.consent_order? %>
+
+        <%= render 'without_consent_order' unless @c100_application.consent_order? %>
+
       </li>
 
       <% if @c100_application.applicants.under_age? %>
@@ -43,6 +43,7 @@
           </p>
         </li>
       <% end %>
+
 
       <li>
         <h3 class="govuk-heading-m">Post it to the court</h3>

--- a/spec/views/steps/completion/confirmation/show.html.erb_spec.rb
+++ b/spec/views/steps/completion/confirmation/show.html.erb_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/completion/confirmation/show', type: :view do
+  let(:consent_order) { GenericYesNo::YES }
+  let(:under_age) { true }
+  let(:applicants_collection_double) { double(under_age?: under_age) }
+  let(:c100_application) { C100Application.new(id: '449362af-0bc3-4953-82a7-1363d479b876', created_at: Time.at(0), consent_order: consent_order) }
+
+  before do
+    allow(c100_application).to receive(:applicants).and_return(applicants_collection_double)
+
+    assign(:c100_application, c100_application)
+
+    assign(
+      :court,
+      double('Court',
+        name: 'Test court',
+        email: 'court@example.com',
+        slug: 'test-court'
+      )
+    )
+
+    render
+  end
+
+  context 'when applicant is under age' do
+    it 'should render the `under_age_section` partial' do
+      expect(view).to render_template('steps/shared/_under_age_section')
+    end
+
+    context 'when application is a consent order' do
+      it 'should render `consent_order_section` partial' do
+        expect(view).to render_template('steps/completion/confirmation/_consent_order_section')
+      end
+    end
+
+    context 'when application is not a consent order' do
+      let(:consent_order) { GenericYesNo::NO }
+
+      it 'should not render `consent_order_section`' do
+        expect(view).to_not render_template('steps/completion/confirmation/_consent_order_section')
+      end
+    end
+  end
+
+  context 'when applicant is an adult' do
+    let(:under_age) { false }
+
+    it 'should not render the `under_age_section` partial' do
+      expect(view).to_not render_template('steps/shared/_under_age_section')
+    end
+
+    context 'when application is a consent order' do
+      it 'should render `consent_order_section` partial' do
+        expect(view).to render_template('steps/completion/confirmation/_consent_order_section')
+      end
+    end
+
+    context 'when application is not a consent order' do
+      let(:consent_order) { GenericYesNo::NO }
+
+      it 'should not render `consent_order_section`' do
+        expect(view).to_not render_template('steps/completion/confirmation/_consent_order_section')
+      end
+    end
+  end
+end

--- a/spec/views/steps/completion/what_next/show.html.erb_spec.rb
+++ b/spec/views/steps/completion/what_next/show.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/completion/what_next/show', type: :view do
+  let(:consent_order) { GenericYesNo::YES }
+  let(:c100_application) { C100Application.new(id: '449362af-0bc3-4953-82a7-1363d479b876', created_at: Time.at(0), consent_order: consent_order) }
+
+  before do
+    assign(:c100_application, c100_application)
+
+    assign(
+        :court,
+        double('Court',
+               name: 'Test court',
+               email: 'court@example.com',
+               slug: 'test-court',
+               full_address: ['10', 'downing', 'st']
+        )
+    )
+
+    render
+  end
+
+  context 'when application is a consent order' do
+    it 'should render `with_consent_order` partial' do
+      expect(view).to_not render_template('steps/completion/what_next/_without_consent_order')
+      expect(view).to render_template('steps/completion/what_next/_with_consent_order')
+    end
+  end
+
+  context 'when application is not a consent order' do
+    let(:consent_order) { GenericYesNo::NO }
+
+    it 'should render `without_consent_order` partial' do
+      expect(view).to_not render_template('steps/completion/what_next/_with_consent_order')
+      expect(view).to render_template('steps/completion/what_next/_without_consent_order')
+    end
+  end
+
+end


### PR DESCRIPTION
We are still waiting for instructions on where to place the confirmation content on the 'digital submission' page.

After changes, it will look like this:

<img width="1406" alt="Screenshot 2020-07-21 at 11 39 42" src="https://user-images.githubusercontent.com/29227502/88045742-ea766b80-cb46-11ea-93fd-8ec3c3802f82.png">


Story: https://mojdigital.teamwork.com/#/tasks/21212954