### PR TITLE
Rollout of online payments batch 2 courts

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -1,4 +1,6 @@
 class Court
+  UNKNOWN_GBS = 'unknown'.freeze
+
   attr_reader :name, :slug, :email, :address, :gbs
 
   # Using `fetch` so an exception is raised and we are alerted if the json
@@ -45,6 +47,10 @@ class Court
     best.fetch('address')
   end
 
+  def gbs_known?
+    !gbs.eql?(UNKNOWN_GBS)
+  end
+
   # No need to memoize, we are using a basic ActiveSupport cache
   def court_data
     C100App::CourtfinderAPI.new.court_lookup(slug)
@@ -63,7 +69,7 @@ class Court
   end
 
   def retrieve_gbs_from_api
-    court_data.fetch('gbs') || 'unknown'
+    court_data.fetch('gbs').presence || UNKNOWN_GBS
   end
 
   def retrieve_emails_from_api

--- a/config/govuk_pay.yml
+++ b/config/govuk_pay.yml
@@ -1,0 +1,14 @@
+# Add court slugs to the blocklist if they do not process online payments.
+#
+# Courts without a GBS code will not receive online payments, no need
+# to add these to the blocklist.
+
+blocklist:
+  - blocklisted-slug-example
+  - preston-crown-court-and-family-court-sessions-house
+  - manchester-civil-justice-centre-civil-and-family-courts
+  - newcastle-civil-family-courts-and-tribunals-centre
+  - bournemouth-and-poole-county-court-and-family-court
+  - york-county-court-and-family-court
+  - barrow-in-furness-county-court-and-family-court
+  - liverpool-civil-and-family-court

--- a/config/govuk_pay.yml
+++ b/config/govuk_pay.yml
@@ -12,3 +12,25 @@ blocklist:
   - york-county-court-and-family-court
   - barrow-in-furness-county-court-and-family-court
   - liverpool-civil-and-family-court
+  #
+  # Following slugs to be removed in 3 weeks. All these had their GBS code
+  # previously set, and now it has been unset, but existing applications
+  # in our database will still have it for a while.
+  #
+  - canterbury-combined-court-centre
+  - carmarthen-county-court-and-family-court
+  - chester-civil-and-family-justice-centre
+  - clerkenwell-and-shoreditch-county-court-and-family-court
+  - crewe-county-court-and-family-court
+  - dartford-county-court-and-family-court
+  - dudley-county-court-and-family-court
+  - haverfordwest-county-court-and-family-court
+  - hertford-county-court-and-family-court
+  - isle-of-wight-combined-court
+  - maidstone-combined-court-centre
+  - staines-county-court-and-family-court
+  - thanet-county-court-and-family-court
+  - torquay-and-newton-abbot-county-court-and-family-court
+  - uxbridge-county-court-and-family-court
+  - weymouth-combined-court
+  - yeovil-county-family-and-magistrates-court

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -111,6 +111,16 @@ describe Court do
           end
         end
 
+        context 'the API returned a blank gbs' do
+          let(:api_response) do
+            { 'gbs' => '' }
+          end
+
+          it 'sets the gbs fallback code' do
+            expect(subject.gbs).to eq('unknown')
+          end
+        end
+
         context 'the API failed to return gbs' do
           let(:api_response) { {} }
           it { expect { subject.gbs }.to raise_error(KeyError, 'key not found: "gbs"') }
@@ -427,6 +437,21 @@ describe Court do
         it 'returns the first email' do
           expect(subject.best_enquiries_email).to eq('my@email')
         end
+      end
+    end
+  end
+
+  describe '#gbs_known?' do
+    context 'for a valid GBS code' do
+      it 'returns true' do
+        expect(subject.gbs_known?).to eq(true)
+      end
+    end
+
+    context 'for an unknown GBS code' do
+      it 'returns false' do
+        expect(subject).to receive(:gbs).and_return('unknown')
+        expect(subject.gbs_known?).to eq(false)
       end
     end
   end

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -27,6 +27,23 @@ RSpec.describe ValidPaymentsArray do
         york-county-court-and-family-court
         barrow-in-furness-county-court-and-family-court
         liverpool-civil-and-family-court
