### PR TITLE
Reintroduce the research consent step

### DIFF
--- a/app/controllers/steps/opening/research_consent_controller.rb
+++ b/app/controllers/steps/opening/research_consent_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Opening
+    class ResearchConsentController < Steps::OpeningStepController
+      def edit
+        @form_object = ResearchConsentForm.build(current_c100_application)
+      end
+
+      def update
+        update_and_advance(ResearchConsentForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/opening/research_consent_form.rb
+++ b/app/forms/steps/opening/research_consent_form.rb
@@ -1,0 +1,14 @@
+module Steps
+  module Opening
+    class ResearchConsentForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :research_consent, reset_when_no: [:research_consent_email]
+
+      attribute :research_consent_email, NormalisedEmail
+
+      validates_presence_of :research_consent_email, if: -> { research_consent&.yes? }
+      validates :research_consent_email, email: true, allow_blank: true, if: -> { research_consent&.yes? }
+    end
+  end
+end

--- a/app/services/c100_app/opening_decision_tree.rb
+++ b/app/services/c100_app/opening_decision_tree.rb
@@ -6,6 +6,8 @@ module C100App
       case step_name
       when :children_postcode
         check_if_court_is_valid
+      when :research_consent
+        edit(:consent_order)
       when :consent_order
         after_consent_order
       when :child_protection_cases
@@ -26,7 +28,12 @@ module C100App
 
       if court
         c100_application.update!(court: court)
-        edit(:consent_order)
+
+        if Rails.configuration.x.opening.hide_research_consent_step
+          edit(:consent_order)
+        else
+          edit(:research_consent)
+        end
       else
         show(:no_court_found)
       end

--- a/app/views/steps/opening/research_consent/edit.html.erb
+++ b/app/views/steps/opening/research_consent/edit.html.erb
@@ -1,0 +1,30 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :research_consent do %>
+        <%= f.govuk_radio_button :research_consent, GenericYesNo::YES, link_errors: true do %>
+          <%= f.govuk_email_field :research_consent_email, width: 'three-quarters', autocomplete: 'email', spellcheck: 'false' %>
+        <% end  %>
+        <%= f.govuk_radio_button :research_consent, GenericYesNo::NO %>
+      <% end %>
+
+      <%= f.continue_button %>
+    <% end %>
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="explanations" data-ga-label="research consent">
+          <%=t '.details.summary' %>
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <%=t '.details.text_html' %>
+      </div>
+    </details>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,6 +59,10 @@ class Application < Rails::Application
   config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 60).to_i
   config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 
+  # Toggle on/off the `research consent` question (used to gather emails of users
+  # for research purposes). Enabled by default. Set this ENV variable to disable it.
+  config.x.opening.hide_research_consent_step = ENV.key?('HIDE_RESEARCH_CONSENT_STEP')
+
   # As part of the opening postcode step, an empty C100Application record is created.
   # If the postcode is not eligible, these records are left orphans and have no use.
   # We will only leave them for some time. Can be configured here.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -929,6 +929,19 @@ en:
             copy: You can go back and try again, or download the C100 paper form to print and fill in offline. You can then submit the completed form by post or in person at the court.
           go_back: Go back and try again
           download_c100_link: Download the form (PDF)
+      research_consent:
+        edit:
+          page_title: Research consent
+          details:
+            summary: What happens if you choose to be contacted
+            text_html: |
+              <p class="govuk-body">By choosing to be contacted by the Ministry of Justice (MOJ) you agree that your personal details and any information you give can be used by MOJ for research purposes.</p>
+              <h2 class="govuk-heading-m">The information we use</h2>
+              <p class="govuk-body">MOJ can use any information you provide, including your name and contact information (such as your email address).</p>
+              <h2 class="govuk-heading-m">Why we use this information</h2>
+              <p class="govuk-body">To get your thoughts on this service - for example, we might send you a satisfaction survey.</p>
+              <h2 class="govuk-heading-m">Data and your rights</h2>
+              <p class="govuk-body">You can find out how long we keep your data, your rights and how to contact us in our <a href="/about/privacy_consent" class="govuk-link">privacy policy</a>.</p>
       consent_order:
         edit:
           page_title: Application kind
@@ -1032,6 +1045,10 @@ en:
       # Opening steps
       steps_opening_postcode_form:
         children_postcode: Postcode
+      steps_opening_research_consent_form:
+        research_consent_email: Email address
+        research_consent_options:
+          <<: *YESNO
       steps_opening_consent_order_form:
         consent_order_options:
           'no': Child arrangements order, prohibited steps order, specific issue order, or to change or end an existing order
@@ -1422,6 +1439,8 @@ en:
         current_password: We need your current password to confirm your changes
       steps_international_jurisdiction_form:
         international_jurisdiction: For example, because a court in another country has the power to act (has jurisdiction).
+      steps_opening_research_consent_form:
+        research_consent: Your insights will help us improve the service.
       steps_opening_consent_order_form:
         consent_order_options:
           'no': This includes deciding who the children live with and where; stopping someone doing something; and resolving a specific matter
@@ -1554,6 +1573,8 @@ en:
     legend:
       steps_opening_consent_order_form:
         consent_order: What kind of application do you want to make?
