### PR TITLE
Add non-parents permission questions framework

### DIFF
--- a/app/controllers/steps/permission/question_controller.rb
+++ b/app/controllers/steps/permission/question_controller.rb
@@ -1,0 +1,31 @@
+module Steps
+  module Permission
+    class QuestionController < Steps::PermissionStepController
+      def edit
+        @form_object = question_form_class.build(
+          current_record, c100_application: current_c100_application,
+        )
+      end
+
+      def update
+        update_and_advance(
+          question_form_class,
+          record: current_record,
+        )
+      end
+
+      private
+
+      # As long as we follow the convention for naming form objects, we will
+      # end up, as an example, for a question named `parental_responsibility`
+      # with the class `Steps::Permission::ParentalResponsibilityForm`
+      #
+      def question_form_class
+        form_class = [question_name.classify, 'Form'].join
+        namespace  = self.class.name.deconstantize
+
+        [namespace, form_class].join('::').constantize
+      end
+    end
+  end
+end

--- a/app/controllers/steps/permission_step_controller.rb
+++ b/app/controllers/steps/permission_step_controller.rb
@@ -1,0 +1,23 @@
+module Steps
+  class PermissionStepController < CrudStepController
+    private
+
+    def decision_tree_class
+      C100App::PermissionDecisionTree
+    end
+
+    def question_name
+      params.require(:question_name)
+    end
+
+    def current_record
+      @_current_record ||= record_collection.find_by!(
+        id: params.require(:relationship_id)
+      )
+    end
+
+    def record_collection
+      @_record_collection ||= current_c100_application.relationships
+    end
+  end
+end

--- a/app/forms/steps/permission/living_order_form.rb
+++ b/app/forms/steps/permission/living_order_form.rb
@@ -1,0 +1,12 @@
+module Steps
+  module Permission
+    class LivingOrderForm < QuestionForm
+      include SingleQuestionForm
+
+      yes_no_attribute :living_order,
+                       reset_when_yes: [
+                         # To be added once we have next questions
+                       ]
+    end
+  end
+end

--- a/app/forms/steps/permission/parental_responsibility_form.rb
+++ b/app/forms/steps/permission/parental_responsibility_form.rb
@@ -1,0 +1,12 @@
+module Steps
+  module Permission
+    class ParentalResponsibilityForm < QuestionForm
+      include SingleQuestionForm
+
+      yes_no_attribute :parental_responsibility,
+                       reset_when_yes: [
+                         :living_order,
+                       ]
+    end
+  end
+end

--- a/app/forms/steps/permission/question_form.rb
+++ b/app/forms/steps/permission/question_form.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Permission
+    class QuestionForm < BaseForm
+      # Used for i18n locales as we are reusing the same view
+      # Corresponds with the yes-no attribute (there is only one)
+      def question_name
+        attributes.keys.first
+      end
+
+      private
+
+      # Here `record` is a `relationship` record
+      # This is used in the `SingleQuestionForm` persist method
+      def record_to_persist
+        record
+      end
+    end
+  end
+end

--- a/app/services/c100_app/permission_decision_tree.rb
+++ b/app/services/c100_app/permission_decision_tree.rb
@@ -1,0 +1,33 @@
+module C100App
+  class PermissionDecisionTree < BaseDecisionTree
+    def destination
+      return next_step if next_step
+
+      case step_name
+      when :parental_responsibility
+        advance_or_exit_journey(next_question: :living_order)
+      when :living_order
+        exit_journey
+      else
+        raise InvalidStep, "Invalid step '#{as || step_params}'"
+      end
+    end
+
+    private
+
+    # Exit the questions journey the moment we get a `yes` answer,
+    # otherwise we keep asking questions until we reach the end.
+    def advance_or_exit_journey(next_question:)
+      return exit_journey if question(step_name, record).yes?
+
+      edit(:question, question_name: next_question, relationship_id: record)
+    end
+
+    # Get back to the applicants-children relationship loop
+    def exit_journey
+      ApplicantDecisionTree.new(
+        c100_application: c100_application, record: record
+      ).children_relationships
+    end
+  end
+end

