### PR TITLE
Add the new solicitor address step to CYA

### DIFF
--- a/app/presenters/summary/html_sections/solicitor_details.rb
+++ b/app/presenters/summary/html_sections/solicitor_details.rb
@@ -9,6 +9,7 @@ module Summary
         [
           Answer.new(:has_solicitor, c100.has_solicitor, change_path: edit_steps_applicant_has_solicitor_path),
           solicitor_personal_details,
+          solicitor_address_details,
           solicitor_contact_details,
         ].flatten.select(&:show?)
       end
@@ -33,15 +34,24 @@ module Summary
         ]
       end
 
+      def solicitor_address_details
+        AnswersGroup.new(
+          :solicitor_address_details,
+          [
+            FreeTextAnswer.new(:solicitor_address, solicitor.address),
+          ],
+          change_path: edit_steps_solicitor_address_details_path
+        )
+      end
+
       def solicitor_contact_details
         AnswersGroup.new(
           :solicitor_contact_details,
           [
-            FreeTextAnswer.new(:solicitor_address, solicitor.address),
-            FreeTextAnswer.new(:solicitor_dx_number, solicitor.dx_number),
             FreeTextAnswer.new(:solicitor_email, solicitor.email),
             FreeTextAnswer.new(:solicitor_phone_number, solicitor.phone_number),
             FreeTextAnswer.new(:solicitor_fax_number, solicitor.fax_number),
+            FreeTextAnswer.new(:solicitor_dx_number, solicitor.dx_number),
           ],
           change_path: edit_steps_solicitor_contact_details_path
         )

--- a/app/presenters/summary/sections/solicitor_details.rb
+++ b/app/presenters/summary/sections/solicitor_details.rb
@@ -20,10 +20,10 @@ module Summary
           FreeTextAnswer.new(:solicitor_full_name, solicitor.full_name),
           FreeTextAnswer.new(:solicitor_firm_name, solicitor.firm_name),
           FreeTextAnswer.new(:solicitor_address, solicitor.address),
+          FreeTextAnswer.new(:solicitor_email, solicitor.email),
           FreeTextAnswer.new(:solicitor_phone_number, solicitor.phone_number),
           FreeTextAnswer.new(:solicitor_fax_number, solicitor.fax_number),
           FreeTextAnswer.new(:solicitor_dx_number, solicitor.dx_number),
-          FreeTextAnswer.new(:solicitor_email, solicitor.email),
           FreeTextAnswer.new(:solicitor_reference, solicitor.reference),
           FreeTextAnswer.new(:solicitor_fee_account, c100.solicitor_account_number, show: true),
         ].select(&:show?)

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -120,6 +120,7 @@ en:
       submission_type: Submission type
       solicitor_contact_details: Your solicitor’s contact details
       solicitor_personal_details: Your solicitor’s personal details
+      solicitor_address_details: Your solicitor’s address details
 
     separators:
       children_details_index_title: Child %{index}

--- a/spec/controllers/steps/solicitor/address_details_controller_spec.rb
+++ b/spec/controllers/steps/solicitor/address_details_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Steps::Solicitor::AddressDetailsController, type: :controller do
   it_behaves_like 'an intermediate step controller', Steps::Solicitor::AddressDetailsForm, C100App::SolicitorDecisionTree
+  it_behaves_like 'a step that can fast-forward to check your answers', Steps::Solicitor::AddressDetailsForm
 end

--- a/spec/presenters/summary/html_sections/solicitor_details_spec.rb
+++ b/spec/presenters/summary/html_sections/solicitor_details_spec.rb
@@ -17,10 +17,10 @@ module Summary
         firm_name: 'firm',
         reference: 'ref',
         address: '22 acacia avenue',
-        dx_number: 'dx012345',
+        email: 'solicitor@example.com',
         phone_number: '0123456789',
         fax_number: '0987654321',
-        email: 'solicitor@example.com'
+        dx_number: 'dx012345',
       )
     }
 
@@ -41,7 +41,7 @@ module Summary
     #
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(3)
+        expect(answers.count).to eq(4)
       end
 
       it 'has the correct rows in the right order' do
@@ -54,7 +54,6 @@ module Summary
         expect(answers[1].name).to eq(:solicitor_personal_details)
         expect(answers[1].change_path).to eq('/steps/solicitor/personal_details')
         expect(answers[1].answers.count).to eq(3)
-
 
           # personal_details group answers ###
           details = answers[1].answers
@@ -72,32 +71,40 @@ module Summary
           expect(details[2].value).to eq('ref')
 
         expect(answers[2]).to be_an_instance_of(AnswersGroup)
