### PR TITLE
Read court details from the new table

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -6,7 +6,7 @@ module CompletionStep
   end
 
   def show
-    @court = current_c100_application.screener_answers_court
+    @court = current_c100_application.court
     @c100_application = current_c100_application
   end
 

--- a/app/controllers/steps/applicant/under_age_controller.rb
+++ b/app/controllers/steps/applicant/under_age_controller.rb
@@ -20,7 +20,7 @@ module Steps
       private
 
       def set_court
-        @court = current_c100_application.screener_answers_court
+        @court = current_c100_application.court
       end
     end
   end

--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -67,7 +67,7 @@ class AuditHelper
     return {} unless c100.online_payment?
 
     {
-      gbs_code: c100.screener_answers_court.gbs,
+      gbs_code: c100.court.gbs,
       payment_id: c100.payment_intent.payment_id,
     }
   end

--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -76,6 +76,6 @@ class NotifySubmissionMailer < NotifyMailer
   end
 
   def court
-    @c100_application.screener_answers_court
+    @c100_application.court
   end
 end

--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -66,4 +66,11 @@ class C100Application < ApplicationRecord
       CompletedApplicationsAudit.log!(self)
     end
   end
+
+  # TODO: preparation for future screener removal
+  # Once we don't have any records using the old `screener_answers`
+  # table we can remove this method.
+  def court
+    super() || screener_answers_court
+  end
 end

--- a/app/models/completed_applications_audit.rb
+++ b/app/models/completed_applications_audit.rb
@@ -10,7 +10,7 @@ class CompletedApplicationsAudit < ApplicationRecord
       completed_at: c100_application.updated_at,
       reference_code: c100_application.reference_code,
       submission_type: c100_application.submission_type,
-      court: c100_application.screener_answers_court.name,
+      court: c100_application.court.name,
       metadata: metadata(c100_application),
     )
   rescue ActiveRecord::RecordNotUnique => ex

--- a/app/presenters/valid_payments_array.rb
+++ b/app/presenters/valid_payments_array.rb
@@ -33,7 +33,7 @@ class ValidPaymentsArray < SimpleDelegator
   end
 
   def court
-    @_court ||= c100_application.screener_answers_court
+    @_court ||= c100_application.court
   end
 
   def choices_to_present

--- a/app/services/c100_app/court_online_submission.rb
+++ b/app/services/c100_app/court_online_submission.rb
@@ -5,7 +5,7 @@ module C100App
     end
 
     def to_address
-      c100_application.screener_answers_court.email
+      c100_application.court.email
     end
 
     private

--- a/app/services/c100_app/online_payments.rb
+++ b/app/services/c100_app/online_payments.rb
@@ -77,9 +77,9 @@ module C100App
     def metadata
       {
         application: APPLICATION_CODE,
-        court_gbs: c100_application.screener_answers_court.gbs,
-        court_name: c100_application.screener_answers_court.name,
-        court_email: c100_application.screener_answers_court.email,
+        court_gbs: c100_application.court.gbs,
+        court_name: c100_application.court.name,
+        court_email: c100_application.court.email,
       }
     end
   end

--- a/app/services/c100_app/screener_decision_tree.rb
+++ b/app/services/c100_app/screener_decision_tree.rb
@@ -22,12 +22,7 @@ module C100App
       court = CourtPostcodeChecker.new.court_for(children_postcode)
 
       if court
-        # Still saving to the old table, for the time being
-        c100_application.screener_answers.update!(local_court: court)
-
-        # New table association
         c100_application.update!(court: court)
-
         show(:done)
       else
         show(:no_court_found)

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -67,7 +67,7 @@
 
                 <% if c100 %>
                   <dt>Court receipt email address</dt>
-                  <dd><%= c100.screener_answers_court.email %> | <%= link_to 'web', C100App::CourtfinderAPI.court_url(c100.screener_answers_court.slug), rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
+                  <dd><%= c100.court.email %> | <%= link_to 'web', C100App::CourtfinderAPI.court_url(c100.court.slug), rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
                   <dt>Applicant receipt email address</dt>
                   <dd><%= c100.receipt_email || 'none' %></dd>
                 <% else %>

--- a/spec/controllers/steps/applicant/under_age_controller_spec.rb
+++ b/spec/controllers/steps/applicant/under_age_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Steps::Applicant::UnderAgeController, type: :controller do
     }
 
     before do
-      allow_any_instance_of(C100Application).to receive(:screener_answers_court).and_return(court)
+      allow_any_instance_of(C100Application).to receive(:court).and_return(court)
     end
 
     it 'assigns the court data' do

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -18,7 +18,7 @@ describe AuditHelper do
   let(:payment_type) { 'cash' }
   let(:court_arrangement) { nil }
 
-  let(:screener_answers_court) { instance_double(Court, name: 'Test Court', gbs: 'X123') }
+  let(:court) { instance_double(Court, name: 'Test Court', gbs: 'X123') }
   let(:screener_answers) { instance_double(ScreenerAnswers, children_postcodes: 'abcd 123') }
 
   subject { described_class.new(c100_application) }
