### PR TITLE
Temporarily disable online payments to Preston court

### DIFF
--- a/app/presenters/valid_payments_array.rb
+++ b/app/presenters/valid_payments_array.rb
@@ -16,7 +16,6 @@ class ValidPaymentsArray < SimpleDelegator
     leeds-combined-court-centre
     medway-county-court-and-family-court
     nottingham-county-court-and-family-court
-    preston-crown-court-and-family-court-sessions-house
   ].freeze
 
   attr_reader :c100_application

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ValidPaymentsArray do
     it {
       expect(
         described_class::COURTS_WITH_ONLINE_PAYMENT.size
-      ).to eq(9)
+      ).to eq(8)
     }
   end
 


### PR DESCRIPTION
GOV.UK Pay has a length limit in the metadata values of 50 characters.

We use the metadata to store the name of the court where the payment was made. Unfortunately we didn't anticipate and some courts have a lengthy name, like this one, taking us over the 50 limit and getting an error when trying to create an online payment.

The name of this court is `Preston Crown Court and Family Court (Sessions House)` which is 53 chars but I've seen other courts with even 64 chars.

Temporarily disable this court. I've contacted GOV.UK Pay to raise the limit in the meantime and will be re-enabled as soon as possible.