### PR TITLE
Place SGO question behind feature flag

### DIFF
--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -28,7 +28,7 @@ module C100App
     private
 
     def after_personal_details
-      if c100_application.consent_order?
+      if c100_application.consent_order? || hide_non_parents?
         # Bypass SGO if this is a consent order application
         choose_orders_step
       else
@@ -70,6 +70,12 @@ module C100App
 
     def next_child_id(current: record)
       next_record_id(c100_application.child_ids, current: current)
+    end
+
+    # TODO: temporarily until we finish all the neccessary work
+    # Will show on local/test/CI and staging, but not in production
+    def hide_non_parents?
+      Rails.env.production? && ENV['DEV_TOOLS_ENABLED'].nil?
     end
   end
 end

--- a/spec/services/c100_app/children_decision_tree_spec.rb
+++ b/spec/services/c100_app/children_decision_tree_spec.rb
@@ -53,8 +53,26 @@ RSpec.describe C100App::ChildrenDecisionTree do
     context 'and the application is not a consent order' do
       let(:consent_order) { false }
 
-      it 'goes to the special guardianship order question for the current record' do
-        expect(subject.destination).to eq(controller: :special_guardianship_order, action: :edit, id: record)
+      # TODO: feature-flag code to be removed once non-parents is released
+      before do
+        expect(Rails.env).to receive(:production?).and_return(true)
+        expect(ENV).to receive(:[]).with('DEV_TOOLS_ENABLED').and_return(dev_tools_enabled)
+      end
+
+      context 'when non-parents feature is enabled' do
+        let(:dev_tools_enabled) { '1' }
+
+        it 'goes to the special guardianship order question for the current record' do
+          expect(subject.destination).to eq(controller: :special_guardianship_order, action: :edit, id: record)
+        end
+      end
+
+      context 'when non-parents feature is disabled' do
+        let(:dev_tools_enabled) { nil }
+
+        it 'goes to edit the orders of the current record' do
+          expect(subject.destination).to eq(controller: :orders, action: :edit, id: record)
+        end
       end
     end
   end


### PR DESCRIPTION
Follow-up to PR's #1028 and #1029.

We don't want this to show on production inadvertently if we deploy, so temporarily until the non-parents work is completed, we are hiding the Special Guardianship Order question in production.

It will show in other environments, including localhost and staging.