### PR TITLE
Ability to set a percentage to show/hide the research consent step

### DIFF
--- a/app/services/c100_app/opening_decision_tree.rb
+++ b/app/services/c100_app/opening_decision_tree.rb
@@ -29,10 +29,10 @@ module C100App
       if court
         c100_application.update!(court: court)
 
-        if Rails.configuration.x.opening.hide_research_consent_step
-          edit(:consent_order)
-        else
+        if show_research_consent?
           edit(:research_consent)
+        else
+          edit(:consent_order)
         end
       else
         show(:no_court_found)
@@ -60,6 +60,12 @@ module C100App
       else
         edit('/steps/miam/acknowledgement')
       end
+    end
+
+    def show_research_consent?
+      ResearchSampler.candidate?(
+        c100_application, Rails.configuration.x.opening.research_consent_weight
+      )
     end
   end
 end

--- a/app/services/c100_app/research_sampler.rb
+++ b/app/services/c100_app/research_sampler.rb
@@ -1,0 +1,35 @@
+module C100App
+  class ResearchSampler
+    # Very simple utility class to give us the ability to run experiments
+    # or A/B testing on a weighted pseudo random population (applications).
+    #
+    # Basically we use the `created_at` date of the application, as this will
+    # never change, and extract the `seconds` part from it, giving us 0-59.
+    # It is deterministic: given the same input, will produce the same output.
+    #
+    # Using a simple percentage 0% to 100% (weight) we return if this second is
+    # part of the population sample or not.
+    #
+    # For example, given a 50% weight, only applications with a `created_at`
+    # second ranging from 0 to 29 will be included, and those with seconds
+    # 30 to 59 will be excluded from the sample.
+    #
+    def self.candidate?(c100_application, weight)
+      unless (0..100).cover?(weight)
+        raise ArgumentError, "Invalid weight `#{weight}`, only values 0 to 100 allowed"
+      end
+
+      # obtain a weighted sample from the seconds in a minute, i.e.
+      #
+      #   - a percentage of 0, or 0.0, will return a sample of 0
+      #   - a percentage of 25, or 0.25, will return a sample of 15
+      #   - a percentage of 100, or 1.0, will return a sample of 60
+      #
+      sample = (weight / 100.0) * 60
+
+      # check if the `second` this application was created (0-59)
+      # is part of the weighted sample
+      c100_application.created_at.sec < sample
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,9 +59,10 @@ class Application < Rails::Application
   config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 60).to_i
   config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 
-  # Toggle on/off the `research consent` question (used to gather emails of users
-  # for research purposes). Enabled by default. Set this ENV variable to disable it.
-  config.x.opening.hide_research_consent_step = ENV.key?('HIDE_RESEARCH_CONSENT_STEP')
+  # Show the `research consent` question (used to gather emails of users for research
+  # purposes) to this percentage of applications.
+  # Defaults to 100 if ENV is not set. Set ENV to any other value, or 0 to disable.
+  config.x.opening.research_consent_weight = ENV.fetch('RESEARCH_CONSENT_WEIGHT', 100).to_i
 
   # As part of the opening postcode step, an empty C100Application record is created.
   # If the postcode is not eligible, these records are left orphans and have no use.

--- a/spec/services/c100_app/opening_decision_tree_spec.rb
+++ b/spec/services/c100_app/opening_decision_tree_spec.rb
@@ -31,23 +31,25 @@ RSpec.describe C100App::OpeningDecisionTree do
       end
 
       it 'assigns the court to the c100 application' do
+        expect(subject).to receive(:show_research_consent?)
         expect(c100_application).to receive(:update!).with(court: court)
-        is_expected.to have_destination(:research_consent, :edit)
+
+        is_expected.to have_destination(:consent_order, :edit)
       end
 
       context 'research consent step' do
         before do
-          allow(c100_application).to receive(:update!)
-          allow(Rails.configuration.x.opening).to receive(:hide_research_consent_step).and_return(research_hidden)
+          allow(c100_application).to receive(:created_at).and_return(Time.at(seconds))
+          allow(Rails.configuration.x.opening).to receive(:research_consent_weight).and_return(25)
         end
 
-        context 'the research consent step is enabled' do
-          let(:research_hidden) { false }
+        context 'the research consent step is shown to this user' do
+          let(:seconds) { 10 }
           it { is_expected.to have_destination(:research_consent, :edit) }
         end
 
