### PR TITLE
Clarify email failures in back office

### DIFF
--- a/app/services/reports/failed_emails_report.rb
+++ b/app/services/reports/failed_emails_report.rb
@@ -18,8 +18,10 @@ module Reports
         self.report_type = :backoffice
         self.failures = []
 
+        # We skip emails created in the last few minutes to give a bit of time
+        # for these recent callbacks to come back.
         EmailSubmission.where(
-          created_at: 1.week.ago.beginning_of_day...Date.current.end_of_day
+          created_at: 1.week.ago.beginning_of_day...10.minutes.ago
         ).joins(:c100_application).find_each(batch_size: 25) do |record|
           reference_code = record.c100_application.reference_code
 

--- a/app/views/backoffice/emails/index.en.html.erb
+++ b/app/views/backoffice/emails/index.en.html.erb
@@ -14,17 +14,23 @@
       This is a report of any failed submission emails (court or applicant confirmation), in the last 7 days.
     </p>
 
-    <p class="govuk-body">
-      <strong>
-        After resending a failed email, wait a few seconds and reload this page. The failure should be gone if the
-        email was sent successfully, otherwise a new error will show.
-      </strong>
-    </p>
-
-    <p class="govuk-body">
-      Please note some failures might be genuine, for instance, due to a typo in the applicant's email address. Do
-      not retry these emails as they will fail again.
-    </p>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          About the resend functionality
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Very recent emails can report as ‘callback-missing’. Notify callbacks might be delayed.</li>
+          <li>Some failures are genuine, for instance, due to a typo in the email address. A resend will fail again.</li>
+          <li>After resending a failed email, wait a few minutes and reload the page. The failure should be gone if the email was sent successfully, otherwise a new error will show.</li>
+        </ul>
+        <p class="govuk-body">
+          In addition to this report, an <strong>automated email</strong> will be sent overnight to all back office users in the event of any failed email to court the day before.
+        </p>
+      </div>
+    </details>
 
     <table class="govuk-table backoffice-table">
       <thead class="govuk-table__head">


### PR DESCRIPTION
And do not show as errors very recent emails (10 minutes), as these might not have received the callback yet, due to Notify delays.

<img width="1001" alt="Screen Shot 2020-07-31 at 17 09 38" src="https://user-images.githubusercontent.com/687910/89054399-a2c6bf80-d350-11ea-9c1d-681a99a727f9.png">
