### PR TITLE
Update `purge:orphans` rake task

### DIFF
--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -40,7 +40,7 @@ class C100Application < ApplicationRecord
 
   scope :with_owner,    -> { where.not(user: nil) }
   scope :not_completed, -> { where.not(status: :completed) }
-  scope :not_eligible_orphans, -> { joins(:screener_answers).where('screener_answers.local_court': nil) }
+  scope :not_eligible_orphans, -> { where.not(children_postcode: nil).where(court: nil) }
 
   delegate :court, to: :screener_answers, prefix: true, allow_nil: true
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,7 +59,7 @@ class Application < Rails::Application
   config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 60).to_i
   config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 
-  # As part of the postcode screening, an empty C100Application record is created.
+  # As part of the opening postcode step, an empty C100Application record is created.
   # If the postcode is not eligible, these records are left orphans and have no use.
   # We will only leave them for some time. Can be configured here.
   config.x.orphans.expire_in_days = 2


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21934280

This is a daily automated task that runs overnight and clean ups "orphaned" c100 application records. These are records that are created in the database as a consequence of entering a postcode that is either not valid, not found, or not eligible to apply.

Update the rake task to keep working as before, now that we've moved away from using the `screener_answers` DB table.

Will purge records that have the `children_postcode` present, but the `court` is nil.