### PR TITLE
Add permission sought and details to main journey

### DIFF
--- a/app/services/c100_app/international_decision_tree.rb
+++ b/app/services/c100_app/international_decision_tree.rb
@@ -9,10 +9,19 @@ module C100App
       when :jurisdiction
         edit(:request)
       when :request
-        edit('/steps/application/details')
+        after_request_step
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
+    end
+
+    private
+
+    # TODO: check the permission rules here to decide if we go to
+    # `application/permission_sought` or to `application/details`
+    #
+    def after_request_step
+      edit('/steps/application/permission_sought')
     end
   end
 end

--- a/spec/services/c100_app/application_decision_tree_spec.rb
+++ b/spec/services/c100_app/application_decision_tree_spec.rb
@@ -70,6 +70,26 @@ RSpec.describe C100App::ApplicationDecisionTree do
     it { is_expected.to have_destination('/steps/international/resident', :edit) }
   end
 
+  context 'when the step is `permission_sought`' do
+    let(:c100_application) { instance_double(C100Application, permission_sought: answer) }
+    let(:step_params) { { permission_sought: 'whatever' } }
+
+    context 'and the answer is `yes`' do
+      let(:answer) { 'yes' }
+      it { is_expected.to have_destination(:details, :edit) }
+    end
+
+    context 'and the answer is `no`' do
+      let(:answer) { 'no' }
+      it { is_expected.to have_destination(:permission_details, :edit) }
+    end
+  end
+
+  context 'when the step is `permission_details`' do
+    let(:step_params) { { permission_details: 'anything' } }
+    it { is_expected.to have_destination(:details, :edit) }
+  end
+
   context 'when the step is `application_details`' do
     let(:step_params) { { application_details: 'anything' } }
     it { is_expected.to have_destination(:litigation_capacity, :edit) }

--- a/spec/services/c100_app/international_decision_tree_spec.rb
+++ b/spec/services/c100_app/international_decision_tree_spec.rb
@@ -22,6 +22,6 @@ RSpec.describe C100App::InternationalDecisionTree do
 
   context 'when the step is `request`' do
     let(:step_params) { { request: 'anything' } }
-    it { is_expected.to have_destination('/steps/application/details', :edit) }
+    it { is_expected.to have_destination('/steps/application/permission_sought', :edit) }
   end
 end


### PR DESCRIPTION
Follow-up to PRs #1048 and #1049.

Incorporate these two questions in the main journey, right after finalising the international sub-journey.

For now, it will always show, as we are not checking the permission rules. This will be done in the next PR.