### PR TITLE
Skip non-parent questions if is a consent order

### DIFF
--- a/app/forms/steps/children/orders_form.rb
+++ b/app/forms/steps/children/orders_form.rb
@@ -15,11 +15,23 @@ module Steps
         errors.add(:orders, :blank) unless selected_options.any?
       end
 
+      def changed?
+        !child_order.orders.eql?(selected_options)
+      end
+
       def persist!
         raise C100ApplicationNotFound unless c100_application
+        return true unless changed?
 
         child_order.update(
           orders: selected_options
+        )
+
+        # Reset the SGO flag of the child as this is dependent on the orders the applicant
+        # have selected, and a change in orders require a re-evaluation of this question.
+        #
+        record.update(
+          special_guardianship_order: nil
         )
       end
 

--- a/app/services/c100_app/permission_rules.rb
+++ b/app/services/c100_app/permission_rules.rb
@@ -20,8 +20,11 @@ module C100App
     #
     # In these cases we need to go through further questions to decide
     # if permission will be needed or not.
+    # Consent order applications do not require permission.
     #
     def permission_undecided?
+      return false if consent_order?
+
       !permission_needed? && other_relationship?
     end
 
@@ -41,6 +44,10 @@ module C100App
       relationship.relation.eql?(
         Relation::OTHER.to_s
       )
+    end
+
+    def consent_order?
+      relationship.c100_application.consent_order?
     end
   end
 end

--- a/spec/services/c100_app/permission_rules_spec.rb
+++ b/spec/services/c100_app/permission_rules_spec.rb
@@ -3,11 +3,21 @@ require 'rails_helper'
 RSpec.describe C100App::PermissionRules do
   subject { described_class.new(relationship) }
 
-  let(:relationship) { instance_double(Relationship, minor: child, relation: relation) }
+  let(:relationship) {
+    instance_double(
+      Relationship,
+      c100_application: c100_application,
+      minor: child,
+      relation: relation
+    )
+  }
+
+  let(:c100_application) { C100Application.new(consent_order: consent_order) }
   let(:child) { instance_double(Child, special_guardianship_order: sgo_order) }
 
   let(:sgo_order) { nil }
   let(:relation)  { 'father' }
+  let(:consent_order) { 'no' }
 
   describe '#permission_needed?' do
     context 'when `special_guardianship_order` is `nil`' do
@@ -34,6 +44,21 @@ RSpec.describe C100App::PermissionRules do
   end
 
   describe '#permission_undecided?' do
+    context 'when application is a consent order' do
+      let(:consent_order) { 'yes' }
+
+      it 'returns false' do
+        expect(subject.permission_undecided?).to eq(false)
+      end
+
+      it 'does not check any other rules' do
+        expect(subject).not_to receive(:permission_needed?)
+        expect(subject).not_to receive(:other_relationship?)
+
+        subject.permission_undecided?
+      end
+    end
+
     context 'when `special_guardianship_order` is `nil`' do
       it 'returns false' do
         expect(subject.permission_undecided?).to eq(false)


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21483487
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

And reset the `special_guardianship_order` flag

Handle the edge case where the orders change and the previous value to the SGO question remains, which could cause some issues down the line.

Now we ensure if the orders change we always re-evaluate the question and force the user to answer it (or if we don't show it because the orders change, then it gets back to be `nil` as expected).