### PR TITLE
Add task to purge old back office audit records

### DIFF
--- a/app/models/backoffice_audit_record.rb
+++ b/app/models/backoffice_audit_record.rb
@@ -18,4 +18,8 @@ class BackofficeAuditRecord < ApplicationRecord
       details: details
     )
   end
+
+  def self.purge!(date)
+    where('created_at <= :date', date: date).destroy_all
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,6 +78,10 @@ class Application < Rails::Application
   # delivery result of these emails for diagnostic and debug purposes.
   config.x.email_submissions_audit.expire_in_days = 90
 
+  # The back office maintains an audit trail of all actions performed (for example, resend
+  # an email). It logs who did what and when. We should maintain it for a few weeks/months.
+  config.x.backoffice_audit.expire_in_days = 90
+
   # Court fee configuration.
   # Not using Fee Register for now as we only have 1 fee, but might be used in the future.
   config.x.court_fee.amount_in_pence = 215_00

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -7,6 +7,7 @@ task daily_tasks: [:stdout_environment] do
   Rake::Task['purge:applications'].invoke
   Rake::Task['purge:orphans'].invoke
   Rake::Task['purge:email_submissions_audit'].invoke
+  Rake::Task['purge:backoffice_audit'].invoke
 
   Rake::Task['draft_reminders:first_email'].invoke
   Rake::Task['draft_reminders:last_email'].invoke
@@ -44,6 +45,13 @@ namespace :purge do
     log "Purging email submissions audit older than #{expire_after} days"
     purged = EmailSubmissionsAudit.purge!(expire_after.days.ago)
     log "Purged #{purged.size} email submissions audit records"
+  end
+
+  task backoffice_audit: :environment do
+    expire_after = Rails.configuration.x.backoffice_audit.expire_in_days
+    log "Purging backoffice audit records older than #{expire_after} days"
+    purged = BackofficeAuditRecord.purge!(expire_after.days.ago)
+    log "Purged #{purged.size} backoffice audit records"
   end
 end
 


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22069087

Similar to other automated daily tasks, create one to clean up older than 90 days back office audit records. These are of no use and they will continue growing otherwise.