### PR TITLE
Add more steps to CYA fast-forward

### DIFF
--- a/app/services/c100_app/navigation_stack.rb
+++ b/app/services/c100_app/navigation_stack.rb
@@ -9,6 +9,10 @@ module C100App
 
     FAST_FORWARD_STEPS = [
       %r{^/steps/abuse_concerns/details.*},
+      %r{^/steps/.+/personal_details.*},
+      %r{^/steps/.+/address_details.*},
+      %r{^/steps/.+/contact_details.*},
+      %r{^/steps/children/additional_details$},
       %r{^/steps/application/details$},
     ].freeze
 

--- a/spec/controllers/steps/applicant/contact_details_controller_spec.rb
+++ b/spec/controllers/steps/applicant/contact_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Applicant::ContactDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Applicant::ContactDetailsForm, C100App::ApplicantDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Applicant::ContactDetailsForm
 end

--- a/spec/controllers/steps/applicant/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/applicant/personal_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Applicant::PersonalDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Applicant::PersonalDetailsForm, C100App::ApplicantDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Applicant::PersonalDetailsForm
 end

--- a/spec/controllers/steps/children/additional_details_controller_spec.rb
+++ b/spec/controllers/steps/children/additional_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Children::AdditionalDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Children::AdditionalDetailsForm, C100App::ChildrenDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Children::AdditionalDetailsForm
 end

--- a/spec/controllers/steps/children/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/children/personal_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Children::PersonalDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Children::PersonalDetailsForm, C100App::ChildrenDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Children::PersonalDetailsForm
 end

--- a/spec/controllers/steps/other_children/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/other_children/personal_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::OtherChildren::PersonalDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::OtherChildren::PersonalDetailsForm, C100App::OtherChildrenDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::OtherChildren::PersonalDetailsForm
 end

--- a/spec/controllers/steps/other_party/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/other_party/personal_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::OtherParty::PersonalDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::OtherParty::PersonalDetailsForm, C100App::OtherPartyDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::OtherParty::PersonalDetailsForm
 end

--- a/spec/controllers/steps/respondent/contact_details_controller_spec.rb
+++ b/spec/controllers/steps/respondent/contact_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Respondent::ContactDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Respondent::ContactDetailsForm, C100App::RespondentDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Respondent::ContactDetailsForm
 end

--- a/spec/controllers/steps/respondent/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/respondent/personal_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Respondent::PersonalDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Respondent::PersonalDetailsForm, C100App::RespondentDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Respondent::PersonalDetailsForm
 end

--- a/spec/controllers/steps/solicitor/contact_details_controller_spec.rb
+++ b/spec/controllers/steps/solicitor/contact_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Solicitor::ContactDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Solicitor::ContactDetailsForm, C100App::SolicitorDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Solicitor::ContactDetailsForm
 end

--- a/spec/controllers/steps/solicitor/personal_details_controller_spec.rb
+++ b/spec/controllers/steps/solicitor/personal_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Solicitor::PersonalDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Solicitor::PersonalDetailsForm, C100App::SolicitorDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Solicitor::PersonalDetailsForm
 end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/18923107

Follow-up to previous PR #1106.

Add some more steps that can safely do a fast-forward to the CYA when editing something.

More to come in next PRs but I think for now these will cover a good chunk of the potential changes a user might need to do.

It will most likely be that we can enable the fast-forward for any step with ends with `_details` so eventually we will be able to simplify a lot the regex but for now it is easier to add one at a time.