--- a/app/views/steps/permission/question/edit.html.erb
+++ b/app/views/steps/permission/question/edit.html.erb
@@ -1,0 +1,20 @@
+<% title t(".page_title.#{@form_object.question_name}") %>
+<% step_header %>
+
+<% heading = t(".heading.#{@form_object.question_name}",
+               applicant_name: @form_object.record.person.full_name,
+               child_name: @form_object.record.minor.full_name) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons @form_object.question_name, GenericYesNo.values, :value, nil, legend: { text: heading } do %>
+        <%=t ".body_text.#{@form_object.question_name}_html" %>
+      <% end %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,6 +178,26 @@ en:
         fieldset_legend: Enter a new name
       children_personal_details:
         heading: "Provide details for %{name}"
+
+    # BEGIN - Non-parents journey
+    # We use the approach of one single controller-view.
+    permission:
+      question:
+        edit:
+          page_title:
+            parental_responsibility: Parental responsibility
+            living_order: Living order
+          heading:
+            parental_responsibility: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
+            living_order: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
+          body_text:
+            parental_responsibility_html: |
+              <p class="govuk-body">
+                They could have parental responsibility by making a formal agreement that has been approved by the court, or following a court order.
+              </p>
+            living_order_html: ""
+    # END - Non-parents journey
+
     applicant:
       names:
         edit:
@@ -778,7 +798,6 @@ en:
           page_title: Details of urgent hearing
           heading: Details of urgent hearing
           court_info_html: If you need to go to court now, <a href="https://courttribunalfinder.service.gov.uk/search/" rel="external" target="_blank" class="govuk-link">contact your nearest family court</a> for assistance.
-    # attending court redesign -- begin
     attending_court:
       language:
         edit:
@@ -794,7 +813,6 @@ en:
       special_assistance:
         edit:
           page_title: Special assistance
-    # attending court redesign -- end
     international:
       resident:
         edit:
@@ -1261,6 +1279,12 @@ en:
         <<: *NAMES_FORM_FIELDS
       steps_children_special_guardianship_order_form:
         special_guardianship_order_options:
+          <<: *YESNO
+      steps_permission_parental_responsibility_form:
+        parental_responsibility_options:
+          <<: *YESNO
+      steps_permission_living_order_form:
+        living_order_options:
           <<: *YESNO
       steps_address_lookup_form:
         postcode: Current postcode

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -487,6 +487,11 @@ en:
             relation_other_value:
               blank: Enter the relationship
 
+        # This error will apply to all questions in the permission journey
+        # No need to declare the individual errors unless we really want them different
+        steps/permission/question_form:
+          inclusion: *yes_no_error
+
         steps/miam_exemptions/domestic_form:
           attributes:
             domestic:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -255,6 +255,11 @@ Rails.application.routes.draw do
         edit_routes ':id/child/:child_id'
       end
     end
+    namespace :permission do
+      namespace :question, path: ':question_name' do
+        edit_routes 'relationship/:relationship_id'
+      end
+    end
     namespace :international do
       edit_step :resident
       edit_step :jurisdiction

