### PR TITLE
Introduce the permission rules in `ApplicantDecisionTree`

### DIFF
--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -44,4 +44,10 @@ class BaseDecisionTree
       collection_ids.at(pos + 1)
     end
   end
+
+  # TODO: temporarily until we finish all the neccessary work for non-parents
+  # Will show on local/test/CI and staging, but not in production
+  def hide_non_parents?
+    Rails.env.production? && ENV['DEV_TOOLS_ENABLED'].nil?
+  end
 end

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -44,13 +44,16 @@ module C100App
     end
 
     def after_relationship
-      rules = PermissionRules.new(record)
+      # TODO: remove feature-flag to enable the non-parents in production
+      unless hide_non_parents?
+        rules = PermissionRules.new(record)
 
-      if rules.permission_undecided?
-        edit('/steps/permission/question', question_name: :parental_responsibility, relationship_id: record)
-      else
-        children_relationships
+        return edit(
+          '/steps/permission/question', question_name: :parental_responsibility, relationship_id: record
+        ) if rules.permission_undecided?
       end
+
+      children_relationships
     end
 
     def after_has_solicitor

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -13,7 +13,7 @@ module C100App
       when :under_age
         edit_first_child_relationships
       when :relationship
-        children_relationships
+        after_relationship
       when :address_details
         edit_contact_details
       when :contact_details
@@ -40,6 +40,16 @@ module C100App
         edit(:personal_details, id: next_applicant_id)
       else
         edit(:has_solicitor)
+      end
+    end
+
+    def after_relationship
+      rules = PermissionRules.new(record)
+
+      if rules.permission_undecided?
+        edit('/steps/permission/question', question_name: :parental_responsibility, relationship_id: record)
+      else
+        children_relationships
       end
     end
 

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -73,11 +73,5 @@ module C100App
     def next_child_id(current: record)
       next_record_id(c100_application.child_ids, current: current)
     end
-
-    # TODO: temporarily until we finish all the neccessary work
-    # Will show on local/test/CI and staging, but not in production
-    def hide_non_parents?
-      Rails.env.production? && ENV['DEV_TOOLS_ENABLED'].nil?
-    end
   end
 end

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -27,11 +27,9 @@ module C100App
 
     private
 
-    # The SGO question is only shown if "home" order is selected,
-    # and this is not a consent order application
-    #
     def after_orders
-      unless c100_application.consent_order? || hide_non_parents?
+      # TODO: remove feature-flag to enable the non-parents in production
+      unless hide_non_parents?
         return edit(:special_guardianship_order, id: record) if cao_home_order?
       end
 

--- a/app/services/c100_app/permission_rules.rb
+++ b/app/services/c100_app/permission_rules.rb
@@ -1,0 +1,46 @@
+module C100App
+  class PermissionRules
+    attr_reader :relationship
+
+    def initialize(relationship)
+      @relationship = relationship
+    end
+
+    # As we only ask the SGO question if the orders for the child include
+    # "home" (decide who they live with and when), and consent orders don't
+    # have "home" in the list of orders to select, we can safely assume
+    # permission is needed if the SGO value equals to 'yes'.
+    #
+    def permission_needed?
+      special_guardianship_order?
+    end
+
+    # Permission undecided happens when there is no SGO in force, and the
+    # applicant's relation to the child is "other".
+    #
+    # In these cases we need to go through further questions to decide
+    # if permission will be needed or not.
+    #
+    def permission_undecided?
+      !permission_needed? && other_relationship?
+    end
+
+    private
+
+    def child
+      @_child ||= relationship.minor
+    end
+
+    def special_guardianship_order?
+      child.special_guardianship_order.eql?(
+        GenericYesNo::YES.to_s
+      )
+    end
+
+    def other_relationship?
+      relationship.relation.eql?(
+        Relation::OTHER.to_s
+      )
+    end
+  end
+end

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -75,20 +75,39 @@ RSpec.describe C100App::ApplicantDecisionTree do
 
     let(:applicant) { Applicant.new }
 
-    context 'when there are remaining children' do
+    let(:rules_mock) { double(permission_undecided?: rule_result) }
+
+    before do
+      allow(C100App::PermissionRules).to receive(:new).with(record).and_return(rules_mock)
+    end
+
+    context 'when permission might be needed' do
       let(:child) { double('Child', id: 1) }
+      let(:rule_result) { true }
 
       it 'goes to edit the relationship of the next child' do
-        expect(subject.destination).to eq(controller: '/steps/applicant/relationship', action: :edit, id: applicant, child_id: 2)
+        expect(subject.destination).to eq(controller: '/steps/permission/question', action: :edit, question_name: :parental_responsibility, relationship_id: record)
       end
     end
 
-    context 'when all child relationships have been edited' do
-      let(:child) { double('Child', id: 3) }
+    context 'when permission is not needed' do
+      let(:rule_result) { false }
 
-      include_examples 'address lookup decision tree' do
-        let(:person) { applicant }
-        let(:namespace) { 'applicant' }
+      context 'when there are remaining children' do
+        let(:child) { double('Child', id: 1) }
+
+        it 'goes to edit the relationship of the next child' do
+          expect(subject.destination).to eq(controller: '/steps/applicant/relationship', action: :edit, id: applicant, child_id: 2)
+        end
+      end
+
+      context 'when all child relationships have been edited' do
+        let(:child) { double('Child', id: 3) }
+
+        include_examples 'address lookup decision tree' do
+          let(:person) { applicant }
+          let(:namespace) { 'applicant' }
+        end
       end
     end
   end

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -77,37 +77,56 @@ RSpec.describe C100App::ApplicantDecisionTree do
 
     let(:rules_mock) { double(permission_undecided?: rule_result) }
 
