### PR TITLE
Bump govuk frontend to 3.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       activesupport (>= 4.2.0)
     govuk-pay-ruby-client (1.0.2)
       faraday (~> 1.0)
-    govuk_design_system_formbuilder (1.2.5)
+    govuk_design_system_formbuilder (1.2.6)
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
-      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.8.0.tgz",
+      "integrity": "sha512-+vgXzFsh7wpLRGjFSDvDcA2zNA2wOxT6gGs/KUpkTjF1Uop9BerW/1W/YB1BMpeTEJoPlmrkA19+DS1fqJtL9Q=="
     }
   }
 }


### PR DESCRIPTION
A new version was released. It has minor changes but some improve the accessibility.

Full list of changes here:
https://github.com/alphagov/govuk-frontend/releases/tag/v3.8.0

Also bump the `govuk_design_system_formbuilder` gem to go along the new frontend version.

Changelog here:
https://github.com/DFE-Digital/govuk_design_system_formbuilder/releases/tag/v1.2.6

No breaking changes.