### PR TITLE
Add permission questions to the PDF

### DIFF
--- a/app/assets/stylesheets/local/check_answers.scss
+++ b/app/assets/stylesheets/local/check_answers.scss
@@ -51,7 +51,8 @@
   }
 }
 
-// Give a bit more space between children
+// Give a bit more space between parties
+#applicants_details, #respondents_details, #other_parties_details,
 #children_details, #other_children_details {
   h3 {
     margin-top: govuk-spacing(3);

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -18,4 +18,6 @@ class Relationship < ApplicationRecord
     local_authority
     relative
   ].freeze
+
+  scope :with_permission_data, -> { where.not(PERMISSION_ATTRIBUTES.first => nil) }
 end

--- a/app/presenters/summary/sections/children_relationships.rb
+++ b/app/presenters/summary/sections/children_relationships.rb
@@ -11,6 +11,7 @@ module Summary
             :applicants_relationships,
             RelationshipsPresenter.new(c100_application).relationship_to_children(c100.applicants)
           ),
+          *affirmative_permission_questions,
           FreeTextAnswer.new(
             :respondents_relationships,
             RelationshipsPresenter.new(c100_application).relationship_to_children(c100.respondents)
@@ -19,7 +20,44 @@ module Summary
             :other_parties_relationships,
             RelationshipsPresenter.new(c100_application).relationship_to_children(c100.other_parties)
           ),
+          Partial.row_blank_space,
         ].select(&:show?)
+      end
+
+      private
+
+      # Only loop through relationships that entered the non-parents journey,
+      # i.e. those having at least the first of those attributes as not `nil`.
+      #
+      # This saves us from having to iterate through all the relationships, as
+      # many of those will be respondents, other parties, or other children.
+      #
+      def affirmative_permission_questions
+        answers = permission_relationships.map do |relationship|
+          permission_attributes.map do |attr|
+            answer = relationship.try!(attr)
+
+            next if answer.eql?(GenericYesNo::NO.to_s)
+
+            # Break the loop and return the first `yes` answer found
+            break Answer.new(
+              "child_permission_#{attr}", answer,
+              i18n_opts: { applicant_name: relationship.person.full_name, child_name: relationship.minor.full_name }
+            )
+          end
+        end.flatten.compact
+
+        # If there are answers, add a separation between these and the
+        # next group (respondents_relationships) to not look so cramped.
+        answers.append(Partial.row_blank_space) if answers.any?
+      end
+
+      def permission_relationships
+        @_permission_relationships ||= c100.relationships.with_permission_data
+      end
+
+      def permission_attributes
+        Relationship::PERMISSION_ATTRIBUTES
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,8 +195,8 @@ en:
             local_authority: Local authority and consent
             relative: Foster parent or relative
           heading:
-            # NOTE: we have a duplication of these headings in the `cya/en.yml` file
-            # If copy changes here, remember to also change the copy in the other file
+            # NOTE: we have duplications of these headings in the `cya/en.yml` and `pdf/en.yml` files
+            # If copy changes here, remember to also change the copy in the other files
             parental_responsibility: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
             living_order: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
             amendment: "Is %{applicant_name} applying to change or end (discharge) an existing court order?"

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -299,6 +299,47 @@ en:
       question: Respondent(s)
     other_parties_relationships:
       question: Other parties
+
+    # BEGIN - Non-parents permission questions
+    # NOTE: these should match the heading locales in the `en.yml` file
+    child_permission_parental_responsibility:
+      question: "Has %{applicant_name} ever been married to or in a civil partnership with %{child_name}’s parent and do they have parental responsibility?"
+      answers:
+        <<: *YESNO
+    child_permission_living_order:
+      question: "Is %{applicant_name} named in a current child arrangements order as someone who %{child_name} should live with?"
+      answers:
+        <<: *YESNO
+    child_permission_amendment:
+      question: "Is %{applicant_name} applying to change or end (discharge) an existing court order?"
+      answers:
+        <<: *YESNO
+    child_permission_time_order:
+      question: "Was %{applicant_name} named in an order about who %{child_name} should spend time with or when that should happen?"
+      answers:
+        <<: *YESNO
+    child_permission_living_arrangement:
+      question: "Has %{child_name} lived with %{applicant_name} for at least 3 years?"
+      answers:
+        <<: *YESNO
+    child_permission_consent:
+      question: "Does %{applicant_name} have everyone’s consent to make this application?"
+      answers:
+        <<: *YESNO
+    child_permission_family:
+      question: "Is %{applicant_name} married or in a civil partnership with %{child_name}’s parent and is the child treated as part of their family?"
+      answers:
+        <<: *YESNO
+    child_permission_local_authority:
+      question: "If %{child_name} is being cared for by the Local Authority, does %{applicant_name} have the Local Authority’s consent to make this application?"
+      answers:
+        <<: *YESNO
+    child_permission_relative:
+      question: "Is %{applicant_name} a foster parent or relative of %{child_name}, and has %{child_name} been living with them for at least one year?"
+      answers:
+        <<: *YESNO
+    # END - Non-parents permission questions
+
     children_residence:
       question: Who do the children currently live with?
       answers:

