### PR TITLE
Protect from nil value in consent_order attribute

### DIFF
--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -18,8 +18,8 @@ class BaseDecisionTree
   end
 
   def question(attribute_name, record = c100_application)
-    value = record.public_send(attribute_name)
-    GenericYesNo.new(value) if value
+    value = record.public_send(attribute_name) || 'na'
+    GenericYesNo.new(value)
   end
 
   def selected?(attribute_name, value: 'yes')

--- a/spec/services/c100_app/miam_decision_tree_spec.rb
+++ b/spec/services/c100_app/miam_decision_tree_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe C100App::MiamDecisionTree do
         it { is_expected.to have_destination(:acknowledgement, :edit) }
       end
     end
+
+    context 'when there is no consent order value (behaves like `no`)' do
+      let(:consent_value) { nil }
+
+      context 'and the answer is `yes`' do
+        let(:value) { 'yes' }
+        it { is_expected.to have_destination(:child_protection_info, :show) }
+      end
+
+      context 'and the answer is `no`' do
+        let(:value) { 'no' }
+        it { is_expected.to have_destination(:acknowledgement, :edit) }
+      end
+    end
   end
 
   context 'when the step is `miam_acknowledgement`' do


### PR DESCRIPTION
This can happen although might be rare, if right after the release to production, an application was in the middle of answering the child protection cases (meaning the `consent_order` question was not answered as it comes before child protection cases).

Given we check the value of consent_order in the child protection cases step, a `nil` would have raised an exception.

Protect from this edge case by ensuring the call to the `#question` method always returns a GenericYesNo instance with a value, which will be 'na' in case if nils.