### PR TITLE
Store courts in the new Courts DB table

### DIFF
--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -7,17 +7,6 @@ module C100App
       File.join(Rails.root, 'config', 'court_slugs.yml')
     ).freeze
 
-    # Separate multiple postcodes/postcode areas by "\n"
-    # Will return an array of courts to which the application
-    # could be sent, based on the postcodes given.
-    # If the courts serving the postcodes given are not
-    # taking part in our service, they will not be returned
-    def courts_for(postcodes)
-      postcodes.to_s.split("\n").reject(&:blank?).map do |postcode|
-        court_for(postcode)
-      end.compact
-    end
-
     def court_for(postcode)
       possible_courts = CourtfinderAPI.new.court_for(AREA_OF_LAW, postcode)
       choose_from(possible_courts)

--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -9,7 +9,9 @@ module C100App
 
     def court_for(postcode)
       possible_courts = CourtfinderAPI.new.court_for(AREA_OF_LAW, postcode)
-      choose_from(possible_courts)
+      candidate_court = choose_from(possible_courts)
+
+      Court.create_or_refresh(candidate_court) if candidate_court
     end
 
     def court_slugs_blocklist

--- a/app/services/c100_app/screener_decision_tree.rb
+++ b/app/services/c100_app/screener_decision_tree.rb
@@ -19,11 +19,15 @@ module C100App
     end
 
     def check_if_court_is_valid
-      court_found = CourtPostcodeChecker.new.court_for(children_postcode)
+      court = CourtPostcodeChecker.new.court_for(children_postcode)
 
-      if court_found
-        court = Court.build(court_found)
+      if court
+        # Still saving to the old table, for the time being
         c100_application.screener_answers.update!(local_court: court)
+
+        # New table association
+        c100_application.update!(court: court)
+
         show(:done)
       else
         show(:no_court_found)

--- a/app/services/c100_app/screener_decision_tree.rb
+++ b/app/services/c100_app/screener_decision_tree.rb
@@ -13,15 +13,20 @@ module C100App
 
     private
 
-    def check_if_court_is_valid
-      courts = CourtPostcodeChecker.new.courts_for(step_params.fetch(:children_postcodes))
+    # TODO: rename param to be singular, not plural, when removing the screener
+    def children_postcode
+      step_params.fetch(:children_postcodes)
+    end
 
-      if courts.empty?
-        show(:no_court_found)
-      else
-        court = Court.build(courts.first)
+    def check_if_court_is_valid
+      court_found = CourtPostcodeChecker.new.court_for(children_postcode)
+
+      if court_found
+        court = Court.build(court_found)
         c100_application.screener_answers.update!(local_court: court)
         show(:done)
+      else
+        show(:no_court_found)
       end
     # `CourtPostcodeChecker` and `Court` already log any potential exceptions
     rescue StandardError

--- a/spec/services/c100_app/court_postcode_checker_spec.rb
+++ b/spec/services/c100_app/court_postcode_checker_spec.rb
@@ -11,61 +11,6 @@ describe C100App::CourtPostcodeChecker do
     end
   end
 
-  describe '#courts_for' do
-    before do
-      allow(subject).to receive(:court_for).and_return( 'call1', 'call2', 'call3' )
-    end
-
-    context 'given several postcodes separated by "\n"' do
-      let(:postcodes) {
-        "A1AAA\nB1BBB\nC1CCC"
-      }
-      it 'calls court_for with each postcode' do
-        expect(subject).to receive(:court_for).once.with('A1AAA')
-        expect(subject).to receive(:court_for).once.with('B1BBB')
-        expect(subject).to receive(:court_for).once.with('C1CCC')
-        subject.courts_for(postcodes)
-      end
-    end
-    context 'when the given postcodes contain blank lines' do
-      let(:postcodes){
-        "\n\nA1AAA\n\nB1BBB\n\n"
-      }
-      it 'does not call court_for with the blank lines' do
-        expect(subject).to_not receive(:court_for).with('')
-        subject.courts_for(postcodes)
-      end
-    end
-    context 'when the given postcodes contain spaces' do
-      let(:postcodes){
-        "B1 BBB"
-      }
-      it 'does not strip the spaces before calling court_for' do
-        expect(subject).to receive(:court_for).with('B1 BBB')
-        subject.courts_for(postcodes)
-      end
-    end
-
-    context 'when given nil' do
-      let(:postcodes){ nil }
-      it 'does not raise an error' do
-        expect{ subject.courts_for(postcodes) }.to_not raise_error
-      end
-    end
-    it 'returns the results of the court_for calls' do
-      expect(subject.courts_for("A1AAA\nB1BBB")).to eq(['call1', 'call2'])
-    end
-
-    context 'when court_for returns nil' do
-      before do
-        allow(subject).to receive(:court_for).and_return(nil)
-      end
-      it 'removes the nils' do
-        expect(subject.courts_for("A1AAA\nB1BBB")).to eq([])
-      end
-    end
-  end
-
   describe '#court_for' do
     let(:dummy_court_objects){
       [{'slug' => 'dummy-court-slug'}]

--- a/spec/services/c100_app/screener_decision_tree_spec.rb
+++ b/spec/services/c100_app/screener_decision_tree_spec.rb
@@ -16,30 +16,27 @@ RSpec.describe C100App::ScreenerDecisionTree do
   context 'when the step is `children_postcodes`' do
     let(:step_params) { { children_postcodes: postcodes } }
 
-    context 'and no valid courts are found' do
+    context 'and no valid court is found' do
       before do
-        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:courts_for).with(postcodes).and_return([])
+        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).with(postcodes).and_return(nil)
       end
       it { is_expected.to have_destination(:no_court_found, :show) }
     end
 