+    # TODO: feature-flag code to be removed once non-parents is released
     before do
-      allow(C100App::PermissionRules).to receive(:new).with(record).and_return(rules_mock)
+      allow(subject).to receive(:hide_non_parents?).and_return(hide_non_parents)
     end
 
-    context 'when permission might be needed' do
-      let(:child) { double('Child', id: 1) }
-      let(:rule_result) { true }
+    context 'when non-parents feature is enabled' do
+      let(:hide_non_parents) { false }
 
-      it 'goes to edit the relationship of the next child' do
-        expect(subject.destination).to eq(controller: '/steps/permission/question', action: :edit, question_name: :parental_responsibility, relationship_id: record)
+      before do
+        allow(C100App::PermissionRules).to receive(:new).with(record).and_return(rules_mock)
       end
-    end
 
-    context 'when permission is not needed' do
-      let(:rule_result) { false }
-
-      context 'when there are remaining children' do
+      context 'when permission might be needed' do
         let(:child) { double('Child', id: 1) }
+        let(:rule_result) { true }
 
         it 'goes to edit the relationship of the next child' do
-          expect(subject.destination).to eq(controller: '/steps/applicant/relationship', action: :edit, id: applicant, child_id: 2)
+          expect(subject.destination).to eq(controller: '/steps/permission/question', action: :edit, question_name: :parental_responsibility, relationship_id: record)
         end
       end
 
-      context 'when all child relationships have been edited' do
-        let(:child) { double('Child', id: 3) }
+      context 'when permission is not needed' do
+        let(:rule_result) { false }
 
-        include_examples 'address lookup decision tree' do
-          let(:person) { applicant }
-          let(:namespace) { 'applicant' }
+        context 'when there are remaining children' do
+          let(:child) { double('Child', id: 1) }
+
+          it 'goes to edit the relationship of the next child' do
+            expect(subject.destination).to eq(controller: '/steps/applicant/relationship', action: :edit, id: applicant, child_id: 2)
+          end
         end
+
+        context 'when all child relationships have been edited' do
+          let(:child) { double('Child', id: 3) }
+
+          include_examples 'address lookup decision tree' do
+            let(:person) { applicant }
+            let(:namespace) { 'applicant' }
+          end
+        end
+      end
+    end
+
+    context 'when non-parents feature is disabled' do
+      let(:hide_non_parents) { true }
+      let(:child) { double('Child', id: 1) }
+
+      it 'goes to edit the relationship of the next child' do
+        expect(subject).to receive(:children_relationships)
+        subject.destination
       end
     end
   end

--- a/spec/services/c100_app/permission_rules_spec.rb
+++ b/spec/services/c100_app/permission_rules_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe C100App::PermissionRules do
+  subject { described_class.new(relationship) }
+
+  let(:relationship) { instance_double(Relationship, minor: child, relation: relation) }
+  let(:child) { instance_double(Child, special_guardianship_order: sgo_order) }
+
+  let(:sgo_order) { nil }
+  let(:relation)  { 'father' }
+
+  describe '#permission_needed?' do
+    context 'when `special_guardianship_order` is `nil`' do
+      it 'returns false' do
+        expect(subject.permission_needed?).to eq(false)
+      end
+    end
+
+    context 'when `special_guardianship_order` is `no`' do
+      let(:sgo_order) { 'no' }
+
+      it 'returns false' do
+        expect(subject.permission_needed?).to eq(false)
+      end
+    end
+
+    context 'when `special_guardianship_order` is `yes`' do
+      let(:sgo_order) { 'yes' }
+
+      it 'returns true' do
+        expect(subject.permission_needed?).to eq(true)
+      end
+    end
+  end
+
+  describe '#permission_undecided?' do
+    context 'when `special_guardianship_order` is `nil`' do
+      it 'returns false' do
+        expect(subject.permission_undecided?).to eq(false)
+      end
+    end
+
+    context 'when `special_guardianship_order` is `no`' do
+      let(:sgo_order) { 'no' }
+
+      context 'when the relation is not `other`' do
+        it 'returns false' do
+          expect(subject.permission_undecided?).to eq(false)
+        end
+      end
+
+      context 'when the relation is `other`' do
+        let(:relation) { 'other' }
+
+        it 'returns true' do
+          expect(subject.permission_undecided?).to eq(true)
+        end
+      end
+    end
+
+    context 'when `special_guardianship_order` is `yes`' do
+      let(:sgo_order) { 'yes' }
+
+      context 'when the relation is not `other`' do
+        it 'returns false' do
+          expect(subject.permission_undecided?).to eq(false)
+        end
+      end
+
+      context 'when the relation is `other`' do
+        let(:relation) { 'other' }
+
+        it 'returns true' do
+          expect(subject.permission_undecided?).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21483487
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

This will decide if further questions are needed in order to decide
if permission is needed or not to make the application.

Rules are based on the previous answer to the SGO question, as well
as the applicant's relation to the child.

**Note**: in a follow-up PR consent orders bypass will be handled.