### PR TITLE
Enable Pay in courts disabled due to char limit

### DIFF
--- a/config/govuk_pay.yml
+++ b/config/govuk_pay.yml
@@ -12,15 +12,6 @@ blocklist:
   - barrow-in-furness-county-court-and-family-court
   - liverpool-civil-and-family-court
 
-  # Temporarily disabled courts due to its name being longer than 50 chars
-  # Awaiting for Pay service to increase the limit in the metadata field
-  #
-  - newport-south-wales-county-court-and-family-court
-  - preston-crown-court-and-family-court-sessions-house
-  - manchester-civil-justice-centre-civil-and-family-courts
-  - newcastle-civil-family-courts-and-tribunals-centre
-  - bournemouth-and-poole-county-court-and-family-court
-
   # Following slugs to be removed in 3 weeks. All these had their GBS code
   # previously set, and now it has been unset, but existing applications
   # in our database will still have it for a while.

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe ValidPaymentsArray do
         barrow-in-furness-county-court-and-family-court
         liverpool-civil-and-family-court
 
-        newport-south-wales-county-court-and-family-court
-        preston-crown-court-and-family-court-sessions-house
-        manchester-civil-justice-centre-civil-and-family-courts
-        newcastle-civil-family-courts-and-tribunals-centre
-        bournemouth-and-poole-county-court-and-family-court
-
         canterbury-combined-court-centre
         carmarthen-county-court-and-family-court
         chester-civil-and-family-justice-centre


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21709675

We disabled temporarily these 5 courts as their names were over the 50 chars metadata limit.

Now Pay team have confirmed they've increased this limit:

```Custom metadata on payments can now have values that are strings of up to 100 characters (previous limit was 50)```