### PR TITLE
Cleanup list of slugs blocked for online payments

### DIFF
--- a/config/govuk_pay.yml
+++ b/config/govuk_pay.yml
@@ -5,25 +5,3 @@
 
 blocklist:
   - blocklisted-slug-example
-
-  # Following slugs to be removed in 3 weeks. All these had their GBS code
-  # previously set, and now it has been unset, but existing applications
-  # in our database will still have it for a while.
-  #
-  - canterbury-combined-court-centre
-  - carmarthen-county-court-and-family-court
-  - chester-civil-and-family-justice-centre
-  - clerkenwell-and-shoreditch-county-court-and-family-court
-  - crewe-county-court-and-family-court
-  - dartford-county-court-and-family-court
-  - dudley-county-court-and-family-court
-  - haverfordwest-county-court-and-family-court
-  - hertford-county-court-and-family-court
-  - isle-of-wight-combined-court
-  - maidstone-combined-court-centre
-  - staines-county-court-and-family-court
-  - thanet-county-court-and-family-court
-  - torquay-and-newton-abbot-county-court-and-family-court
-  - uxbridge-county-court-and-family-court
-  - weymouth-combined-court
-  - yeovil-county-family-and-magistrates-court

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -20,24 +20,6 @@ RSpec.describe ValidPaymentsArray do
         subject.pay_blocklist
       ).to match_array(%w(
         blocklisted-slug-example
-
-        canterbury-combined-court-centre
-        carmarthen-county-court-and-family-court
-        chester-civil-and-family-justice-centre
-        clerkenwell-and-shoreditch-county-court-and-family-court
-        crewe-county-court-and-family-court
-        dartford-county-court-and-family-court
-        dudley-county-court-and-family-court
-        haverfordwest-county-court-and-family-court
-        hertford-county-court-and-family-court
-        isle-of-wight-combined-court
-        maidstone-combined-court-centre
-        staines-county-court-and-family-court
-        thanet-county-court-and-family-court
-        torquay-and-newton-abbot-county-court-and-family-court
-        uxbridge-county-court-and-family-court
-        weymouth-combined-court
-        yeovil-county-family-and-magistrates-court
       ))
     end
   end


### PR DESCRIPTION
This was introduced as a temporary measure while existing applications in the database refreshed their GBS code.

There is no longer a need to explicitly block these, as all the existing applications (and future ones) will have the GBS code of these courts to `nil` or `unknown` so will be automatically blocked from taking online payments.