### PR TITLE
Remove solicitor address text area from contact details step

### DIFF
--- a/app/forms/steps/solicitor/contact_details_form.rb
+++ b/app/forms/steps/solicitor/contact_details_form.rb
@@ -5,14 +5,13 @@ module Steps
 
       has_one_association :solicitor
 
-      attribute :address, StrippedString
-      attribute :dx_number, StrippedString
+      attribute :email, NormalisedEmail
       attribute :phone_number, StrippedString
       attribute :fax_number, StrippedString
-      attribute :email, NormalisedEmail
+      attribute :dx_number, StrippedString
 
-      validates_presence_of :address, :phone_number
       validates :email, email: true, allow_blank: true
+      validates_presence_of :email, :phone_number
 
       # Used to present the solicitor's name in the view
       delegate :full_name, to: :record_to_persist

--- a/app/services/c100_app/solicitor_decision_tree.rb
+++ b/app/services/c100_app/solicitor_decision_tree.rb
@@ -5,6 +5,8 @@ module C100App
 
       case step_name
       when :personal_details
+        edit(:address_details)
+      when :address_details
         edit(:contact_details)
       when :contact_details
         edit('/steps/respondent/names')

--- a/app/views/steps/solicitor/contact_details/edit.html.erb
+++ b/app/views/steps/solicitor/contact_details/edit.html.erb
@@ -10,12 +10,12 @@
     </h1>
 
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_text_area :address %>
-
-      <%= f.govuk_text_field :dx_number, width: 'one-half' %>
       <%= f.govuk_email_field :email %>
+
       <%= f.govuk_phone_field :phone_number, width: 'one-half' %>
       <%= f.govuk_phone_field :fax_number, width: 'one-half' %>
+
+      <%= f.govuk_text_field :dx_number, width: 'one-half' %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1427,8 +1427,9 @@ en:
         full_name: Full name
         firm_name: Name of firm
         reference: Solicitor’s reference
-      steps_solicitor_contact_details_form:
+      steps_solicitor_address_details_form:
         address: Address
+      steps_solicitor_contact_details_form:
         dx_number: DX number
         phone_number: Phone number
         fax_number: Fax number
@@ -1563,8 +1564,9 @@ en:
         miam_certification_sole_trader_name: *leave_blank_if_unknown
       steps_solicitor_personal_details_form:
         reference: This is the reference for this case
-      steps_solicitor_contact_details_form:
+      steps_solicitor_address_details_form:
         address: Enter the full address including postcode
+      steps_solicitor_contact_details_form:
         dx_number: This is a secure document exchange system used by the legal profession
       steps_attending_court_intermediary_form:
         intermediary_help: An intermediary is appointed by the court to help people participate in court. For example, you may need an intermediary if you have a learning, mental or physical disability.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -439,10 +439,12 @@ en:
               blank: Enter the full name
             firm_name:
               blank: Enter the name of the firm
-        steps/solicitor/contact_details_form:
+        steps/solicitor/address_details_form:
           attributes:
             address:
               blank: Enter the address
+        steps/solicitor/contact_details_form:
+          attributes:
             phone_number:
               blank: Enter the phone number
         steps/applicant/names_split_form:

--- a/spec/forms/steps/solicitor/contact_details_form_spec.rb
+++ b/spec/forms/steps/solicitor/contact_details_form_spec.rb
@@ -3,11 +3,10 @@ require 'spec_helper'
 RSpec.describe Steps::Solicitor::ContactDetailsForm do
   let(:arguments) { {
     c100_application: c100_application,
-    address: 'address',
-    dx_number: 'dx_number',
+    email: email,
     phone_number: 'phone_number',
     fax_number: 'fax_number',
-    email: email,
+    dx_number: 'dx_number',
   } }
 
   let(:email) { 'test@example.com' }
@@ -18,20 +17,25 @@ RSpec.describe Steps::Solicitor::ContactDetailsForm do
 
   describe '#save' do
     context 'validations' do
-      it { should validate_presence_of(:address) }
+      it { should validate_presence_of(:email) }
       it { should validate_presence_of(:phone_number) }
 
       context 'email validation' do
-        context 'email is not validated if not present' do
-          let(:email) { nil }
-          it { expect(subject).to be_valid }
-        end
-
-        context 'email is validated if present' do
+        context 'email is invalid' do
           let(:email) { 'xxx' }
+
           it {
             expect(subject).not_to be_valid
-            expect(subject.errors[:email]).to_not be_empty
+            expect(subject.errors.added?(:email, :invalid)).to eq(true)
+          }
+        end
+
+        context 'email domain contains a typo' do
+          let(:email) { 'test@gamil.com' }
+
+          it {
+            expect(subject).not_to be_valid
+            expect(subject.errors.added?(:email, :typo)).to eq(true)
           }
         end
       end
@@ -40,11 +44,10 @@ RSpec.describe Steps::Solicitor::ContactDetailsForm do
     it_behaves_like 'a has-one-association form',
                     association_name: :solicitor,
                     expected_attributes: {
-                      address: 'address',
-                      dx_number: 'dx_number',
+                      email: 'test@example.com',
                       phone_number: 'phone_number',
                       fax_number: 'fax_number',
-                      email: 'test@example.com',
+                      dx_number: 'dx_number',
                     }
   end
 end

--- a/spec/services/c100_app/solicitor_decision_tree_spec.rb
+++ b/spec/services/c100_app/solicitor_decision_tree_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe C100App::SolicitorDecisionTree do
 
   context 'when the step is `personal_details`' do
     let(:step_params) { { personal_details: 'anything' } }
+    it { is_expected.to have_destination(:address_details, :edit) }
+  end
+
+  context 'when the step is `address_details`' do
+    let(:step_params) { { address_details: 'anything' } }
     it { is_expected.to have_destination(:contact_details, :edit) }
   end
 


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22442150

Follow-up to PR #1118.
In this PR we are removing the existing text area in the contact details step, as we've now introduced this same text area in a separate "address details" step.

Update the validations and the order of the fields in the contact details form object.

Update the solicitor decision tree to introduce this new address details step, before the contact details one.

Note: still pending, in follow-up PRs, update the CYA page to be able to get back to the new address step. Also enable the fast-track.

Once we have all this refactored and up and running, we can start structuring the text area into individual fields.

<img width="701" alt="Screenshot 2020-11-11 at 15 17 16" src="https://user-images.githubusercontent.com/687910/98829367-0b820580-2431-11eb-80d2-07522e08abed.png">

<img width="716" alt="Screenshot 2020-11-11 at 15 17 25" src="https://user-images.githubusercontent.com/687910/98829381-0f158c80-2431-11eb-8ea7-fc29e1b91222.png">
