### PR TITLE
Update sentry feedback code

### DIFF
--- a/app/assets/stylesheets/local/util.scss
+++ b/app/assets/stylesheets/local/util.scss
@@ -1,9 +1,3 @@
-// This will hide the Sentry user-feedback attribution. There is a setting
-// to hide it but currently it is not working, so this is an alternative.
-div.sentry-error-embed-wrapper p.powered-by {
-  display: none;
-}
-
 address {
   font-style: normal;
 }

--- a/app/views/layouts/_sentry_feedback.html.erb
+++ b/app/views/layouts/_sentry_feedback.html.erb
@@ -1,13 +1,16 @@
 <% content_for(:head) do %>
-  <script src="https://cdn.ravenjs.com/3.24.0/raven.min.js"></script>
+  <script src="https://browser.sentry-cdn.com/5.20.1/bundle.min.js" integrity="O8HdAJg1h8RARFowXd2J/r5fIWuinSBtjhwQoPesfVILeXzGpJxvyY/77OaPPXUo" crossorigin="anonymous"></script>
 <% end %>
 
 <% content_for(:body_end) do %>
   <script>
-    Raven.showReportDialog({
-      eventId: '<%= Raven.last_event_id %>',
-      // Use only the public DSN here!
-      dsn: '<%= "https://#{Raven.configuration.public_key}@sentry.service.dsd.io/#{Raven.configuration.project_id}" %>'
+    // Use only the public DSN here!
+    Sentry.init({
+      dsn: '<%= "https://#{Raven.configuration.public_key}@#{Raven.configuration.host}/#{Raven.configuration.project_id}" %>'
+    });
+
+    Sentry.showReportDialog({
+      eventId: '<%= Raven.last_event_id %>'
     });
   </script>
 <% end %>


### PR DESCRIPTION
We've moved away from the self-hosted sentry instance, so this code needs to be updated.
It also was using a very old JS version.

I've removed as well the custom CSS as I've seen the bug is now fixed on the Sentry side.