### PR TITLE
Refactor `children_postcodes`

### DIFF
--- a/app/controllers/steps/screener/postcode_controller.rb
+++ b/app/controllers/steps/screener/postcode_controller.rb
@@ -4,9 +4,7 @@ module Steps
       include StartingPointStep
 
       def edit
-        @form_object = PostcodeForm.build(
-          c100_application: current_c100_application
-        )
+        @form_object = PostcodeForm.build(current_c100_application)
       end
 
       def update

--- a/app/forms/steps/screener/postcode_form.rb
+++ b/app/forms/steps/screener/postcode_form.rb
@@ -1,29 +1,17 @@
 module Steps
   module Screener
     class PostcodeForm < BaseForm
-      include HasOneAssociationForm
-
-      has_one_association :screener_answers
-
-      attribute :children_postcodes, StrippedString
-      validates :children_postcodes, presence: true, full_uk_postcode: true
+      attribute :children_postcode, StrippedString
+      validates :children_postcode, presence: true, full_uk_postcode: true
 
       private
 
       def persist!
         raise C100ApplicationNotFound unless c100_application
 
-        record_to_persist.update(
-          children_postcodes: children_postcodes
-        )
-
-        # TODO: preparation for future screener removal.
-        # Soon we will get rid of the `screener_answers` DB table and
-        # refactor the postcode screener question to be part of the main
-        # application. For now, we just copy over this to the new DB field.
-        #
         c100_application.update(
-          children_postcode: children_postcodes
+          children_postcode: children_postcode,
+          court: nil, # reset court attribute, so we start fresh
         )
       end
     end

--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -41,7 +41,8 @@ class AuditHelper
 
   def postcode
     # We blind a bit the postcode to anonymize it
-    postcode = c100.screener_answers.children_postcodes
+    # TODO: maintain backwards compatibility until all applications use the new attribute
+    postcode = c100.children_postcode || c100.screener_answers.children_postcodes
     postcode.sub(/\s+/, '').upcase.at(0..-3) + '**'
   end
 

--- a/app/services/c100_app/screener_decision_tree.rb
+++ b/app/services/c100_app/screener_decision_tree.rb
@@ -4,7 +4,7 @@ module C100App
       return next_step if next_step
 
       case step_name
-      when :children_postcodes
+      when :children_postcode
         check_if_court_is_valid
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
@@ -13,9 +13,8 @@ module C100App
 
     private
 
-    # TODO: rename param to be singular, not plural, when removing the screener
     def children_postcode
-      step_params.fetch(:children_postcodes)
+      step_params.fetch(:children_postcode)
     end
 
     def check_if_court_is_valid

--- a/app/views/steps/screener/postcode/edit.html.erb
+++ b/app/views/steps/screener/postcode/edit.html.erb
@@ -10,7 +10,7 @@
     <p class="govuk-body-l"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :children_postcodes, width: 'one-third', autocomplete: 'postal-code' %>
+      <%= f.govuk_text_field :children_postcode, width: 'one-third', autocomplete: 'postal-code' %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1020,7 +1020,7 @@ en:
 
       # Screener steps
       steps_screener_postcode_form:
-        children_postcodes: Postcode
+        children_postcode: Postcode
 
       # MIAM steps
       steps_miam_consent_order_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -53,7 +53,7 @@ en:
         invalid: *invalid_email_error
         blank: *blank_email_error
         typo: *email_typo_error
-      children_postcodes:
+      children_postcode:
         invalid: Enter a valid full postcode, with or without a space
         blank: Enter a full postcode, with or without a space
     # fallback error messages in case no specific one is found

--- a/features/screener.feature
+++ b/features/screener.feature
@@ -30,11 +30,11 @@ Feature: Screener
     Then I should be on "/steps/screener/postcode"
     And Page has title "Error: Where the children live - Apply to court about child arrangements - GOV.UK"
     And I should see "There is a problem on this page" in the error summary
