### PR TITLE
Tweak permission undecided rules

### DIFF
--- a/app/services/c100_app/permission/relationship_rules.rb
+++ b/app/services/c100_app/permission/relationship_rules.rb
@@ -7,27 +7,20 @@ module C100App
         @relationship = relationship
       end
 
-      # As we only ask the SGO question if the orders for the child include
-      # "home" (decide who they live with and when), and consent orders don't
-      # have "home" in the list of orders to select, we can safely assume
-      # permission is needed if the SGO value equals to 'yes'.
-      #
-      def permission_needed?
-        special_guardianship_order?
-      end
-
       # Permission undecided happens when there is no SGO in force, and the
       # applicant's relation to the child is "other".
       #
       # In these cases we need to go through further questions to decide
       # if permission will be needed or not.
+      #
       # Consent order applications or 'OtherChild' skip permission rules.
       #
       def permission_undecided?
         return false if consent_order?
         return false if is_other_child?
+        return false if special_guardianship_order?
 
-        !permission_needed? && other_relationship?
+        other_relationship?
       end
 
       private

--- a/spec/services/c100_app/permission/relationship_rules_spec.rb
+++ b/spec/services/c100_app/permission/relationship_rules_spec.rb
@@ -19,30 +19,6 @@ RSpec.describe C100App::Permission::RelationshipRules do
   let(:relation)  { 'father' }
   let(:consent_order) { 'no' }
 
-  describe '#permission_needed?' do
-    context 'when `special_guardianship_order` is `nil`' do
-      it 'returns false' do
-        expect(subject.permission_needed?).to eq(false)
-      end
-    end
-
-    context 'when `special_guardianship_order` is `no`' do
-      let(:sgo_order) { 'no' }
-
-      it 'returns false' do
-        expect(subject.permission_needed?).to eq(false)
-      end
-    end
-
-    context 'when `special_guardianship_order` is `yes`' do
-      let(:sgo_order) { 'yes' }
-
-      it 'returns true' do
-        expect(subject.permission_needed?).to eq(true)
-      end
-    end
-  end
-
   describe '#permission_undecided?' do
     context 'when application is a consent order' do
       let(:consent_order) { 'yes' }
@@ -52,7 +28,6 @@ RSpec.describe C100App::Permission::RelationshipRules do
       end
 
       it 'does not check any other rules' do
-        expect(subject).not_to receive(:permission_needed?)
         expect(subject).not_to receive(:other_relationship?)
 
         subject.permission_undecided?
@@ -67,7 +42,6 @@ RSpec.describe C100App::Permission::RelationshipRules do
       end
 
       it 'does not check any other rules' do
-        expect(subject).not_to receive(:permission_needed?)
         expect(subject).not_to receive(:other_relationship?)
 
         subject.permission_undecided?
@@ -77,6 +51,26 @@ RSpec.describe C100App::Permission::RelationshipRules do
     context 'when `special_guardianship_order` is `nil`' do
       it 'returns false' do
         expect(subject.permission_undecided?).to eq(false)
+      end
+
+      it 'keeps running any other rules' do
+        expect(subject).to receive(:other_relationship?)
+
+        subject.permission_undecided?
+      end
+    end
+
+    context 'when `special_guardianship_order` is `yes`' do
+      let(:sgo_order) { 'yes' }
+
+      it 'returns false' do
+        expect(subject.permission_undecided?).to eq(false)
+      end
+
+      it 'does not check any other rules' do
+        expect(subject).not_to receive(:other_relationship?)
+
+        subject.permission_undecided?
       end
     end
 
@@ -94,24 +88,6 @@ RSpec.describe C100App::Permission::RelationshipRules do
 
         it 'returns true' do
           expect(subject.permission_undecided?).to eq(true)
-        end
-      end
-    end
-
-    context 'when `special_guardianship_order` is `yes`' do
-      let(:sgo_order) { 'yes' }
-
-      context 'when the relation is not `other`' do
-        it 'returns false' do
-          expect(subject.permission_undecided?).to eq(false)
-        end
-      end
-
-      context 'when the relation is `other`' do
-        let(:relation) { 'other' }
-
-        it 'returns true' do
-          expect(subject.permission_undecided?).to eq(false)
         end
       end
     end


### PR DESCRIPTION
Having a child in the application with a special guardianship order in force, automatically makes the application require permission.

Before, we were still asking the 9-questions in these cases, but with this change, we don't need to, and we assume straight away the permission will be needed.

Simplified so the `#permission_needed?` is no longer needed and is more clear what is going on.