-    context 'and at least one valid court is found' do
-      let(:courts){
-        ['i am a court',
-         'i am another court']
-      }
-      let(:court){ instance_double('Court') }
+    context 'and one valid court is found' do
+      let(:found_court) { double('raw court data') }
+      let(:court) { instance_double('Court') }
 
       before do
-        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:courts_for).with(postcodes).and_return(courts)
+        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).with(postcodes).and_return(found_court)
         allow(screener_answers).to receive(:update!)
         allow(Court).to receive(:build).and_return(court)
       end
 
       it { is_expected.to have_destination(:done, :show) }
 
-      it 'creates a Court from the first result' do
-        expect(Court).to receive(:build).with(courts.first)
+      it 'creates a Court from the result' do
+        expect(Court).to receive(:build).with(found_court)
         subject.destination
       end
 
@@ -51,7 +48,7 @@ RSpec.describe C100App::ScreenerDecisionTree do
 
     context 'when the postcode checker raises an error' do
       before do
-        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:courts_for).and_raise("expected exception for testing, please ignore")
+        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).and_raise("expected exception for testing, please ignore")
       end
       it { is_expected.to have_destination(:error_but_continue, :show)}
     end
@@ -59,7 +56,7 @@ RSpec.describe C100App::ScreenerDecisionTree do
     context 'when the children_postcodes are nil' do
       let(:postcodes){ nil }
       before do
-        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:courts_for).and_raise("expected exception for testing, please ignore")
+        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).and_raise("expected exception for testing, please ignore")
       end
       it { is_expected.to have_destination(:error_but_continue, :show)}
     end

--- a/spec/services/c100_app/screener_decision_tree_spec.rb
+++ b/spec/services/c100_app/screener_decision_tree_spec.rb
@@ -24,25 +24,23 @@ RSpec.describe C100App::ScreenerDecisionTree do
     end
 
     context 'and one valid court is found' do
-      let(:found_court) { double('raw court data') }
       let(:court) { instance_double('Court') }
 
       before do
-        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).with(postcodes).and_return(found_court)
+        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).with(postcodes).and_return(court)
         allow(screener_answers).to receive(:update!)
-        allow(Court).to receive(:build).and_return(court)
-      end
-
-      it { is_expected.to have_destination(:done, :show) }
-
-      it 'creates a Court from the result' do
-        expect(Court).to receive(:build).with(found_court)
-        subject.destination
+        allow(c100_application).to receive(:update!)
       end
 
       it 'updates the screener_answers with the Court' do
         expect(screener_answers).to receive(:update!).with(local_court: court)
-        subject.destination
+        is_expected.to have_destination(:done, :show)
+      end
+
+      # TODO: preparation for future screener removal
+      it 'assigns the court to the c100 application' do
+        expect(c100_application).to receive(:update!).with(court: court)
+        is_expected.to have_destination(:done, :show)
       end
     end
 


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21633615

Follow-up to PR #1079.

Now we can use the new table to store courts and link the c100 application to the corresponding court with the `slug` as primary key (as they are unique).

This table acts as a cache as well (in a follow-up PR the redis-backed cache can be removed as is redundant):

- if a court is seen by the first time, a new record is created.
- if a court already exists in the table, we check how old the data is (`updated_at`) and if it is older than a threshold (currently 72 hours) we refresh the data by performing again the CTF request.

For now, we only store courts, and link the application to the court, but we still don't read data back from this table in the rest of the service. We continue using the old `screener_answers` table.
In a follow-up PR we can start using this new table.