### PR TITLE
Refactor the court finder API class

### DIFF
--- a/app/controllers/steps/screener/error_but_continue_controller.rb
+++ b/app/controllers/steps/screener/error_but_continue_controller.rb
@@ -2,11 +2,7 @@ module Steps
   module Screener
     class ErrorButContinueController < Steps::ScreenerStepController
       def show
-        @courtfinder_ok = begin
-                            C100App::CourtfinderAPI.new.is_ok?
-                          rescue SocketError
-                            false
-                          end
+        @courtfinder_ok = C100App::CourtfinderAPI.new.is_ok?
       end
     end
   end

--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -43,7 +43,7 @@ class NotifySubmissionMailer < NotifyMailer
       shared_personalisation.merge(
         court_name: court.name,
         court_email: court.email,
-        court_url: C100App::CourtfinderAPI.new.court_url(court.slug),
+        court_url: C100App::CourtfinderAPI.court_url(court.slug),
         is_under_age: notify_boolean(@c100_application.applicants.under_age?),
         is_consent_order: @c100_application.consent_order || 'no',
         payment_instructions: payment_instructions,

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -62,7 +62,7 @@
 
                 <% if c100 %>
                   <dt>Court receipt email address</dt>
-                  <dd><%= c100.screener_answers_court.email %> | <%= link_to 'web', C100App::CourtfinderAPI.new.court_url(c100.screener_answers_court.slug), rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
+                  <dd><%= c100.screener_answers_court.email %> | <%= link_to 'web', C100App::CourtfinderAPI.court_url(c100.screener_answers_court.slug), rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
                   <dt>Applicant receipt email address</dt>
                   <dd><%= c100.receipt_email || 'none' %></dd>
                 <% else %>

--- a/app/views/steps/applicant/under_age/edit.html.erb
+++ b/app/views/steps/applicant/under_age/edit.html.erb
@@ -24,7 +24,7 @@
       <%
         court_and_tribunal_finder_url = link_to(
           'Court and tribunal finder',
-          C100App::CourtfinderAPI.new.court_url(@court.slug),
+          C100App::CourtfinderAPI.court_url(@court.slug),
           target: :_blank,
           rel: :external,
           class: 'govuk-link'

--- a/app/views/steps/completion/confirmation/_under_age_section.html.erb
+++ b/app/views/steps/completion/confirmation/_under_age_section.html.erb
@@ -7,7 +7,7 @@
 <%
   court_and_tribunal_finder_url = link_to(
     'Court and tribunal finder',
-    C100App::CourtfinderAPI.new.court_url(@court.slug),
+    C100App::CourtfinderAPI.court_url(@court.slug),
     class: 'govuk-link',
     target: :_blank,
     rel: :external

--- a/app/views/steps/shared/_court_help.en.html.erb
+++ b/app/views/steps/shared/_court_help.en.html.erb
@@ -13,5 +13,5 @@
   <dd><%= mail_to court.email, court.email, class: 'ga-pageLink govuk-link', data: { ga_category: 'completion', ga_label: 'email court' } %></dd>
 
   <dt>More information</dt>
-  <dd><%= link_to court.name, C100App::CourtfinderAPI.new.court_url(court.slug), class: 'govuk-link', rel: 'external', target: '_blank' %></dd>
+  <dd><%= link_to court.name, C100App::CourtfinderAPI.court_url(court.slug), class: 'govuk-link', rel: 'external', target: '_blank' %></dd>
 </dl>

--- a/spec/controllers/steps/screener/error_but_continue_controller_spec.rb
+++ b/spec/controllers/steps/screener/error_but_continue_controller_spec.rb
@@ -1,47 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Screener::ErrorButContinueController, type: :controller do
-  let(:courtfinder_ok){ true }
-
   before do
-    allow_any_instance_of(C100App::CourtfinderAPI).to receive(:is_ok?).and_return(courtfinder_ok)
+    # We test the healthcheck in `courtfinder_api_spec.rb` and in
+    # cucumber tests so this can be mocked to not repeat ourselves.
+    allow_any_instance_of(
+      C100App::CourtfinderAPI
+    ).to receive(:is_ok?).and_return(true)
   end
+
   it_behaves_like 'a show step controller'
-
-  describe '#show' do
-    let!(:existing_case) { C100Application.create }
-    let(:courtfinder_ok){ 'foo' }
-
-    it 'checks if the courtfinder api is ok' do
-      expect_any_instance_of(C100App::CourtfinderAPI).to receive(:is_ok?)
-      get :show, session: { c100_application_id: existing_case.id }
-    end
-
-    context 'when the courtfinder api does not throw an exception' do
-      it 'sets @courtfinder_ok with the value of CourtfinderAPI.is_ok?' do
-        get :show, session: { c100_application_id: existing_case.id }
-        expect( assigns[:courtfinder_ok] ).to_not be_nil
-      end
-    end
-
-    context 'when the courtfinder api does throw an exception' do
-      before do
-        allow_any_instance_of(C100App::CourtfinderAPI).to receive(:is_ok?).and_raise(error_class)
-      end
-      context 'of class SocketError' do
-        let(:error_class){ SocketError }
-        it 'sets @courtfinder_ok to false' do
-          get :show, session: { c100_application_id: existing_case.id }
-          expect( assigns[:courtfinder_ok] ).to eq(false)
-        end
-      end
-      context 'of another type' do
-        let(:error_class){ ArgumentError }
-        it 'lets the exception bubble out' do
-          expect{ get :show, session: { c100_application_id: existing_case.id } }.to raise_error
-        end
-      end
-    end
-
-  end
 end

--- a/spec/views/steps/screener/error_but_continue/show.html.erb_spec.rb
+++ b/spec/views/steps/screener/error_but_continue/show.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'steps/screener/error_but_continue/show', type: :view do
+  before do
+    allow(view).to receive(:step_header)
+
+    assign(
+      :courtfinder_ok, courtfinder_ok
+    )
+
+    render
+  end
+
+  context 'when court tribunal finder is healthy' do
+    let(:courtfinder_ok) { true }
+
+    it 'shows the appropriate error message' do
+      expect(rendered).to match(/our checker didn’t recognize it/)
+    end
+  end
+
+  context 'when court tribunal finder is unhealthy' do
+    let(:courtfinder_ok) { false }
+
+    it 'shows the appropriate error message' do
+      expect(rendered).to match(/trouble connecting to our postcode checker/)
+    end
+  end
+end


### PR DESCRIPTION
As a consequence of the rubocop bump in PR #1020 a series of offences were raised, in particular, the use of `open()` to do requests in this class.

I've now fixed that by doing a big refactor and cleanup to make this class more easy to understand and maintain, with less code.

I've moved to constants many of the strings that previously were used in multiple places or were hard to find, and also made possible to customise the http request timeouts (which I've reduced from the default 60 secs to something more sensible).

Individual commits for more context.

Incidentally now mutant takes a lot less time in this class than before:
```
Before refactor: 135.05s
After refactor: 87.71s
```