### PR TITLE
Remove the non-parents feature flag

### DIFF
--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -44,10 +44,4 @@ class BaseDecisionTree
       collection_ids.at(pos + 1)
     end
   end
-
-  # TODO: temporarily until we finish all the neccessary work for non-parents
-  # Will show on local/test/CI and staging, but not in production
-  def hide_non_parents?
-    Rails.env.production? && ENV['DEV_TOOLS_ENABLED'].nil?
-  end
 end

--- a/app/services/c100_app/applicant_decision_tree.rb
+++ b/app/services/c100_app/applicant_decision_tree.rb
@@ -44,16 +44,14 @@ module C100App
     end
 
     def after_relationship
-      # TODO: remove feature-flag to enable the non-parents in production
-      unless hide_non_parents?
-        rules = Permission::RelationshipRules.new(record)
+      rules = Permission::RelationshipRules.new(record)
 
-        return edit(
-          '/steps/permission/question', question_name: :parental_responsibility, relationship_id: record
-        ) if rules.permission_undecided?
+      # Non-parents - permission to be decided
+      if rules.permission_undecided?
+        edit('/steps/permission/question', question_name: :parental_responsibility, relationship_id: record)
+      else
+        children_relationships
       end
-
-      children_relationships
     end
 
     def after_has_solicitor

--- a/app/services/c100_app/children_decision_tree.rb
+++ b/app/services/c100_app/children_decision_tree.rb
@@ -28,12 +28,11 @@ module C100App
     private
 
     def after_orders
-      # TODO: remove feature-flag to enable the non-parents in production
-      unless hide_non_parents?
-        return edit(:special_guardianship_order, id: record) if cao_home_order?
+      if cao_home_order?
+        edit(:special_guardianship_order, id: record)
+      else
+        next_child_step
       end
-
-      next_child_step
     end
 
     def after_has_other_children

--- a/spec/services/c100_app/applicant_decision_tree_spec.rb
+++ b/spec/services/c100_app/applicant_decision_tree_spec.rb
@@ -77,56 +77,37 @@ RSpec.describe C100App::ApplicantDecisionTree do
 
     let(:rules_mock) { double(permission_undecided?: rule_result) }
 
-    # TODO: feature-flag code to be removed once non-parents is released
     before do
-      allow(subject).to receive(:hide_non_parents?).and_return(hide_non_parents)
+      allow(C100App::Permission::RelationshipRules).to receive(:new).with(record).and_return(rules_mock)
     end
 
-    context 'when non-parents feature is enabled' do
-      let(:hide_non_parents) { false }
-
-      before do
-        allow(C100App::Permission::RelationshipRules).to receive(:new).with(record).and_return(rules_mock)
-      end
-
-      context 'when permission might be needed' do
-        let(:child) { double('Child', id: 1) }
-        let(:rule_result) { true }
-
-        it 'goes to edit the relationship of the next child' do
-          expect(subject.destination).to eq(controller: '/steps/permission/question', action: :edit, question_name: :parental_responsibility, relationship_id: record)
-        end
-      end
-
-      context 'when permission is not needed' do
-        let(:rule_result) { false }
-
-        context 'when there are remaining children' do
-          let(:child) { double('Child', id: 1) }
-
-          it 'goes to edit the relationship of the next child' do
-            expect(subject.destination).to eq(controller: '/steps/applicant/relationship', action: :edit, id: applicant, child_id: 2)
-          end
-        end
-
-        context 'when all child relationships have been edited' do
-          let(:child) { double('Child', id: 3) }
-
-          include_examples 'address lookup decision tree' do
-            let(:person) { applicant }
-            let(:namespace) { 'applicant' }
-          end
-        end
-      end
-    end
-
-    context 'when non-parents feature is disabled' do
-      let(:hide_non_parents) { true }
+    context 'when permission might be needed' do
       let(:child) { double('Child', id: 1) }
+      let(:rule_result) { true }
 
       it 'goes to edit the relationship of the next child' do
-        expect(subject).to receive(:children_relationships)
-        subject.destination
+        expect(subject.destination).to eq(controller: '/steps/permission/question', action: :edit, question_name: :parental_responsibility, relationship_id: record)
+      end
+    end
+
+    context 'when permission is not needed' do
+      let(:rule_result) { false }
+
+      context 'when there are remaining children' do
+        let(:child) { double('Child', id: 1) }
+
+        it 'goes to edit the relationship of the next child' do
+          expect(subject.destination).to eq(controller: '/steps/applicant/relationship', action: :edit, id: applicant, child_id: 2)
+        end
+      end
+
+      context 'when all child relationships have been edited' do
+        let(:child) { double('Child', id: 3) }
+
+        include_examples 'address lookup decision tree' do
+          let(:person) { applicant }
+          let(:namespace) { 'applicant' }
+        end
       end
     end
   end

--- a/spec/services/c100_app/children_decision_tree_spec.rb
+++ b/spec/services/c100_app/children_decision_tree_spec.rb
@@ -50,34 +50,15 @@ RSpec.describe C100App::ChildrenDecisionTree do
 
     let(:orders) { ['foobar_order'] }
 
-    # TODO: feature-flag code to be removed once non-parents is released
-    before do
-      expect(Rails.env).to receive(:production?).and_return(true)
-      expect(ENV).to receive(:[]).with('DEV_TOOLS_ENABLED').and_return(dev_tools_enabled)
-    end
+    context 'and selected orders include `child_arrangements_home`' do
+      let(:orders) { ['child_arrangements_home'] }
 
-    context 'when non-parents feature is enabled' do
-      let(:dev_tools_enabled) { '1' }
-
-      context 'and selected orders include `child_arrangements_home`' do
-        let(:orders) { ['child_arrangements_home'] }
-
-        it 'goes to the special guardianship order question for the current record' do
-          expect(subject.destination).to eq(controller: :special_guardianship_order, action: :edit, id: record)
-        end
-      end
-
-      context 'and selected orders does not include `child_arrangements_home`' do
-        it 'goes to edit the next child' do
-          expect(subject).to receive(:next_child_step)
-          subject.destination
-        end
+      it 'goes to the special guardianship order question for the current record' do
+        expect(subject.destination).to eq(controller: :special_guardianship_order, action: :edit, id: record)
       end
     end
 
-    context 'when non-parents feature is disabled' do
-      let(:dev_tools_enabled) { nil }
-
+    context 'and selected orders does not include `child_arrangements_home`' do
       it 'goes to edit the next child' do
         expect(subject).to receive(:next_child_step)
         subject.destination


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21498766
Parent ticket: https://mojdigital.teamwork.com/#/tasks/21392255

Remove the code that was maintaining the non-parents hidden in production envs, as we are about to go live with this feature.

To be merged and deployed to production next week together with the other PR #1064