### PR TITLE
Refactor bypass functionality

### DIFF
--- a/app/controllers/concerns/savepoint_step.rb
+++ b/app/controllers/concerns/savepoint_step.rb
@@ -4,7 +4,7 @@ module SavepointStep
   included do
     skip_before_action :check_application_not_screening
 
-    before_action :screener_sanity_check
+    before_action :court_sanity_check
     before_action :mark_in_progress, only: [:update]
     before_action :save_application_for_later, if: :user_signed_in?, only: [:update]
   end
@@ -18,9 +18,9 @@ module SavepointStep
     super
   end
 
-  def screener_sanity_check
-    screener = current_c100_application.screener_answers
-    raise Errors::ApplicationScreening unless screener.present? && screener.valid?(:completion)
+  # TODO: refactor the error page and copy as we really don't have a screener anymore
+  def court_sanity_check
+    raise Errors::ApplicationScreening unless current_c100_application.court.present?
   end
 
   def mark_in_progress

--- a/app/models/screener_answers.rb
+++ b/app/models/screener_answers.rb
@@ -1,13 +1,6 @@
 class ScreenerAnswers < ApplicationRecord
   belongs_to :c100_application
 
-  # Absolute minimum details needed to consider the screener completed
-  def self.attributes_to_validate
-    %w[children_postcodes]
-  end.freeze
-
-  validates_presence_of attributes_to_validate, on: :completion
-
   def court
     Court.build(local_court) if local_court
   end

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -10,11 +10,11 @@
         <h4 class="govuk-heading-s">Current Application ID</h4>
         <p><%= current_c100_application.id %></p>
 
-        <% if current_c100_application.screener_answers_court %>
+        <% if current_c100_application.court %>
           <h4 class="govuk-heading-s">Current court data</h4>
           <p>
-            <%= current_c100_application.screener_answers_court.name %><br/>
-            <%= current_c100_application.screener_answers_court.email %>
+            <%= current_c100_application.court.name %><br/>
+            <%= current_c100_application.court.email %>
           </p>
         <% end %>
       <% end %>
@@ -29,9 +29,9 @@
       <h3 class="govuk-heading-m">Bypass steps</h3>
       <p>Speed up some common test scenarios by pre-filling some information</p>
 
-      <%= button_to bypass_screener_session_path,
+      <%= button_to bypass_postcode_session_path,
                     class: 'govuk-button govuk-!-margin-right-1',
-                    data: { module: 'govuk-button' } do; 'Bypass screener'; end %>
+                    data: { module: 'govuk-button' } do; 'Bypass postcode'; end %>
 
       <%= button_to bypass_to_cya_session_path,
                     class: 'govuk-button',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,7 +282,7 @@ Rails.application.routes.draw do
   resource :session, only: [:destroy] do
     member do
       get :ping
-      post :bypass_screener
+      post :bypass_postcode
       post :bypass_to_cya
     end
   end

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -36,14 +36,14 @@ When(/^I click the "([^"]*)" button$/) do |text|
   find("input[value='#{text}']").click
 end
 
-When(/^I bypass the screener$/) do
+When(/^I bypass the postcode$/) do
   step %[I open the "Developer Tools" summary details]
-  find('button', text: 'Bypass screener').click
+  find('button', text: 'Bypass postcode').click
 end
 
 When(/^I have started an application$/) do
   step %[I visit "/"]
-  step %[I bypass the screener]
+  step %[I bypass the postcode]
   step %[I click the "Start application" link]
   step %[I click the "Continue" link] # Before you continue
   step %[I click the "Continue" link] # How long it takes

--- a/spec/controllers/steps/miam/consent_order_controller_spec.rb
+++ b/spec/controllers/steps/miam/consent_order_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Steps::Miam::ConsentOrderController, type: :controller do
 
   it_behaves_like 'an intermediate step controller', Steps::Miam::ConsentOrderForm, C100App::MiamDecisionTree do
     before do
-      allow(controller).to receive(:screener_sanity_check).and_return(true)
+      allow(controller).to receive(:court_sanity_check).and_return(true)
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe Steps::Miam::ConsentOrderController, type: :controller do
   # The important thing is to be tested in at least one, as any other will behave the same.
   it_behaves_like 'a step that can be drafted', Steps::Miam::ConsentOrderForm do
     before do
-      allow(controller).to receive(:screener_sanity_check).and_return(true)
+      allow(controller).to receive(:court_sanity_check).and_return(true)
     end
   end
 end

--- a/spec/models/screener_answers_spec.rb
+++ b/spec/models/screener_answers_spec.rb
@@ -5,29 +5,6 @@ RSpec.describe ScreenerAnswers, type: :model do
 
   let(:local_court) { nil }
 
-  describe '.attributes_to_validate' do
-    it 'returns only the attributes that should be validated' do
-      expect(
-        described_class.attributes_to_validate
-      ).to match_array(%w[
-        children_postcodes
-      ])
-    end
-  end
-
-  describe 'validations' do
-    # One example for an attribute is enough as we have already another test
-    # for all the attributes that will be run through the validator.
-    #
-    context 'when context is `completion`' do
-      it { should validate_presence_of(:children_postcodes, :blank).on_context(:completion) }
-    end
-
-    context 'when context is not `completion`' do
-      it { should_not validate_presence_of(:children_postcodes, :blank) }
-    end
-  end
-
   describe '#court' do
     context 'when there is a local_court' do
       let(:local_court) { { "name" => 'whatever' } }


### PR DESCRIPTION
Follow-up to PR #1084.

The bypass is not really a "bypass screener" anymore, but instead a "bypass postcode" as that is the only thing we have left of the screener.

Also, do not write to the old `screener_answers` table, and instead we use the new `courts` table mechanism.