### PR TITLE
Fix i18n permission string in back office

### DIFF
--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -37,8 +37,8 @@
                   <dt>Without notice hearing</dt>
                   <dd><%= completion.metadata['without_notice'] || 'N/A' %></dd>
                   <dt>Permission to make application</dt>
-                  <dd><%= t(completion.metadata['permission_sought'], scope: 'backoffice.permission_sought',
-                            default: AuditHelper::PERMISSION_NOT_REQUIRED) %></dd>
+                  <dd><%= t(completion.metadata['permission_sought'] || AuditHelper::PERMISSION_NOT_REQUIRED,
+                            scope: 'backoffice.permission_sought') %></dd>
 
                   <% if completion.metadata['payment_details'].present? %>
                     <dt>GBS code</dt>


### PR DESCRIPTION
I totally forgot the `default` option in the translate does not get itself translated but it outputs the raw value.

This fixes it so instead of `not_required` is shows as `Not required` :facepalm: