### PR TITLE
Add permission sought yes-no question

### DIFF
--- a/app/controllers/steps/application/permission_sought_controller.rb
+++ b/app/controllers/steps/application/permission_sought_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Application
+    class PermissionSoughtController < Steps::ApplicationStepController
+      def edit
+        @form_object = PermissionSoughtForm.new(
+          c100_application: current_c100_application,
+          permission_sought: current_c100_application.permission_sought
+        )
+      end
+
+      def update
+        update_and_advance(PermissionSoughtForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/application/permission_sought_form.rb
+++ b/app/forms/steps/application/permission_sought_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Application
+    class PermissionSoughtForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :permission_sought, reset_when_yes: [:permission_details]
+    end
+  end
+end

--- a/app/views/steps/application/permission_sought/edit.html.erb
+++ b/app/views/steps/application/permission_sought/edit.html.erb
@@ -1,0 +1,16 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :permission_sought, GenericYesNo.values, :value, nil do %>
+        <p class="govuk-body-l"><%=t '.lead_text' %></p>
+      <% end %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -750,6 +750,10 @@ en:
         edit:
           page_title: Factors affecting ability to participate
           heading: Factors affecting ability to participate
+      permission_sought:
+        edit:
+          page_title: Permission to apply details
+          lead_text: You may already have permission from the court, or applied for permission separately. If not, you will be able to apply as part of this application.
       details:
         edit:
           page_title: Application details
@@ -1222,6 +1226,9 @@ en:
         participation_capacity_details: Details of any adult in this application who lacks the mental capacity to conduct these court proceedings (if applicable)
         participation_other_factors_details: Details of anything else that could affect any adult in this application taking part in these court proceedings (if applicable)
         participation_referral_or_assessment_details: Details of anyone in this application who has been referred to or assessed by an Adult Learning Disability team or any adult health service and what the outcome was (if you know)
+      steps_application_permission_sought_form:
+        permission_sought_options:
+          <<: *YESNO
       steps_application_details_form:
         application_details: *provide_details
       steps_attending_court_intermediary_form:
@@ -1715,6 +1722,8 @@ en:
         without_notice_impossible: Are you asking for a without notice hearing because there is literally no time to give notice of the application to the other person or people?
       steps_application_urgent_hearing_details_form:
         urgent_hearing_short_notice: Do you need a hearing within the next 48 hours?
+      steps_application_permission_sought_form:
+        permission_sought: Have you already applied to the court for permission to make this application?
 
       # International steps
       steps_international_jurisdiction_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -573,6 +573,10 @@ en:
               inclusion: *yes_no_error
             international_request_details:
               blank: *blank_details_error
+        steps/application/permission_sought_form:
+          attributes:
+            permission_sought:
+              inclusion: *yes_no_error
         steps/application/details_form:
           attributes:
             application_details:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,7 @@ Rails.application.routes.draw do
       edit_step :urgent_hearing_details
       edit_step :without_notice
       edit_step :without_notice_details
+      edit_step :permission_sought
       edit_step :details
       edit_step :litigation_capacity
       edit_step :litigation_capacity_details

--- a/db/migrate/20200817145208_add_permission_sought_fields.rb
+++ b/db/migrate/20200817145208_add_permission_sought_fields.rb
@@ -1,0 +1,6 @@
+class AddPermissionSoughtFields < ActiveRecord::Migration[5.2]
+  def change
+    add_column :c100_applications, :permission_sought,  :string
+    add_column :c100_applications, :permission_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_11_110454) do
+ActiveRecord::Schema.define(version: 2020_08_17_145208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -143,6 +143,8 @@ ActiveRecord::Schema.define(version: 2020_08_11_110454) do
     t.string "declaration_signee_capacity"
     t.text "international_resident_details"
     t.string "reminder_status"
+    t.string "permission_sought"
+    t.text "permission_details"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"
   end

--- a/spec/controllers/steps/application/permission_sought_controller_spec.rb
+++ b/spec/controllers/steps/application/permission_sought_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Application::PermissionSoughtController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Application::PermissionSoughtForm, C100App::ApplicationDecisionTree
+end

--- a/spec/forms/steps/application/permission_sought_form_spec.rb
+++ b/spec/forms/steps/application/permission_sought_form_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Application::PermissionSoughtForm do
+  it_behaves_like 'a yes-no question form', attribute_name: :permission_sought,
+                                            reset_when_yes: [:permission_details]
+end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21450255
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

Simple yes-no question as per design.
At the moment, this is not visible nor part of the journey. Once we create the follow-up step I will add these to the decision tree.

But it can be accessed directly by knowing the URL.

Added a couple of DB attributes, one is needed for this step, the other `permission_details` will be used in the follow-up step.

<img width="679" alt="Screen Shot 2020-08-17 at 16 58 22" src="https://user-images.githubusercontent.com/687910/90416847-e8062380-e0aa-11ea-8a76-c93abfc224d4.png">