-        context 'the research consent step is disabled' do
-          let(:research_hidden) { true }
+        context 'the research consent step is not shown to this user' do
+          let(:seconds) { 30 }
           it { is_expected.to have_destination(:consent_order, :edit) }
         end
       end

--- a/spec/services/c100_app/research_sampler_spec.rb
+++ b/spec/services/c100_app/research_sampler_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe C100App::ResearchSampler do
+  subject { described_class.candidate?(c100_application, weight_pc) }
+
+  let(:c100_application) { instance_double(C100Application, created_at: Time.at(seconds).to_datetime) }
+
+  let(:seconds) { 15 }
+  let(:weight_pc) { nil }
+
+  describe '.candidate?' do
+    context 'for an invalid `weight` input (nil)' do
+      let(:weight_pc) { nil }
+      it { expect { subject }.to raise_error(ArgumentError, 'Invalid weight ``, only values 0 to 100 allowed') }
+    end
+
+    context 'for an invalid `weight` input (string)' do
+      let(:weight_pc) { '50%' }
+      it { expect { subject }.to raise_error(ArgumentError, /`50%`/) }
+    end
+
+    context 'for an invalid `weight` input (over the range)' do
+      let(:weight_pc) { 101 }
+      it { expect { subject }.to raise_error(ArgumentError, /`101`/) }
+    end
+
+    context 'for an invalid `weight` input (below the range)' do
+      let(:weight_pc) { -1 }
+      it { expect { subject }.to raise_error(ArgumentError, /`-1`/) }
+    end
+
+    context 'for a 100% weight' do
+      let(:weight_pc) { 100 }
+      it { expect(subject).to be_truthy }
+    end
+
+    context 'for a 75% weight' do
+      let(:weight_pc) { 75 }
+      it { expect(subject).to be_truthy }
+    end
+
+    context 'for a 50% weight' do
+      let(:weight_pc) { 50 }
+      it { expect(subject).to be_truthy }
+    end
+
+    context 'for a 26% weight' do
+      let(:weight_pc) { 26 }
+      it { expect(subject).to be_truthy }
+    end
+
+    # Seconds go from 0 to 59, so for seconds = 15,
+    # a weight of 25% will return false (sample goes 0-14)
+    context 'for a 25% weight' do
+      let(:weight_pc) { 25 }
+      it { expect(subject).to be_falsey }
+    end
+
+    context 'for a 10% weight' do
+      let(:weight_pc) { 10 }
+      it { expect(subject).to be_falsey }
+    end
+
+    context 'for a 0% weight' do
+      let(:weight_pc) { 0 }
+
+      context 'and the `created_at` seconds is 0' do
+        let(:seconds) { 0 }
+        it { expect(subject).to be_falsey }
+      end
+
+      context 'and the `created_at` seconds is 1' do
+        let(:seconds) { 1 }
+        it { expect(subject).to be_falsey }
+      end
+
+      context 'and the `created_at` seconds is 59' do
+        let(:seconds) { 59 }
+        it { expect(subject).to be_falsey }
+      end
+    end
+
+    context 'for a 100% weight' do
+      let(:weight_pc) { 100 }
+
+      context 'and the `created_at` seconds is 0' do
+        let(:seconds) { 0 }
+        it { expect(subject).to be_truthy }
+      end
+
+      context 'and the `created_at` seconds is 1' do
+        let(:seconds) { 1 }
+        it { expect(subject).to be_truthy }
+      end
+
+      context 'and the `created_at` seconds is 59' do
+        let(:seconds) { 59 }
+        it { expect(subject).to be_truthy }
+      end
+    end
+  end
+end


### PR DESCRIPTION
We implemented over a week ago the ability to gather users's consent for user research purposes, by showing them a page where they can enter their email address.

This was present some time ago but we removed it. Now we've reintroduce it, but we are getting quite a few too much candidates and will be difficult if not impossible to really manage all of them and the list is growing every day.

As a potential improvement, instead of turning off completely the gathering of this consent, with this PR we prepare the path for, if we want, show this consent only to a percentage of the new applications.

By default at the moment is 100% meaning all applications/users are shown the consent step, but we can let's say in a week decide to reduce this to 50%, and then the consent will be shown only to a 50% of the new applications, in a pesudo-random, deterministic way (based on the application creation date).

The little utility class to calculate the sampling can be reused of other purposes and a/b testing if we wanted to, as it is abstract and simple enough.