+      steps_opening_research_consent_form:
+        research_consent: Are you willing to be contacted to share your experience of using this service?
       steps_opening_child_protection_cases_form:
         child_protection_cases: Are the children involved in any emergency protection, care or supervision proceedings (or have they been)?
 

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -115,6 +115,14 @@ en:
           attributes:
             consent_order:
               inclusion: Select what kind of application you want to make
+        steps/opening/research_consent_form:
+          attributes:
+            research_consent:
+              inclusion: Select yes if you’re willing to be contacted about using this service
+            research_consent_email:
+              invalid: *invalid_email_error
+              blank: *blank_email_error
+              typo: *email_typo_error
         steps/opening/child_protection_cases_form:
           attributes:
             child_protection_cases:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,7 @@ Rails.application.routes.draw do
       edit_step :postcode
       show_step :error_but_continue
       show_step :no_court_found
+      edit_step :research_consent
       edit_step :consent_order
       show_step :consent_order_sought
       edit_step :child_protection_cases

--- a/db/migrate/20201029112416_add_research_consent_fields.rb
+++ b/db/migrate/20201029112416_add_research_consent_fields.rb
@@ -1,0 +1,6 @@
+class AddResearchConsentFields < ActiveRecord::Migration[5.2]
+  def change
+    add_column :c100_applications, :research_consent, :string
+    add_column :c100_applications, :research_consent_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_21_112304) do
+ActiveRecord::Schema.define(version: 2020_10_29_112416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -147,6 +147,8 @@ ActiveRecord::Schema.define(version: 2020_10_21_112304) do
     t.text "permission_details"
     t.string "children_postcode"
     t.string "court_id"
+    t.string "research_consent"
+    t.string "research_consent_email"
     t.index ["court_id"], name: "index_c100_applications_on_court_id"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"

--- a/features/00_opening.feature
+++ b/features/00_opening.feature
@@ -14,6 +14,9 @@ Feature: Opening
   Scenario: Complete the opening
     When I fill in "Postcode" with "MK9 3DX"
     And I click the "Continue" button
+    Then I should see "Are you willing to be contacted to share your experience of using this service?"
+    And I should not see the save draft button
+    And I choose "No"
     Then I should see "What kind of application do you want to make?"
     And I should not see the save draft button
     And I choose "Child arrangements order, prohibited steps order, specific issue order, or to change or end an existing order"

--- a/spec/controllers/steps/opening/research_consent_controller_spec.rb
+++ b/spec/controllers/steps/opening/research_consent_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Opening::ResearchConsentController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Opening::ResearchConsentForm, C100App::OpeningDecisionTree
+end

--- a/spec/forms/steps/opening/research_consent_form_spec.rb
+++ b/spec/forms/steps/opening/research_consent_form_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Opening::ResearchConsentForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    research_consent: research_consent,
+    research_consent_email: research_consent_email,
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  let(:research_consent) { 'no' }
+  let(:research_consent_email) { nil }
+
+  subject { described_class.new(arguments) }
+
+  context 'when no c100_application is associated with the form' do
+    let(:c100_application) { nil }
+
+    it 'raises an error' do
+      expect { subject.save }.to raise_error(BaseForm::C100ApplicationNotFound)
+    end
+  end
+
+  context 'validations' do
+    it { should validate_presence_of(:research_consent, :inclusion) }
+
+    context 'research_consent_email attribute' do
+      let(:research_consent) { 'no' }
+
+      context 'when consent is `no`' do
+        it { should_not validate_presence_of(:research_consent_email) }
+      end
+
+      context 'when consent is `yes`' do
+        let(:research_consent) { 'yes' }
+
+        it { should validate_presence_of(:research_consent_email) }
+
+        context 'email is invalid' do
+          let(:research_consent_email) { 'xxx' }
+
+          it {
+            expect(subject).not_to be_valid
+            expect(subject.errors.added?(:research_consent_email, :invalid)).to eq(true)
+          }
+        end
+
+        context 'email domain contains a typo' do
+          let(:research_consent_email) { 'test@gamil.com' }
+
+          it {
+            expect(subject).not_to be_valid
+            expect(subject.errors.added?(:research_consent_email, :typo)).to eq(true)
+          }
+        end
+      end
+    end
+  end
+
+  describe '#save' do
+    context 'when form is valid' do
+      context 'when `research_consent` is `yes`' do
+        let(:research_consent) { 'yes' }
+        let(:research_consent_email) { 'test@example.com' }
+
+        it 'saves the record' do
+          expect(c100_application).to receive(:update).with(
+            research_consent: GenericYesNo::YES,
+            research_consent_email: research_consent_email,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when `research_consent` is `no`' do
+        let(:research_consent) { 'no' }
+
+        it 'saves the record' do
+          expect(c100_application).to receive(:update).with(
+            research_consent: GenericYesNo::NO,
+            research_consent_email: nil,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22337703

In order to plan for user research and to gather participants, we are reintroducing a step we had some months ago and got removed as part of the removal of the screener.

It will show right after the postcode step, and can be disabled by setting an ENV variable `HIDE_RESEARCH_CONSENT_STEP` in case we want to stop showing this step to users.

Some copy amendments have been made but overall is pretty much the same as it was before.