### PR TITLE
Hotfix for Court Tribunal Finder invalid certificate

### DIFF
--- a/app/services/c100_app/courtfinder_api.rb
+++ b/app/services/c100_app/courtfinder_api.rb
@@ -16,6 +16,7 @@ module C100App
       open_timeout: 10,
       read_timeout: 20,
       use_ssl: true,
+      verify_mode: OpenSSL::SSL::VERIFY_NONE, # HORRIBLE TEMP WORKAROUND
     }.freeze
 
     def self.court_url(slug)

--- a/spec/services/c100_app/courtfinder_api_spec.rb
+++ b/spec/services/c100_app/courtfinder_api_spec.rb
@@ -49,7 +49,7 @@ describe C100App::CourtfinderAPI do
         expect(
           Net::HTTP
         ).to receive(:start).with(
-          'courttribunalfinder.service.gov.uk', 443, :ENV, { open_timeout: 10, read_timeout: 20, use_ssl: true }
+          'courttribunalfinder.service.gov.uk', 443, :ENV, { open_timeout: 10, read_timeout: 20, use_ssl: true, verify_mode: 0 }
         ).and_return(response_double)
 
         subject.court_for('Children', 'MK9 3DX')


### PR DESCRIPTION
There seem to be some problem verifying the Ghandi certificate but as CTF might need to either update or change certificate (maybe to Let's encrypt) and that might take a while, this at least makes the API calls to CTF work again despite being a horrible workaround.

We will re-evaluate in the coming days and hopefully we can get rid of it soon.