### PR TITLE
Reduce level of payment debug captured in Sentry

### DIFF
--- a/app/services/c100_app/payments_flow_control.rb
+++ b/app/services/c100_app/payments_flow_control.rb
@@ -27,9 +27,6 @@ module C100App
         return confirmation_url
       end
 
-      # For a while, until we are confident, let's log these failures
-      log_failure_info
-
       # Revert to `in_progress` as we are certain at this point payment failed
       move_status_to :in_progress
 
@@ -66,13 +63,6 @@ module C100App
       when :completed
         c100_application.mark_as_completed!
       end
-    end
-
-    def log_failure_info
-      Raven.capture_exception(
-        Errors::PaymentError.new(payment_intent.state),
-        level: 'info', tags: { payment_id: payment_intent.payment_id }
-      )
     end
   end
 end

--- a/spec/services/c100_app/payments_flow_control_spec.rb
+++ b/spec/services/c100_app/payments_flow_control_spec.rb
@@ -121,10 +121,6 @@ RSpec.describe C100App::PaymentsFlowControl do
       end
 
       it 'reports the error and returns the error page' do
-        expect(Raven).to receive(:capture_exception).with(
-          error_to_report, level: 'info', tags: { payment_id: 'xyz123' }
-        )
-
         expect(c100_application).to receive(:in_progress!)
         expect(subject.next_url).to eq('/errors/payment_error')
       end


### PR DESCRIPTION
We had this code to report payment failures (as in, users cancelling their payment, or payment card rejected) for some time while we made sure online payments were working fine.

We can now remove this info logs.

Any exception produced by the payments API will regardless be reported  to Sentry as those are important errors.

We can also see all these details and errors in the Payments transaction list.