### PR TITLE
Show more detail in payments back office

### DIFF
--- a/app/views/backoffice/dashboard/_payment.en.html.erb
+++ b/app/views/backoffice/dashboard/_payment.en.html.erb
@@ -8,7 +8,19 @@
   </td>
   <td class="govuk-table__cell">
     <% if payment.state.key?('code') %>
-      <%= payment.state.slice('code', 'message') %> <em class="app-util--disabled-color">Ref. <%= payment.c100_application.reference_code %></em>
+      <% c100_application = payment.c100_application %>
+
+      <%= format("%<message>s (%<code>s)", payment.state.symbolize_keys) %>
+
+      <div class="app-util--disabled-color">
+        <% if c100_application.completed? %>
+          Final payment method: <%= t(c100_application.payment_type, scope: 'backoffice.payment') %>
+        <% else %>
+          Application waiting to be completed
+        <% end %>
+      </div>
+
+      <div class="app-util--disabled-color">Ref. <%= c100_application.reference_code %></div>
     <% end %>
   </td>
 </tr>


### PR DESCRIPTION
If the online payment returned an error, apart from showing this error and code, we can also show what was the final payment method the user chose as in most cases they would have to select a new payment method.

If the application is still awaiting to be completed we also show this.

### Before:
<img width="943" alt="Screen Shot 2020-08-12 at 13 00 47" src="https://user-images.githubusercontent.com/687910/90012734-dfbd7b00-dc9b-11ea-85d9-2bfc3f220fd4.png">

### After:
<img width="944" alt="Screen Shot 2020-08-12 at 12 53 48" src="https://user-images.githubusercontent.com/687910/90012700-ccaaab00-dc9b-11ea-96ad-08c6ef1f0978.png">
