### PR TITLE
Add kick out page when there is no document from mediator

### DIFF
--- a/app/controllers/steps/miam/certification_exit_controller.rb
+++ b/app/controllers/steps/miam/certification_exit_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Miam
+    class CertificationExitController < Steps::MiamStepController
+      def show; end
+    end
+  end
+end

--- a/app/services/c100_app/miam_decision_tree.rb
+++ b/app/services/c100_app/miam_decision_tree.rb
@@ -43,7 +43,7 @@ module C100App
       if question(:miam_certification).yes?
         edit(:certification_date)
       else
-        edit(:exemption_claim)
+        show(:certification_exit)
       end
     end
 

--- a/app/views/steps/miam/certification_exit/show.html.erb
+++ b/app/views/steps/miam/certification_exit/show.html.erb
@@ -1,0 +1,14 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <%=t '.body_text_html' %>
+
+    <%= link_button t('helpers.submit.save_and_come_back_later'), new_user_registration_path, class: 'ga-pageLink',
+                    data: { module: 'govuk-button', ga_category: 'miam', ga_label: 'save application' } %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -605,7 +605,7 @@ en:
       certification:
         edit:
           page_title: MIAM certification
-          lead_text: Your mediator should have signed a document confirming your MIAM attendance. You may need to go back to the mediator and ask for a signed document if you don't have one.
+          lead_text: The mediator should provide you with a signed document to confirm you attended a MIAM, or do not need to attend. If you haven’t got a document, you should ask the mediator for one.
       certification_date:
         edit:
           page_title: MIAM certification date
@@ -615,6 +615,14 @@ en:
           page_title: MIAM certification details
           heading: Enter details of MIAM certification
           lead_text: You can find this information at the bottom of the document your mediator signed.
+      certification_exit:
+        show:
+          page_title: MIAM certification document
+          heading: You need to get a document from the mediator
+          body_text_html: |
+            <p class="govuk-body-l">Ask the mediator to provide you with a signed document confirming you attended a MIAM, or did not need to attend.</p>
+            <p class="govuk-body">You will need to bring this document to your first court hearing.</p>
+            <p class="govuk-body">When you have a document from the mediator, return to continue with your application.</p>
     petition:
       orders:
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
       edit_step :attended
       edit_step :exemption_claim
       edit_step :certification
+      show_step :certification_exit
       edit_step :certification_date
       show_step :certification_expired_info
       edit_step :certification_details

--- a/features/miam.feature
+++ b/features/miam.feature
@@ -26,21 +26,15 @@ Feature: MIAM journey
     Then I should see "MIAM attendance confirmation"
 
   @unhappy_path
-  Scenario Outline: Applicant attended a MIAM but lacks the certificate
+  Scenario: Applicant attended a MIAM but lacks the certificate
     Then I should see "Have you attended a MIAM?"
     And I choose "Yes"
 
     Then I should see "Have you got a document signed by the mediator?"
     And I choose "No"
 
-    Then I should see "Do you have a valid reason for not attending a MIAM?"
-    And I choose "<has_valid_reason>"
-    Then I should see "<outcome_page_header>"
-
-    Examples:
-      | has_valid_reason | outcome_page_header                                       |
-      | Yes              | Providing evidence of domestic violence or abuse concerns |
-      | No               | Safety concerns                                           |
+    Then I should see "You need to get a document from the mediator"
+    Then I should see "Save and come back later"
 
   @unhappy_path
   Scenario Outline: Applicant attended a MIAM but the certificate is too old

--- a/spec/controllers/steps/miam/certification_exit_controller_spec.rb
+++ b/spec/controllers/steps/miam/certification_exit_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Miam::CertificationExitController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/services/c100_app/miam_decision_tree_spec.rb
+++ b/spec/services/c100_app/miam_decision_tree_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe C100App::MiamDecisionTree do
 
     context 'and the answer is `no`' do
       let(:value) { 'no' }
-      it { is_expected.to have_destination(:exemption_claim, :edit) }
+      it { is_expected.to have_destination(:certification_exit, :show) }
     end
   end
 


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22821248

As part of the changes proposed for the MIAM journey, a new kick out page needs to be added if the user answer NO to the question `Have you got a document signed by the mediator?`

Updated the decision tree and some copy.

<img width="681" alt="Screenshot 2020-12-15 at 11 48 37" src="https://user-images.githubusercontent.com/687910/102211423-7fe61380-3ecb-11eb-8504-3169b8fb2845.png">
