### PR TITLE
Remove dependency on `email_validator` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.6.5'
 
 gem 'devise', '~> 4.7.1'
-gem 'email_validator', '< 2.0.0'
 gem 'govuk_design_system_formbuilder', '~> 1.2.5'
 gem 'govuk_notify_rails', '~> 2.1.0'
 gem 'govuk-pay-ruby-client', '~> 1.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,8 +129,6 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
-    email_validator (1.6.0)
-      activemodel
     equalizer (0.0.11)
     erubi (1.9.0)
     execjs (2.7.0)
@@ -416,7 +414,6 @@ DEPENDENCIES
   cucumber-rails
   devise (~> 4.7.1)
   dotenv-rails
-  email_validator (< 2.0.0)
   govuk-pay-ruby-client (~> 1.0.2)
   govuk_design_system_formbuilder (~> 1.2.5)
   govuk_notify_rails (~> 2.1.0)

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,0 +1,32 @@
+class EmailValidator < ActiveModel::EachValidator
+  EMAIL_REGEX = /\A\s*([-\p{L}\d+._]{1,64})@((?:[-\p{L}\d]+\.)+?\p{L}{2,})\s*\z/i
+  COMMON_DOMAIN_TYPOS = %w[
+    gamil.com
+    gmail.con
+    gmail.co
+    hotmial.com
+    hotmail.con
+    hotmail.co
+  ].freeze
+
+  def validate_each(record, attribute, value)
+    if valid_format?(value)
+      record.errors.add(attribute, :typo) if domain_typo?(value)
+    else
+      record.errors.add(attribute, :invalid)
+    end
+  end
+
+  private
+
+  def valid_format?(value)
+    EMAIL_REGEX.match?(value)
+  end
+
+  # Very simplistic but we see these typos quite frequently
+  def domain_typo?(value)
+    COMMON_DOMAIN_TYPOS.include?(
+      value.rpartition('@').last
+    )
+  end
+end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -2,6 +2,7 @@ en:
   dictionary:
     invalid_email_error: &invalid_email_error "Enter an email address in the correct format, like name@example.com"
     blank_email_error: &blank_email_error "Enter an email address"
+    email_typo_error: &email_typo_error "The email address seems to have a typing error"
     yes_no_error: &yes_no_error "Select yes or no"
     blank_details_error: &blank_details_error "Enter details"
     blank_exemptions_error: &blank_exemptions_error "Select at least one exemption or ‘None of these’"
@@ -47,9 +48,11 @@ en:
       email:
         invalid: *invalid_email_error
         blank: *blank_email_error
+        typo: *email_typo_error
       email_address:
         invalid: *invalid_email_error
         blank: *blank_email_error
+        typo: *email_typo_error
       children_postcodes:
         invalid: Enter a valid full postcode, with or without a space
         blank: Enter a full postcode, with or without a space
@@ -598,6 +601,7 @@ en:
               inclusion: Select how you’ll submit your application
             receipt_email:
               invalid: *invalid_email_error
+              typo: *email_typo_error
         steps/application/declaration_form:
           attributes:
             declaration_signee:

--- a/spec/forms/steps/application/submission_form_spec.rb
+++ b/spec/forms/steps/application/submission_form_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Steps::Application::SubmissionForm do
             expect(subject.errors[:receipt_email]).to_not be_empty
           }
         end
