### PR TITLE
Copy tweaks to the payment error page

### DIFF
--- a/app/views/errors/payment_error.html.erb
+++ b/app/views/errors/payment_error.html.erb
@@ -12,6 +12,12 @@
       <%=t '.more_text' %>
     </p>
 
+    <h2 class="govuk-heading-m"><%=t '.what_now_heading' %></h2>
+
+    <p class="govuk-body">
+      <%=t '.what_now_html' %>
+    </p>
+
     <p class="govuk-body govuk-!-margin-top-8">
       <%= link_button t('shared.retry_payment'), edit_steps_application_check_your_answers_path, class: 'ga-pageLink govuk-!-margin-right-1',
                       data: { module: 'govuk-button', ga_category: 'online payments', ga_label: 'retry payment' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1021,8 +1021,13 @@ en:
     payment_error:
       page_title: Payment error
       heading: Your payment was not completed
-      lead_text: No money has been taken from your account.
-      more_text: There are a few different reasons that payments fail. You can either try again or choose another way to pay.
+      lead_text: No money has been taken from your account and your application has not been submitted.
+      more_text: There are a few different reasons that payments fail.
+      what_now_heading: What to do now
+      what_now_html: |
+        <p class="govuk-body">Try payment again or choose another way to pay.</p>
+        <p class="govuk-body">You may see the payment amount as a pending or pre-authorised transaction in your bank account, but the money will not leave your account.</p>
+        <p class="govuk-body">Depending on your bank, pending or pre-authorised transactions should clear in 7 working days.</p>
 
   helpers:
     label:
@@ -1816,7 +1821,7 @@ en:
   shared:
     start_again: Start again
     retry_payment: Try payment again
-    change_payment: Change payment method
+    change_payment: Choose another way to pay
     finish: Finish
     back_link: Back
     password_toggle:


### PR DESCRIPTION
Following some concerns about users not understanding why they have a pre-auth transaction, this PR tweaks the copy as per content designer to explain a bit more.