### PR TITLE
Update MIAM reset mechanism in multiple steps

### DIFF
--- a/app/forms/steps/miam/attended_form.rb
+++ b/app/forms/steps/miam/attended_form.rb
@@ -3,12 +3,17 @@ module Steps
     class AttendedForm < BaseForm
       include SingleQuestionForm
 
-      yes_no_attribute :miam_attended, reset_when_no: [
-        :miam_exemption_claim,
-        :miam_certification,
-        Steps::Miam::CertificationDateForm,
-        Steps::Miam::CertificationDetailsForm,
-      ]
+      yes_no_attribute :miam_attended,
+                       reset_when_yes: [
+                         :miam_mediator_exemption,
+                         :miam_exemption_claim,
+                         :miam_exemption,
+                       ],
+                       reset_when_no: [
+                         :miam_certification,
+                         Steps::Miam::CertificationDateForm,
+                         Steps::Miam::CertificationDetailsForm,
+                       ]
     end
   end
 end

--- a/app/forms/steps/miam/certification_form.rb
+++ b/app/forms/steps/miam/certification_form.rb
@@ -4,7 +4,6 @@ module Steps
       include SingleQuestionForm
 
       yes_no_attribute :miam_certification, reset_when_no: [
-        :miam_exemption_claim,
         Steps::Miam::CertificationDateForm,
         Steps::Miam::CertificationDetailsForm,
       ]

--- a/app/forms/steps/miam/mediator_exemption_form.rb
+++ b/app/forms/steps/miam/mediator_exemption_form.rb
@@ -5,7 +5,12 @@ module Steps
 
       # The reset will delete the row from the `miam_exemptions` table
       yes_no_attribute :miam_mediator_exemption,
-                       reset_when_yes: [:miam_exemption_claim, :miam_exemption]
+                       reset_when_yes: [:miam_exemption_claim, :miam_exemption],
+                       reset_when_no: [
+                         :miam_certification,
+                         Steps::Miam::CertificationDateForm,
+                         Steps::Miam::CertificationDetailsForm,
+                       ]
     end
   end
 end

