### PR TITLE
Revert "Hotfix for Court Tribunal Finder invalid certificate"

### DIFF
--- a/app/services/c100_app/courtfinder_api.rb
+++ b/app/services/c100_app/courtfinder_api.rb
@@ -16,7 +16,6 @@ module C100App
       open_timeout: 10,
       read_timeout: 20,
       use_ssl: true,
-      verify_mode: OpenSSL::SSL::VERIFY_NONE, # HORRIBLE TEMP WORKAROUND
     }.freeze
 
     def self.court_url(slug)

--- a/spec/services/c100_app/courtfinder_api_spec.rb
+++ b/spec/services/c100_app/courtfinder_api_spec.rb
@@ -49,7 +49,7 @@ describe C100App::CourtfinderAPI do
         expect(
           Net::HTTP
         ).to receive(:start).with(
-          'courttribunalfinder.service.gov.uk', 443, :ENV, { open_timeout: 10, read_timeout: 20, use_ssl: true, verify_mode: 0 }
+          'courttribunalfinder.service.gov.uk', 443, :ENV, { open_timeout: 10, read_timeout: 20, use_ssl: true }
         ).and_return(response_double)
 
         subject.court_for('Children', 'MK9 3DX')


### PR DESCRIPTION
This reverts commit b2ad1146f3c41538c6e7b9daef199b8f05e50b49.

Problems with CTF certificate seems to have been solved now. We didn't need to release this to PROD after all.