### PR TITLE
Move PDF permission questions into its own section

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -1,5 +1,6 @@
 #application-details-pdf {
   $light-grey: #cccccc;
+  $very-light-grey: #eeeeee;
   $dark-grey: #6f777b;
 
   $heading-font-size: 16px;
@@ -67,8 +68,9 @@
   h2.main-section-header {
     font-size: $heading-font-size;
     font-weight: bold;
+    background-color: $very-light-grey;
     border-bottom: 1px solid $dark-grey;
-    padding: 2px 0 0 0;
+    padding: 5px;
   }
 
   h3.section-header {
@@ -161,7 +163,11 @@
     }
   }
 
-  #additional_information {
+  // These sections are heavy on long questions with short answers (Yes/No)
+  // so we give more space to the question (90%) and less to the answer (10%)
+  //
+  #additional_information,
+  #permission_questions {
     td {
       border: none;
       padding: 5px 0 0 0;
@@ -202,7 +208,7 @@
   #c100_court_details,
   #c1a_court_details,
   #c8_court_details {
-    background-color: #eee;
+    background-color: $very-light-grey;
     padding: 10px;
     margin-bottom: 20px;
 

--- a/app/presenters/summary/c100_form.rb
+++ b/app/presenters/summary/c100_form.rb
@@ -39,6 +39,7 @@ module Summary
         Sections::ChildrenDetails.new(c100_application),
         Sections::ChildrenRelationships.new(c100_application),
         Sections::ChildrenResidence.new(c100_application),
+        Sections::PermissionQuestions.new(c100_application),
       ]
     end
 

--- a/app/presenters/summary/sections/children_relationships.rb
+++ b/app/presenters/summary/sections/children_relationships.rb
@@ -11,7 +11,6 @@ module Summary
             :applicants_relationships,
             RelationshipsPresenter.new(c100_application).relationship_to_children(c100.applicants)
           ),
-          *affirmative_permission_questions,
           FreeTextAnswer.new(
             :respondents_relationships,
             RelationshipsPresenter.new(c100_application).relationship_to_children(c100.respondents)
@@ -22,42 +21,6 @@ module Summary
           ),
           Partial.row_blank_space,
         ].select(&:show?)
-      end
-
-      private
-
-      # Only loop through relationships that entered the non-parents journey,
-      # i.e. those having at least the first of those attributes as not `nil`.
-      #
-      # This saves us from having to iterate through all the relationships, as
-      # many of those will be respondents, other parties, or other children.
-      #
-      def affirmative_permission_questions
-        answers = permission_relationships.map do |relationship|
-          permission_attributes.map do |attr|
-            answer = relationship.try!(attr)
-
-            next if answer.eql?(GenericYesNo::NO.to_s)
-
-            # Break the loop and return the first `yes` answer found
-            break Answer.new(
-              "child_permission_#{attr}", answer,
-              i18n_opts: { applicant_name: relationship.person.full_name, child_name: relationship.minor.full_name }
-            )
-          end
-        end.flatten.compact
-
-        # If there are answers, add a separation between these and the
-        # next group (respondents_relationships) to not look so cramped.
-        answers.append(Partial.row_blank_space) if answers.any?
-      end
-
-      def permission_relationships
-        @_permission_relationships ||= c100.relationships.with_permission_data
-      end
-
-      def permission_attributes
-        Relationship::PERMISSION_ATTRIBUTES
       end
     end
   end

