### PR TITLE
Add a couple more email domain typos

### DIFF
--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,9 +1,11 @@
 class EmailValidator < ActiveModel::EachValidator
   EMAIL_REGEX = /\A\s*([-\p{L}\d+._]{1,64})@((?:[-\p{L}\d]+\.)+?\p{L}{2,})\s*\z/i.freeze
   COMMON_DOMAIN_TYPOS = %w[
+    cloud.com
     gamil.com
     gmail.con
     gmail.co
+    hotmailco.uk
     hotmial.com
     hotmail.con
     hotmail.co

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -30,9 +30,11 @@ describe EmailValidator do
       expect(
         described_class::COMMON_DOMAIN_TYPOS
       ).to eq(%w[
+        cloud.com
         gamil.com
         gmail.con
         gmail.co
+        hotmailco.uk
         hotmial.com
         hotmail.con
         hotmail.co


### PR DESCRIPTION
These are some mistakes users make, and although these domains exist, they are not what the user intended (domain typosquatting).