+
+        context 'email domain contains a typo' do
+          let(:receipt_email) { 'test@gamil.com' }
+          it {
+            expect(subject).not_to be_valid
+            expect(subject.errors.added?(:receipt_email, :typo)).to eq(true)
+          }
+        end
       end
     end
 

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -1,0 +1,140 @@
+require 'rails_helper'
+
+class TestModel
+  include ActiveModel::Validations
+
+  def initialize(attributes = {})
+    @attributes = attributes
+  end
+
+  def read_attribute_for_validation(key)
+    @attributes[key]
+  end
+end
+
+class TestUser < TestModel
+  validates :email, email: true
+end
+
+class TestUserAllowsNil < TestModel
+  validates :email, email: { allow_nil: true }
+end
+
+class TestUserAllowsNilFalse < TestModel
+  validates :email, email: { allow_nil: false }
+end
+
+describe EmailValidator do
+  describe 'COMMON_DOMAIN_TYPOS' do
+    it 'has a small list of common email domain typos' do
+      expect(
+        described_class::COMMON_DOMAIN_TYPOS
+      ).to eq(%w[
+        gamil.com
+        gmail.con
+        gmail.co
+        hotmial.com
+        hotmail.con
+        hotmail.co
+      ])
+    end
+  end
+
+  describe 'validation' do
+    context 'given the valid emails' do
+      [
+        "a+b@plus-in-local.com",
+        "a_b@underscore-in-local.com",
+        "test@example.com",
+        " user@example.com ",
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@letters-in-local.org",
+        "01234567890@numbers-in-local.net",
+        "a@single-character-in-local.org",
+        "one-character-third-level@a.example.com",
+        "single-character-in-sld@x.org",
+        "local@dash-in-sld.com",
+        "letters-in-sld@123.com",
+        "one-letter-sld@x.org",
+        "uncommon-tld@sld.museum",
+        "uncommon-tld@sld.travel",
+        "uncommon-tld@sld.mobi",
+        "country-code-tld@sld.uk",
+        "country-code-tld@sld.rw",
+        "local@sld.newTLD",
+        "local@sub.domains.com",
+        "aaa@bbb.co.jp",
+        "nigel.worthington@big.co.uk",
+        "f@c.com",
+        "areallylongnameaasdfasdfasdfasdf@asdfasdfasdfasdfasdf.ab.cd.ef.gh.co.ca",
+        "ящик@яндекс.рф",
+      ].each do |email|
+        it "#{email.inspect} should be valid" do
+          expect(TestUser.new(:email => email)).to be_valid
+        end
+      end
+    end
+
+    context 'given the invalid emails' do
+      [
+        "",
+        "f@s",
+        "f@s.c",
+        "@bar.com",
+        "test@example.com@example.com",
+        "test@",
+        "@missing-local.org",
+        "a b@space-in-local.com",
+        "! \#$%\`|@invalid-characters-in-local.org",
+        "<>@[]\`|@even-more-invalid-characters-in-local.org",
+        "missing-sld@.com",
+        "invalid-characters-in-sld@! \"\#$%(),/;<>_[]\`|.org",
+        "missing-dot-before-tld@com",
+        "missing-tld@sld.",
+        " ",
+        "missing-at-sign.net",
+        "unbracketed-IP@127.0.0.1",
+        "invalid-ip@127.0.0.1.26",
+        "another-invalid-ip@127.0.0.256",
+        "IP-and-port@127.0.0.1:25",
+        "the-local-part-is-invalid-if-it-is-longer-than-sixty-four-characters@sld.net",
+        "user@example.com\n<script>alert('hello')</script>",
+        "hans,peter@example.com",
+        "hans(peter@example.com",
+        "hans)peter@example.com",
+        "partially.\"quoted\"@sld.com",
+        "&'*+-./=?^_{}~@other-valid-characters-in-local.net",
+        "mixed-1234-in-{+^}-local@sld.net",
+      ].each do |email|
+        it "#{email.inspect} should not be valid" do
+          expect(TestUser.new(:email => email)).not_to be_valid
+        end
+      end
+    end
+
+    context 'given the silly email typos' do
+      %w(
+        test@gamil.com
+        test@gmail.co
+        test@hotmial.com
+      ).each do |email|
+        it "#{email.inspect} should not be valid" do
+          expect(TestUser.new(email: email)).not_to be_valid
+        end
+      end
+    end
+  end
+
+  describe 'nil email' do
+    it 'should not be valid when `allow_nil` option is missing' do
+      expect(TestUser.new(email: nil)).not_to be_valid
+    end
+
+    it 'should be valid when `allow_nil` option is set to true' do
+      expect(TestUserAllowsNil.new(email: nil)).to be_valid
+    end
+
+    it 'should not be valid when `allow_nil` option is set to false' do
+      expect(TestUserAllowsNilFalse.new(email: nil)).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21318405

The code in the gem is minimum and we can move it to our service and simplify it, reducing an external dependency and minimising the risk of this dependency being updated/changed and then our validations could break.

In fact this gem was already locked in version `< 2.0.0` because in greater version they introduced a change that didn't fit well with our validations (they made the regex much more simple thus emails like `a@b` would be valid).

I've moved the code and cleaned up to remove anything we don't need so it is just the regex.

Also as part of this I've added a very simple list of common domain typos we see frequently to try to avoid some of them. This was not part of the original gem.

For reference this is the code of the validator in the gem (< 2.0.0) I've based this work on:

https://github.com/K-and-R/email_validator/blob/ee5a44dcb936e9dae4a179e55c8be85742b601c3/lib/email_validator.rb