### PR TITLE
Add button to download draft application in CYA

### DIFF
--- a/app/controllers/steps/completion/summary_controller.rb
+++ b/app/controllers/steps/completion/summary_controller.rb
@@ -7,7 +7,8 @@ module Steps
             presenter = Summary::PdfPresenter.new(current_c100_application)
             presenter.generate
 
-            # render plain: presenter.to_pdf
+            # Will render the template defined in `BasePdfForm#template`
+            # i.e. `steps/completion/summary/show.pdf.erb`
             send_data(presenter.to_pdf, filename: presenter.filename)
           end
         end

--- a/app/views/steps/application/check_your_answers/edit.html.erb
+++ b/app/views/steps/application/check_your_answers/edit.html.erb
@@ -51,5 +51,20 @@
         save_and_continue: @presenter.submit_button_label
       ) %>
     <% end %>
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" data-ga-category="explanations" data-ga-label="cya download draft">
+          <%=t '.details.summary' %>
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <%=t '.details.text_html' %>
+        <%= link_button t('.details.download_draft_button'), steps_completion_summary_path(format: :pdf),
+                        class: 'ga-pageLink govuk-button--secondary', download: '',
+                        data: { module: 'govuk-button', ga_category: 'check your answers', ga_label: 'download draft' } %>
+
+      </div>
+    </details>
   </div>
 </div>

--- a/app/views/steps/shared/_download_pdf_copy.en.html.erb
+++ b/app/views/steps/shared/_download_pdf_copy.en.html.erb
@@ -9,5 +9,5 @@
   </div>
 <% end %>
 
-<%= link_button 'Download your PDF application', steps_completion_summary_path(format: :pdf), class: 'ga-pageLink',
+<%= link_button 'Download your PDF application', steps_completion_summary_path(format: :pdf), class: 'ga-pageLink', download: '',
                 data: { module: 'govuk-button', ga_category: 'completion', ga_label: 'download application' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -778,8 +778,19 @@ en:
           false_information_warning: You could be fined or imprisoned for contempt of court if you deliberately submit false information, or cause false information to be submitted.
           submit_warning:
             online: Once you submit your application, you cannot make any further changes. You can download a copy of your submitted application on the next page.
-            online_payment: Once you submit your application, you cannot make any further changes. You will be able to download a copy of your application after you have paid the %{fee} court fee.
-            print_and_post: Once you continue, you cannot make any further changes to your application. You can download a copy of your application on the next page.
+            online_payment: Once you submit your application, you cannot make any further changes. You will be able to download a copy of your submitted application after you have paid the %{fee} court fee.
+            print_and_post: Once you continue, you cannot make any further changes. You can download a copy of your completed application on the next page.
+          details:
+            summary: Download a draft PDF of your application
+            text_html: |
+              <p class="govuk-body">
+                If you cannot open the file after downloading, try using
+                <a href="https://get.adobe.com/uk/reader/" class="govuk-link" rel="external" target="_blank">Adobe Acrobat Reader</a>.
+              </p>
+              <p class="govuk-body">
+                Please note this is not the completed application and will not be admitted in court.
+              </p>
+            download_draft_button: Download draft application
         resume:
           page_title: Resume application
           heading: Resume application


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22631863

Follow-up to PR #1127

Add a new revealing link to the `Check your answers` page to let the applicant download a draft of their application before submitting it.

The PDF will have the "draft" watermark. But other than that it will be identical to the final PDF once the applicant submits their application.

Also as part of this work, I've added th `download` attribute to the links as per:
https://www.w3schools.com/tags/att_a_download.asp

Note: copy is still TBD and to be reviewed by content designer.

<img width="931" alt="Screenshot 2020-12-09 at 14 03 47" src="https://user-images.githubusercontent.com/687910/101639687-7f5f0000-3a27-11eb-9b51-74aa775f40c4.png">
