### PR TITLE
Change SGO question position

### DIFF
--- a/app/presenters/summary/html_sections/base_children_details.rb
+++ b/app/presenters/summary/html_sections/base_children_details.rb
@@ -25,14 +25,14 @@ module Summary
               personal_details_questions(child),
               change_path: personal_details_path(child)
             ),
-            # SGO only shows if a value is present (will not show for `OtherChild` or consent orders)
-            Answer.new(:special_guardianship_order, child.special_guardianship_order,
-                       change_path: edit_steps_children_special_guardianship_order_path(child)),
             MultiAnswer.new(
               :child_orders,
               order_types(child),
               change_path: edit_steps_children_orders_path(child)
             ),
+            # SGO only shows if a value is present
+            Answer.new(:special_guardianship_order, child.special_guardianship_order,
+                       change_path: edit_steps_children_special_guardianship_order_path(child)),
           ]
         end.flatten.select(&:show?)
       end

--- a/app/presenters/summary/sections/children_details.rb
+++ b/app/presenters/summary/sections/children_details.rb
@@ -22,8 +22,9 @@ module Summary
             Separator.new(:child_index_title, index: index),
             personal_details(child),
             relationships(child),
-            Answer.new(:special_guardianship_order, child.special_guardianship_order),
             MultiAnswer.new(:child_orders, order_types(child)),
+            # SGO only shows if a value is present
+            Answer.new(:special_guardianship_order, child.special_guardianship_order),
             Partial.row_blank_space,
           ]
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,8 +212,8 @@ Rails.application.routes.draw do
     namespace :children do
       crud_step :names
       crud_step :personal_details, only: [:edit, :update]
-      crud_step :special_guardianship_order, only: [:edit, :update]
       crud_step :orders, only: [:edit, :update]
+      crud_step :special_guardianship_order, only: [:edit, :update]
       edit_step :additional_details
       edit_step :has_other_children
       crud_step :residence, only: [:edit, :update]

--- a/features/children_details.feature
+++ b/features/children_details.feature
@@ -33,15 +33,6 @@ Feature: Add children to the application
     And I choose "Male"
 
     When I click the "Continue" button
-    Then I should see "Is there a Special Guardianship Order in force in relation to John Doe Junior?"
-
-    # Provoke validation errors
-    When I click the "Continue" button
-    Then Page has title "Error: Special Guardianship Order - Apply to court about child arrangements - GOV.UK"
-    And I should see a "Select yes or no" link to "#steps-children-special-guardianship-order-form-special-guardianship-order-field-error"
-
-    # Fix validation errors and continue
-    And I choose "No"
     Then I should see "Which of the decisions you’re asking the court to resolve relate to John Doe Junior?"
 
     # Provoke validation errors
@@ -56,6 +47,21 @@ Feature: Add children to the application
     Then I should see "Further information"
     And I should see "Are any of the children known to social services?"
     And I should see "Are any of the children the subject of a child protection plan?"
+
+    # Go back and select "home" order to enter the special guardianship question
+    When I click the "Back" link
+    And I check "Decide who they live with and when"
+    When I click the "Continue" button
+    Then I should see "Is there a Special Guardianship Order in force in relation to John Doe Junior?"
+
+    # Provoke validation errors
+    When I click the "Continue" button
+    Then Page has title "Error: Special Guardianship Order - Apply to court about child arrangements - GOV.UK"
+    And I should see a "Select yes or no" link to "#steps-children-special-guardianship-order-form-special-guardianship-order-field-error"
+
+    # Fix validation errors and continue
+    And I choose "No"
+    Then I should see "Further information"
 
     # Provoke validation errors
     When I click the "Continue" button

--- a/features/step_definitions/forms.rb
+++ b/features/step_definitions/forms.rb
@@ -67,6 +67,7 @@ end
 # Needed for the children journey
 When(/^I have selected orders for the court to decide$/) do
   step %[I visit "steps/petition/orders"]
+  step %[I check "Decide who they live with and when"]
   step %[I check "Decide how much time they spend with each person"]
   step %[I click the "Continue" button]
   step %[I should see "Decide how much time they spend with each person"]

--- a/spec/presenters/summary/html_sections/children_details_spec.rb
+++ b/spec/presenters/summary/html_sections/children_details_spec.rb
@@ -96,10 +96,10 @@ module Summary
         let(:special_guardianship_order) { 'yes' }
 
         it 'shows the question-answer' do
-          expect(answers[3]).to be_an_instance_of(Answer)
-          expect(answers[3].question).to eq(:special_guardianship_order)
-          expect(answers[3].value).to eq('yes')
-          expect(answers[3].change_path).to eq('/steps/children/special_guardianship_order/uuid-123')
+          expect(answers[4]).to be_an_instance_of(Answer)
+          expect(answers[4].question).to eq(:special_guardianship_order)
+          expect(answers[4].value).to eq('yes')
+          expect(answers[4].change_path).to eq('/steps/children/special_guardianship_order/uuid-123')
         end
       end
     end

--- a/spec/presenters/summary/sections/children_details_spec.rb
+++ b/spec/presenters/summary/sections/children_details_spec.rb
@@ -118,9 +118,9 @@ module Summary
         let(:special_guardianship_order) { 'yes' }
 
         it 'shows the question-answer' do
-          expect(answers[6]).to be_an_instance_of(Answer)
-          expect(answers[6].question).to eq(:special_guardianship_order)
-          expect(answers[6].value).to eq('yes')
+          expect(answers[7]).to be_an_instance_of(Answer)
+          expect(answers[7].question).to eq(:special_guardianship_order)
+          expect(answers[7].value).to eq('yes')
         end
       end
     end


### PR DESCRIPTION
It now goes after the selection of orders for the child, as this way, we can skip the SGO question if the orders does not include "home" (Decide who they live with and when).

Updated tests according to this as well as CYA and PDF.