### PR TITLE
Add functionality to back office to complete applications

### DIFF
--- a/app/controllers/backoffice/dashboard_controller.rb
+++ b/app/controllers/backoffice/dashboard_controller.rb
@@ -15,12 +15,48 @@ module Backoffice
 
       render :lookup && return if @form.invalid?
 
-      @report = CompletedApplicationsAudit.where(reference_code: @form.reference_code)
+      if (@application = CompletedApplicationsAudit.find_by(reference_code: @form.reference_code))
+        audit!(
+          action: :application_lookup,
+          details: { reference_code: @form.reference_code, found: true, completed: true }
+        )
+      elsif (@application = C100Application.find_by_reference_code(@form.reference_code))
+        audit!(
+          action: :application_lookup,
+          details: { reference_code: @form.reference_code, found: true, completed: false }
+        )
+      else
+        audit!(
+          action: :application_lookup,
+          details: { reference_code: @form.reference_code, found: false }
+        )
+      end
+    end
+
+    # Will change the payment method to phone, as a fallback, as this is most likely
+    # an application having issues with online payments, or an user not fully completing
+    # the payment journey and letting the payment expire (time out).
+    # This is mainly an issue with non-saved applications as the user can't return to it.
+    # Mark as completed and trigger the submission emails.
+    #
+    def complete_application
+      c100_application = C100Application.not_completed.find(params[:dashboard_id])
+
+      c100_application.update_column(
+        :payment_type, PaymentType::SELF_PAYMENT_CARD.value
+      )
+
+      c100_application.mark_as_completed!
+      C100App::OnlineSubmissionQueue.new(c100_application).process
 
       audit!(
-        action: :application_lookup,
-        details: { reference_code: @form.reference_code, found: @report.size }
+        action: :application_completed,
+        details: { reference_code: c100_application.reference_code, payment_type: c100_application.payment_type }
       )
+
+      redirect_to backoffice_dashboard_index_path, flash: {
+        alert: "Application #{c100_application.reference_code} has been completed and emails will be sent shortly."
+      }
     end
 
     private

--- a/app/models/backoffice_audit_record.rb
+++ b/app/models/backoffice_audit_record.rb
@@ -7,6 +7,7 @@ class BackofficeAuditRecord < ApplicationRecord
     logout: 'logout',
     forbidden: 'forbidden',
     application_lookup: 'application_lookup',
+    application_completed: 'application_completed',
     email_lookup: 'email_lookup',
     resend_email: 'resend_email',
   }

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -69,7 +69,7 @@
                   <dt>Court receipt email address</dt>
                   <dd><%= c100.court.email %> | <%= link_to 'web', C100App::CourtfinderAPI.court_url(c100.court.slug), rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
                   <dt>Applicant receipt email address</dt>
-                  <dd><%= c100.receipt_email || 'none' %></dd>
+                  <dd><%= c100.receipt_email.presence || 'none' %></dd>
                 <% else %>
                   <dt>Court receipt email address</dt>
                   <dd>(purged from database)</dd>

