### PR TITLE
Add to audit table the applicant(s) relation to child(ren)

### DIFF
--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -17,6 +17,7 @@ class AuditHelper
       c8_form: c100.confidentiality_enabled?,
       under_age: c100.applicants.under_age?,
       children_sgo: c100.children.with_special_guardianship_order?,
+      relationships: relationships_to_children,
       saved_for_later: c100.user_id.present?,
       consent_order: c100.consent_order,
       legal_representation: c100.has_solicitor,
@@ -53,6 +54,13 @@ class AuditHelper
       options << arrangement.special_arrangements
       options << arrangement.special_assistance
     end.flatten
+  end
+
+  # Applicant(s) relation to the main child(ren), removing repetitions, i.e. ["father", "other"]
+  def relationships_to_children
+    Relationship.distinct.where(
+      person_id: c100.applicant_ids, minor_id: c100.child_ids
+    ).pluck(:relation)
   end
 
   def payment_metadata

--- a/lib/tasks/audit_relations.rake
+++ b/lib/tasks/audit_relations.rake
@@ -1,0 +1,22 @@
+# This task can be removed once run.
+# It is only needed to retroactively populate some audit information
+#
+task :audit_relations => :environment do
+  C100Application.completed.where.not(permission_sought: nil).each do |c100|
+    audit = CompletedApplicationsAudit.find_by(reference_code: c100.reference_code)
+    next unless audit
+
+    puts "Updating relationships for application #{c100.id}"
+
+    audit.metadata[:relationships] = relationships_to_children(c100)
+    audit.save
+  end
+end
+
+private
+
+def relationships_to_children(c100)
+  Relationship.distinct.where(
+    person_id: c100.applicant_ids, minor_id: c100.child_ids
+  ).pluck(:relation)
+end

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -43,6 +43,7 @@ describe AuditHelper do
         c8_form: false,
         under_age: false,
         children_sgo: false,
+        relationships: [],
         saved_for_later: false,
         consent_order: 'yes',
         legal_representation: 'yes',
@@ -100,6 +101,32 @@ describe AuditHelper do
         expect(
           subject.metadata
         ).to include(saved_for_later: true)
+      end
+    end
+
+    context 'applicant relationships to children' do
+      let(:scope_double) { double('scope') }
+      let(:relation_result) { %w(father other) }
+
+      before do
+        allow(c100_application).to receive(:applicant_ids).and_return(['123'])
+        allow(c100_application).to receive(:child_ids).and_return(['456'])
+
+        allow(Relationship).to receive(:distinct).and_return(scope_double)
+      end
+
+      it 'returns an array of relations' do
+        expect(scope_double).to receive(:where).with(
+          person_id: ['123'], minor_id: ['456']
+        ).ordered.and_return(scope_double)
+
+        expect(scope_double).to receive(:pluck).with(
+          :relation
+        ).ordered.and_return(relation_result)
+
+        expect(
+          subject.metadata[:relationships]
+        ).to eq(relation_result)
       end
     end
   end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21737933

This is in relation to the difficulty we have to know how many fathers, mothers, etc. triggered non-parent applications (those with the `permission_sought` attribute not `nil`).

If we store an array of the relations (for example `["father", "other"]`) at least we can map this in a chart although still we will not be certain what was the trigger of the permission (but chances are 99% will be the "other" relationship).

There is a rake task to be run manually once deployed, to retroactively populate existing non-parents completed applications (there are a few, less than 20).
New ones will contain this metadata detail by default.