### PR TITLE
Enable save draft button on bypass to CYA

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -34,6 +34,9 @@ class SessionsController < ApplicationController
     c100_application.update(
       court: find_or_initialize_court,
       status: 1,
+      # fill out the first steps, so `save and return` button shows
+      consent_order: 'no',
+      child_protection_cases: 'no',
     )
 
     redirect_to edit_steps_application_check_your_answers_path

--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -15,7 +15,7 @@ module CustomFormHelpers
 
   private
 
-  # The `save an return` button will show once the application has advanced
+  # The `save and return` button will show once the application has advanced
   # a few steps, currently 3 steps (`child_protection_cases` attr is present).
   def show_draft_button?
     current_c100_application.try(:child_protection_cases)


### PR DESCRIPTION
Minor tweak to get the bypass to CYA in line with the code that decides if the `save and return` button will show or not.

It shows if we've advanced at least until the `child_protection_cases`.