### PR TITLE
Add 9 permission questions to CYA

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -3,4 +3,19 @@ class Relationship < ApplicationRecord
 
   belongs_to :minor
   belongs_to :person
+
+  # Used in non-parents journey, each being one question that we need
+  # to ask in order to decide if permission to apply is required.
+  #
+  PERMISSION_ATTRIBUTES = %i[
+    parental_responsibility
+    living_order
+    amendment
+    time_order
+    living_arrangement
+    consent
+    family
+    local_authority
+    relative
+  ].freeze
 end

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -176,6 +176,47 @@ en:
       question: Relationship to %{child_name}
       answers:
         <<: *RELATIONS
+
+    # BEGIN - Non-parents permission questions
+    # NOTE: these should match the heading locales in the `en.yml` file
+    child_permission_parental_responsibility:
+      question: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
+      answers:
+        <<: *YESNO
+    child_permission_living_order:
+      question: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
+      answers:
+        <<: *YESNO
+    child_permission_amendment:
+      question: "Is %{applicant_name} applying to change or end (discharge) an existing court order?"
+      answers:
+        <<: *YESNO
+    child_permission_time_order:
+      question: "Was %{applicant_name} named in an order about who %{child_name} should spend time with or when that should happen?"
+      answers:
+        <<: *YESNO
+    child_permission_living_arrangement:
+      question: "Has %{child_name} lived with %{applicant_name} for at least 3 years?"
+      answers:
+        <<: *YESNO
+    child_permission_consent:
+      question: "Does %{applicant_name} have everyone’s consent to make this application?"
+      answers:
+        <<: *YESNO
+    child_permission_family:
+      question: "Is %{applicant_name} married or in a civil partnership with %{child_name}’s parent and is the child treated as part of their family?"
+      answers:
+        <<: *YESNO
+    child_permission_local_authority:
+      question: "If %{child_name} is being cared for by the Local Authority, does %{applicant_name} have the Local Authority’s consent to make this application?"
+      answers:
+        <<: *YESNO
+    child_permission_relative:
+      question: "Is %{applicant_name} a foster parent or relative of %{child_name}, and has %{child_name} been living with them for at least one year?"
+      answers:
+        <<: *YESNO
+    # END - Non-parents permission questions
+
     child_orders:
       question: Orders applied for
       answers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,8 @@ en:
             local_authority: Local authority and consent
             relative: Foster parent or relative
           heading:
+            # NOTE: we have a duplication of these headings in the `cya/en.yml` file
+            # If copy changes here, remember to also change the copy in the other file
             parental_responsibility: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
             living_order: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
             amendment: "Is %{applicant_name} applying to change or end (discharge) an existing court order?"

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+  describe 'PERMISSION_ATTRIBUTES' do
+    it 'returns the expected attributes' do
+      expect(
+        described_class::PERMISSION_ATTRIBUTES
+      ).to match_array(%i[
+        parental_responsibility
+        living_order
+        amendment
+        time_order
+        living_arrangement
+        consent
+        family
+        local_authority
+        relative
+      ])
+    end
+  end
+end

--- a/spec/presenters/summary/html_sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/html_sections/other_parties_details_spec.rb
@@ -25,7 +25,7 @@ module Summary
         home_phone: nil,
         mobile_phone: nil,
         email: nil,
-        relationships: [relationships],
+        relationships: [relationship],
       )
     }
 
@@ -36,12 +36,13 @@ module Summary
 
     subject { described_class.new(c100_application) }
 
-    let(:relationships) {
+    let(:relationship) {
       instance_double(
         Relationship,
         relation: 'mother',
         relation_other_value: nil,
         minor: child,
+        parental_responsibility: nil,
       )
     }
     let(:child) { instance_double(Child, to_param: 'uuid-555', full_name: 'Child Test') }
@@ -143,12 +144,13 @@ module Summary
       end
 
       context 'for `other` children relationship' do
-        let(:relationships) {
+        let(:relationship) {
           instance_double(
             Relationship,
             relation: 'other',
             relation_other_value: 'Aunt',
             minor: child,
+            parental_responsibility: nil,
           )
         }
 

--- a/spec/presenters/summary/html_sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/html_sections/respondents_details_spec.rb
@@ -25,7 +25,7 @@ module Summary
         mobile_phone: 'mobile_phone',
         voicemail_consent: nil,
         email: 'email',
-        relationships: [relationships],
+        relationships: [relationship],
       )
     }
 
@@ -38,12 +38,13 @@ module Summary
     let(:has_previous_name) { 'no' }
     let(:previous_name) { nil }
 
-    let(:relationships) {
+    let(:relationship) {
       instance_double(
         Relationship,
         relation: 'mother',
         relation_other_value: nil,
         minor: child,
+        parental_responsibility: nil,
       )
     }
     let(:child) { instance_double(Child, to_param: 'uuid-555', full_name: 'Child Test') }
@@ -170,12 +171,13 @@ module Summary
       end
 
       context 'for `other` children relationship' do
-        let(:relationships) {
+        let(:relationship) {
           instance_double(
             Relationship,
             relation: 'other',
             relation_other_value: 'Aunt',
             minor: child,
+            parental_responsibility: nil,
           )
         }
 


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21498747
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

For each of these questions with a value (either yes or no) we have to show it in the CYA page so the user can go back an change the answer if they wish.

This repeats for each combination applicant-child as long as there is data in these attributes.

In a follow-up PR will do the PDF.

### Example:
<img width="515" alt="Screen Shot 2020-08-12 at 15 18 30" src="https://user-images.githubusercontent.com/687910/90110484-3632c400-dd45-11ea-8a1d-f3a450130259.png">
