### PR TITLE
Refactor `update_navigation_stack` code into separate class

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -107,13 +107,8 @@ class StepController < ApplicationController
   end
 
   def update_navigation_stack
-    return unless current_c100_application
-
-    stack_until_current_page = current_c100_application.navigation_stack.take_while do |path|
-      path != request.fullpath
-    end
-
-    current_c100_application.navigation_stack = stack_until_current_page + [request.fullpath]
-    current_c100_application.save!(touch: false)
+    C100App::NavigationStack.new(
+      current_c100_application, request
+    ).update!
   end
 end

--- a/app/services/c100_app/navigation_stack.rb
+++ b/app/services/c100_app/navigation_stack.rb
@@ -1,0 +1,44 @@
+module C100App
+  class NavigationStack
+    attr_reader :c100_application, :request
+
+    CYA_FUNNEL = %w[
+      /steps/application/payment
+      /steps/application/check_your_answers
+    ].freeze
+
+    def initialize(c100_application, request)
+      @c100_application = c100_application
+      @request = request
+    end
+
+    # This method serves two purposes, related one with another:
+    #
+    #   1. Set a session flag if a page is visited through the CYA `change` link,
+    #      so we can return the user back to the CYA again if possible, but only
+    #      if they've already completed all the steps (thus the funnel).
+    #
+    #   2. Update the `navigation_stack` record attribute, used for the `back` links.
+    #
+    def update!
+      session[:cya_origin] = CYA_FUNNEL.eql?(
+        c100_application.navigation_stack.last(CYA_FUNNEL.size)
+      )
+
+      stack_until_current_page = c100_application.navigation_stack.take_while { |path| !path.eql?(current_path) }
+
+      c100_application.navigation_stack = stack_until_current_page + [current_path]
+      c100_application.save!(touch: false)
+    end
+
+    private
+
+    def session
+      request.session
+    end
+
+    def current_path
+      request.fullpath
+    end
+  end
+end

--- a/spec/controllers/step_controller_spec.rb
+++ b/spec/controllers/step_controller_spec.rb
@@ -19,13 +19,8 @@ RSpec.describe DummyStepController, type: :controller do
   end
 
   describe 'navigation stack' do
-    let!(:c100_application) { C100Application.create(navigation_stack: navigation_stack, updated_at: updated_at) }
-    let(:updated_at) { Time.at(0) }
-
-    before do
-      get :show, session: { c100_application_id: c100_application.id }
-      c100_application.reload
-    end
+    let!(:c100_application) { C100Application.create }
+    let(:navigation_stack) { double.as_null_object }
 
     # In these tests we are persisting the application record,
     # so we need to cleanup after we are finished with it.
@@ -33,32 +28,14 @@ RSpec.describe DummyStepController, type: :controller do
       c100_application.destroy
     end
 
-    context 'when the stack is empty' do
-      let(:navigation_stack) { [] }
+    it 'handles the navigation stack update' do
+      expect(
+        C100App::NavigationStack
+      ).to receive(:new).with(c100_application, anything).and_return(navigation_stack)
 
-      it 'adds the page to the stack' do
-        expect(c100_application.navigation_stack).to eq(['/dummy_step'])
-      end
+      expect(navigation_stack).to receive(:update!)
 
-      it 'does not `touch` timestamps on save' do
-        expect(c100_application.updated_at).to eq(updated_at)
-      end
-    end
-
-    context 'when the current page is on the stack' do
-      let(:navigation_stack) { ['/foo', '/bar', '/dummy_step', '/baz'] }
-
-      it 'rewinds the stack to the appropriate point' do
-        expect(c100_application.navigation_stack).to eq(['/foo', '/bar', '/dummy_step'])
-      end
-    end
-
-    context 'when the current page is not on the stack' do
-      let(:navigation_stack) { ['/foo', '/bar', '/baz'] }
-
-      it 'adds it to the end of the stack' do
-        expect(c100_application.navigation_stack).to eq(['/foo', '/bar', '/baz', '/dummy_step'])
-      end
+      get :show, session: { c100_application_id: c100_application.id }
     end
   end
 

--- a/spec/services/c100_app/navigation_stack_spec.rb
+++ b/spec/services/c100_app/navigation_stack_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe C100App::NavigationStack do
+  subject { described_class.new(c100_application, request) }
+
+  let(:c100_application) { C100Application.new(navigation_stack: navigation_stack) }
+  let(:request) { double('Request', session: session, fullpath: '/dummy_step') }
+  let(:session) { double('Session') }
+
+  let(:navigation_stack) { [] }
+
+  before do
+    allow(session).to receive(:[]=)
+    allow(c100_application).to receive(:save!)
+  end
+
+  describe '#update!' do
+    it 'does not `touch` timestamps on save' do
+      expect(c100_application).to receive(:save!).with(touch: false)
+      subject.update!
+    end
+
+    it 'sets the CYA origin flag to `false`' do
+      expect(session).to receive(:[]=).with(:cya_origin, false)
+      subject.update!
+    end
+
+    context 'when the stack is empty' do
+      let(:navigation_stack) { [] }
+
+      it 'adds the page to the stack' do
+        subject.update!
+        expect(c100_application.navigation_stack).to eq(['/dummy_step'])
+      end
+    end
+
+    context 'when the current page is on the stack' do
+      let(:navigation_stack) { %w(/foo /bar /dummy_step /baz )}
+
+      it 'rewinds the stack to the appropriate point' do
+        subject.update!
+        expect(c100_application.navigation_stack).to eq(%w(/foo /bar /dummy_step))
+      end
+    end
+
+    context 'when the current page is not on the stack' do
+      let(:navigation_stack) { %w(/foo /bar /baz) }
+
+      it 'adds it to the end of the stack' do
+        subject.update!
+        expect(c100_application.navigation_stack).to eq(%w(/foo /bar /baz /dummy_step))
+      end
+    end
+
+    context 'when coming from check your answers' do
+      context 'for a complete funnel' do
+        let(:navigation_stack) { %w(/foo /bar /dummy_step /steps/application/payment /steps/application/check_your_answers)}
+
+        it 'sets the CYA origin flag to `true`' do
+          expect(session).to receive(:[]=).with(:cya_origin, true)
+          subject.update!
+        end
+      end
+
+      context 'for an incomplete funnel' do
+        let(:navigation_stack) { %w(/foo /bar /dummy_step /another_step /steps/application/check_your_answers)}
+
+        it 'sets the CYA origin flag to `false`' do
+          expect(session).to receive(:[]=).with(:cya_origin, false)
+          subject.update!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/18923107

This is the first part of a "potential" improvement to the check your answers page. Mainly a refactor at this point.

Main idea is to set a flag in the session if we detect the user accessed a page through the `change link` in the CYA. This flag will later on (in a follow-up PR) allow us to decide if we can take the user back straight to CYA.

In this PR we set the session flag but do nothing.