### PR TITLE
Copy tweak in PDF miam certification section

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,8 +35,9 @@ class SessionsController < ApplicationController
       court: find_or_initialize_court,
       status: 1,
       # fill out the first steps, so `save and return` button shows
-      consent_order: 'no',
-      child_protection_cases: 'no',
+      # if a value already exists we use it
+      consent_order: c100_application.consent_order.presence || 'no',
+      child_protection_cases: c100_application.child_protection_cases.presence || 'no',
     )
 
     redirect_to edit_steps_application_check_your_answers_path

--- a/app/presenters/summary/sections/miam_requirement.rb
+++ b/app/presenters/summary/sections/miam_requirement.rb
@@ -12,8 +12,10 @@ module Summary
       def answers
         [
           Partial.new(:miam_information),
-          Answer.new(:miam_consent_order,        c100.consent_order,          default: default_value),
-          Answer.new(:miam_child_protection,     c100.child_protection_cases, default: default_value),
+
+          Answer.new(:miam_consent_order,        c100.consent_order),
+          Answer.new(:miam_child_protection,     c100.child_protection_cases),
+
           Answer.new(:miam_exemption_claim,      c100.miam_exemption_claim,   default: default_value),
           Answer.new(:miam_certificate_received, c100.miam_certification,     default: default_value),
           Answer.new(:miam_attended,             c100.miam_attended,          default: default_value),
@@ -22,7 +24,11 @@ module Summary
 
       private
 
+      # For consent orders or child protection cases we don't ask the applicant
+      # the MIAM certification questions, as these do not apply.
       def default_value
+        return :not_applicable if c100.consent_order? || c100.child_protection_cases?
+
         GenericYesNo::NO
       end
     end

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -370,14 +370,17 @@ en:
       question: Are you claiming exemption from the requirement to attend a MIAM?
       answers:
         <<: *YESNO
+        not_applicable: *not_applicable
     miam_certificate_received:
       question: Have you got a signed document from the mediator?
       answers:
         <<: *YESNO
+        not_applicable: *not_applicable
     miam_attended:
       question: Have you attended a MIAM?
       answers:
         <<: *YESNO
+        not_applicable: *not_applicable
     miam_certification_number:
       question: FMC registration no
     miam_certification_service_name:

--- a/spec/presenters/summary/sections/miam_requirement_spec.rb
+++ b/spec/presenters/summary/sections/miam_requirement_spec.rb
@@ -29,6 +29,14 @@ module Summary
     # of sync, which means a quite solid safety net for any maintainers in the future.
     #
     describe '#answers' do
+      let(:consent_order) { false }
+      let(:child_protection_cases) { false }
+
+      before do
+        allow(c100_application).to receive(:consent_order?).and_return(consent_order)
+        allow(c100_application).to receive(:child_protection_cases?).and_return(child_protection_cases)
+      end
+
       it 'has the correct rows' do
         expect(answers.count).to eq(6)
 
@@ -56,41 +64,85 @@ module Summary
         expect(answers[5].value).to eq('yes')
       end
 
-      context 'uses the default when value is `nil`' do
-        let(:c100_application) {
-          instance_double(C100Application,
-            consent_order: nil,
-            child_protection_cases: nil,
-            miam_exemption_claim: nil,
-            miam_certification: nil,
-            miam_attended: nil,
+      context 'uses the default value' do
+        context 'for a consent order' do
+          let(:c100_application) {
+            instance_double(C100Application,
+              consent_order: 'yes',
+              child_protection_cases: 'no',
+              miam_exemption_claim: nil,
+              miam_certification: nil,
+              miam_attended: nil,
           ) }
 
-        it 'has the correct rows' do
-          expect(answers.count).to eq(6)
+          let(:consent_order) { true }
 
-          expect(answers[0]).to be_an_instance_of(Partial)
-          expect(answers[0].name).to eq(:miam_information)
+          it 'has the correct rows' do
+            expect(answers.count).to eq(6)
 
-          expect(answers[1]).to be_an_instance_of(Answer)
-          expect(answers[1].question).to eq(:miam_consent_order)
-          expect(answers[1].value).to eq(GenericYesNo::NO)
+            expect(answers[0]).to be_an_instance_of(Partial)
+            expect(answers[0].name).to eq(:miam_information)
 
-          expect(answers[2]).to be_an_instance_of(Answer)
-          expect(answers[2].question).to eq(:miam_child_protection)
-          expect(answers[2].value).to eq(GenericYesNo::NO)
+            expect(answers[1]).to be_an_instance_of(Answer)
+            expect(answers[1].question).to eq(:miam_consent_order)
+            expect(answers[1].value).to eq('yes')
 
-          expect(answers[3]).to be_an_instance_of(Answer)
-          expect(answers[3].question).to eq(:miam_exemption_claim)
-          expect(answers[3].value).to eq(GenericYesNo::NO)
+            expect(answers[2]).to be_an_instance_of(Answer)
+            expect(answers[2].question).to eq(:miam_child_protection)
+            expect(answers[2].value).to eq('no')
 
-          expect(answers[4]).to be_an_instance_of(Answer)
-          expect(answers[4].question).to eq(:miam_certificate_received)
-          expect(answers[4].value).to eq(GenericYesNo::NO)
+            expect(answers[3]).to be_an_instance_of(Answer)
+            expect(answers[3].question).to eq(:miam_exemption_claim)
+            expect(answers[3].value).to eq(:not_applicable)
 
-          expect(answers[5]).to be_an_instance_of(Answer)
-          expect(answers[5].question).to eq(:miam_attended)
-          expect(answers[5].value).to eq(GenericYesNo::NO)
+            expect(answers[4]).to be_an_instance_of(Answer)
+            expect(answers[4].question).to eq(:miam_certificate_received)
+            expect(answers[4].value).to eq(:not_applicable)
+
+            expect(answers[5]).to be_an_instance_of(Answer)
+            expect(answers[5].question).to eq(:miam_attended)
+            expect(answers[5].value).to eq(:not_applicable)
+          end
+        end
+
+        context 'for a case with child protection' do
+          let(:c100_application) {
+            instance_double(C100Application,
+              consent_order: 'no',
+              child_protection_cases: 'yes',
+              miam_exemption_claim: nil,
+              miam_certification: nil,
+              miam_attended: nil,
+          ) }
+
+          let(:child_protection_cases) { true }
+
+          it 'has the correct rows' do
+            expect(answers.count).to eq(6)
+
+            expect(answers[0]).to be_an_instance_of(Partial)
+            expect(answers[0].name).to eq(:miam_information)
+
+            expect(answers[1]).to be_an_instance_of(Answer)
+            expect(answers[1].question).to eq(:miam_consent_order)
+            expect(answers[1].value).to eq('no')
+
+            expect(answers[2]).to be_an_instance_of(Answer)
+            expect(answers[2].question).to eq(:miam_child_protection)
+            expect(answers[2].value).to eq('yes')
+
+            expect(answers[3]).to be_an_instance_of(Answer)
+            expect(answers[3].question).to eq(:miam_exemption_claim)
+            expect(answers[3].value).to eq(:not_applicable)
+
+            expect(answers[4]).to be_an_instance_of(Answer)
+            expect(answers[4].question).to eq(:miam_certificate_received)
+            expect(answers[4].value).to eq(:not_applicable)
+
+            expect(answers[5]).to be_an_instance_of(Answer)
+            expect(answers[5].question).to eq(:miam_attended)
+            expect(answers[5].value).to eq(:not_applicable)
+          end
         end
       end
     end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22085448

This is related to the MIAM certification rework that is undergoing, however is somehow unrelated and just a minor copy change to make it more clear some sections does not apply if the applicant is exempt from going to MIAM due to a consent order, or child protection cases.

Before it looked like the applicant had answered those questions with NO, however, that's not how it works, because if the applicant is exempt due to any of the first 2 questions (consent or child protection cases) then the rest of the miam certification questions are skipped, thus the applicant is not really answering with NO, is the system who is marking those as not required.

We use the same copy as we use in other places to mark not required sections, for consistency.

Also, removed the default value for these 2 initial questions because these are mandatory, can't be left unanswered so the default value is not needed.

### Before
<img width="846" alt="Screenshot 2020-10-14 at 15 22 13" src="https://user-images.githubusercontent.com/687910/96104278-8c042380-0ed0-11eb-81a0-a950d862c060.png">

### After
<img width="842" alt="Screenshot 2020-10-14 at 15 45 08" src="https://user-images.githubusercontent.com/687910/96104319-9b836c80-0ed0-11eb-9588-a6798c5c8730.png">