--- a/spec/presenters/summary/sections/children_relationships_spec.rb
+++ b/spec/presenters/summary/sections/children_relationships_spec.rb
@@ -7,12 +7,16 @@ module Summary
         applicants: applicants,
         respondents: respondents,
         other_parties: other_parties,
+        relationships: relationships_scope,
       )
     }
 
     let(:applicants) { double('applicants') }
     let(:respondents) { double('respondents') }
     let(:other_parties) { double('other_parties') }
+
+    let(:relationships_scope) { double('relationships', with_permission_data: relationships) }
+    let(:relationships) { [] }
 
     subject { described_class.new(c100_application) }
 
@@ -40,7 +44,7 @@ module Summary
       end
 
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(3)
+        expect(answers.count).to eq(4)
       end
 
       it 'has the correct rows in the right order' do
@@ -55,6 +59,73 @@ module Summary
         expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
         expect(answers[2].question).to eq(:other_parties_relationships)
         expect(answers[2].value).to eq('other_parties_relationships')
+
+        expect(answers[3]).to be_an_instance_of(Partial)
+        expect(answers[3].name).to eq(:row_blank_space)
+      end
+
+      context 'when there are relationships with permission details' do
+        let(:relationships) { [relationship1, relationship2] }
+
+        let(:person) { instance_double(Applicant, full_name: 'Applicant Test') }
+        let(:minor)  { instance_double(Child, full_name: 'Child Test') }
+
+        let(:relationship1) {
+          instance_double(
+            Relationship,
+            person: person,
+            minor: minor,
+            parental_responsibility: 'no',
+            living_order: 'yes',
+            amendment: nil,
+            time_order: nil,
+            living_arrangement: nil,
+            consent: nil,
+            family: nil,
+            local_authority: nil,
+            relative: nil,
+          )
+        }
+
+        let(:relationship2) {
+          instance_double(
+            Relationship,
+            person: person,
+            minor: minor,
+            parental_responsibility: 'no',
+            living_order: 'no',
+            amendment: 'no',
+            time_order: 'yes',
+            living_arrangement: nil,
+            consent: nil,
+            family: nil,
+            local_authority: nil,
+            relative: nil,
+          )
+        }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(7)
+        end
+
+        it 'has the correct rows in the right order' do
+          expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[0].question).to eq(:applicants_relationships)
+          expect(answers[0].value).to eq('applicants_relationships')
+
+          expect(answers[1]).to be_an_instance_of(Answer)
+          expect(answers[1].question).to eq('child_permission_living_order')
+          expect(answers[1].value).to eq('yes')
+          expect(answers[1].i18n_opts).to eq({ applicant_name: 'Applicant Test', child_name: 'Child Test'})
+
+          expect(answers[2]).to be_an_instance_of(Answer)
+          expect(answers[2].question).to eq('child_permission_time_order')
+          expect(answers[2].value).to eq('yes')
+          expect(answers[2].i18n_opts).to eq({ applicant_name: 'Applicant Test', child_name: 'Child Test'})
+
+          expect(answers[3]).to be_an_instance_of(Partial)
+          expect(answers[3].name).to eq(:row_blank_space)
+        end
       end
     end
   end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21498747
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

Similar to the previous PR, but in this case we only show the qustion that was answered YES, ignoring the NO questions, and of course `nil` ones.

This repeats for each combination applicant-child as long as there is data in these attributes.

However as we know if the first attribute is `nil` the following attributes will also be `nil` we just optimise for this by only iterating through relationships that has some value in their first attribute.

### Example (I'm awful with fake names)
<img width="833" alt="Screen Shot 2020-08-13 at 14 55 17" src="https://user-images.githubusercontent.com/687910/90155280-0d312400-dd83-11ea-9f50-f3bbfd16af2a.png">
