### PR TITLE
Reset non-parent questions if relation changes

### DIFF
--- a/app/forms/steps/shared/relationship_form.rb
+++ b/app/forms/steps/shared/relationship_form.rb
@@ -25,12 +25,24 @@ module Steps
         relation.eql?(Relation::OTHER.to_s)
       end
 
+      def attributes_to_reset
+        return {} if record.relation.eql?(relation_value.to_s)
+
+        # If the `relation` has changed we need to ensure all the non-parent
+        # attributes are reset as well, in case some were previously set.
+        Hash[Relationship::PERMISSION_ATTRIBUTES.each_slice(1).to_a]
+      end
+
       def persist!
         raise C100ApplicationNotFound unless c100_application
 
         record.update(
-          relation: relation_value,
-          relation_other_value: other_value
+          {
+            relation: relation_value,
+            relation_other_value: other_value
+          }.merge(
+            attributes_to_reset
+          )
         )
       end
     end

--- a/spec/forms/steps/shared/relationship_form_spec.rb
+++ b/spec/forms/steps/shared/relationship_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Steps::Shared::RelationshipForm do
 
   let(:c100_application) { instance_double(C100Application) }
 
-  let(:record) { double('Relationship') }
+  let(:record) { Relationship.new }
   let(:relation) { 'mother' }
   let(:relation_other_value) { nil }
 
@@ -69,22 +69,54 @@ RSpec.describe Steps::Shared::RelationshipForm do
     context 'for valid details' do
       let(:relation_other_value) { 'anything' }
 
-      it 'updates the record' do
-        expect(record).to receive(:update).with(
-          relation: Relation::MOTHER,
-          relation_other_value: nil
-        ).and_return(true)
-
-        expect(subject.save).to be(true)
+      before do
+        allow(record).to receive(:relation).and_return(existing_relation)
       end
 
       context 'for `other` relation' do
+        let(:existing_relation) { 'other' }
         let(:relation) { 'other' }
 
         it 'updates the record' do
           expect(record).to receive(:update).with(
             relation: Relation::OTHER,
-            relation_other_value: 'anything'
+            relation_other_value: 'anything',
+            ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when there are no changes in the relation' do
+        let(:existing_relation) { 'mother' }
+
+        it 'updates the record' do
+          expect(record).to receive(:update).with(
+            relation: Relation::MOTHER,
+            relation_other_value: nil,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when there are changes in the relation' do
+        let(:existing_relation) { 'father' }
+
+        it 'updates the record' do
+          expect(record).to receive(:update).with(
+            relation: Relation::MOTHER,
+            relation_other_value: nil,
+            # non-parents reset
+            parental_responsibility: nil,
+            living_order: nil,
+            amendment: nil,
+            time_order: nil,
+            living_arrangement: nil,
+            consent: nil,
+            family: nil,
+            local_authority: nil,
+            relative: nil,
           ).and_return(true)
 
           expect(subject.save).to be(true)


### PR DESCRIPTION
Similar to what we did for the SGO order reset in commit f45515d8045afae0158e258f50ce0581033f0d82, if the relation between the applicant and the child changes but somehow before some non-parents were answered, we make sure these are reset as a change in relationship effectivelly requires to re-evaluate the journey and decisions.