### PR TITLE
Create solicitor address details step

### DIFF
--- a/app/controllers/steps/solicitor/address_details_controller.rb
+++ b/app/controllers/steps/solicitor/address_details_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Solicitor
+    class AddressDetailsController < Steps::SolicitorStepController
+      def edit
+        @form_object = AddressDetailsForm.build(
+          c100_application: current_c100_application
+        )
+      end
+
+      def update
+        update_and_advance(AddressDetailsForm, as: :address_details)
+      end
+    end
+  end
+end

--- a/app/forms/steps/solicitor/address_details_form.rb
+++ b/app/forms/steps/solicitor/address_details_form.rb
@@ -1,0 +1,26 @@
+module Steps
+  module Solicitor
+    class AddressDetailsForm < BaseForm
+      include HasOneAssociationForm
+
+      has_one_association :solicitor
+
+      attribute :address, StrippedString
+
+      validates_presence_of :address
+
+      # Used to present the solicitor's name in the view
+      delegate :full_name, to: :record_to_persist
+
+      private
+
+      def persist!
+        raise C100ApplicationNotFound unless c100_application
+
+        record_to_persist.update(
+          attributes_map
+        )
+      end
+    end
+  end
+end

--- a/app/views/steps/solicitor/address_details/edit.html.erb
+++ b/app/views/steps/solicitor/address_details/edit.html.erb
@@ -1,0 +1,18 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+
+    <h1 class="govuk-heading-xl">
+      <%= t '.heading', name: @form_object.full_name %>
+    </h1>
+
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_text_area :address %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,6 +385,10 @@ en:
           page_title: Details of solicitor
           heading: Details of solicitor
           lead_text: This is the person who’s been instructed to act in these proceedings.
+      address_details:
+        edit:
+          page_title: Address details of solicitor
+          heading: "Address details of %{name}"
       contact_details:
         edit:
           page_title: Contact details of solicitor

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,6 +235,7 @@ Rails.application.routes.draw do
     end
     namespace :solicitor do
       edit_step :personal_details
+      edit_step :address_details
       edit_step :contact_details
     end
     namespace :respondent do

--- a/spec/controllers/steps/solicitor/address_details_controller_spec.rb
+++ b/spec/controllers/steps/solicitor/address_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Solicitor::AddressDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Solicitor::AddressDetailsForm, C100App::SolicitorDecisionTree
+end

--- a/spec/forms/steps/solicitor/address_details_form_spec.rb
+++ b/spec/forms/steps/solicitor/address_details_form_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Solicitor::AddressDetailsForm do
+  let(:arguments) { {
+    c100_application: c100_application,
+    address: 'address',
+  } }
+
+  let(:c100_application) { instance_double(C100Application) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'validations' do
+      it { should validate_presence_of(:address) }
+    end
+
+    it_behaves_like 'a has-one-association form',
+                    association_name: :solicitor,
+                    expected_attributes: {
+                      address: 'address',
+                    }
+  end
+end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22442150

We want to refactor the solicitor's address text area into structured individual text inputs, like we did in the past for applicants, respondents, etc.

As a first step we are creating a new intermediate page step to hold the address text area, and in follow-up PRs we will remove the text are from the current (contact details) step as well as update the decision tree.

Then we can structure the data, which will need to be backwards compatible with existing and in progress applications.

I'm creating small PRs so it is easier to review but it will not be entirely functional until the next PR at least.