+        canterbury-combined-court-centre
+        carmarthen-county-court-and-family-court
+        chester-civil-and-family-justice-centre
+        clerkenwell-and-shoreditch-county-court-and-family-court
+        crewe-county-court-and-family-court
+        dartford-county-court-and-family-court
+        dudley-county-court-and-family-court
+        haverfordwest-county-court-and-family-court
+        hertford-county-court-and-family-court
+        isle-of-wight-combined-court
+        maidstone-combined-court-centre
+        staines-county-court-and-family-court
+        thanet-county-court-and-family-court
+        torquay-and-newton-abbot-county-court-and-family-court
+        uxbridge-county-court-and-family-court
+        weymouth-combined-court
+        yeovil-county-family-and-magistrates-court
       ))
     end
   end

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -14,12 +14,21 @@ RSpec.describe ValidPaymentsArray do
 
   let(:common_choices) { described_class::COMMON_CHOICES }
 
-  describe 'COURTS_WITH_ONLINE_PAYMENT' do
-    it {
+  describe '#pay_blocklist' do
+    it 'returns the blocked slugs' do
       expect(
-        described_class::COURTS_WITH_ONLINE_PAYMENT.size
-      ).to eq(8)
-    }
+        subject.pay_blocklist
+      ).to match_array(%w(
+        blocklisted-slug-example
+        preston-crown-court-and-family-court-sessions-house
+        manchester-civil-justice-centre-civil-and-family-courts
+        newcastle-civil-family-courts-and-tribunals-centre
+        bournemouth-and-poole-county-court-and-family-court
+        york-county-court-and-family-court
+        barrow-in-furness-county-court-and-family-court
+        liverpool-civil-and-family-court
+      ))
+    end
   end
 
   describe '#include?' do
@@ -51,15 +60,38 @@ RSpec.describe ValidPaymentsArray do
   context 'for an online submission' do
     let(:submission_type) { SubmissionType::ONLINE.to_s }
 
-    let(:court_double) { double(slug: court_slug) }
+    let(:court_double) { Court.new(court_data) }
+    let(:court_data) {
+      {
+        'name' => 'Test court',
+        'email' => 'court@example.com',
+        'address' => 'Court address',
+        'slug' => court_slug,
+        'gbs' => court_gbs,
+      }
+    }
+
+    let(:court_gbs) { 'XYZ' }
     let(:court_slug) { 'west-london-family-court' }
 
     before do
       allow(c100_application).to receive(:screener_answers_court).and_return(court_double)
     end
 
-    context 'for a court slug without govuk pay enabled' do
-      let(:court_slug) { 'test-slug' }
+    context 'for a court slug included in the blocklist' do
+      let(:court_slug) { 'blocklisted-slug-example' }
+
+      it 'does not include the online option' do
+        expect(subject).not_to include(PaymentType::ONLINE)
+      end
+
+      it 'includes the pay by phone option' do
+        expect(subject).to include(PaymentType::SELF_PAYMENT_CARD)
+      end
+    end
+
+    context 'for a court without GBS code' do
+      let(:court_gbs) { Court::UNKNOWN_GBS }
 
       it 'does not include the online option' do
         expect(subject).not_to include(PaymentType::ONLINE)


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21709675

**Online payments rollout -- batch 2**

Instead of having to add one by one all the courts that accept online payments (as these are a lot after batch 2), a blocklist is more efficient and cleaner, adding only those courts that for whatever reason can't take online payments.

Also, disallow online payments for courts without a GBS code set.

Currently we are adding the courts from batch 3 as these courts will go live next week, as well as a few courts with names taking us over the 50 chars limit on GOV.UK Pay.

Once Pay increase the limit we can removed those. And next week we will be able as well to hopefully remove the remaining ones, leaving the blocklist empty (that's the theory).