### PR TITLE
Enable some CYA changes to fast-forward back

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ AbcSize:
   Max: 24
 
 CyclomaticComplexity:
-  Max: 15
+  Max: 12
 
 Documentation:
   Enabled: false

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,7 +17,14 @@ module ApplicationHelper
   end
 
   # Render a back link pointing to the user's previous step
+  # or to the CYA page if using the fast-forward functionality.
+  # If a specific path is provided, it takes precedence.
+  #
   def step_header(path: nil)
+    if path.nil? && controller.fast_forward_to_cya?
+      path = edit_steps_application_check_your_answers_path
+    end
+
     render partial: 'layouts/step_header', locals: {
       path: path || controller.previous_step_path
     }

--- a/spec/controllers/step_controller_spec.rb
+++ b/spec/controllers/step_controller_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe DummyStepController, type: :controller do
     end
   end
 
+  describe '#fast_forward_to_cya?' do
+    let(:c100_application) { double('C100Application') }
+    let(:request) { double('Request') }
+    let(:navigation_stack) { double.as_null_object }
+
+    before do
+      allow(subject).to receive(:current_c100_application).and_return(c100_application)
+      allow(subject).to receive(:request).and_return(request)
+    end
+
+    it 'queries the navigation stack to see if fast forward is available' do
+      expect(
+        C100App::NavigationStack
+      ).to receive(:new).with(c100_application, request).and_return(navigation_stack)
+
+      expect(navigation_stack).to receive(:fast_forward_to_cya?)
+
+      subject.fast_forward_to_cya?
+    end
+  end
+
   # Note this method is private as it is used via another method but as the logic
   # is quite self contained it makes sense to test it in isolation.
   #

--- a/spec/controllers/steps/abuse_concerns/details_controller_spec.rb
+++ b/spec/controllers/steps/abuse_concerns/details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::AbuseConcerns::DetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::AbuseConcerns::DetailsForm, C100App::AbuseConcernsDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::AbuseConcerns::DetailsForm
 end

--- a/spec/controllers/steps/application/details_controller_spec.rb
+++ b/spec/controllers/steps/application/details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Application::DetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Application::DetailsForm, C100App::ApplicationDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Application::DetailsForm
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,6 +5,10 @@ class ActionView::TestCase::TestController
   def previous_step_path
     '/foo/bar'
   end
+
+  def fast_forward_to_cya?
+    false
+  end
 end
 
 RSpec.describe ApplicationHelper, type: :helper do
@@ -57,6 +61,17 @@ RSpec.describe ApplicationHelper, type: :helper do
         assign(:form_object, form_object)
 
         expect(helper.step_header(path: '/another/step')).to eq('foobar')
+      end
+    end
+
+    context 'when using fast-forward to CYA' do
+      it 'renders the back link with the check your answers path' do
+        expect(controller).to receive(:fast_forward_to_cya?).and_return(true)
+
+        expect(helper).to receive(:render).with(partial: 'layouts/step_header', locals: {path: '/steps/application/check_your_answers'}).and_return('foobar')
+        assign(:form_object, form_object)
+
+        expect(helper.step_header).to eq('foobar')
       end
     end
   end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/18923107

Follow-up to PR #1105.

This is the actual implementation of the fast-forward functionality, that started with the previous PR.

For now there is just a handful of steps that have this enabled, defined as regexp in `FAST_FORWARD_STEPS`.

Basically all the abuse concerns detail steps either for applicant or children, and the application details step.
This is mainly a proof of concept, so starting small and we will think how to scale up.

Exposed a helper method `#fast_forward_to_cya?` that can be used in the `#update_and_advance` to know if after updating a form object it can jump straight back to the CYA page, and is also used in the `#step_header` method, so we can modify the `back link` to point to the CYA as well.

I had fun with the navigation stack. Basically when using fast forward we can't really use it, otherwise if jumping from CYA to any intermediate step, will remove from the stack all the following steps from that intermediate point up until the CYA.

So I came to the conclusion that when using the fast-forward, we can let the navigation stack intact, so when returning to CYA everything is still there as if the user would have go one by one through all the intermediate steps again (pretty much as it happens with any other step not having fast-forward enabled).