### PR TITLE
Remove no longer needed CTF redis cache

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -88,11 +88,6 @@ class Court < ApplicationRecord
     updated_at.nil? || updated_at <= REFRESH_DATA_AFTER.ago
   end
 
-  # No need to memoize, we are using a basic ActiveSupport cache
-  def court_data
-    C100App::CourtfinderAPI.new.court_lookup(slug)
-  end
-
   # TODO: preparation for future screener removal
   # Maintain backwards compatibility with current stored data,
   # while we do the refactor of the screener.
@@ -120,6 +115,10 @@ class Court < ApplicationRecord
 
   def retrieve_emails_from_api
     court_data.fetch('emails')
+  end
+
+  def court_data
+    @_court_data ||= C100App::CourtfinderAPI.new.court_lookup(slug)
   end
 
   def self.log_and_raise(exception, data)

--- a/app/services/c100_app/courtfinder_api.rb
+++ b/app/services/c100_app/courtfinder_api.rb
@@ -18,13 +18,6 @@ module C100App
       use_ssl: true,
     }.freeze
 
-    SLUGS_CACHE_OPTIONS ||= {
-      namespace: 'courtfinder',
-      expires_in: 72.hours,
-      compress: false,
-      skip_nil: true
-    }.freeze
-
     def self.court_url(slug)
       URI.join(API_BASE_URL, '/courts/', slug).to_s
     end
@@ -39,21 +32,11 @@ module C100App
     def court_lookup(slug)
       path = format(COURT_PATH, slug: slug)
 
-      cache.fetch(slug, SLUGS_CACHE_OPTIONS) do
-        get_request(path)
-      end
+      get_request(path)
     end
 
     def is_ok?
       status
-    end
-
-    # Very basic cache to save a few API requests.
-    # It uses `MemoryStore` on dev/test by default, and `RedisCacheStore` on prod.
-    # Refer to `config/initializers/cache_store.rb` for more details.
-    #
-    def cache
-      Rails.cache
     end
 
     private


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21633615

Follow-up to PR #1080.

After the introduction of the new `Courts` DB table in the previous PR, we don't need to use the Redis cache for the court details API request, because we are now storing for up to 72h the court data in a record in the database, so it acts as a cache in effect.

I've manitained the Rails.cache configuration `config/initializers/cache_store.rb` as we might need to use it in other places. It is just a config file.