--- a/app/presenters/summary/sections/permission_questions.rb
+++ b/app/presenters/summary/sections/permission_questions.rb
@@ -1,0 +1,45 @@
+module Summary
+  module Sections
+    class PermissionQuestions < BaseSectionPresenter
+      def name
+        :permission_questions
+      end
+
+      def answers
+        affirmative_permission_questions
+      end
+
+      private
+
+      # Only loop through relationships that entered the non-parents journey,
+      # i.e. those having at least the first of those attributes as not `nil`.
+      #
+      # This saves us from having to iterate through all the relationships, as
+      # many of those will be respondents, other parties, or other children.
+      #
+      def affirmative_permission_questions
+        permission_relationships.map do |relationship|
+          permission_attributes.map do |attr|
+            answer = relationship.try!(attr)
+
+            next if answer.eql?(GenericYesNo::NO.to_s)
+
+            # Break the loop and return the first `yes` answer found
+            break Answer.new(
+              "child_permission_#{attr}", answer,
+              i18n_opts: { applicant_name: relationship.person.full_name, child_name: relationship.minor.full_name }
+            )
+          end
+        end.flatten.compact
+      end
+
+      def permission_relationships
+        @_permission_relationships ||= c100.relationships.with_permission_data
+      end
+
+      def permission_attributes
+        Relationship::PERMISSION_ATTRIBUTES
+      end
+    end
+  end
+end

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -130,6 +130,7 @@ en:
       additional_information: Additional information
       children_details: Summary of children’s details
       children_relationships: Children’s relationship with parties
+      permission_questions: Permission for non-parents to apply
       urgent_hearing: Urgent hearing
       without_notice_hearing: Without notice hearing
       other_children_details: Other children not part of the application

--- a/spec/presenters/summary/c100_form_spec.rb
+++ b/spec/presenters/summary/c100_form_spec.rb
@@ -37,6 +37,7 @@ module Summary
           Sections::ChildrenDetails,
           Sections::ChildrenRelationships,
           Sections::ChildrenResidence,
+          Sections::PermissionQuestions,
           Sections::SectionHeader,
           Sections::MiamRequirement,
           Sections::SectionHeader,

--- a/spec/presenters/summary/sections/children_relationships_spec.rb
+++ b/spec/presenters/summary/sections/children_relationships_spec.rb
@@ -7,16 +7,12 @@ module Summary
         applicants: applicants,
         respondents: respondents,
         other_parties: other_parties,
-        relationships: relationships_scope,
       )
     }
 
     let(:applicants) { double('applicants') }
     let(:respondents) { double('respondents') }
     let(:other_parties) { double('other_parties') }
-
-    let(:relationships_scope) { double('relationships', with_permission_data: relationships) }
-    let(:relationships) { [] }
 
     subject { described_class.new(c100_application) }
 
@@ -62,70 +58,6 @@ module Summary
 
         expect(answers[3]).to be_an_instance_of(Partial)
         expect(answers[3].name).to eq(:row_blank_space)
-      end
-
-      context 'when there are relationships with permission details' do
-        let(:relationships) { [relationship1, relationship2] }
-
-        let(:person) { instance_double(Applicant, full_name: 'Applicant Test') }
-        let(:minor)  { instance_double(Child, full_name: 'Child Test') }
-
-        let(:relationship1) {
-          instance_double(
-            Relationship,
-            person: person,
-            minor: minor,
-            parental_responsibility: 'no',
-            living_order: 'yes',
-            amendment: nil,
-            time_order: nil,
-            living_arrangement: nil,
-            consent: nil,
-            family: nil,
-            local_authority: nil,
-            relative: nil,
-          )
-        }
-
-        let(:relationship2) {
-          instance_double(
-            Relationship,
-            person: person,
-            minor: minor,
-            parental_responsibility: 'no',
-            living_order: 'no',
-            amendment: 'no',
-            time_order: 'yes',
-            living_arrangement: nil,
-            consent: nil,
-            family: nil,
-            local_authority: nil,
-            relative: nil,
-          )
-        }
-
-        it 'has the correct number of rows' do
-          expect(answers.count).to eq(7)
-        end
-
-        it 'has the correct rows in the right order' do
-          expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[0].question).to eq(:applicants_relationships)
-          expect(answers[0].value).to eq('applicants_relationships')
-
-          expect(answers[1]).to be_an_instance_of(Answer)
-          expect(answers[1].question).to eq('child_permission_living_order')
-          expect(answers[1].value).to eq('yes')
-          expect(answers[1].i18n_opts).to eq({ applicant_name: 'Applicant Test', child_name: 'Child Test'})
-
-          expect(answers[2]).to be_an_instance_of(Answer)
-          expect(answers[2].question).to eq('child_permission_time_order')
-          expect(answers[2].value).to eq('yes')
-          expect(answers[2].i18n_opts).to eq({ applicant_name: 'Applicant Test', child_name: 'Child Test'})
-
-          expect(answers[3]).to be_an_instance_of(Partial)
-          expect(answers[3].name).to eq(:row_blank_space)
-        end
       end
     end
   end