@@ -28,7 +28,7 @@ describe AuditHelper do
     allow(c100_application).to receive(:payment_type).and_return(payment_type)
 
     allow(c100_application).to receive(:screener_answers).and_return(screener_answers)
-    allow(c100_application).to receive(:screener_answers_court).and_return(screener_answers_court)
+    allow(c100_application).to receive(:court).and_return(court)
     allow(c100_application).to receive(:court_arrangement).and_return(court_arrangement)
   end
 

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
 
   describe '#application_to_user' do
     before do
-      allow(c100_application).to receive(:screener_answers_court).and_return(court)
+      allow(c100_application).to receive(:court).and_return(court)
 
       allow(I18n).to receive(:translate!).with(
         'foobar_payment', scope: [:notify_submission_mailer, :payment_instructions], fee: '£215'

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -222,4 +222,23 @@ RSpec.describe C100Application, type: :model do
       end
     end
   end
+
+  # TODO: preparation for future screener removal
+  describe '#court' do
+    context 'when we have a court record' do
+      let(:court) { Court.new(id: 'slug') }
+      let(:attributes) { { court: court } }
+
+      it 'returns the court record' do
+        expect(subject.court).to eq(court)
+      end
+    end
+
+    context 'when we do not have a court record (legacy code)' do
+      it 'returns the court from the screener_answers table' do
+        expect(subject).to receive(:screener_answers_court).and_return('screener answers court')
+        expect(subject.court).to eq('screener answers court')
+      end
+    end
+  end
 end

--- a/spec/models/completed_applications_audit_spec.rb
+++ b/spec/models/completed_applications_audit_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CompletedApplicationsAudit, type: :model do
-  let(:screener_answers_court) { instance_double(Court, name: 'Test Court') }
+  let(:court) { instance_double(Court, name: 'Test Court') }
 
   let(:c100_application) {
     C100Application.new(
@@ -13,7 +13,7 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
   }
 
   before do
-    allow(c100_application).to receive(:screener_answers_court).and_return(screener_answers_court)
+    allow(c100_application).to receive(:court).and_return(court)
   end
 
   describe 'db table name' do

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe ValidPaymentsArray do
     let(:court_slug) { 'west-london-family-court' }
 
     before do
-      allow(c100_application).to receive(:screener_answers_court).and_return(court_double)
+      allow(c100_application).to receive(:court).and_return(court_double)
     end
 
     context 'for a court slug included in the blocklist' do

--- a/spec/services/c100_app/court_online_submission_spec.rb
+++ b/spec/services/c100_app/court_online_submission_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe C100App::CourtOnlineSubmission do
-  let(:c100_application) { instance_double(C100Application, email_submission: email_submission, screener_answers_court: screener_answers_court) }
+  let(:c100_application) { instance_double(C100Application, email_submission: email_submission, court: court) }
   let(:email_submission) { instance_double(EmailSubmission, update: true) }
-  let(:screener_answers_court) { double(email: 'court@email.com') }
+  let(:court) { double(email: 'court@email.com') }
 
   subject { described_class.new(c100_application) }
 

--- a/spec/services/c100_app/online_payments_spec.rb
+++ b/spec/services/c100_app/online_payments_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe C100App::OnlinePayments do
     end
 
     before do
-      allow(c100_application).to receive(:screener_answers_court).and_return(court_double)
+      allow(c100_application).to receive(:court).and_return(court_double)
 
       allow(
         PaymentsApi::Requests::CreateCardPayment

--- a/spec/services/c100_app/screener_decision_tree_spec.rb
+++ b/spec/services/c100_app/screener_decision_tree_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe C100App::ScreenerDecisionTree do
   let(:postcodes)        { 'anything' }
   let(:local_court)      { {} }
-  let(:screener_answers) { double('screener_answers', children_postcodes: postcodes, local_court: local_court) }
-  let(:c100_application) { double('Object', screener_answers: screener_answers) }
+  let(:c100_application) { double('Object') }
   let(:step_params)      { double('Step') }
   let(:next_step)        { nil }
   let(:as)               { nil }
@@ -28,16 +27,9 @@ RSpec.describe C100App::ScreenerDecisionTree do
 
       before do
         allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).with(postcodes).and_return(court)
-        allow(screener_answers).to receive(:update!)
         allow(c100_application).to receive(:update!)
       end
 
-      it 'updates the screener_answers with the Court' do
-        expect(screener_answers).to receive(:update!).with(local_court: court)
-        is_expected.to have_destination(:done, :show)
-      end
-
-      # TODO: preparation for future screener removal
       it 'assigns the court to the c100 application' do
         expect(c100_application).to receive(:update!).with(court: court)
         is_expected.to have_destination(:done, :show)


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21633615

We will expose a `#court` method in the C100Application model, that will check if we have a court record in the new `courts` table, and if not, fallback to the legacy `screener_answers` table.

We can remove this method once we don't have any more records using the old table.

Changed a lot of the `screener_answers_court` references. Some remain (specifically in the developer tools bypass functionality) that will be refactored in the next PR.