### PR TITLE
Track more precisely CYA change links

### DIFF
--- a/app/views/steps/completion/shared/_change_link.html.erb
+++ b/app/views/steps/completion/shared/_change_link.html.erb
@@ -1,5 +1,7 @@
 <% if question.show_change_link? %>
   <%
+    link_ga_label = question.is_a?(Summary::AnswersGroup) ? question.name : question.question
+
     a11y_question = if question.is_a?(Summary::AnswersGroup)
                       t("check_answers_html.groups.#{question.name}")
                     else
@@ -13,7 +15,7 @@
                     end
   %>
 
-  <%= link_to question.change_path, class: 'govuk-link govuk-link--no-visited-state ga-pageLink', data: { ga_category: 'check your answers', ga_label: 'change link' } do %>
+  <%= link_to question.change_path, class: 'govuk-link govuk-link--no-visited-state ga-pageLink', data: { ga_category: 'check your answers', ga_label: "change link: #{link_ga_label}" } do %>
     <%= t('check_answers_html.change_link_html', a11y_question: a11y_question) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/18923107

This small tweak is related to the above ticket and will allow us to track more precisely which "change" links are more frequently clicked in the CYA page.

Instead of just having an event with a "change link" label, the label now will be a bit more specific, for example: `change link: miam_certification_details`.

This will then allow us to make an informed decision on what kind of improvements we can make to return the user back to the CYA after they've changed something.