### PR TITLE
Update CYA to move 2 questions out of MIAM group

### DIFF
--- a/app/presenters/summary/html_presenter.rb
+++ b/app/presenters/summary/html_presenter.rb
@@ -8,6 +8,7 @@ module Summary
 
     def sections
       [
+        HtmlSections::OpeningQuestions.new(c100_application),
         *miam_questions,
         *safety_and_abuse_questions,
         HtmlSections::NatureOfApplication.new(c100_application),

--- a/app/presenters/summary/html_sections/miam_requirement.rb
+++ b/app/presenters/summary/html_sections/miam_requirement.rb
@@ -7,10 +7,6 @@ module Summary
 
       def answers
         [
-          Answer.new(:consent_order_application, c100.consent_order,
-                     change_path: edit_steps_opening_consent_order_path),
-          Answer.new(:child_protection_cases, c100.child_protection_cases,
-                     change_path: edit_steps_opening_child_protection_cases_path),
           Answer.new(:miam_attended, c100.miam_attended,
                      change_path: edit_steps_miam_attended_path),
           Answer.new(:miam_certification, c100.miam_certification,

--- a/app/presenters/summary/html_sections/opening_questions.rb
+++ b/app/presenters/summary/html_sections/opening_questions.rb
@@ -1,0 +1,22 @@
+module Summary
+  module HtmlSections
+    class OpeningQuestions < Sections::BaseSectionPresenter
+      def name
+        :opening_questions
+      end
+
+      def show_header?
+        false
+      end
+
+      def answers
+        [
+          Answer.new(:consent_order_application, c100.consent_order,
+                     change_path: edit_steps_opening_consent_order_path),
+          Answer.new(:child_protection_cases, c100.child_protection_cases,
+                     change_path: edit_steps_opening_child_protection_cases_path),
+        ].select(&:show?)
+      end
+    end
+  end
+end

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -62,6 +62,7 @@ en:
   check_answers_html:
     change_link_html: Change <span class="govuk-visually-hidden">your answer to, %{a11y_question}</span>
     sections:
+      opening_questions: Opening questions
       miam_requirement: MIAM requirement
       miam_attendance: MIAM attendance
       miam_exemptions: MIAM exemption

--- a/spec/presenters/summary/html_presenter_spec.rb
+++ b/spec/presenters/summary/html_presenter_spec.rb
@@ -86,6 +86,7 @@ describe Summary::HtmlPresenter do
 
     it 'has the right sections in the right order' do
       expect(subject.sections).to match_instances_array([
+        Summary::HtmlSections::OpeningQuestions,
         Summary::HtmlSections::MiamRequirement,
         Summary::HtmlSections::MiamAttendance,
         Summary::HtmlSections::MiamExemptions,

--- a/spec/presenters/summary/html_sections/miam_requirement_spec.rb
+++ b/spec/presenters/summary/html_sections/miam_requirement_spec.rb
@@ -4,8 +4,6 @@ module Summary
   describe HtmlSections::MiamRequirement do
     let(:c100_application) {
       instance_double(C100Application,
-        consent_order: 'no',
-        child_protection_cases: 'no',
         miam_attended: 'yes',
         miam_certification: 'yes',
         miam_exemption_claim: 'no',
@@ -21,32 +19,22 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(5)
+        expect(answers.count).to eq(3)
 
         expect(answers[0]).to be_an_instance_of(Answer)
-        expect(answers[0].question).to eq(:consent_order_application)
-        expect(answers[0].change_path).to eq('/steps/opening/consent_order')
-        expect(answers[0].value).to eq('no')
+        expect(answers[0].question).to eq(:miam_attended)
+        expect(answers[0].change_path).to eq('/steps/miam/attended')
+        expect(answers[0].value).to eq('yes')
 
         expect(answers[1]).to be_an_instance_of(Answer)
-        expect(answers[1].question).to eq(:child_protection_cases)
-        expect(answers[1].change_path).to eq('/steps/opening/child_protection_cases')
-        expect(answers[1].value).to eq('no')
+        expect(answers[1].question).to eq(:miam_certification)
+        expect(answers[1].change_path).to eq('/steps/miam/certification')
+        expect(answers[1].value).to eq('yes')
 
         expect(answers[2]).to be_an_instance_of(Answer)
-        expect(answers[2].question).to eq(:miam_attended)
-        expect(answers[2].change_path).to eq('/steps/miam/attended')
-        expect(answers[2].value).to eq('yes')
-
-        expect(answers[3]).to be_an_instance_of(Answer)
-        expect(answers[3].question).to eq(:miam_certification)
-        expect(answers[3].change_path).to eq('/steps/miam/certification')
-        expect(answers[3].value).to eq('yes')
-
-        expect(answers[4]).to be_an_instance_of(Answer)
-        expect(answers[4].question).to eq(:miam_exemption_claim)
-        expect(answers[4].change_path).to eq('/steps/miam/exemption_claim')
-        expect(answers[4].value).to eq('no')
+        expect(answers[2].question).to eq(:miam_exemption_claim)
+        expect(answers[2].change_path).to eq('/steps/miam/exemption_claim')
+        expect(answers[2].value).to eq('no')
       end
     end
   end

--- a/spec/presenters/summary/html_sections/opening_questions_spec.rb
+++ b/spec/presenters/summary/html_sections/opening_questions_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+module Summary
+  describe HtmlSections::OpeningQuestions do
+    let(:c100_application) {
+      instance_double(C100Application,
+        consent_order: 'no',
+        child_protection_cases: 'no',
+    ) }
+
+    subject { described_class.new(c100_application) }
+
+    let(:answers) { subject.answers }
+
+    describe '#name' do
+      it { expect(subject.name).to eq(:opening_questions) }
+    end
+
+    describe '#show_header?' do
+      it { expect(subject.show_header?).to eq(false) }
+    end
+
+    describe '#answers' do
+      it 'has the correct rows' do
+        expect(answers.count).to eq(2)
+
+        expect(answers[0]).to be_an_instance_of(Answer)
+        expect(answers[0].question).to eq(:consent_order_application)
+        expect(answers[0].change_path).to eq('/steps/opening/consent_order')
+        expect(answers[0].value).to eq('no')
+
+        expect(answers[1]).to be_an_instance_of(Answer)
+        expect(answers[1].question).to eq(:child_protection_cases)
+        expect(answers[1].change_path).to eq('/steps/opening/child_protection_cases')
+        expect(answers[1].value).to eq('no')
+      end
+    end
+  end
+end


### PR DESCRIPTION
These are the 2 questions we moved in the previous PR #1088 out of the MIAM group as they are not directly linked to MIAM.

They will continue working the same but just outside the MIAM requirement group.
This has been agreed and discussed with the service designer.

Before:
<img width="783" alt="Screenshot 2020-09-24 at 14 50 00" src="https://user-images.githubusercontent.com/687910/94156281-d537f900-fe77-11ea-8101-62340aae3291.png">

After:
<img width="788" alt="Screenshot 2020-09-24 at 14 48 48" src="https://user-images.githubusercontent.com/687910/94156294-d9641680-fe77-11ea-8f1c-d3c0d3b8438b.png">
