### PR TITLE
Add amendment and time order questions

### DIFF
--- a/app/forms/steps/permission/amendment_form.rb
+++ b/app/forms/steps/permission/amendment_form.rb
@@ -1,11 +1,11 @@
 module Steps
   module Permission
-    class LivingOrderForm < QuestionForm
+    class AmendmentForm < QuestionForm
       include SingleQuestionForm
 
-      yes_no_attribute :living_order,
+      yes_no_attribute :amendment,
                        reset_when_yes: [
-                         :amendment,
+                         # To be added once we have next questions
                        ]
     end
   end

--- a/app/forms/steps/permission/time_order_form.rb
+++ b/app/forms/steps/permission/time_order_form.rb
@@ -1,11 +1,11 @@
 module Steps
   module Permission
-    class AmendmentForm < QuestionForm
+    class TimeOrderForm < QuestionForm
       include SingleQuestionForm
 
-      yes_no_attribute :amendment,
+      yes_no_attribute :time_order,
                        reset_when_yes: [
-                         :time_order,
+                         # To be added once we have next questions
                        ]
     end
   end

--- a/app/services/c100_app/permission_decision_tree.rb
+++ b/app/services/c100_app/permission_decision_tree.rb
@@ -9,8 +9,9 @@ module C100App
       when :living_order
         advance_or_exit_journey(next_question: :amendment)
       when :amendment
+        advance_or_exit_journey(next_question: :time_order)
+      when :time_order
         exit_journey
-
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/app/services/c100_app/permission_decision_tree.rb
+++ b/app/services/c100_app/permission_decision_tree.rb
@@ -7,7 +7,10 @@ module C100App
       when :parental_responsibility
         advance_or_exit_journey(next_question: :living_order)
       when :living_order
+        advance_or_exit_journey(next_question: :amendment)
+      when :amendment
         exit_journey
+
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,12 +185,15 @@ en:
       question:
         edit:
           page_title:
-            parental_responsibility: Parental responsibility
-            living_order: Living order
+            parental_responsibility: Marriage, civil partnership and parental responsibility
+            living_order: Named in current child arrangements order
+            amendment: Applying to vary or discharge
+            time_order: Named in order about spending time
           heading:
             parental_responsibility: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
             living_order: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
-            amendment: "Is %{applicant name} applying to vary or discharge an order which was made on their application to the court?"
+            amendment: "Is %{applicant_name} applying to vary or discharge an order which was made on their application to the court?"
+            time_order: "Was %{applicant_name} named in an order about who %{child_name} should spend time with or when that should happen?"
           body_text:
             parental_responsibility_html: |
               <p class="govuk-body">
@@ -198,6 +201,7 @@ en:
               </p>
             living_order_html: ""
             amendment_html: ""
+            time_order_html: ""
     # END - Non-parents journey
 
     applicant:
@@ -1290,6 +1294,9 @@ en:
           <<: *YESNO
       steps_permission_amendment_form:
         amendment_options:
+          <<: *YESNO
+      steps_permission_time_order_form:
+        time_order_options:
           <<: *YESNO
       steps_address_lookup_form:
         postcode: Current postcode

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,12 +190,14 @@ en:
           heading:
             parental_responsibility: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
             living_order: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
+            amendment: "Is %{applicant name} applying to vary or discharge an order which was made on their application to the court?"
           body_text:
             parental_responsibility_html: |
               <p class="govuk-body">
                 They could have parental responsibility by making a formal agreement that has been approved by the court, or following a court order.
               </p>
             living_order_html: ""
+            amendment_html: ""
     # END - Non-parents journey
 
     applicant:
@@ -1285,6 +1287,9 @@ en:
           <<: *YESNO
       steps_permission_living_order_form:
         living_order_options:
+          <<: *YESNO
+      steps_permission_amendment_form:
+        amendment_options:
           <<: *YESNO
       steps_address_lookup_form:
         postcode: Current postcode

--- a/spec/forms/steps/permission/amendment_form_spec.rb
+++ b/spec/forms/steps/permission/amendment_form_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Permission::AmendmentForm do
+  it_behaves_like 'a permission yes-no question form',
+                  attribute_name: :amendment
+end

--- a/spec/forms/steps/permission/amendment_form_spec.rb
+++ b/spec/forms/steps/permission/amendment_form_spec.rb
@@ -2,5 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Steps::Permission::AmendmentForm do
   it_behaves_like 'a permission yes-no question form',
-                  attribute_name: :amendment
+                  attribute_name: :amendment,
+                  reset_when_yes: [
+                      :time_order,
+                  ]
 end

--- a/spec/forms/steps/permission/living_order_form_spec.rb
+++ b/spec/forms/steps/permission/living_order_form_spec.rb
@@ -2,5 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Steps::Permission::LivingOrderForm do
   it_behaves_like 'a permission yes-no question form',
-                  attribute_name: :living_order
+                  attribute_name: :living_order,
+                  reset_when_yes: [
+                      :amendment,
+                  ]
 end

--- a/spec/forms/steps/permission/time_order_form_spec.rb
+++ b/spec/forms/steps/permission/time_order_form_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Permission::TimeOrderForm do
+  it_behaves_like 'a permission yes-no question form',
+                  attribute_name: :time_order
+end

--- a/spec/services/c100_app/permission_decision_tree_spec.rb
+++ b/spec/services/c100_app/permission_decision_tree_spec.rb
@@ -103,6 +103,28 @@ RSpec.describe C100App::PermissionDecisionTree do
     context 'and the answer is `no`' do
       let(:value) { 'no' }
 
+      it 'advances to the next question' do
+        expect(subject.destination).to eq(controller: :question, action: :edit, question_name: :time_order, relationship_id: record)
+      end
+    end
+  end
+
+  context 'when the step is `time_order`' do
+    let(:step_params) { { time_order: 'anything' } }
+    let(:record) { instance_double(Relationship, time_order: value) }
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+
+      it 'exists the journey' do
+        expect(subject).to receive(:exit_journey)
+        subject.destination
+      end
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+
       # TODO: adapt tests when we add new questions
       it 'exists the journey' do
         expect(subject).to receive(:exit_journey)

--- a/spec/services/c100_app/permission_decision_tree_spec.rb
+++ b/spec/services/c100_app/permission_decision_tree_spec.rb
@@ -81,6 +81,28 @@ RSpec.describe C100App::PermissionDecisionTree do
     context 'and the answer is `no`' do
       let(:value) { 'no' }
 
+      it 'advances to the next question' do
+        expect(subject.destination).to eq(controller: :question, action: :edit, question_name: :amendment, relationship_id: record)
+      end
+    end
+  end
+
+  context 'when the step is `amendment`' do
+    let(:step_params) { { amendment: 'anything' } }
+    let(:record) { instance_double(Relationship, amendment: value) }
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+
+      it 'exists the journey' do
+        expect(subject).to receive(:exit_journey)
+        subject.destination
+      end
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+
       # TODO: adapt tests when we add new questions
       it 'exists the journey' do
         expect(subject).to receive(:exit_journey)


### PR DESCRIPTION
Task: https://mojdigital.teamwork.com/#/tasks/21392212

I've completed the next 2 questions, one question per commit.
This is because from this point onwards (ie: living_arrangements question onwards), a 'yes' answer will yield a different set of permissions required.