### PR TITLE
Reset address leftovers if `address_unknown` is checked

### DIFF
--- a/app/forms/address_base_form.rb
+++ b/app/forms/address_base_form.rb
@@ -12,6 +12,11 @@ class AddressBaseForm < BaseForm
   private
 
   def address_values
+    return {
+      address_data: {},
+      address_unknown: address_unknown,
+    } if address_unknown?
+
     {
       address_data: {
         address_line_1: address_line_1,

--- a/spec/forms/steps/other_party/address_details_form_spec.rb
+++ b/spec/forms/steps/other_party/address_details_form_spec.rb
@@ -101,6 +101,22 @@ RSpec.describe Steps::OtherParty::AddressDetailsForm do
 
           expect(subject.save).to be(true)
         end
+
+        context 'when `address_unknown` is selected' do
+          let(:address_unknown) { true }
+
+          it 'resets previous address details, if any' do
+            expect(other_parties_collection).to receive(:find_or_initialize_by).with(
+              id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe6'
+            ).and_return(party)
+
+            expect(party).to receive(:update).with(
+              hash_including(address_data: {}, address_unknown: true)
+            ).and_return(true)
+
+            expect(subject.save).to be(true)
+          end
+        end
       end
     end
   end

--- a/spec/forms/steps/respondent/address_details_form_spec.rb
+++ b/spec/forms/steps/respondent/address_details_form_spec.rb
@@ -139,6 +139,22 @@ RSpec.describe Steps::Respondent::AddressDetailsForm do
 
           expect(subject.save).to be(true)
         end
+
+        context 'when `address_unknown` is selected' do
+          let(:address_unknown) { true }
+
+          it 'resets previous address details, if any' do
+            expect(respondents_collection).to receive(:find_or_initialize_by).with(
+              id: 'ae4ed69e-bcb3-49cc-b19e-7287b1f2abe9'
+            ).and_return(respondent)
+
+            expect(respondent).to receive(:update).with(
+              hash_including(address_data: {}, address_unknown: true)
+            ).and_return(true)
+
+            expect(subject.save).to be(true)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Small follow-up refinement to previous PR #1124.

In case some details were previously entered, when selecting the `address_unknown` checkbox, these leftovers will be reset, maintaining the DB consistency and not showing them in CYA.