-    And I should see a "Enter a full postcode, with or without a space" link to "#steps-screener-postcode-form-children-postcodes-field-error"
+    And I should see a "Enter a full postcode, with or without a space" link to "#steps-screener-postcode-form-children-postcode-field-error"
 
     Then I click the "Enter a full postcode, with or without a space" link
     And I should see "Enter a full postcode, with or without a space" error in the form
-    And "steps-screener-postcode-form-children-postcodes-field-error" has focus
+    And "steps-screener-postcode-form-children-postcode-field-error" has focus
 
   @unhappy_path
   Scenario: Postcode not eligible

--- a/spec/forms/steps/screener/postcode_form_spec.rb
+++ b/spec/forms/steps/screener/postcode_form_spec.rb
@@ -1,101 +1,17 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Screener::PostcodeForm do
-
   let(:arguments) { {
     c100_application: c100_application,
-    children_postcodes: children_postcodes
+    children_postcode: children_postcode
   } }
 
-  let(:screener_answers){ instance_double(ScreenerAnswers, children_postcodes: '') }
-
-  let(:c100_application) {
-    instance_double(C100Application, screener_answers: screener_answers, children_postcode: nil)
-  }
-  let(:children_postcodes)  { 'E3 6AA' }
+  let(:c100_application) { instance_double(C100Application) }
+  let(:children_postcode) { 'E3 6AA' }
 
   subject { described_class.new(arguments) }
 
   describe '#save' do
-    # TODO: preparation for future screener removal
-    before do
-      allow(c100_application).to receive(:update).with(children_postcode: children_postcodes).and_return(true)
-    end
-
-    it_behaves_like 'a has-one-association form',
-                    association_name: :screener_answers,
-                    expected_attributes: {
-                      children_postcodes: "E3 6AA"
-                    }
-
-    context 'when the attribute is not given' do
-      let(:children_postcodes){ nil }
-      it 'is not valid' do
-        expect(subject).to_not be_valid
-      end
-
-      it 'adds an error on the children_postcodes attribute' do
-        subject.valid?
-        expect(subject.errors[:children_postcodes]).to_not be_empty
-      end
-    end
-
-    context 'when the attribute is given' do
-      context 'but not a valid full postcode' do
-        let(:children_postcodes){ 'SE1' }
-
-        it 'is not valid' do
-          expect(subject).to_not be_valid
-        end
-
-        it 'adds an error on the children_postcodes attribute' do
-          subject.valid?
-          expect(subject.errors[:children_postcodes]).to_not be_empty
-        end
-      end
-      context 'and is a valid postcode' do
-        context 'without a space, upper case' do
-          let(:children_postcodes){ 'SW1H9AJ' }
-          it 'is valid' do
-            expect(subject).to be_valid
-          end
-        end
-        context 'without a space, mixed case' do
-          let(:children_postcodes){ 'SW1h9aj' }
-          it 'is valid' do
-            expect(subject).to be_valid
-          end
-        end
-        context 'with a space, upper case' do
-          let(:children_postcodes){ 'SW1H 9AJ' }
-          it 'is valid' do
-            expect(subject).to be_valid
-          end
-        end
-        context 'with a space, mixed case' do
-          let(:children_postcodes){ 'SW1h 9aj' }
-          it 'is valid' do
-            expect(subject).to be_valid
-          end
-        end
-      end
-    end
-
-    context 'when form is valid' do
-      it 'saves the record' do
-        expect(screener_answers).to receive(:update).with(
-          children_postcodes: children_postcodes
-        ).and_return(true)
-
-        # TODO: preparation for future screener removal
-        expect(c100_application).to receive(:update).with(
-          children_postcode: children_postcodes
-        ).and_return(true)
-
-        expect(subject.save).to be(true)
-      end
-    end
-
     context 'when no c100_application is associated with the form' do
       let(:c100_application) { nil }
 
@@ -104,5 +20,70 @@ RSpec.describe Steps::Screener::PostcodeForm do
       end
     end
 
