### PR TITLE
Skip persist if submission form has not changed

### DIFF
--- a/app/forms/steps/application/submission_form.rb
+++ b/app/forms/steps/application/submission_form.rb
@@ -11,7 +11,7 @@ module Steps
 
       def changed?
         !c100_application.submission_type.eql?(submission_type) ||
-          !c100_application.receipt_email.eql?(receipt_email)
+          !c100_application.receipt_email.to_s.eql?(receipt_email)
       end
 
       def online_submission?

--- a/spec/forms/steps/application/submission_form_spec.rb
+++ b/spec/forms/steps/application/submission_form_spec.rb
@@ -90,11 +90,10 @@ RSpec.describe Steps::Application::SubmissionForm do
 
       context 'when submission type is `print_and_post`' do
         let(:submission_type) { SubmissionType::PRINT_AND_POST.to_s }
-        let(:receipt_email) { '' }
 
         context 'when the form has changed' do
           let(:c100_application) {
-            instance_double(C100Application, submission_type: submission_type, receipt_email: nil)
+            instance_double(C100Application, submission_type: submission_type, receipt_email: 'foo@bar')
           }
 
           it 'saves the record' do
@@ -110,7 +109,7 @@ RSpec.describe Steps::Application::SubmissionForm do
 
         context 'when the form has not changed' do
           let(:c100_application) {
-            instance_double(C100Application, submission_type: submission_type, receipt_email: receipt_email)
+            instance_double(C100Application, submission_type: submission_type, receipt_email: nil)
           }
 
           it 'does not save the record but returns true' do


### PR DESCRIPTION
While doing many many rounds of tests for the previous PRs (CYA fast forward) I realised there was a scenario where the submission form would perform a `#persist!` even tho it was not strictly neccessary.

This is because in the database the `receipt_email` attribute can be nil while the form param sent is an empty string.

Tweaked the condition equality so it compares always strings even if these are empty.