--- a/app/forms/steps/opening/child_protection_cases_form.rb
+++ b/app/forms/steps/opening/child_protection_cases_form.rb
@@ -10,6 +10,7 @@ module Steps
       yes_no_attribute :child_protection_cases, reset_when_yes: [
         :miam_acknowledgement,
         :miam_attended,
+        :miam_mediator_exemption,
         :miam_exemption_claim,
         :miam_certification,
         Steps::Miam::CertificationDateForm,

--- a/app/forms/steps/opening/consent_order_form.rb
+++ b/app/forms/steps/opening/consent_order_form.rb
@@ -11,6 +11,7 @@ module Steps
         :child_protection_cases,
         :miam_acknowledgement,
         :miam_attended,
+        :miam_mediator_exemption,
         :miam_exemption_claim,
         :miam_certification,
         Steps::Miam::CertificationDateForm,

--- a/app/services/c100_app/miam_decision_tree.rb
+++ b/app/services/c100_app/miam_decision_tree.rb
@@ -8,6 +8,8 @@ module C100App
         edit(:attended)
       when :miam_attended
         after_miam_attended
+      when :miam_mediator_exemption
+        after_miam_mediator_exemption
       when :miam_exemption_claim
         after_miam_exemption_claim
       when :miam_certification
@@ -33,6 +35,15 @@ module C100App
 
     def after_miam_attended
       if question(:miam_attended).yes?
+        edit(:certification)
+      else
+        # TODO: replace with `edit(:mediator_exemption)` to enable the new question
+        edit(:exemption_claim)
+      end
+    end
+
+    def after_miam_mediator_exemption
+      if question(:miam_mediator_exemption).yes?
         edit(:certification)
       else
         edit(:exemption_claim)

--- a/spec/forms/steps/miam/attended_form_spec.rb
+++ b/spec/forms/steps/miam/attended_form_spec.rb
@@ -1,13 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Miam::AttendedForm do
-  it_behaves_like 'a yes-no question form', attribute_name: :miam_attended,
-    reset_when_no: [
-      :miam_exemption_claim,
-      :miam_certification,
-      :miam_certification_date,
-      :miam_certification_number,
-      :miam_certification_service_name,
-      :miam_certification_sole_trader_name
-    ]
+  it_behaves_like 'a yes-no question form',
+                  attribute_name: :miam_attended,
+                  reset_when_yes: [
+                    :miam_mediator_exemption,
+                    :miam_exemption_claim,
+                    :miam_exemption,
+                  ],
+                  reset_when_no: [
+                    :miam_certification,
+                    :miam_certification_date,
+                    :miam_certification_number,
+                    :miam_certification_service_name,
+                    :miam_certification_sole_trader_name,
+                  ]
 end

--- a/spec/forms/steps/miam/certification_form_spec.rb
+++ b/spec/forms/steps/miam/certification_form_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Steps::Miam::CertificationForm do
   it_behaves_like 'a yes-no question form',
                   attribute_name: :miam_certification,
                   reset_when_no: [
-                    :miam_exemption_claim,
                     :miam_certification_date,
                     :miam_certification_number,
                     :miam_certification_service_name,

--- a/spec/forms/steps/miam/mediator_exemption_form_spec.rb
+++ b/spec/forms/steps/miam/mediator_exemption_form_spec.rb
@@ -3,5 +3,15 @@ require 'spec_helper'
 RSpec.describe Steps::Miam::MediatorExemptionForm do
   it_behaves_like 'a yes-no question form',
                   attribute_name: :miam_mediator_exemption,
-                  reset_when_yes: [:miam_exemption_claim, :miam_exemption]
+                  reset_when_yes: [
+                    :miam_exemption_claim,
+                    :miam_exemption,
+                  ],
+                  reset_when_no: [
+                    :miam_certification,
+                    :miam_certification_date,
+                    :miam_certification_number,
+                    :miam_certification_service_name,
+                    :miam_certification_sole_trader_name,
+                  ]
 end

--- a/spec/forms/steps/opening/child_protection_cases_form_spec.rb
+++ b/spec/forms/steps/opening/child_protection_cases_form_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Steps::Opening::ChildProtectionCasesForm do
                   reset_when_yes: [
                     :miam_acknowledgement,
                     :miam_attended,
+                    :miam_mediator_exemption,
                     :miam_exemption_claim,
                     :miam_certification,
                     :miam_certification_date,

--- a/spec/forms/steps/opening/consent_order_form_spec.rb
+++ b/spec/forms/steps/opening/consent_order_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Steps::Opening::ConsentOrderForm do
                     :child_protection_cases,
                     :miam_acknowledgement,
                     :miam_attended,
+                    :miam_mediator_exemption,
                     :miam_exemption_claim,
                     :miam_certification,
                     :miam_certification_date,

--- a/spec/services/c100_app/miam_decision_tree_spec.rb
+++ b/spec/services/c100_app/miam_decision_tree_spec.rb
@@ -26,6 +26,22 @@ RSpec.describe C100App::MiamDecisionTree do
       it { is_expected.to have_destination(:certification, :edit) }
     end
 
+    # TODO: replace destination with `mediator_exemption`
+    context 'and the answer is `no`' do
+      let(:value) { 'no' }
+      it { is_expected.to have_destination(:exemption_claim, :edit) }
+    end
+  end
+
+  context 'when the step is `miam_mediator_exemption`' do
+    let(:c100_application) { instance_double(C100Application, miam_mediator_exemption: value) }
+    let(:step_params) { { miam_mediator_exemption: 'anything' } }
+
+    context 'and the answer is `yes`' do
+      let(:value) { 'yes' }
+      it { is_expected.to have_destination(:certification, :edit) }
+    end
+
     context 'and the answer is `no`' do
       let(:value) { 'no' }
       it { is_expected.to have_destination(:exemption_claim, :edit) }


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22821199

Follow-up to PR #1132

Update the decision tree (but the new step is still not showing) so the journey is still the same.

Updated several form objects to perform the correct reset of attributes when changing from yes to no, or viceversa, in order to not leave inconsistent selected options across the journey.