+    context 'validations' do
+      context 'when the attribute is not given' do
+        it { should validate_presence_of(:children_postcode) }
+      end
+
+      context 'when the attribute is given' do
+        context 'but not a valid full postcode' do
+          let(:children_postcode) { 'SE1' }
+
+          it 'is not valid' do
+            expect(subject).to_not be_valid
+          end
+
+          it 'adds an error on the attribute' do
+            subject.valid?
+            expect(subject.errors[:children_postcode]).to_not be_empty
+          end
+        end
+
+        context 'and is a valid postcode' do
+          context 'without a space, upper case' do
+            let(:children_postcode) { 'SW1H9AJ' }
+
+            it 'is valid' do
+              expect(subject).to be_valid
+            end
+          end
+
+          context 'without a space, mixed case' do
+            let(:children_postcode) { 'SW1h9aj' }
+
+            it 'is valid' do
+              expect(subject).to be_valid
+            end
+          end
+
+          context 'with a space, upper case' do
+            let(:children_postcode) { 'SW1H 9AJ' }
+
+            it 'is valid' do
+              expect(subject).to be_valid
+            end
+          end
+
+          context 'with a space, mixed case' do
+            let(:children_postcode) { 'SW1h 9aj' }
+
+            it 'is valid' do
+              expect(subject).to be_valid
+            end
+          end
+        end
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(c100_application).to receive(:update).with(
+          children_postcode: children_postcode,
+          court: nil,
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
   end
 end

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -58,6 +58,21 @@ describe AuditHelper do
       )
     end
 
+    # TODO: maintain backwards compatibility until all applications use the new attribute
+    context 'when new `children_postcode` attribute is present' do
+      before do
+        allow(c100_application).to receive(:children_postcode).and_return('XYZ123')
+      end
+
+      it 'returns the expected information' do
+        expect(c100_application).not_to receive(:screener_answers)
+
+        expect(
+          subject.metadata
+        ).to include(postcode: 'XYZ1**')
+      end
+    end
+
     context 'when we have court arrangements' do
       let(:court_arrangement) {
         CourtArrangement.new(

--- a/spec/services/c100_app/screener_decision_tree_spec.rb
+++ b/spec/services/c100_app/screener_decision_tree_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe C100App::ScreenerDecisionTree do
-  let(:postcodes)        { 'anything' }
+  let(:postcode)         { 'anything' }
   let(:local_court)      { {} }
   let(:c100_application) { double('Object') }
   let(:step_params)      { double('Step') }
@@ -12,12 +12,12 @@ RSpec.describe C100App::ScreenerDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-  context 'when the step is `children_postcodes`' do
-    let(:step_params) { { children_postcodes: postcodes } }
+  context 'when the step is `children_postcode`' do
+    let(:step_params) { { children_postcode: postcode } }
 
     context 'and no valid court is found' do
       before do
-        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).with(postcodes).and_return(nil)
+        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).with(postcode).and_return(nil)
       end
       it { is_expected.to have_destination(:no_court_found, :show) }
     end
@@ -26,7 +26,7 @@ RSpec.describe C100App::ScreenerDecisionTree do
       let(:court) { instance_double('Court') }
 
       before do
-        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).with(postcodes).and_return(court)
+        allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).with(postcode).and_return(court)
         allow(c100_application).to receive(:update!)
       end
 
@@ -43,8 +43,8 @@ RSpec.describe C100App::ScreenerDecisionTree do
       it { is_expected.to have_destination(:error_but_continue, :show)}
     end
 
-    context 'when the children_postcodes are nil' do
-      let(:postcodes){ nil }
+    context 'when the postcode is nil' do
+      let(:postcode){ nil }
       before do
         allow_any_instance_of(C100App::CourtPostcodeChecker).to receive(:court_for).and_raise("expected exception for testing, please ignore")
       end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21633615

Similar to what we did in PR #1084, we now want to start using only the new `children_postcode` DB field (which is part of the C100Application record) instead of the previous `children_postcodes` (note plural) in the old ScreenerAnswers record.

We need to maintain backwards compatibility until all applications use the new attribute.