### PR TITLE
Change order of the payments report in back office

### DIFF
--- a/app/controllers/backoffice/dashboard_controller.rb
+++ b/app/controllers/backoffice/dashboard_controller.rb
@@ -38,7 +38,7 @@ module Backoffice
     end
 
     def payments_report
-      PaymentIntent.order(created_at: :desc).limit(default_limit)
+      PaymentIntent.order(updated_at: :desc).limit(default_limit)
     end
   end
 end


### PR DESCRIPTION
Ordering by `updated_at` is more accurate, as a payment intent could have been created a few days ago but not completed the payment, and left to expire, but then user comes back and complete the payment (the created_at would remain the same but the updated_at will change).

This is just for the reports in the back office and do not affect anything else.