### PR TITLE
Prepare DB to split solicitor address

### DIFF
--- a/app/models/concerns/person_with_address.rb
+++ b/app/models/concerns/person_with_address.rb
@@ -1,0 +1,23 @@
+module PersonWithAddress
+  extend ActiveSupport::Concern
+
+  ADDRESS_DATA_FIELDS = %i[
+    address_line_1
+    address_line_2
+    town
+    country
+    postcode
+  ].freeze
+
+  included do
+    store_accessor :address_data, ADDRESS_DATA_FIELDS
+  end
+
+  def full_address
+    # Ensure, no matter the order of the keys in the hash, we return the values
+    # in a predictable order, matching the `store_accessor` declaration.
+    address_data.symbolize_keys.values_at(
+      *ADDRESS_DATA_FIELDS
+    ).presence_join(', ')
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,9 +1,8 @@
 class Person < ApplicationRecord
+  include PersonWithAddress
+
   belongs_to :c100_application
   has_many :relationships, source: :person, dependent: :destroy
-
-  store_accessor :address_data,
-                 :address_line_1, :address_line_2, :town, :country, :postcode
 
   # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
   default_scope { order(created_at: :asc) }
@@ -14,13 +13,5 @@ class Person < ApplicationRecord
 
   def full_name
     [first_name, last_name].compact.join(' ')
-  end
-
-  def full_address
-    # Ensure, no matter the order of the keys in the hash, we return the values
-    # in a predictable order, matching the `store_accessor` declaration.
-    address_data.symbolize_keys.values_at(
-      *self.class.stored_attributes.fetch(:address_data)
-    ).presence_join(', ')
   end
 end

--- a/app/models/solicitor.rb
+++ b/app/models/solicitor.rb
@@ -1,3 +1,5 @@
 class Solicitor < ApplicationRecord
+  include PersonWithAddress
+
   belongs_to :c100_application
 end

--- a/db/migrate/20201112150154_add_solicitor_address_fields.rb
+++ b/db/migrate/20201112150154_add_solicitor_address_fields.rb
@@ -1,0 +1,5 @@
+class AddSolicitorAddressFields < ActiveRecord::Migration[5.2]
+  def change
+    add_column :solicitors, :address_data, :json, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_29_112416) do
+ActiveRecord::Schema.define(version: 2020_11_12_150154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -369,6 +369,7 @@ ActiveRecord::Schema.define(version: 2020_10_29_112416) do
     t.string "fax_number"
     t.string "email"
     t.uuid "c100_application_id"
+    t.json "address_data", default: {}
     t.index ["c100_application_id"], name: "index_solicitors_on_c100_application_id", unique: true
   end
 

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -87,7 +87,6 @@ def models
     C100Application
     User
     Court
-    Person
     PaymentIntent
     CompletedApplicationsAudit
   ).freeze

--- a/spec/models/solicitor_spec.rb
+++ b/spec/models/solicitor_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Solicitor, type: :model do
+  subject { solicitor }
+
+  let(:address_hash) do
+    {
+      address_line_1: 'address_line_1',
+      address_line_2: '',
+      town: 'town',
+      country: 'country',
+      postcode: 'postcode'
+    }
+  end
+
+  let(:address_string) { 'address' }
+
+  describe '#full_address' do
+    let(:solicitor) { Solicitor.new(address: address_string, address_data: address_hash) }
+
+    it { expect(subject.full_address).to eq('address_line_1, town, country, postcode') }
+
+    context 'when the hash keys are in a different order or missing' do
+      let(:address_hash) do
+        {
+          postcode: 'postcode',
+          country: 'country',
+          address_line_1: 'address_line_1',
+          town: 'town',
+        }
+      end
+
+      it 'returns the value in the expected order' do
+        expect(subject.full_address).to eq('address_line_1, town, country, postcode')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22442150

We are already using split address for applicant, respondent and other party (all inheriting from Person).

For `solicitor` model we want the same, so it makes sense to extract this concrete behaviour to a concern module `PersonWithAddress` that can be used in any model that has an address.

Refactored it a bit to make it simpler to read.