### PR TITLE
Permission rules do not apply to `OtherChild`

### DIFF
--- a/app/services/c100_app/permission_rules.rb
+++ b/app/services/c100_app/permission_rules.rb
@@ -20,10 +20,11 @@ module C100App
     #
     # In these cases we need to go through further questions to decide
     # if permission will be needed or not.
-    # Consent order applications do not require permission.
+    # Consent order applications or 'OtherChild' skip permission rules.
     #
     def permission_undecided?
       return false if consent_order?
+      return false if is_other_child?
 
       !permission_needed? && other_relationship?
     end
@@ -32,6 +33,10 @@ module C100App
 
     def child
       @_child ||= relationship.minor
+    end
+
+    def is_other_child?
+      child.instance_of?(OtherChild)
     end
 
     def special_guardianship_order?

--- a/spec/services/c100_app/permission_rules_spec.rb
+++ b/spec/services/c100_app/permission_rules_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe C100App::PermissionRules do
       end
     end
 
+    context 'when relationship is with other child (`OtherChild`)' do
+      let(:child) { OtherChild.new }
+
+      it 'returns false' do
+        expect(subject.permission_undecided?).to eq(false)
+      end
+
+      it 'does not check any other rules' do
+        expect(subject).not_to receive(:permission_needed?)
+        expect(subject).not_to receive(:other_relationship?)
+
+        subject.permission_undecided?
+      end
+    end
+
     context 'when `special_guardianship_order` is `nil`' do
       it 'returns false' do
         expect(subject.permission_undecided?).to eq(false)


### PR DESCRIPTION
Permission (and any rules and questions derived from it) is only required for "main" children, i.e. children the application is about.

Other children that are not subject of the proceedings should not enter the 9-questions journey.