### PR TITLE
Rollout of online payments - batch 3

### DIFF
--- a/config/govuk_pay.yml
+++ b/config/govuk_pay.yml
@@ -6,12 +6,6 @@
 blocklist:
   - blocklisted-slug-example
 
-  # Batch 3 - due 17/09/2020
-  #
-  - york-county-court-and-family-court
-  - barrow-in-furness-county-court-and-family-court
-  - liverpool-civil-and-family-court
-
   # Following slugs to be removed in 3 weeks. All these had their GBS code
   # previously set, and now it has been unset, but existing applications
   # in our database will still have it for a while.

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe ValidPaymentsArray do
       ).to match_array(%w(
         blocklisted-slug-example
 
-        york-county-court-and-family-court
-        barrow-in-furness-county-court-and-family-court
-        liverpool-civil-and-family-court
-
         canterbury-combined-court-centre
         carmarthen-county-court-and-family-court
         chester-civil-and-family-justice-centre


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21709675

**Online payments rollout -- batch 3**

We just remove these 3 courts from the block list to allow them to use GOV.UK Pay.

In this batch:

- Barrow-in-Furness County Court and Family Court
- Liverpool Civil and Family Court
- York County Court and Family Court