### PR TITLE
Tweak the address unknown in CYA block

### DIFF
--- a/app/presenters/summary/html_sections/people_details.rb
+++ b/app/presenters/summary/html_sections/people_details.rb
@@ -64,7 +64,8 @@ module Summary
 
       def address_details_questions(person)
         [
-          FreeTextAnswer.new(:person_address, person.full_address, show: true),
+          FreeTextAnswer.new(:person_address, person.full_address),
+          Answer.new(:person_address_unknown, person.address_unknown), # This shows only if a value is present
           Answer.new(:person_residence_requirement_met, person.residence_requirement_met),
           FreeTextAnswer.new(:person_residence_history, person.residence_history)
         ]

--- a/config/locales/cya/en.yml
+++ b/config/locales/cya/en.yml
@@ -514,7 +514,10 @@ en:
       question: Place of birth
     person_address:
       question: Address
-      absence_answer: *unknown
+    person_address_unknown:
+      question: ''
+      answers:
+        'true': *unknown
     person_residence_requirement_met:
       question: Lived at this address for more than 5 years?
       answers:

--- a/spec/presenters/summary/html_sections/applicants_details_spec.rb
+++ b/spec/presenters/summary/html_sections/applicants_details_spec.rb
@@ -19,6 +19,7 @@ module Summary
         age_estimate: nil,
         gender: 'female',
         birthplace: 'birthplace',
+        address_unknown: false, # for applicants this can only be `false`
         residence_requirement_met: 'yes',
         residence_history: 'history',
         home_phone: 'home_phone',

--- a/spec/presenters/summary/html_sections/other_parties_details_spec.rb
+++ b/spec/presenters/summary/html_sections/other_parties_details_spec.rb
@@ -20,6 +20,7 @@ module Summary
         age_estimate: nil,
         gender: 'female',
         birthplace: nil,
+        address_unknown: address_unknown,
         residence_requirement_met: nil,
         residence_history: nil,
         home_phone: nil,
@@ -35,6 +36,8 @@ module Summary
     end
 
     subject { described_class.new(c100_application) }
+
+    let(:address_unknown) { false }
 
     let(:relationship) {
       instance_double(
@@ -140,6 +143,23 @@ module Summary
           expect(answers[0].question).to eq(:has_other_parties)
           expect(answers[0].change_path).to eq('/steps/respondent/has_other_parties')
           expect(answers[0].value).to eq('no')
+        end
+      end
+
+      context 'for an unknown address' do
+        let(:address_unknown) { true }
+
+        before do
+          allow(other_party).to receive(:full_address).and_return(nil)
+        end
+
+        it 'renders the expected answer row' do
+          expect(answers[4]).to be_an_instance_of(AnswersGroup)
+
+          details = answers[4].answers
+          expect(details[0]).to be_an_instance_of(Answer)
+          expect(details[0].question).to eq(:person_address_unknown)
+          expect(details[0].value).to eq(true)
         end
       end
 

--- a/spec/presenters/summary/html_sections/respondents_details_spec.rb
+++ b/spec/presenters/summary/html_sections/respondents_details_spec.rb
@@ -19,6 +19,7 @@ module Summary
         age_estimate: nil,
         gender: 'female',
         birthplace: 'birthplace',
+        address_unknown: address_unknown,
         residence_requirement_met: 'yes',
         residence_history: 'history',
         home_phone: 'home_phone',
@@ -37,6 +38,7 @@ module Summary
 
     let(:has_previous_name) { 'no' }
     let(:previous_name) { nil }
+    let(:address_unknown) { false }
 
     let(:relationship) {
       instance_double(
@@ -167,6 +169,23 @@ module Summary
           expect(details[0]).to be_an_instance_of(FreeTextAnswer)
           expect(details[0].question).to eq(:person_previous_name)
           expect(details[0].value).to eq('previous_name')
+        end
+      end
+
+      context 'for an unknown address' do
+        let(:address_unknown) { true }
+
+        before do
+          allow(respondent).to receive(:full_address).and_return(nil)
+        end
+
+        it 'renders the expected answer row' do
+          expect(answers[3]).to be_an_instance_of(AnswersGroup)
+
+          details = answers[3].answers
+          expect(details[0]).to be_an_instance_of(Answer)
+          expect(details[0].question).to eq(:person_address_unknown)
+          expect(details[0].value).to eq(true)
         end
       end
 


### PR DESCRIPTION
Previously the address unknown would show even if the user didn't yet entered an address at all, because we were using the flag `show: true` which indicates to always show that row even if their value is blank/nil (rendering the absense locale).

This usually is fine, but if the user for some reason did save the application for later, in the personal details of the applicant, respondent or other party, then on resuming the application the CYA would show address as 'Don't know' which is misleading.

It was easy to reproduce this behaviour on staging by using the 'Bypass to CYA' functionality.

Change this behaviour so address will show only if there is value, and 'Don't know' will show as well if there is a value.