### PR TITLE
Living arrangements and consent questions

### DIFF
--- a/app/forms/steps/permission/consent_form.rb
+++ b/app/forms/steps/permission/consent_form.rb
@@ -1,11 +1,11 @@
 module Steps
   module Permission
-    class LivingArrangementForm < QuestionForm
+    class ConsentForm < QuestionForm
       include SingleQuestionForm
 
-      yes_no_attribute :living_arrangement,
+      yes_no_attribute :consent,
                        reset_when_yes: [
-                         :consent
+                         # To be added once we have next questions
                        ]
     end
   end

--- a/app/forms/steps/permission/living_arrangement_form.rb
+++ b/app/forms/steps/permission/living_arrangement_form.rb
@@ -1,0 +1,12 @@
+module Steps
+  module Permission
+    class LivingArrangementForm < QuestionForm
+      include SingleQuestionForm
+
+      yes_no_attribute :living_arrangement,
+                       reset_when_yes: [
+                         # To be added once we have next questions
+                       ]
+    end
+  end
+end

--- a/app/forms/steps/permission/time_order_form.rb
+++ b/app/forms/steps/permission/time_order_form.rb
@@ -5,7 +5,7 @@ module Steps
 
       yes_no_attribute :time_order,
                        reset_when_yes: [
-                         # To be added once we have next questions
+                         :living_arrangement,
                        ]
     end
   end

--- a/app/services/c100_app/permission_decision_tree.rb
+++ b/app/services/c100_app/permission_decision_tree.rb
@@ -11,6 +11,8 @@ module C100App
       when :amendment
         advance_or_exit_journey(next_question: :time_order)
       when :time_order
+        advance_or_exit_journey(next_question: :living_arrangement)
+      when :living_arrangement
         exit_journey
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"

--- a/app/services/c100_app/permission_decision_tree.rb
+++ b/app/services/c100_app/permission_decision_tree.rb
@@ -13,6 +13,8 @@ module C100App
       when :time_order
         advance_or_exit_journey(next_question: :living_arrangement)
       when :living_arrangement
+        advance_or_exit_journey(next_question: :consent)
+      when :consent
         exit_journey
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -189,11 +189,13 @@ en:
             living_order: Named in current child arrangements order
             amendment: Applying to vary or discharge
             time_order: Named in order about spending time
+            living_arrangement: Living arrangements
           heading:
             parental_responsibility: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
             living_order: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
             amendment: "Is %{applicant_name} applying to vary or discharge an order which was made on their application to the court?"
             time_order: "Was %{applicant_name} named in an order about who %{child_name} should spend time with or when that should happen?"
+            living_arrangement: "Has %{child_name} lived with %{applicant_name} for at least 3 years?"
           body_text:
             parental_responsibility_html: |
               <p class="govuk-body">
@@ -202,6 +204,7 @@ en:
             living_order_html: ""
             amendment_html: ""
             time_order_html: ""
+            living_arrangement_html: ""
     # END - Non-parents journey
 
     applicant:
@@ -1297,6 +1300,9 @@ en:
           <<: *YESNO
       steps_permission_time_order_form:
         time_order_options:
+          <<: *YESNO
+      steps_permission_living_arrangement_form:
+        living_arrangement_options:
           <<: *YESNO
       steps_address_lookup_form:
         postcode: Current postcode

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,12 +190,14 @@ en:
             amendment: Applying to vary or discharge
             time_order: Named in order about spending time
             living_arrangement: Living arrangements
+            consent: Consent to apply
           heading:
             parental_responsibility: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
             living_order: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
             amendment: "Is %{applicant_name} applying to vary or discharge an order which was made on their application to the court?"
             time_order: "Was %{applicant_name} named in an order about who %{child_name} should spend time with or when that should happen?"
             living_arrangement: "Has %{child_name} lived with %{applicant_name} for at least 3 years?"
+            consent: "Does %{applicant_name} have everyone’s consent to make this application?"
           body_text:
             parental_responsibility_html: |
               <p class="govuk-body">
@@ -205,6 +207,13 @@ en:
             amendment_html: ""
             time_order_html: ""
             living_arrangement_html: ""
+            consent_html: |
+               <p class="govuk-body">Consent needs to be given by everyone who:</p>
+               <ul class="govuk-list govuk-list--bullet">
+                 <li>is named in a current child arrangements order (which sets out who the children should live with or when)</li>
+                 <li>has parental responsibility for the children</li>
+               </ul>
+
     # END - Non-parents journey
 
     applicant:
@@ -1303,6 +1312,9 @@ en:
           <<: *YESNO
       steps_permission_living_arrangement_form:
         living_arrangement_options:
+          <<: *YESNO
+      steps_permission_consent_form:
+        consent_options:
           <<: *YESNO
       steps_address_lookup_form:
         postcode: Current postcode

