### PR TITLE
Reset permission detail attributes if no longer needed

### DIFF
--- a/app/services/c100_app/international_decision_tree.rb
+++ b/app/services/c100_app/international_decision_tree.rb
@@ -24,6 +24,7 @@ module C100App
       if rules.permission_needed?
         edit('/steps/application/permission_sought')
       else
+        rules.reset_permission_details!
         edit('/steps/application/details')
       end
     end

--- a/app/services/c100_app/permission/application_rules.rb
+++ b/app/services/c100_app/permission/application_rules.rb
@@ -40,7 +40,7 @@ module C100App
       #   1. Consent order applications are exempt from permission.
       #
       #   2. If any of the children in the application has a SGO in force,
-      #      permission is required, no ned to check anything else.
+      #      permission is required, no need to check anything else.
       #
       #   3. Finally, we need to check each applicant-child relationship and the
       #      orders they are applying for to decide if permission will be needed.
@@ -50,6 +50,18 @@ module C100App
         return true  if children_with_sgo?
 
         relationships_require_permission?
+      end
+
+      # If for some reason permission was required, and details entered, but later
+      # something changed in the application that made the permission not required,
+      # we wipe/reset these attributes as otherwise showing their values would be
+      # confusing on the CYA page and on the PDF.
+      #
+      def reset_permission_details!
+        c100_application.update(
+          permission_sought: nil,
+          permission_details: nil,
+        )
       end
 
       private

--- a/spec/services/c100_app/international_decision_tree_spec.rb
+++ b/spec/services/c100_app/international_decision_tree_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe C100App::InternationalDecisionTree do
 
   context 'when the step is `request`' do
     let(:step_params) { { request: 'anything' } }
-    let(:rules_mock)  { double(permission_needed?: rule_result) }
+    let(:rules_mock)  { double(permission_needed?: rule_result, reset_permission_details!: true) }
 
     before do
       allow(C100App::Permission::ApplicationRules).to receive(:new).with(c100_application).and_return(rules_mock)
@@ -35,7 +35,11 @@ RSpec.describe C100App::InternationalDecisionTree do
 
     context 'when permission to apply is not needed' do
       let(:rule_result) { false }
-      it { is_expected.to have_destination('/steps/application/details', :edit) }
+
+      it 'resets the permission details, in case these exists, and continue to application details' do
+        expect(subject).to have_destination('/steps/application/details', :edit)
+        expect(rules_mock).to have_received(:reset_permission_details!)
+      end
     end
   end
 end

--- a/spec/services/c100_app/permission/application_rules_spec.rb
+++ b/spec/services/c100_app/permission/application_rules_spec.rb
@@ -51,6 +51,19 @@ RSpec.describe C100App::Permission::ApplicationRules do
     end
   end
 
+  describe '#reset_permission_details!' do
+    it 'updates with `nil` values the attributes' do
+      expect(
+        c100_application
+      ).to receive(:update).with(
+        permission_sought: nil,
+        permission_details: nil,
+      )
+
+      subject.reset_permission_details!
+    end
+  end
+
   describe '#permission_needed?' do
     context 'when application is a consent order' do
       let(:consent_order) { 'yes' }

--- a/spec/support/matchers/decision_tree_matcher.rb
+++ b/spec/support/matchers/decision_tree_matcher.rb
@@ -2,9 +2,10 @@ require 'rspec/expectations'
 
 RSpec::Matchers.define :have_destination do |controller, action, params = {}|
   match do |decision_tree|
-    decision_tree.destination[:controller] == controller &&
-      decision_tree.destination[:action] == action &&
-      params.keys.all? { |key| decision_tree.destination[key].to_s == params[key].to_s }
+    destination = decision_tree.destination
+
+    destination[:controller] == controller && destination[:action] == action &&
+      params.keys.all? { |key| destination[key].to_s == params[key].to_s }
   end
 
   failure_message do |decision_tree|


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21603793
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

If for some reason permission was required, and details entered, but later something changed in the application (for example the applicant changing something through the CYA page) that made the permission not required, we wipe/reset these attributes as otherwise showing their values would be confusing on the CYA page and on the PDF.

This is the simplest possible approach to this otherwise quite complex problem.
There are just too many interrelated questions-answers and attributes in the course of the application, and it is not that simple to know when changing a Yes to a No, or viceversa, could affect something complex as the permission to apply down the line.

But I think this should cover the most common use-cases and make sure we only have this values/attributes with data, if permission is really needed, otherwise they will be `nil`.