### PR TITLE
Create MIAM mediator exemption yes-no step and DB attr

### DIFF
--- a/app/controllers/steps/miam/mediator_exemption_controller.rb
+++ b/app/controllers/steps/miam/mediator_exemption_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Miam
+    class MediatorExemptionController < Steps::MiamStepController
+      def edit
+        @form_object = MediatorExemptionForm.new(
+          c100_application: current_c100_application,
+          miam_mediator_exemption: current_c100_application.miam_mediator_exemption
+        )
+      end
+
+      def update
+        update_and_advance(MediatorExemptionForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/miam/mediator_exemption_form.rb
+++ b/app/forms/steps/miam/mediator_exemption_form.rb
@@ -1,0 +1,11 @@
+module Steps
+  module Miam
+    class MediatorExemptionForm < BaseForm
+      include SingleQuestionForm
+
+      # The reset will delete the row from the `miam_exemptions` table
+      yes_no_attribute :miam_mediator_exemption,
+                       reset_when_yes: [:miam_exemption_claim, :miam_exemption]
+    end
+  end
+end

--- a/app/views/steps/miam/mediator_exemption/edit.html.erb
+++ b/app/views/steps/miam/mediator_exemption/edit.html.erb
@@ -1,0 +1,13 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :miam_mediator_exemption, GenericYesNo.values, :value, nil %>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -597,9 +597,12 @@ en:
               <li>taken place within the past 4 months</li>
               <li>been about the same or a very similar issue about the children</li>
             </ul>
+      mediator_exemption:
+        edit:
+          page_title: MIAM mediator’s exemption
       exemption_claim:
         edit:
-          page_title: Exemption claim
+          page_title: MIAM exemption claim
           lead_text_html: If you’re unsure you can <a href="/about/miam_exemptions" class="govuk-link" target="_blank">check the list of valid reasons</a>.
           info_notice: If you're claiming that you do not have to attend a MIAM before making this application, you may need to provide evidence in support of this.
       certification:
@@ -1088,6 +1091,9 @@ en:
       # MIAM steps
       steps_miam_attended_form:
         miam_attended_options:
+          <<: *YESNO
+      steps_miam_mediator_exemption_form:
+        miam_mediator_exemption_options:
           <<: *YESNO
       steps_miam_certification_form:
         miam_certification_options:
@@ -1611,6 +1617,8 @@ en:
         miam_acknowledgement: Attending a MIAM
       steps_miam_attended_form:
         miam_attended: Have you attended a MIAM?
+      steps_miam_mediator_exemption_form:
+        miam_mediator_exemption: Has a mediator confirmed that you do not need to attend a MIAM?
       steps_miam_certification_form:
         miam_certification: Have you got a document signed by the mediator?
       steps_miam_certification_date_form:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -144,6 +144,10 @@ en:
           attributes:
             miam_attended:
               inclusion: Select yes if you’ve attended a MIAM
+        steps/miam/mediator_exemption_form:
+          attributes:
+            miam_mediator_exemption:
+              inclusion: Select yes if you have an exemption from a mediator
         steps/miam/certification_form:
           attributes:
             miam_certification:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,7 @@ Rails.application.routes.draw do
     namespace :miam do
       edit_step :acknowledgement
       edit_step :attended
+      edit_step :mediator_exemption
       edit_step :exemption_claim
       edit_step :certification
       show_step :certification_exit

--- a/db/migrate/20201216130249_add_miam_mediator_exemption_field.rb
+++ b/db/migrate/20201216130249_add_miam_mediator_exemption_field.rb
@@ -1,0 +1,5 @@
+class AddMiamMediatorExemptionField < ActiveRecord::Migration[5.2]
+  def change
+    add_column :c100_applications, :miam_mediator_exemption, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_124339) do
+ActiveRecord::Schema.define(version: 2020_12_16_130249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -149,6 +149,7 @@ ActiveRecord::Schema.define(version: 2020_11_18_124339) do
     t.string "court_id"
     t.string "research_consent"
     t.string "research_consent_email"
+    t.string "miam_mediator_exemption"
     t.index ["court_id"], name: "index_c100_applications_on_court_id"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"

--- a/spec/controllers/steps/miam/mediator_exemption_controller_spec.rb
+++ b/spec/controllers/steps/miam/mediator_exemption_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Miam::MediatorExemptionController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Miam::MediatorExemptionForm, C100App::MiamDecisionTree
+end

--- a/spec/forms/steps/miam/mediator_exemption_form_spec.rb
+++ b/spec/forms/steps/miam/mediator_exemption_form_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Miam::MediatorExemptionForm do
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :miam_mediator_exemption,
+                  reset_when_yes: [:miam_exemption_claim, :miam_exemption]
+end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22821199

This PR adds the new step (yes-no question) with the controller, form object and view, as well as the new DB attribute.

It is still not linked in the decision tree and not visible, unless it is accessed directly by going to the URL.

In following PRs it will be linked to the decision tree as well as adding the new question to the CYA and the PDF.

<img width="631" alt="Screenshot 2020-12-16 at 13 33 03" src="https://user-images.githubusercontent.com/687910/102355058-3ec13280-3fa3-11eb-8efb-5bc75166bc0b.png">
