### PR TITLE
Fix GA tracking in FMC postcode lookup

### DIFF
--- a/app/services/c100_app/courtfinder_api.rb
+++ b/app/services/c100_app/courtfinder_api.rb
@@ -1,6 +1,3 @@
-require 'json'
-require 'open-uri'
-
 module C100App
   class CourtfinderAPI
     API_BASE_URL = "https://courttribunalfinder.service.gov.uk".freeze

--- a/app/views/steps/miam_exemptions/exit_page/show.en.html.erb
+++ b/app/views/steps/miam_exemptions/exit_page/show.en.html.erb
@@ -21,7 +21,8 @@
             <input id="postcode-field" class="govuk-input govuk-!-width-one-third" autocomplete="postal-code" type="text" value="" name="pc"/>
           </div>
           <input type="submit" name="commit" value="Find a mediator" class="govuk-button govuk-!-margin-bottom-1 ga-clickAction" formnovalidate="formnovalidate"
-                 data-module="govuk-button" data-ga-action="submit" data-ga-label="fmc postcode" data-prevent-double-click="true" data-disable-with="Find a mediator"/>
+                 data-module="govuk-button" data-ga-category="miam kickout" data-ga-action="submit" data-ga-label="fmc postcode"
+                 data-prevent-double-click="true" data-disable-with="Find a mediator"/>
         </form>
       </li>
       <li>Book initial meeting with mediator</li>


### PR DESCRIPTION
After the migration to the new design system back in May, this button lost their `data-ga-category` attribute, and thus the GA tracking stopped working.

Restore the missing attribute.

Also, although unrelated, cleanup a couple of unnecessary requires.