### PR TITLE
Add new courts to online payments rollout

### DIFF
--- a/app/presenters/valid_payments_array.rb
+++ b/app/presenters/valid_payments_array.rb
@@ -1,7 +1,6 @@
 class ValidPaymentsArray < SimpleDelegator
   COMMON_CHOICES = [
     PaymentType::HELP_WITH_FEES,
-    PaymentType::SELF_PAYMENT_CARD,
     PaymentType::SELF_PAYMENT_CHEQUE,
   ].freeze
 
@@ -11,11 +10,22 @@ class ValidPaymentsArray < SimpleDelegator
     chelmsford-county-and-family-court
     chelmsford-magistrates-court-and-family-court
     west-london-family-court
+
+    bristol-civil-and-family-justice-centre
+    east-london-family-court
+    leeds-combined-court-centre
+    medway-county-court-and-family-court
+    nottingham-county-court-and-family-court
+    preston-crown-court-and-family-court-sessions-house
   ].freeze
 
+  attr_reader :c100_application
+
   def initialize(c100_application)
+    @c100_application = c100_application
+
     super(
-      choices_to_present(c100_application)
+      choices_to_present
     )
   end
 
@@ -29,18 +39,36 @@ class ValidPaymentsArray < SimpleDelegator
     __getobj__
   end
 
-  def choices_to_present(c100_application)
+  def choices_to_present
     COMMON_CHOICES.dup.tap do |choices|
-      choices.append(PaymentType::SOLICITOR) if c100_application.has_solicitor?
-      choices.append(PaymentType::ONLINE)    if govuk_pay_enabled_for(c100_application)
+      choices.append(
+        PaymentType::SOLICITOR
+      ) if c100_application.has_solicitor?
+
+      choices.append(
+        PaymentType::ONLINE
+      ) if govuk_pay_enabled?
+
+      choices.append(
+        PaymentType::SELF_PAYMENT_CARD
+      ) if phone_pay_enabled?
     end
   end
 
-  def govuk_pay_enabled_for(c100_application)
-    return unless c100_application.online_submission?
+  def govuk_pay_enabled?
+    return false unless c100_application.online_submission?
 
     COURTS_WITH_ONLINE_PAYMENT.include?(
       c100_application.screener_answers_court.slug
     )
+  end
+
+  # Do not show `pay by phone` option if the application can
+  # use online payment, or if it is print&post.
+  #
+  def phone_pay_enabled?
+    return false unless c100_application.online_submission?
+
+    !govuk_pay_enabled?
   end
 end

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -17,12 +17,8 @@ RSpec.describe ValidPaymentsArray do
   describe 'COURTS_WITH_ONLINE_PAYMENT' do
     it {
       expect(
-        described_class::COURTS_WITH_ONLINE_PAYMENT
-      ).to eq(%w[
-        chelmsford-county-and-family-court
-        chelmsford-magistrates-court-and-family-court
-        west-london-family-court
-      ])
+        described_class::COURTS_WITH_ONLINE_PAYMENT.size
+      ).to eq(9)
     }
   end
 
@@ -68,6 +64,10 @@ RSpec.describe ValidPaymentsArray do
       it 'does not include the online option' do
         expect(subject).not_to include(PaymentType::ONLINE)
       end
+
+      it 'includes the pay by phone option' do
+        expect(subject).to include(PaymentType::SELF_PAYMENT_CARD)
+      end
     end
 
     context 'with solicitor' do
@@ -89,6 +89,10 @@ RSpec.describe ValidPaymentsArray do
 
   context 'for a print and post submission' do
     let(:submission_type) { SubmissionType::PRINT_AND_POST.to_s }
+
+    it 'does not include the pay by phone option' do
+      expect(subject).not_to include(PaymentType::SELF_PAYMENT_CARD)
+    end
 
     context 'with solicitor' do
       let(:has_solicitor) { 'yes' }


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21709675

We are slowly rolling out new courts that accept online payments.
In this PR we add 6 more courts.

In addition, the following changes have been agreed with HMCTS business:

* Remove "pay over the phone" option for applications routed to the courts that accept online payment.

* Remove "pay over the phone" for print&post applications.

Note: to go live tomorrow.