### PR TITLE
Do not touch `updated_at` on navigation updates

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -114,6 +114,6 @@ class StepController < ApplicationController
     end
 
     current_c100_application.navigation_stack = stack_until_current_page + [request.fullpath]
-    current_c100_application.save!
+    current_c100_application.save!(touch: false)
   end
 end

--- a/spec/controllers/step_controller_spec.rb
+++ b/spec/controllers/step_controller_spec.rb
@@ -19,11 +19,18 @@ RSpec.describe DummyStepController, type: :controller do
   end
 
   describe 'navigation stack' do
-    let!(:c100_application) { C100Application.create(navigation_stack: navigation_stack) }
+    let!(:c100_application) { C100Application.create(navigation_stack: navigation_stack, updated_at: updated_at) }
+    let(:updated_at) { Time.at(0) }
 
     before do
       get :show, session: { c100_application_id: c100_application.id }
       c100_application.reload
+    end
+
+    # In these tests we are persisting the application record,
+    # so we need to cleanup after we are finished with it.
+    after do
+      c100_application.destroy
     end
 
     context 'when the stack is empty' do
@@ -31,6 +38,10 @@ RSpec.describe DummyStepController, type: :controller do
 
       it 'adds the page to the stack' do
         expect(c100_application.navigation_stack).to eq(['/dummy_step'])
+      end
+
+      it 'does not `touch` timestamps on save' do
+        expect(c100_application.updated_at).to eq(updated_at)
       end
     end
 
@@ -56,6 +67,12 @@ RSpec.describe DummyStepController, type: :controller do
 
     before do
       get :show, session: { c100_application_id: c100_application.id }
+    end
+
+    # In these tests we are persisting the application record,
+    # so we need to cleanup after we are finished with it.
+    after do
+      c100_application.destroy
     end
 
     context 'when the stack is empty' do


### PR DESCRIPTION
This was messing a bit with some reports and statistics we have, because each time there is a navigation change (`navigation_stack` gets updated) it did a save and touched the `updated_at` magic column too.
And we tend to sort many of these report by updated_at.

The timestamp changes separately from the `navigation_stack` each time there is an attribute update, i.e. when the user is answering questions and entering details.