### PR TITLE
Add permission to apply details step

### DIFF
--- a/app/controllers/steps/application/permission_details_controller.rb
+++ b/app/controllers/steps/application/permission_details_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Application
+    class PermissionDetailsController < Steps::ApplicationStepController
+      def edit
+        @form_object = PermissionDetailsForm.new(
+          c100_application: current_c100_application,
+          permission_details: current_c100_application.permission_details
+        )
+      end
+
+      def update
+        update_and_advance(PermissionDetailsForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/application/permission_details_form.rb
+++ b/app/forms/steps/application/permission_details_form.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Application
+    class PermissionDetailsForm < BaseForm
+      attribute :permission_details, String
+
+      validates_presence_of :permission_details
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        c100_application.update(
+          permission_details: permission_details
+        )
+      end
+    end
+  end
+end

--- a/app/views/steps/application/permission_details/edit.html.erb
+++ b/app/views/steps/application/permission_details/edit.html.erb
@@ -7,10 +7,12 @@
 
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
+    <p class="govuk-body-l"><%=t '.lead_text' %></p>
+
     <%=t '.info_html' %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_area :application_details, rows: 8, label: { size: 's' } %>
+      <%= f.govuk_text_area :permission_details, rows: 8, label: { size: 's' } %>
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -752,8 +752,21 @@ en:
           heading: Factors affecting ability to participate
       permission_sought:
         edit:
-          page_title: Permission to apply details
+          page_title: Permission to apply
           lead_text: You may already have permission from the court, or applied for permission separately. If not, you will be able to apply as part of this application.
+      permission_details:
+        edit:
+          page_title: Permission to apply details
+          heading: Give details to ask for permission to apply
+          lead_text: You need to give details for the court to consider whether to give permission for this application to be made.
+          info_html: |
+            <p class="govuk-body">You could include:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>details of your relationship with the children</li>
+              <li>details of any risk of disruption to the child that may be caused by this application</li>
+              <li>any plans the Local Authority have made for the children (if this applies)</li>
+              <li>the wishes and feelings of the children’s parents (if the child is being looked after by the Local Authority)</li>
+            </ul>
       details:
         edit:
           page_title: Application details
@@ -766,7 +779,6 @@ en:
               <li>why the other person disagrees</li>
               <li>any previous <a href="https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/parenting-plan/" class="govuk-link" rel="external" target="_blank">parenting plans</a> or agreements (formal or informal), and why they broke down</li>
             </ul>
-          timeout_warning: For your security, your session ends after %{session_timeout} minutes if there’s no activity on your application. To avoid losing your application, make sure you save it. Any unsaved details will be deleted.
       payment:
         edit:
           page_title: Payment type
@@ -1229,6 +1241,8 @@ en:
       steps_application_permission_sought_form:
         permission_sought_options:
           <<: *YESNO
+      steps_application_permission_details_form:
+        permission_details: Provide details to ask for permission
       steps_application_details_form:
         application_details: *provide_details
       steps_attending_court_intermediary_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -577,6 +577,10 @@ en:
           attributes:
             permission_sought:
               inclusion: *yes_no_error
+        steps/application/permission_details_form:
+          attributes:
+            permission_details:
+              blank: Enter details to ask for permission to apply
         steps/application/details_form:
           attributes:
             application_details:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
       edit_step :without_notice
       edit_step :without_notice_details
       edit_step :permission_sought
+      edit_step :permission_details
       edit_step :details
       edit_step :litigation_capacity
       edit_step :litigation_capacity_details

--- a/spec/controllers/steps/application/permission_details_controller_spec.rb
+++ b/spec/controllers/steps/application/permission_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Application::PermissionDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Application::PermissionDetailsForm, C100App::ApplicationDecisionTree
+end

--- a/spec/forms/steps/application/permission_details_form_spec.rb
+++ b/spec/forms/steps/application/permission_details_form_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Application::PermissionDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    permission_details: permission_details
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+  let(:permission_details) { 'permission details' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no c100_application is associated with the form' do
+      let(:c100_application) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+      end
+    end
+
+    context 'validations' do
+      it { should validate_presence_of(:permission_details) }
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(c100_application).to receive(:update).with(
+          permission_details: 'permission details'
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21392567
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

Follow-up to PR #1048.

Simple details page, with a text area to enter details. Validate presence.

Made the exinsting application details, and this new permission details, more consistent by using same form labels size and removing an obsolete timeout warning text.

Still not integrated in the decision trees so it is not visible unless accessing the URL by hand.

<img width="591" alt="Screen Shot 2020-08-18 at 11 43 39" src="https://user-images.githubusercontent.com/687910/90503853-0ec66780-e148-11ea-8e66-a16522a1ed0d.png">