--- a/db/migrate/20200811110454_rename_living_arrangements_to_living_arrangement.rb
+++ b/db/migrate/20200811110454_rename_living_arrangements_to_living_arrangement.rb
@@ -1,0 +1,5 @@
+class RenameLivingArrangementsToLivingArrangement < ActiveRecord::Migration[5.2]
+  def change
+    rename_column  :relationships, :living_arrangements, :living_arrangement
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_06_085153) do
+ActiveRecord::Schema.define(version: 2020_08_11_110454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -321,7 +321,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_085153) do
     t.string "living_order"
     t.string "amendment"
     t.string "time_order"
-    t.string "living_arrangements"
+    t.string "living_arrangement"
     t.string "consent"
     t.string "family"
     t.string "local_authority"

--- a/spec/forms/steps/permission/consent_form_spec.rb
+++ b/spec/forms/steps/permission/consent_form_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Permission::ConsentForm do
+  it_behaves_like 'a permission yes-no question form',
+                  attribute_name: :consent
+end

--- a/spec/forms/steps/permission/living_arrangement_form_spec.rb
+++ b/spec/forms/steps/permission/living_arrangement_form_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Permission::LivingArrangementForm do
+  it_behaves_like 'a permission yes-no question form',
+                  attribute_name: :living_arrangement
+end

--- a/spec/forms/steps/permission/living_arrangement_form_spec.rb
+++ b/spec/forms/steps/permission/living_arrangement_form_spec.rb
@@ -2,5 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Steps::Permission::LivingArrangementForm do
   it_behaves_like 'a permission yes-no question form',
-                  attribute_name: :living_arrangement
+                  attribute_name: :living_arrangement,
+                  reset_when_yes: [
+                      :consent,
+                  ]
 end

--- a/spec/forms/steps/permission/time_order_form_spec.rb
+++ b/spec/forms/steps/permission/time_order_form_spec.rb
@@ -2,5 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Steps::Permission::TimeOrderForm do
   it_behaves_like 'a permission yes-no question form',
-                  attribute_name: :time_order
+                  attribute_name: :time_order,
+                  reset_when_yes: [
+                      :living_arrangement,
+                  ]
 end

--- a/spec/services/c100_app/permission_decision_tree_spec.rb
+++ b/spec/services/c100_app/permission_decision_tree_spec.rb
@@ -125,6 +125,28 @@ RSpec.describe C100App::PermissionDecisionTree do
     context 'and the answer is `no`' do
       let(:value) { 'no' }
 
+      it 'advances to the next question' do
+        expect(subject.destination).to eq(controller: :question, action: :edit, question_name: :living_arrangement, relationship_id: record)
+      end
+    end
+  end
+
+  context 'when the step is `living_arrangement`' do
+    let(:step_params) { { living_arrangement: 'anything' } }
+    let(:record) { instance_double(Relationship, living_arrangement: value) }
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+
+      it 'exists the journey' do
+        expect(subject).to receive(:exit_journey)
+        subject.destination
+      end
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+
       # TODO: adapt tests when we add new questions
       it 'exists the journey' do
         expect(subject).to receive(:exit_journey)

--- a/spec/services/c100_app/permission_decision_tree_spec.rb
+++ b/spec/services/c100_app/permission_decision_tree_spec.rb
@@ -147,6 +147,28 @@ RSpec.describe C100App::PermissionDecisionTree do
     context 'and the answer is `no`' do
       let(:value) { 'no' }
 
+      it 'advances to the next question' do
+        expect(subject.destination).to eq(controller: :question, action: :edit, question_name: :consent, relationship_id: record)
+      end
+    end
+  end
+
+  context 'when the step is `consent`' do
+    let(:step_params) { { consent: 'anything' } }
+    let(:record) { instance_double(Relationship, consent: value) }
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+
+      it 'exists the journey' do
+        expect(subject).to receive(:exit_journey)
+        subject.destination
+      end
+    end
+
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+
       # TODO: adapt tests when we add new questions
       it 'exists the journey' do
         expect(subject).to receive(:exit_journey)


### PR DESCRIPTION
Task: https://mojdigital.teamwork.com/#/tasks/21392212

This PR adds the next 2 questions to the non-parents journey, living arrangement and consent.
The database has also changed, the column `living_arrangements` has been renamed to `living_arrangement` to deal with Rails' attempts to remove plurals during initialisation of constants.
I've made smaller commits to help make following the changes a little easier!

If this PR is approved, the two questions will appear as below:
![Screenshot 2020-08-11 at 12 10 19](https://user-images.githubusercontent.com/29227502/89892676-ee8a2c00-dbce-11ea-8302-dbab518687c5.png)

![Screenshot 2020-08-11 at 12 21 33](https://user-images.githubusercontent.com/29227502/89892682-f053ef80-dbce-11ea-8969-aebb30ea8404.png)
