### PR TITLE
Log in the audit table permission info

### DIFF
--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -2,6 +2,8 @@ class AuditHelper
   attr_reader :c100_application
   alias_attribute :c100, :c100_application
 
+  PERMISSION_NOT_REQUIRED = 'not_required'.freeze
+
   def initialize(c100_application)
     @c100_application = c100_application
   end
@@ -14,11 +16,13 @@ class AuditHelper
       c1a_form: c100.has_safety_concerns?,
       c8_form: c100.confidentiality_enabled?,
       under_age: c100.applicants.under_age?,
+      children_sgo: c100.children.with_special_guardianship_order?,
       saved_for_later: c100.user_id.present?,
-      consent_order: c100.consent_order || 'no',
+      consent_order: c100.consent_order,
       legal_representation: c100.has_solicitor,
       urgent_hearing: c100.urgent_hearing,
       without_notice: c100.without_notice,
+      permission_sought: c100_application.permission_sought || PERMISSION_NOT_REQUIRED,
       reduced_litigation: c100.reduced_litigation_capacity,
       payment_type: c100.payment_type,
       signee_capacity: c100.declaration_signee_capacity,

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -3,4 +3,8 @@ class Child < Minor
   has_one :child_residence, dependent: :destroy
 
   scope :with_special_guardianship_order, -> { where(special_guardianship_order: GenericYesNo::YES.to_s) }
+
+  def self.with_special_guardianship_order?
+    with_special_guardianship_order.any?
+  end
 end

--- a/app/services/c100_app/permission/application_rules.rb
+++ b/app/services/c100_app/permission/application_rules.rb
@@ -71,7 +71,7 @@ module C100App
       end
 
       def children_with_sgo?
-        c100_application.children.with_special_guardianship_order.any?
+        c100_application.children.with_special_guardianship_order?
       end
 
       # Only loop through relationships that entered the non-parents journey,

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -30,12 +30,15 @@
                   <dd><%= completion.metadata['saved_for_later'] %></dd>
                   <dt>Any applicant under 18?</dt>
                   <dd><%= completion.metadata['under_age'] || false %></dd>
-                  <dt>Legal representation</dt>
-                  <dd><%= completion.metadata['legal_representation'] || 'N/A' %></dd>
+                  <dt>Any children with SGO?</dt>
+                  <dd><%= completion.metadata['children_sgo'] || false %></dd>
                   <dt>Urgent hearing</dt>
                   <dd><%= completion.metadata['urgent_hearing'] || 'N/A' %></dd>
                   <dt>Without notice hearing</dt>
                   <dd><%= completion.metadata['without_notice'] || 'N/A' %></dd>
+                  <dt>Permission to make application</dt>
+                  <dd><%= t(completion.metadata['permission_sought'], scope: 'backoffice.permission_sought',
+                            default: AuditHelper::PERMISSION_NOT_REQUIRED) %></dd>
 
                   <% if completion.metadata['payment_details'].present? %>
                     <dt>GBS code</dt>
@@ -57,6 +60,8 @@
                 <dd><%= completion.metadata['c1a_form'] %></dd>
                 <dt>C8 form?</dt>
                 <dd><%= completion.metadata['c8_form'] %></dd>
+                <dt>Legal representation</dt>
+                <dd><%= completion.metadata['legal_representation'] || 'N/A' %></dd>
                 <dt>Signee capacity</dt>
                 <dd><%= completion.metadata['signee_capacity'] %></dd>
 

--- a/config/locales/backoffice/en.yml
+++ b/config/locales/backoffice/en.yml
@@ -1,5 +1,9 @@
 en:
   backoffice:
+    permission_sought:
+      'yes': Already applied
+      'no': Seeking permission
+      not_required: Not required
     submission:
       online: Online
       print_and_post: Print & Post

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -387,7 +387,7 @@ en:
       answers:
         'yes': 'Yes'
         'no': No - permission now sought
-        'not_required': No - permission not required
+        not_required: No - permission not required
     permission_details:
       question: Reasons for permission
     application_details:

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -9,6 +9,7 @@ describe AuditHelper do
       reduced_litigation_capacity: 'yes',
       urgent_hearing: 'no',
       without_notice: 'yes',
+      permission_sought: nil,
       declaration_signee_capacity: 'applicant',
     )
   }
@@ -41,11 +42,13 @@ describe AuditHelper do
         c1a_form: false,
         c8_form: false,
         under_age: false,
+        children_sgo: false,
         saved_for_later: false,
         consent_order: 'yes',
         legal_representation: 'yes',
         urgent_hearing: 'no',
         without_notice: 'yes',
+        permission_sought: 'not_required',
         reduced_litigation: 'yes',
         payment_type: 'cash',
         signee_capacity: 'applicant',

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Child, type: :model do
+  describe '.with_special_guardianship_order?' do
+    let(:scoped_query) { double('scoped_query') }
+
+    before do
+      allow(described_class).to receive(:with_special_guardianship_order).and_return(scoped_query)
+    end
+
+    it 'delegates to the scope' do
+      expect(scoped_query).to receive(:any?).and_return(true)
+
+      expect(
+        described_class.with_special_guardianship_order?
+      ).to eq(true)
+    end
+  end
+end

--- a/spec/services/c100_app/permission/application_rules_spec.rb
+++ b/spec/services/c100_app/permission/application_rules_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe C100App::Permission::ApplicationRules do
 
   let(:consent_order) { 'no' }
   let(:children_scope) { double('children_scope') }
-  let(:children_with_sgo) { [] }
+  let(:children_with_sgo) { false }
 
   before do
     allow(c100_application).to receive(:children).and_return(children_scope)
-    allow(children_scope).to receive(:with_special_guardianship_order).and_return(children_with_sgo)
+    allow(children_scope).to receive(:with_special_guardianship_order?).and_return(children_with_sgo)
   end
 
   describe 'ALL_ORDERS' do
@@ -81,7 +81,7 @@ RSpec.describe C100App::Permission::ApplicationRules do
     end
 
     context 'when at least one child has a special guardianship order in force' do
-      let(:children_with_sgo) { [anything] }
+      let(:children_with_sgo) { true }
 
       it 'returns true' do
         expect(subject.permission_needed?).to eq(true)


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21633583

This will log if the application had any children with a special guardianship order in force, and if permission was sought (or is not required, which happens if the question is not asked and thus attribute is `nil`).
It will also show this info in the back office.

Individual commits for more context.

Note: Even if we've not released yet non-parents, these are not breaking changes and can be released at any time.