### PR TITLE
Add special guardianship question to CYA and PDF

### DIFF
--- a/app/assets/stylesheets/local/check_answers.scss
+++ b/app/assets/stylesheets/local/check_answers.scss
@@ -51,6 +51,13 @@
   }
 }
 
+// Give a bit more space between children
+#children_details, #other_children_details {
+  h3 {
+    margin-top: govuk-spacing(3);
+  }
+}
+
 // BEGIN -- Overrides for design system styles. Use with caution.
 //
 .govuk-summary-list {

--- a/app/presenters/summary/html_sections/base_children_details.rb
+++ b/app/presenters/summary/html_sections/base_children_details.rb
@@ -25,6 +25,9 @@ module Summary
               personal_details_questions(child),
               change_path: personal_details_path(child)
             ),
+            # SGO only shows if a value is present (will not show for `OtherChild` or consent orders)
+            Answer.new(:special_guardianship_order, child.special_guardianship_order,
+                       change_path: edit_steps_children_special_guardianship_order_path(child)),
             MultiAnswer.new(
               :child_orders,
               order_types(child),

--- a/app/presenters/summary/sections/children_details.rb
+++ b/app/presenters/summary/sections/children_details.rb
@@ -22,6 +22,7 @@ module Summary
             Separator.new(:child_index_title, index: index),
             personal_details(child),
             relationships(child),
+            Answer.new(:special_guardianship_order, child.special_guardianship_order),
             MultiAnswer.new(:child_orders, order_types(child)),
             Partial.row_blank_space,
           ]

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -178,6 +178,10 @@ en:
       question: Orders applied for
       answers:
         <<: *PETITION_ORDER_TYPES
+    special_guardianship_order:
+      question: Special Guardianship Order in force?
+      answers:
+        <<: *YESNO
     children_known_to_authorities:
       question: Are any of the children known to social services?
       answers:

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -287,6 +287,10 @@ en:
       question: Are any of the children the subject of a child protection plan?
       answers:
         <<: *YESNO
+    special_guardianship_order:
+      question: Special Guardianship Order in force?
+      answers:
+        <<: *YESNO
     applicants_relationships:
       question: Applicant(s)
     respondents_relationships:

--- a/spec/presenters/summary/html_sections/children_details_spec.rb
+++ b/spec/presenters/summary/html_sections/children_details_spec.rb
@@ -15,12 +15,14 @@ module Summary
         dob: dob,
         age_estimate: age_estimate,
         gender: 'female',
+        special_guardianship_order: special_guardianship_order,
         child_order: child_order,
       )
     }
 
     let(:dob) { Date.new(2018, 1, 20) }
     let(:age_estimate) { nil }
+    let(:special_guardianship_order) { nil }
     let(:child_order) { instance_double(ChildOrder, orders: ['an_order']) }
 
     subject { described_class.new(c100_application) }
@@ -87,6 +89,17 @@ module Summary
           expect(details[0]).to be_an_instance_of(FreeTextAnswer)
           expect(details[0].question).to eq(:person_age_estimate)
           expect(details[0].value).to eq(18)
+        end
+      end
+
+      context 'when the `special_guardianship_order` attribute is not `nil`' do
+        let(:special_guardianship_order) { 'yes' }
+
+        it 'shows the question-answer' do
+          expect(answers[3]).to be_an_instance_of(Answer)
+          expect(answers[3].question).to eq(:special_guardianship_order)
+          expect(answers[3].value).to eq('yes')
+          expect(answers[3].change_path).to eq('/steps/children/special_guardianship_order/uuid-123')
         end
       end
     end

--- a/spec/presenters/summary/html_sections/other_children_details_spec.rb
+++ b/spec/presenters/summary/html_sections/other_children_details_spec.rb
@@ -15,6 +15,7 @@ module Summary
         dob: Date.new(2018, 1, 20),
         age_estimate: nil,
         gender: 'female',
+        special_guardianship_order: nil,
       )
     }
 

--- a/spec/presenters/summary/sections/children_details_spec.rb
+++ b/spec/presenters/summary/sections/children_details_spec.rb
@@ -19,6 +19,7 @@ module Summary
         dob: dob,
         age_estimate: age_estimate,
         gender: 'female',
+        special_guardianship_order: special_guardianship_order,
         child_order: child_order,
         relationships: relationships,
       )
@@ -26,6 +27,8 @@ module Summary
 
     let(:dob) { Date.new(2018, 1, 20) }
     let(:age_estimate) { nil }
+    let(:special_guardianship_order) { nil }
+
     let(:child_order) { instance_double(ChildOrder, orders: ['an_order']) }
     let(:relationships) { double('relationships') }
 
@@ -108,6 +111,16 @@ module Summary
           expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
           expect(answers[2].question).to eq(:child_age_estimate)
           expect(answers[2].value).to eq(18)
+        end
+      end
+
+      context 'when the `special_guardianship_order` attribute is not `nil`' do
+        let(:special_guardianship_order) { 'yes' }
+
+        it 'shows the question-answer' do
+          expect(answers[6]).to be_an_instance_of(Answer)
+          expect(answers[6].question).to eq(:special_guardianship_order)
+          expect(answers[6].value).to eq('yes')
         end
       end
     end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21392185
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

This PR adds the special guardianship question to the CYA and the PDF.

Individual commits for more context.

## CYA example:
<img width="1014" alt="Screen Shot 2020-08-04 at 16 21 30" src="https://user-images.githubusercontent.com/687910/89311972-956e4580-d66e-11ea-90f6-f34873f26579.png">

## PDF example:
<img width="660" alt="Screen Shot 2020-08-04 at 16 11 12" src="https://user-images.githubusercontent.com/687910/89311870-740d5980-d66e-11ea-9902-5932b045423e.png">