--- a/db/migrate/20200806085153_add_permission_fields_to_relationship.rb
+++ b/db/migrate/20200806085153_add_permission_fields_to_relationship.rb
@@ -1,0 +1,13 @@
+class AddPermissionFieldsToRelationship < ActiveRecord::Migration[5.2]
+  def change
+    add_column :relationships, :parental_responsibility, :string
+    add_column :relationships, :living_order,            :string
+    add_column :relationships, :amendment,               :string
+    add_column :relationships, :time_order,              :string
+    add_column :relationships, :living_arrangements,     :string
+    add_column :relationships, :consent,                 :string
+    add_column :relationships, :family,                  :string
+    add_column :relationships, :local_authority,         :string
+    add_column :relationships, :relative,                :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_03_111915) do
+ActiveRecord::Schema.define(version: 2020_08_06_085153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -317,6 +317,15 @@ ActiveRecord::Schema.define(version: 2020_08_03_111915) do
     t.uuid "minor_id", null: false
     t.uuid "person_id", null: false
     t.uuid "c100_application_id"
+    t.string "parental_responsibility"
+    t.string "living_order"
+    t.string "amendment"
+    t.string "time_order"
+    t.string "living_arrangements"
+    t.string "consent"
+    t.string "family"
+    t.string "local_authority"
+    t.string "relative"
     t.index ["c100_application_id"], name: "index_relationships_on_c100_application_id"
     t.index ["minor_id", "person_id"], name: "index_relationships_on_minor_id_and_person_id", unique: true
   end

--- a/spec/controllers/steps/permission/question_controller_spec.rb
+++ b/spec/controllers/steps/permission/question_controller_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Permission::QuestionController, type: :controller do
+  # There will be 9 different form classes but all behave the same, so we just pick one
+  let(:form_class) { Steps::Permission::ParentalResponsibilityForm }
+  let(:decision_tree_class) { C100App::PermissionDecisionTree }
+
+  let(:question_name) { 'parental_responsibility' }
+  let(:relationship_id) { 'uuid-123' }
+
+  let(:params) { { question_name: question_name, relationship_id: relationship_id } }
+
+  let(:relationships_scope) { double('relationships_scope') }
+  let(:relationship) { Relationship.new }
+
+  before do
+    allow_any_instance_of(C100Application).to receive(:relationships).and_return(relationships_scope)
+    allow(relationships_scope).to receive(:find_by!).with(id: relationship_id).and_return(relationship)
+  end
+
+  describe '#edit' do
+    context 'when no case exists in the session yet' do
+      before do
+        # Needed because some specs that include these examples stub current_c100_application,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_c100_application).and_return(nil)
+      end
+
+      it 'redirects to the invalid session error page' do
+        get :edit, params: params
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when a case exists in the session' do
+      let!(:existing_case) { C100Application.create(status: :in_progress) }
+
+      after do
+        existing_case.destroy
+      end
+
+      context 'when the question is unknown' do
+        let(:question_name) { 'foobar' }
+
+        it 'raises an exception' do
+          expect {
+            get :edit, params: params, session: { c100_application_id: existing_case.id }
+          }.to raise_error(NameError, 'uninitialized constant Steps::Permission::FoobarForm')
+        end
+      end
+
+      it 'responds with HTTP success' do
+        expect(
+          form_class
+        ).to receive(:build).with(
+          relationship, c100_application: existing_case
+        )
+
+        get :edit, params: params, session: { c100_application_id: existing_case.id }
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+    let(:form_class_params_name) { form_class.name.underscore }
+    let(:expected_params) { params.merge({ form_class_params_name => { foo: 'bar' } }) }
+
+    context 'when there is no case in the session' do
+      before do
+        # Needed because some specs that include these examples stub current_c100_application,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_c100_application).and_return(nil)
+      end
+
+      it 'redirects to the invalid session error page' do
+        put :update, params: expected_params
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when a case in progress is in the session' do
+      let!(:existing_case) { C100Application.create(status: :in_progress) }
+
+      before do
+        allow(form_class).to receive(:new).and_return(form_object)
+      end
+
+      after do
+        existing_case.destroy
+      end
+
+      context 'when the form saves successfully' do
+        before do
+          expect(form_object).to receive(:save).and_return(true)
+        end
+
+        let(:decision_tree) { instance_double(decision_tree_class, destination: '/expected_destination') }
+
+        it 'asks the decision tree for the next destination and redirects there' do
+          expect(decision_tree_class).to receive(:new).and_return(decision_tree)
+          put :update, params: expected_params, session: { c100_application_id: existing_case.id }
+          expect(subject).to redirect_to('/expected_destination')
+        end
+      end
+
+      context 'when the form fails to save' do
+        before do
+          expect(form_object).to receive(:save).and_return(false)
+        end
+
+        it 'renders the question page again' do
+          put :update, params: expected_params, session: { c100_application_id: existing_case.id }
+          expect(subject).to render_template(:edit)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/steps/permission/living_order_form_spec.rb
+++ b/spec/forms/steps/permission/living_order_form_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Permission::LivingOrderForm do
+  it_behaves_like 'a permission yes-no question form',
+                  attribute_name: :living_order
+end

--- a/spec/forms/steps/permission/parental_responsibility_form_spec.rb
+++ b/spec/forms/steps/permission/parental_responsibility_form_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Permission::ParentalResponsibilityForm do
+  it_behaves_like 'a permission yes-no question form',
+                  attribute_name: :parental_responsibility,
+                  reset_when_yes: [
+                    :living_order,
+                  ]
+end

--- a/spec/services/c100_app/permission_decision_tree_spec.rb
+++ b/spec/services/c100_app/permission_decision_tree_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe C100App::PermissionDecisionTree do
+  let(:c100_application) { double('Object') }
+  let(:step_params)      { double('Step') }
+  let(:next_step)        { nil }
+  let(:as)               { nil }
+  let(:record)           { nil }
+  let(:c100_application) { instance_double(C100Application) }
+
+  subject {
+    described_class.new(
+      c100_application: c100_application,
+      record: record,
+      step_params: step_params,
+      as: as,
+      next_step: next_step
+    )
+  }
+
+  it_behaves_like 'a decision tree'
+
+  # We only test the call to the `ApplicantDecisionTree`, as the `children_relationships`
+  # method is already tested in other decision trees, so no need to repeat that.
+  describe '#exit_journey' do
+    let(:step_params) { { parental_responsibility: 'anything' } }
+    let(:record) { instance_double(Relationship, parental_responsibility: 'yes') }
+
+    let(:applicant_decision_tree) { instance_double(C100App::ApplicantDecisionTree) }
+
+    before do
+      allow(
+        C100App::ApplicantDecisionTree
+      ).to receive(:new).with(
+        c100_application: c100_application, record: record
+      ).and_return(applicant_decision_tree)
+
+      allow(applicant_decision_tree).to receive(:children_relationships).and_return(foo: :bar)
+    end
+
+    it 'returns the next child destination' do
+      expect(subject.destination).to eq(foo: :bar)
+    end
+  end
+
+  context 'when the step is `parental_responsibility`' do
+    let(:step_params) { { parental_responsibility: 'anything' } }
+    let(:record) { instance_double(Relationship, parental_responsibility: value) }
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+
+      it 'exists the journey' do
+        expect(subject).to receive(:exit_journey)
+        subject.destination
+      end
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+
+      it 'advances to the next question' do
+        expect(subject.destination).to eq(controller: :question, action: :edit, question_name: :living_order, relationship_id: record)
+      end
+    end
+  end
+
+  context 'when the step is `living_order`' do
+    let(:step_params) { { living_order: 'anything' } }
+    let(:record) { instance_double(Relationship, living_order: value) }
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+
+      it 'exists the journey' do
+        expect(subject).to receive(:exit_journey)
+        subject.destination
+      end
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+
+      # TODO: adapt tests when we add new questions
+      it 'exists the journey' do
+        expect(subject).to receive(:exit_journey)
+        subject.destination
+      end
+    end
+  end
+end

--- a/spec/support/form_validation_shared_examples.rb
+++ b/spec/support/form_validation_shared_examples.rb
@@ -125,6 +125,35 @@ RSpec.shared_examples 'a yes-no question form' do |options|
   end
 end
 
+RSpec.shared_examples 'a permission yes-no question form' do |options|
+  include_examples 'a yes-no question form', options do
+    let(:relationship) { instance_double(Relationship) }
+    let(:association) { relationship }
+
+    let(:arguments) {
+      {
+        record: relationship,
+        c100_application: c100_application,
+        question_attribute => answer_value
+      }.merge(linked_attributes)
+    }
+
+    describe '#question_name' do
+      let(:attributes_mock) { {a: '1', b: '2', c: '3'} }
+
+      # mutant kill
+      it 'picks the first attribute in case there are more than one' do
+        expect(subject).to receive(:attributes).and_return(attributes_mock)
+        expect(subject.question_name).to eq(:a)
+      end
+
+      it 'is equal to the yes-no attribute' do
+        expect(subject.question_name).to eq(question_attribute)
+      end
+    end
+  end
+end
+
 RSpec.shared_examples 'a has-one-association form' do |options|
   let(:association_name) { options[:association_name] }
   let(:expected_attributes) { options[:expected_attributes] }


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21392212
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

This is a big PR but couldn't split it in smaller chunks as all is part of the same and is required for tests to pass properly.
To be honest, more than half the lines are tests 😄 

Individual commits for more context.
The work is not yet finished (pending CYA, PDF, and implementing the rules to enter this journey), but all this will come in follow-up PRs.

## Example of question:
<img width="688" alt="Screen Shot 2020-08-07 at 14 35 21" src="https://user-images.githubusercontent.com/687910/89651065-3e10e500-d8bb-11ea-9851-b110a9c97260.png">