--- a/app/views/backoffice/dashboard/_incomplete_table.en.html.erb
+++ b/app/views/backoffice/dashboard/_incomplete_table.en.html.erb
@@ -1,0 +1,98 @@
+<table class="backoffice-table govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Created at</th>
+      <th class="govuk-table__header">Updated at</th>
+      <th class="govuk-table__header">Submission</th>
+      <th class="govuk-table__header">Payment</th>
+      <th class="govuk-table__header">Status</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <%= application.created_at %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= application.updated_at %>
+      </td>
+      <td class="govuk-table__cell app-util--no-wrap">
+        <%= t(application.submission_type, scope: 'backoffice.submission', default: 'N/A') %>
+      </td>
+      <td class="govuk-table__cell app-util--no-wrap">
+        <%= t(application.payment_type, scope: 'backoffice.payment', default: 'N/A') %>
+      </td>
+      <td class="govuk-table__cell app-util--no-wrap">
+        <strong class="govuk-tag govuk-tag--orange">
+          <%= application.status %>
+        </strong>
+      </td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td colspan="5" class="no-border govuk-table__cell">
+        <div class="govuk-inset-text backoffice-extra-details">
+          <table class="govuk-table">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell no-border" width="50%">
+                <dl class="app-description-list">
+                  <dt>Saved for later?</dt>
+                  <dd><%= application.user_id? %></dd>
+                  <dt>Last submitted step</dt>
+                  <dd><%= application.navigation_stack.last %></dd>
+                  <dt>Applicant receipt email address</dt>
+                  <dd><%= application.receipt_email.presence || 'none' %></dd>
+
+                  <% if (payment_intent = application.payment_intent) %>
+                    <dt>GOV.UK payment created at</dt>
+                    <dd><%= payment_intent.created_at %></dd>
+                    <dt>GOV.UK payment updated at</dt>
+                    <dd><%= payment_intent.updated_at %></dd>
+                    <dt>GOV.UK payment reference</dt>
+                    <dd><%= application.reference_code %></dd>
+                    <dt>GOV.UK payment ID</dt>
+                    <dd>
+                      <%= payment_intent.payment_id %>
+                      (<%= link_to 'details', "https://selfservice.payments.service.gov.uk/transactions/#{payment_intent.payment_id}",
+                                   target: '_blank', rel: 'external', class: 'govuk-link govuk-link--no-visited-state' %>)
+                    </dd>
+                    <dt>GOV.UK payment state</dt>
+                    <dd>
+                      <strong class="govuk-tag app-tag--<%= payment_intent.state['status'] %>">
+                        <%= payment_intent.state['status'] %>
+                      </strong>
+                      <%= payment_intent.state['message'] %>
+                    </dd>
+                  <% end %>
+                </dl>
+              </td>
+              <td class="govuk-table__cell no-border">
+                <% if application.online_payment? && payment_intent %>
+                  <div class="govuk-warning-text govuk-!-margin-bottom-0">
+                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <strong class="govuk-warning-text__text">
+                      <span class="govuk-warning-text__assistive">Warning</span>
+                      <% if payment_intent.in_progress? %>
+                        Online payment still in progress. Online payments, if not completed, will time out after 90 minutes of being created.
+                      <% else %>
+                        Online payment has failed. If the applicant is unable to resume their application, it can be completed manually.
+
+                        <p class="govuk-body govuk-body govuk-!-margin-top-3">
+                          Note: in order to proceed, the payment method will be reassigned as <strong>phone</strong>.
+                        </p>
+
+                        <%= button_to 'Complete this application', backoffice_dashboard_complete_application_path(application),
+                                      method: :put, data: { confirm: 'Are you sure?' }, class: 'govuk-button' %>
+                      <% end %>
+                    </strong>
+                  </div>
+                <% end %>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/backoffice/dashboard/_lookup_form.en.html.erb
+++ b/app/views/backoffice/dashboard/_lookup_form.en.html.erb
@@ -4,6 +4,8 @@
 
 <p class="govuk-body">
   This will search the given reference in the historical audit table, no matter how old the application is.
+  <br/>
+  Incomplete applications can also be searched, as long as they are still in the database.
 </p>
 
 <%= form_for(@form, url: lookup_backoffice_dashboard_index_path, html: { class: 'govuk-!-margin-bottom-5' }) do |f| %>

--- a/app/views/backoffice/dashboard/lookup.en.html.erb
+++ b/app/views/backoffice/dashboard/lookup.en.html.erb
@@ -6,6 +6,16 @@
 
     <%= render partial: 'lookup_form' %>
 
-    <%= render partial: 'results_table', locals: { report: @report } %>
+    <% if @application %>
+      <% if @application.is_a?(C100Application) %>
+        <%# This is an incomplete application and we show different details/actions %>
+        <%= render partial: 'incomplete_table', locals: { application: @application } %>
+      <% else %>
+        <%# This is a completed application so behave the same as the report of last 50 %>
+        <%= render partial: 'results_table', locals: { report: Array(@application) } %>
+      <% end %>
+    <% else %>
+      <%= render partial: 'results_table', locals: { report: @report } %>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
     # Auth0-protected routes
     resources :dashboard, only: [:index] do
       post :lookup, on: :collection
+      put :complete_application
     end
 
     resources :emails, only: [:index] do


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22084915

This is a first step towards improving the situation where some online payments are left incompleted by mistake, as the user think the pre-auth is the payment, and then their application is not submitted to court.

For saved applications it is not much of an issue as the user can resume their application and retry the payment.
But not-saved applications can't be resumed and the user might have to start over again from the beginning which is not great.

With this new functionality exposed in the back office, it is now possible to search the reference of an incomplete application and if found, will give some details.

If the online payment failed or expired (and the application was not already completed by other means) then there is a button to complete it ad-hoc, changing the payment method to "phone".

This is mainly intended for users that can't resume the application as they didn't save it and contact us in the helpdesk mailbox, and hopefully avoid them having to start over again.

Some refinements might need to come up as a follow-up PR.

<img width="890" alt="Screenshot 2020-10-08 at 12 14 41" src="https://user-images.githubusercontent.com/687910/95452853-cebe7c80-0961-11eb-8775-afa9b88a26f3.png">
