### PR TITLE
Reduce race-condition edge cases in online payments

### DIFF
--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -12,6 +12,10 @@ class PaymentIntent < ApplicationRecord
     update_column(:nonce, nil)
   end
 
+  def in_progress?
+    state['finished'].equal?(false)
+  end
+
   private
 
   def init_nonce

--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -7,3 +7,7 @@ end
 class String
   include StringExtension
 end
+
+module ActiveRecord::Querying
+  include RelationExtension
+end

--- a/lib/extensions/relation_extension.rb
+++ b/lib/extensions/relation_extension.rb
@@ -1,0 +1,12 @@
+# Note: backported from Rails 6
+# Refer to https://github.com/rails/rails/pull/31989
+
+module RelationExtension
+  #:nocov:
+  def create_or_find_by!(attributes, &block)
+    transaction(requires_new: true) { create!(attributes, &block) }
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(attributes)
+  end
+  #:nocov:
+end

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -36,4 +36,34 @@ RSpec.describe PaymentIntent, type: :model do
       subject.revoke_nonce!
     end
   end
+
+  describe '#in_progress?' do
+    subject { described_class.new(state: state) }
+
+    context 'there is a finished attribute' do
+      context 'and it is true' do
+        let(:state) { { 'finished' => true } }
+
+        it 'returns false' do
+          expect(subject.in_progress?).to eq(false)
+        end
+      end
+
+      context 'and it is false' do
+        let(:state) { { 'finished' => false } }
+
+        it 'returns true' do
+          expect(subject.in_progress?).to eq(true)
+        end
+      end
+    end
+
+    context 'there is no finished attribute' do
+      let(:state) { {} }
+
+      it 'returns false' do
+        expect(subject.in_progress?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21915640

We've had a couple of cases (out of almost 500 successful transactions, so really edge case) where a payment was created on GOV.UK Pay twice at the (almost) same time.
**Note: payment in this context is the "attempt or intent", not the actual take of funds.**

One of these transactions usually will progress to success and funds will be taken, the other will remain "In progress" for up to 90 minutes and then time out.

Problem with this is, in our database we need to link the c100 application to the corresponding online payment, with a unique ID that Pay provides to us after the creation of each payment.

As 2 payments are created sequentially almost at the same time, only one of these transactions will "win the race" and write its unique payment ID to our database.
This usually is not a problem, if the second transaction is the one that we store in the database and the one that completes the payment online. But if it is the first instead, then we will not be able to know if the payment has been successful or not (as we have a different ID).

This PR tries a first attempt (hopefully it is enough) to reduce as much as possible the points where a race-condition can happen, as well as to reuse payment intents where possible in order to continue an "in progress" payment and to not create a new unnecessary payment.

**Individual commits with more context.**