### PR TITLE
Add Guardian and Special Guardian options to relationship step

### DIFF
--- a/app/value_objects/relation.rb
+++ b/app/value_objects/relation.rb
@@ -2,7 +2,9 @@ class Relation < ValueObject
   VALUES = [
     MOTHER = new(:mother),
     FATHER = new(:father),
-    OTHER  = new(:other),
+    GUARDIAN = new(:guardian),
+    SPECIAL_GUARDIAN = new(:special_guardian),
+    OTHER = new(:other),
   ].freeze
 
   def self.values

--- a/app/views/steps/shared/_relationship_step.html.erb
+++ b/app/views/steps/shared/_relationship_step.html.erb
@@ -4,6 +4,8 @@
   <%= f.govuk_radio_buttons_fieldset :relation, legend: { text: heading } do %>
     <%= f.govuk_radio_button :relation, Relation::MOTHER, link_errors: true %>
     <%= f.govuk_radio_button :relation, Relation::FATHER %>
+    <%= f.govuk_radio_button :relation, Relation::GUARDIAN %>
+    <%= f.govuk_radio_button :relation, Relation::SPECIAL_GUARDIAN %>
     <%= f.govuk_radio_button :relation, Relation::OTHER do %>
       <%= f.govuk_text_field :relation_other_value, label: { size: 's'} %>
     <% end %>

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -18,6 +18,8 @@ en:
     RELATIONS: &RELATIONS
       mother: Mother
       father: Father
+      guardian: Guardian
+      special_guardian: Special Guardian
       other: Other
 
     # Important: maintain these orders in sync with the rest of locale files

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,8 @@ en:
     RELATIONS: &RELATIONS
       mother: Mother
       father: Father
+      guardian: Guardian
+      special_guardian: Special Guardian
       other: Other
 
     PETITION_ORDERS: &PETITION_ORDERS
@@ -1472,6 +1474,10 @@ en:
         special_arrangements: *one_of_the_people_needs
       steps_attending_court_special_assistance_form:
         special_assistance: *one_of_the_people_needs
+      steps_shared_relationship_form:
+        relation_options:
+          guardian: Someone who represents the rights of a child, appointed by the court
+          special_guardian: Someone who a child lives with, appointed by the court
 
     legend:
       # Screener steps

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -22,6 +22,8 @@ en:
     RELATIONS: &RELATIONS
       mother: Mother
       father: Father
+      guardian: Guardian
+      special_guardian: Special Guardian
       other: Other
 
     # Important: maintain these orders in sync with the rest of locale files

--- a/spec/forms/steps/shared/relationship_form_spec.rb
+++ b/spec/forms/steps/shared/relationship_form_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Steps::Shared::RelationshipForm do
       expect(described_class.choices).to eq(%w(
         mother
         father
+        guardian
+        special_guardian
         other
       ))
     end

--- a/spec/value_objects/relation_spec.rb
+++ b/spec/value_objects/relation_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Relation do
       expect(described_class.values.map(&:to_s)).to eq(%w(
         mother
         father
+        guardian
+        special_guardian
         other
       ))
     end


### PR DESCRIPTION
This change adds the 'Guardian' and 'Special Guardian' options to the relationship step.
The CYA and PDF also reflects the new relationships.

Note: Need confirmation of the hint text before we can merge.

![Screenshot 2020-08-05 at 11 47 19](https://user-images.githubusercontent.com/29227502/89405713-ed12bc80-d713-11ea-9224-2a26dd8acf11.png)

![Screenshot 2020-08-05 at 11 50 39](https://user-images.githubusercontent.com/29227502/89405732-f13eda00-d713-11ea-9491-5f325f8ff389.png)

![Screenshot 2020-08-05 at 11 50 47](https://user-images.githubusercontent.com/29227502/89405743-f4d26100-d713-11ea-95e3-3cf85383a972.png)

![Screenshot 2020-08-05 at 11 51 38](https://user-images.githubusercontent.com/29227502/89405780-00be2300-d714-11ea-8b0f-2afbcdfdc33e.png)