--- a/spec/presenters/summary/sections/permission_questions_spec.rb
+++ b/spec/presenters/summary/sections/permission_questions_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::PermissionQuestions do
+    let(:c100_application) { instance_double(C100Application, relationships: relationships_scope) }
+    let(:relationships_scope) { double('relationships', with_permission_data: relationships) }
+    let(:relationships) { [] }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:permission_questions)
+      end
+    end
+
+    describe '#answers' do
+      context 'when there are no relationships with permission details' do
+        it 'does not show the section' do
+          expect(subject.show?).to eq(false)
+        end
+      end
+
+      context 'when there are relationships with permission details' do
+        let(:relationships) { [relationship1, relationship2] }
+
+        let(:person) { instance_double(Applicant, full_name: 'Applicant Test') }
+        let(:minor)  { instance_double(Child, full_name: 'Child Test') }
+
+        let(:relationship1) {
+          instance_double(
+            Relationship,
+            person: person,
+            minor: minor,
+            parental_responsibility: 'no',
+            living_order: 'yes',
+            amendment: nil,
+            time_order: nil,
+            living_arrangement: nil,
+            consent: nil,
+            family: nil,
+            local_authority: nil,
+            relative: nil,
+          )
+        }
+
+        let(:relationship2) {
+          instance_double(
+            Relationship,
+            person: person,
+            minor: minor,
+            parental_responsibility: 'no',
+            living_order: 'no',
+            amendment: 'no',
+            time_order: 'yes',
+            living_arrangement: nil,
+            consent: nil,
+            family: nil,
+            local_authority: nil,
+            relative: nil,
+          )
+        }
+
+        it 'has the correct number of rows' do
+          expect(answers.count).to eq(2)
+        end
+
+        it 'has the correct rows in the right order' do
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq('child_permission_living_order')
+          expect(answers[0].value).to eq('yes')
+          expect(answers[0].i18n_opts).to eq({ applicant_name: 'Applicant Test', child_name: 'Child Test'})
+
+          expect(answers[1]).to be_an_instance_of(Answer)
+          expect(answers[1].question).to eq('child_permission_time_order')
+          expect(answers[1].value).to eq('yes')
+          expect(answers[1].i18n_opts).to eq({ applicant_name: 'Applicant Test', child_name: 'Child Test'})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This improves upon PR #1044 by moving the permission questions into its own sub-section in the PDF right below the "Children’s relationship with parties" one, so it is a bit more clear.

Also because it is a separate section we can apply a bit of styling so the question column is much wider than the answer column (because answer can only be "Yes").

Apart from that, and to make things even more easy and clear to read, I've applied a bit of shading to the top-level section headers to separate further each of the parts of the form.

<img width="832" alt="Screen Shot 2020-08-14 at 11 09 02" src="https://user-images.githubusercontent.com/687910/90239469-79f9fc00-de1f-11ea-839a-56494a266d6a.png">

### Example of header shading
<img width="820" alt="Screen Shot 2020-08-14 at 11 16 17" src="https://user-images.githubusercontent.com/687910/90239552-9d24ab80-de1f-11ea-88c1-6e64b290d746.png">
