### PR TITLE
Improve error handling

### DIFF
--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -60,6 +60,9 @@ class C100Application < ApplicationRecord
   end
 
   def mark_as_completed!
-    completed! && CompletedApplicationsAudit.log!(self)
+    transaction do
+      completed!
+      CompletedApplicationsAudit.log!(self)
+    end
   end
 end

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -196,5 +196,30 @@ RSpec.describe C100Application, type: :model do
 
       subject.mark_as_completed!
     end
+
+    context 'transaction' do
+      let(:attributes) { {
+        status: :in_progress
+      } }
+
+      # In these tests we are testing DB transactions, so we need to persist
+      # the record, and cleanup after we are finished with it.
+      before do
+        subject.save
+      end
+
+      after do
+        subject.destroy
+      end
+
+      it 'reverts the application status to how it was before (rollbacks)' do
+        expect(subject.status).to eq('in_progress')
+        expect(subject).to receive(:completed!).and_call_original
+
+        expect { subject.mark_as_completed! }.to raise_error
+
+        expect(subject.reload.status).to eq('in_progress')
+      end
+    end
   end
 end


### PR DESCRIPTION
We had an edge case where if the application at point of submission lack some vital information used in the `CompletedApplicationsAudit` then it was giving a misleading "payment error" message.

This is because the `#confirmation_url` method (which triggers the completion and audit) raised an exception but was being captured by the rescue in the `#payment_url` method.

I've now moved the call to `confirmation_url` outside a begin-rescue so in the rare occasion it raises an exception it bubble ups and is not re-raised as a `PaymentUnexpectedError`

Also improved the overall status changes using transactions, so if either the Audit or the `create_payment` methods fail, the status is reverted to how it was automatically with a rollback.