### PR TITLE
Update questions for non-parents journey.

### DIFF
--- a/app/forms/steps/permission/amendment_form.rb
+++ b/app/forms/steps/permission/amendment_form.rb
@@ -4,6 +4,11 @@ module Steps
       yes_no_attribute :amendment,
                        reset_when_yes: [
                          :time_order,
+                         :living_arrangement,
+                         :consent,
+                         :family,
+                         :local_authority,
+                         :relative
                        ]
     end
   end

--- a/app/forms/steps/permission/amendment_form.rb
+++ b/app/forms/steps/permission/amendment_form.rb
@@ -1,8 +1,6 @@
 module Steps
   module Permission
     class AmendmentForm < QuestionForm
-      include SingleQuestionForm
-
       yes_no_attribute :amendment,
                        reset_when_yes: [
                          :time_order,

--- a/app/forms/steps/permission/consent_form.rb
+++ b/app/forms/steps/permission/consent_form.rb
@@ -4,6 +4,8 @@ module Steps
       yes_no_attribute :consent,
                        reset_when_yes: [
                          :family,
+                         :local_authority,
+                         :relative
                        ]
     end
   end

--- a/app/forms/steps/permission/consent_form.rb
+++ b/app/forms/steps/permission/consent_form.rb
@@ -1,8 +1,6 @@
 module Steps
   module Permission
     class ConsentForm < QuestionForm
-      include SingleQuestionForm
-
       yes_no_attribute :consent,
                        reset_when_yes: [
                          :family,

--- a/app/forms/steps/permission/family_form.rb
+++ b/app/forms/steps/permission/family_form.rb
@@ -3,7 +3,8 @@ module Steps
     class FamilyForm < QuestionForm
       yes_no_attribute :family,
                        reset_when_yes: [
-                         :local_authority
+                         :local_authority,
+                         :relative
                        ]
     end
   end

--- a/app/forms/steps/permission/family_form.rb
+++ b/app/forms/steps/permission/family_form.rb
@@ -1,8 +1,6 @@
 module Steps
   module Permission
     class FamilyForm < QuestionForm
-      include SingleQuestionForm
-
       yes_no_attribute :family,
                        reset_when_yes: [
                          :local_authority

--- a/app/forms/steps/permission/living_arrangement_form.rb
+++ b/app/forms/steps/permission/living_arrangement_form.rb
@@ -1,8 +1,6 @@
 module Steps
   module Permission
     class LivingArrangementForm < QuestionForm
-      include SingleQuestionForm
-
       yes_no_attribute :living_arrangement,
                        reset_when_yes: [
                          :consent

--- a/app/forms/steps/permission/living_arrangement_form.rb
+++ b/app/forms/steps/permission/living_arrangement_form.rb
@@ -3,7 +3,10 @@ module Steps
     class LivingArrangementForm < QuestionForm
       yes_no_attribute :living_arrangement,
                        reset_when_yes: [
-                         :consent
+                         :consent,
+                         :family,
+                         :local_authority,
+                         :relative
                        ]
     end
   end

--- a/app/forms/steps/permission/living_order_form.rb
+++ b/app/forms/steps/permission/living_order_form.rb
@@ -4,6 +4,12 @@ module Steps
       yes_no_attribute :living_order,
                        reset_when_yes: [
                          :amendment,
+                         :time_order,
+                         :living_arrangement,
+                         :consent,
+                         :family,
+                         :local_authority,
+                         :relative
                        ]
     end
   end

--- a/app/forms/steps/permission/living_order_form.rb
+++ b/app/forms/steps/permission/living_order_form.rb
@@ -1,8 +1,6 @@
 module Steps
   module Permission
     class LivingOrderForm < QuestionForm
-      include SingleQuestionForm
-
       yes_no_attribute :living_order,
                        reset_when_yes: [
                          :amendment,

--- a/app/forms/steps/permission/local_authority_form.rb
+++ b/app/forms/steps/permission/local_authority_form.rb
@@ -1,8 +1,6 @@
 module Steps
   module Permission
     class LocalAuthorityForm < QuestionForm
-      include SingleQuestionForm
-
       yes_no_attribute :local_authority,
                        reset_when_yes: [
                          :relative,

--- a/app/forms/steps/permission/parental_responsibility_form.rb
+++ b/app/forms/steps/permission/parental_responsibility_form.rb
@@ -1,8 +1,6 @@
 module Steps
   module Permission
     class ParentalResponsibilityForm < QuestionForm
-      include SingleQuestionForm
-
       yes_no_attribute :parental_responsibility,
                        reset_when_yes: [
                          :living_order,

--- a/app/forms/steps/permission/parental_responsibility_form.rb
+++ b/app/forms/steps/permission/parental_responsibility_form.rb
@@ -4,6 +4,13 @@ module Steps
       yes_no_attribute :parental_responsibility,
                        reset_when_yes: [
                          :living_order,
+                         :amendment,
+                         :time_order,
+                         :living_arrangement,
+                         :consent,
+                         :family,
+                         :local_authority,
+                         :relative
                        ]
     end
   end

--- a/app/forms/steps/permission/question_form.rb
+++ b/app/forms/steps/permission/question_form.rb
@@ -1,6 +1,8 @@
 module Steps
   module Permission
     class QuestionForm < BaseForm
+      include SingleQuestionForm
+
       # Used for i18n locales as we are reusing the same view
       # Corresponds with the yes-no attribute (there is only one)
       def question_name

--- a/app/forms/steps/permission/relative_form.rb
+++ b/app/forms/steps/permission/relative_form.rb
@@ -1,8 +1,6 @@
 module Steps
   module Permission
     class RelativeForm < QuestionForm
-      include SingleQuestionForm
-
       yes_no_attribute :relative
     end
   end

--- a/app/forms/steps/permission/time_order_form.rb
+++ b/app/forms/steps/permission/time_order_form.rb
@@ -4,6 +4,10 @@ module Steps
       yes_no_attribute :time_order,
                        reset_when_yes: [
                          :living_arrangement,
+                         :consent,
+                         :family,
+                         :local_authority,
+                         :relative
                        ]
     end
   end

--- a/app/forms/steps/permission/time_order_form.rb
+++ b/app/forms/steps/permission/time_order_form.rb
@@ -1,8 +1,6 @@
 module Steps
   module Permission
     class TimeOrderForm < QuestionForm
-      include SingleQuestionForm
-
       yes_no_attribute :time_order,
                        reset_when_yes: [
                          :living_arrangement,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,7 +197,7 @@ en:
           heading:
             parental_responsibility: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
             living_order: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
-            amendment: "Is %{applicant_name} applying to vary or discharge an order which was made on their application to the court?"
+            amendment: "Is %{applicant_name} applying to change or end (discharge) an existing court order?"
             time_order: "Was %{applicant_name} named in an order about who %{child_name} should spend time with or when that should happen?"
             living_arrangement: "Has %{child_name} lived with %{applicant_name} for at least 3 years?"
             consent: "Does %{applicant_name} have everyone’s consent to make this application?"
@@ -207,7 +207,7 @@ en:
           body_text:
             parental_responsibility_html: |
               <p class="govuk-body">
-                They could have parental responsibility by making a formal agreement that has been approved by the court, or following a court order.
+                They could have parental responsibility by making a formal agreement that has been registered with the court, or following a court order.
               </p>
             living_order_html: ""
             amendment_html: ""

--- a/spec/forms/steps/permission/amendment_form_spec.rb
+++ b/spec/forms/steps/permission/amendment_form_spec.rb
@@ -5,5 +5,10 @@ RSpec.describe Steps::Permission::AmendmentForm do
                   attribute_name: :amendment,
                   reset_when_yes: [
                       :time_order,
+                      :living_arrangement,
+                      :consent,
+                      :family,
+                      :local_authority,
+                      :relative
                   ]
 end

--- a/spec/forms/steps/permission/consent_form_spec.rb
+++ b/spec/forms/steps/permission/consent_form_spec.rb
@@ -5,5 +5,7 @@ RSpec.describe Steps::Permission::ConsentForm do
                   attribute_name: :consent,
                   reset_when_yes: [
                       :family,
+                      :local_authority,
+                      :relative
                   ]
 end

--- a/spec/forms/steps/permission/family_form_spec.rb
+++ b/spec/forms/steps/permission/family_form_spec.rb
@@ -5,5 +5,6 @@ RSpec.describe Steps::Permission::FamilyForm do
                   attribute_name: :family,
                   reset_when_yes: [
                       :local_authority,
+                      :relative
                   ]
 end

--- a/spec/forms/steps/permission/living_arrangement_form_spec.rb
+++ b/spec/forms/steps/permission/living_arrangement_form_spec.rb
@@ -5,5 +5,8 @@ RSpec.describe Steps::Permission::LivingArrangementForm do
                   attribute_name: :living_arrangement,
                   reset_when_yes: [
                       :consent,
+                      :family,
+                      :local_authority,
+                      :relative
                   ]
 end

--- a/spec/forms/steps/permission/living_order_form_spec.rb
+++ b/spec/forms/steps/permission/living_order_form_spec.rb
@@ -5,5 +5,11 @@ RSpec.describe Steps::Permission::LivingOrderForm do
                   attribute_name: :living_order,
                   reset_when_yes: [
                       :amendment,
+                      :time_order,
+                      :living_arrangement,
+                      :consent,
+                      :family,
+                      :local_authority,
+                      :relative
                   ]
 end

--- a/spec/forms/steps/permission/parental_responsibility_form_spec.rb
+++ b/spec/forms/steps/permission/parental_responsibility_form_spec.rb
@@ -4,6 +4,13 @@ RSpec.describe Steps::Permission::ParentalResponsibilityForm do
   it_behaves_like 'a permission yes-no question form',
                   attribute_name: :parental_responsibility,
                   reset_when_yes: [
-                    :living_order,
+                      :living_order,
+                      :amendment,
+                      :time_order,
+                      :living_arrangement,
+                      :consent,
+                      :family,
+                      :local_authority,
+                      :relative
                   ]
 end

--- a/spec/forms/steps/permission/time_order_form_spec.rb
+++ b/spec/forms/steps/permission/time_order_form_spec.rb
@@ -5,5 +5,9 @@ RSpec.describe Steps::Permission::TimeOrderForm do
                   attribute_name: :time_order,
                   reset_when_yes: [
                       :living_arrangement,
+                      :consent,
+                      :family,
+                      :local_authority,
+                      :relative
                   ]
 end


### PR DESCRIPTION
Task: https://mojdigital.teamwork.com/#/tasks/21392212

Copy changes include:
- Updating the hint text for the parental_responsibility question
- updating the wording of the amendment question

Other changes in this PR include:
- Refactoring the 9 questions so they inherit a common characteristic from the superclass
- Improve the reset mechanism of the questions
A lot of files have been changed so there are multiple commits to help with keep track of these changes.

If approved the updated question copies will look like:

![Screenshot 2020-08-12 at 11 16 31](https://user-images.githubusercontent.com/29227502/90004767-21472980-dc8e-11ea-84ee-2d61ef9cfe54.png)

![Screenshot 2020-08-12 at 11 16 44](https://user-images.githubusercontent.com/29227502/90004773-22785680-dc8e-11ea-86ff-82992d6dff85.png)