### PR TITLE
Disable Newport court from online payments

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -14,7 +14,7 @@ module ErrorHandling
         redirect_to application_completed_errors_path
       when Errors::PaymentError
         # Payment errors are reported to Sentry as it is important to know
-        Raven.capture_exception(exception)
+        Raven.capture_exception(exception, tags: { c100_application_id: session[:c100_application_id] })
         redirect_to payment_error_errors_path
       else
         raise if Rails.application.config.consider_all_requests_local

--- a/config/govuk_pay.yml
+++ b/config/govuk_pay.yml
@@ -5,14 +5,22 @@
 
 blocklist:
   - blocklisted-slug-example
+
+  # Batch 3 - due 17/09/2020
+  #
+  - york-county-court-and-family-court
+  - barrow-in-furness-county-court-and-family-court
+  - liverpool-civil-and-family-court
+
+  # Temporarily disabled courts due to its name being longer than 50 chars
+  # Awaiting for Pay service to increase the limit in the metadata field
+  #
+  - newport-south-wales-county-court-and-family-court
   - preston-crown-court-and-family-court-sessions-house
   - manchester-civil-justice-centre-civil-and-family-courts
   - newcastle-civil-family-courts-and-tribunals-centre
   - bournemouth-and-poole-county-court-and-family-court
-  - york-county-court-and-family-court
-  - barrow-in-furness-county-court-and-family-court
-  - liverpool-civil-and-family-court
-  #
+
   # Following slugs to be removed in 3 weeks. All these had their GBS code
   # previously set, and now it has been unset, but existing applications
   # in our database will still have it for a while.

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -151,7 +151,9 @@ RSpec.describe ApplicationController do
       it 'should report the exception, and redirect to the payment error page' do
         routes.draw { get 'payment_error' => 'anonymous#payment_error' }
 
-        expect(Raven).to receive(:capture_exception)
+        expect(Raven).to receive(:capture_exception).with(
+          Errors::PaymentError, tags: { c100_application_id: nil }
+        )
 
         get :payment_error
         expect(response).to redirect_to(payment_error_errors_path)

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -20,13 +20,17 @@ RSpec.describe ValidPaymentsArray do
         subject.pay_blocklist
       ).to match_array(%w(
         blocklisted-slug-example
+
+        york-county-court-and-family-court
+        barrow-in-furness-county-court-and-family-court
+        liverpool-civil-and-family-court
+
+        newport-south-wales-county-court-and-family-court
         preston-crown-court-and-family-court-sessions-house
         manchester-civil-justice-centre-civil-and-family-courts
         newcastle-civil-family-courts-and-tribunals-centre
         bournemouth-and-poole-county-court-and-family-court
-        york-county-court-and-family-court
-        barrow-in-furness-county-court-and-family-court
-        liverpool-civil-and-family-court
+
         canterbury-combined-court-centre
         carmarthen-county-court-and-family-court
         chester-civil-and-family-justice-centre


### PR DESCRIPTION
As we did with other courts, this one has a name over 50 chars, and unfortunetely GOV.UK Pay have not released the increase yet, so attempts to call the API with this court name will fail with code P0102.

Add to the sentry exception the application ID if we have it to help debug wich courts are failing more easily.