-        expect(answers[2].name).to eq(:solicitor_contact_details)
-        expect(answers[2].change_path).to eq('/steps/solicitor/contact_details')
-        expect(answers[2].answers.count).to eq(5)
+        expect(answers[2].name).to eq(:solicitor_address_details)
+        expect(answers[2].change_path).to eq('/steps/solicitor/address_details')
+        expect(answers[2].answers.count).to eq(1)
 
-          # personal_details group answers ###
+          # address_details group answers ###
           details = answers[2].answers
 
           expect(details[0]).to be_an_instance_of(FreeTextAnswer)
           expect(details[0].question).to eq(:solicitor_address)
           expect(details[0].value).to eq('22 acacia avenue')
 
+        expect(answers[3]).to be_an_instance_of(AnswersGroup)
+        expect(answers[3].name).to eq(:solicitor_contact_details)
+        expect(answers[3].change_path).to eq('/steps/solicitor/contact_details')
+        expect(answers[3].answers.count).to eq(4)
+
+          # contact_details group answers ###
+          details = answers[3].answers
+
+          expect(details[0]).to be_an_instance_of(FreeTextAnswer)
+          expect(details[0].question).to eq(:solicitor_email)
+          expect(details[0].value).to eq('solicitor@example.com')
+
           expect(details[1]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[1].question).to eq(:solicitor_dx_number)
-          expect(details[1].value).to eq('dx012345')
+          expect(details[1].question).to eq(:solicitor_phone_number)
+          expect(details[1].value).to eq('0123456789')
 
           expect(details[2]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[2].question).to eq(:solicitor_email)
-          expect(details[2].value).to eq('solicitor@example.com')
+          expect(details[2].question).to eq(:solicitor_fax_number)
+          expect(details[2].value).to eq('0987654321')
 
           expect(details[3]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[3].question).to eq(:solicitor_phone_number)
-          expect(details[3].value).to eq('0123456789')
-
-          expect(details[4]).to be_an_instance_of(FreeTextAnswer)
-          expect(details[4].question).to eq(:solicitor_fax_number)
-          expect(details[4].value).to eq('0987654321')
+          expect(details[3].question).to eq(:solicitor_dx_number)
+          expect(details[3].value).to eq('dx012345')
       end
     end
   end

--- a/spec/presenters/summary/sections/solicitor_details_spec.rb
+++ b/spec/presenters/summary/sections/solicitor_details_spec.rb
@@ -19,10 +19,10 @@ module Summary
         firm_name: 'firm_name',
         reference: 'reference',
         address: 'address',
-        dx_number: 'dx_number',
+        email: 'email',
         phone_number: 'phone_number',
         fax_number: 'fax_number',
-        email: 'email',
+        dx_number: 'dx_number',
     ) }
     let(:solicitor_account_number) { '12345' }
 
@@ -83,20 +83,20 @@ module Summary
           expect(answers[3].value).to eq('address')
 
           expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[4].question).to eq(:solicitor_phone_number)
-          expect(answers[4].value).to eq('phone_number')
+          expect(answers[4].question).to eq(:solicitor_email)
+          expect(answers[4].value).to eq('email')
 
           expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[5].question).to eq(:solicitor_fax_number)
-          expect(answers[5].value).to eq('fax_number')
+          expect(answers[5].question).to eq(:solicitor_phone_number)
+          expect(answers[5].value).to eq('phone_number')
 
           expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[6].question).to eq(:solicitor_dx_number)
-          expect(answers[6].value).to eq('dx_number')
+          expect(answers[6].question).to eq(:solicitor_fax_number)
+          expect(answers[6].value).to eq('fax_number')
 
           expect(answers[7]).to be_an_instance_of(FreeTextAnswer)
-          expect(answers[7].question).to eq(:solicitor_email)
-          expect(answers[7].value).to eq('email')
+          expect(answers[7].question).to eq(:solicitor_dx_number)
+          expect(answers[7].value).to eq('dx_number')
 
           expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
           expect(answers[8].question).to eq(:solicitor_reference)


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22442150

Continuation to previous PR #1120.

We now have a new intermediate page to enter the solicitor address details.
In this PR we add this section to the CYA too, and make the fast-forward link to work.
Remove the address from the contact details section.

Reorder the contact details in the CYA to show in the same order as in the page (email show first).

<img width="870" alt="Screenshot 2020-11-12 at 12 12 45" src="https://user-images.githubusercontent.com/687910/98938819-69215b00-24e0-11eb-8de6-0abe2b58d400.png">
