### PR TITLE
Extend CYA permission tests

### DIFF
--- a/spec/presenters/summary/html_sections/application_reasons_spec.rb
+++ b/spec/presenters/summary/html_sections/application_reasons_spec.rb
@@ -3,11 +3,17 @@ require 'spec_helper'
 module Summary
   describe HtmlSections::ApplicationReasons do
     let(:c100_application) {
-      instance_double(C100Application,
-        application_details: 'details',
-              permission_sought: 'yes',
-              permission_details: 'details',
-    ) }
+      instance_double(
+        C100Application,
+        permission_sought: permission_sought,
+        permission_details: permission_details,
+        application_details: application_details,
+      )
+    }
+
+    let(:permission_sought) { nil }
+    let(:permission_details) { nil }
+    let(:application_details) { 'application details' }
 
     subject { described_class.new(c100_application) }
 
@@ -18,23 +24,57 @@ module Summary
     end
 
     describe '#answers' do
-      it 'has the correct rows' do
-        expect(answers.count).to eq(3)
+      context 'when permission question was not asked' do
+        it 'has the correct rows' do
+          expect(answers.count).to eq(1)
 
-        expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:permission_sought)
-        expect(c100_application).to have_received(:permission_sought)
-        expect(answers[0].change_path).to eq('/steps/application/permission_sought')
+          expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[0].question).to eq(:application_details)
+          expect(answers[0].value).to eq(application_details)
+          expect(answers[0].change_path).to eq('/steps/application/details')
+        end
+      end
 
-        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[1].question).to eq(:permission_details)
-        expect(c100_application).to have_received(:permission_details)
-        expect(answers[1].change_path).to eq('/steps/application/permission_details')
+      context 'when permission sought is `yes`' do
+        let(:permission_sought) { 'yes' }
 
-        expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[2].question).to eq(:application_details)
-        expect(c100_application).to have_received(:application_details)
-        expect(answers[2].change_path).to eq('/steps/application/details')
+        it 'has the correct rows' do
+          expect(answers.count).to eq(2)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:permission_sought)
+          expect(answers[0].value).to eq(permission_sought)
+          expect(answers[0].change_path).to eq('/steps/application/permission_sought')
+
+          expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[1].question).to eq(:application_details)
+          expect(answers[1].value).to eq(application_details)
+          expect(answers[1].change_path).to eq('/steps/application/details')
+        end
+      end
+
+      context 'when permission sought is `no`' do
+        let(:permission_sought) { 'no' }
+        let(:permission_details) { 'permission details' }
+
+        it 'has the correct rows' do
+          expect(answers.count).to eq(3)
+
+          expect(answers[0]).to be_an_instance_of(Answer)
+          expect(answers[0].question).to eq(:permission_sought)
+          expect(answers[0].value).to eq(permission_sought)
+          expect(answers[0].change_path).to eq('/steps/application/permission_sought')
+
+          expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[1].question).to eq(:permission_details)
+          expect(answers[1].value).to eq(permission_details)
+          expect(answers[1].change_path).to eq('/steps/application/permission_details')
+
+          expect(answers[2]).to be_an_instance_of(FreeTextAnswer)
+          expect(answers[2].question).to eq(:application_details)
+          expect(answers[2].value).to eq(application_details)
+          expect(answers[2].change_path).to eq('/steps/application/details')
+        end
       end
     end
   end


### PR DESCRIPTION
Just a minor refactor in line with the PDF tests, so it covers all possible options (including the permission question not being asked and thus being `nil`).