### PR TITLE
Show page to find a mediator when user has not attended MIAM

### DIFF
--- a/app/services/c100_app/miam_decision_tree.rb
+++ b/app/services/c100_app/miam_decision_tree.rb
@@ -29,7 +29,7 @@ module C100App
       if question(:miam_exemption_claim).yes?
         edit('/steps/miam_exemptions/domestic')
       else
-        show('/steps/safety_questions/start')
+        show('/steps/miam_exemptions/exit_page')
       end
     end
 

--- a/app/services/c100_app/miam_exemptions_decision_tree.rb
+++ b/app/services/c100_app/miam_exemptions_decision_tree.rb
@@ -13,7 +13,7 @@ module C100App
       when :adr
         edit(:misc)
       when :misc
-        show('/steps/safety_questions/start')
+        after_miam_exemption_misc
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
@@ -37,6 +37,14 @@ module C100App
       MiamExemptionsPresenter.new(
         c100_application.miam_exemption
       ).exemptions.any?
+    end
+
+    def after_miam_exemption_misc
+      if has_miam_exemptions?
+        show('/steps/safety_questions/start')
+      else
+        show('/steps/miam_exemptions/exit_page')
+      end
     end
 
     def has_safety_concerns?

--- a/features/miam.feature
+++ b/features/miam.feature
@@ -62,3 +62,54 @@ Feature: MIAM journey
       | has_valid_reason | outcome_page_header                                       |
       | Yes              | Providing evidence of domestic violence or abuse concerns |
       | No               | You must attend a MIAM                                    |
+
+  @unhappy_path
+  Scenario: Applicant did not attend a MIAM and has not selected a valid reason
+    Then I should see "Have you attended a Mediation Information and Assessment Meeting (MIAM)?"
+    And I choose "No"
+    Then I should see "Has a mediator confirmed that you do not need to attend a MIAM?"
+    And I choose "No"
+    Then I should see "Do you have a valid reason for not attending a MIAM?"
+    And I choose "Yes"
+    Then I should see "Providing evidence of domestic violence or abuse concerns"
+    And I check "None of these"
+    And I click the "Continue" button
+    Then I should see "Confirming child protection concerns"
+    And I check "None of these"
+    And I click the "Continue" button
+    Then I should see "Confirming why your application is urgent"
+    And I check "None of these"
+    And I click the "Continue" button
+    Then I should see "Confirming that you’ve previously been to a MIAM or had a valid reason for not attending one"
+    And I check "None of these"
+    And I click the "Continue" button
+    Then I should see "Confirming other valid reasons for not attending"
+    And I check "None of these"
+    And I click the "Continue" button
+    Then I should see "You must attend a MIAM"
+
+  @unhappy_path
+  Scenario: Applicant did not attend a MIAM and has selected a misc valid reason
+    Then I should see "Have you attended a Mediation Information and Assessment Meeting (MIAM)?"
+    And I choose "No"
+    Then I should see "Has a mediator confirmed that you do not need to attend a MIAM?"
+    And I choose "No"
+    Then I should see "Do you have a valid reason for not attending a MIAM?"
+    And I choose "Yes"
+    Then I should see "Providing evidence of domestic violence or abuse concerns"
+    And I check "None of these"
+    And I click the "Continue" button
+    Then I should see "Confirming child protection concerns"
+    And I check "None of these"
+    And I click the "Continue" button
+    Then I should see "Confirming why your application is urgent"
+    And I check "None of these"
+    And I click the "Continue" button
+    Then I should see "Confirming that you’ve previously been to a MIAM or had a valid reason for not attending one"
+    And I check "None of these"
+    And I click the "Continue" button
+    Then I should see "Confirming other valid reasons for not attending"
+    And I check "You can’t access a mediator"
+    And I check "There is no authorised family mediator with an office within 15 miles of your home"
+    And I click the "Continue" button
+    Then I should see "Safety concerns"

--- a/features/miam.feature
+++ b/features/miam.feature
@@ -61,4 +61,4 @@ Feature: MIAM journey
     Examples:
       | has_valid_reason | outcome_page_header                                       |
       | Yes              | Providing evidence of domestic violence or abuse concerns |
-      | No               | Safety concerns                                           |
+      | No               | You must attend a MIAM                                    |

--- a/spec/services/c100_app/miam_decision_tree_spec.rb
+++ b/spec/services/c100_app/miam_decision_tree_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe C100App::MiamDecisionTree do
 
     context 'and the answer is `no`' do
       let(:value) { 'no' }
-      it { is_expected.to have_destination('/steps/safety_questions/start', :show) }
+      it { is_expected.to have_destination('/steps/miam_exemptions/exit_page', :show) }
     end
   end
 

--- a/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
+++ b/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
@@ -31,8 +31,23 @@ RSpec.describe C100App::MiamExemptionsDecisionTree do
   end
 
   context 'when the step is `misc`' do
+    let(:c100_application) { C100Application.new(attributes) }
     let(:step_params) { { misc: 'anything' } }
-    it { is_expected.to have_destination('/steps/safety_questions/start', :show) }
+    let(:attributes) {
+      {
+        miam_exemption: nil,
+      }
+    }
+
+    context 'when there are no MIAM exemptions' do
+      it { is_expected.to have_destination('/steps/miam_exemptions/exit_page', :show) }
+    end
+
+    context 'when there are MIAM exemptions' do
+      let(:attributes) { super().merge(miam_exemption: MiamExemption.new(misc: ['applicant_under_age'])) }
+
+      it { is_expected.to have_destination('/steps/safety_questions/start', :show) }
+    end
   end
 
   describe '#playback_destination' do


### PR DESCRIPTION
As part of the changes proposed for the MIAM journey, we are closing the loophole where a user could continue with the application even without exemption and no attendance to MIAM.
This is in line with the paper form.

If the applicant didn't attend a MIAM, didn't have a meditor's exemption and didn't have another reason not to attend, then instead of continuing to safety concerns like now, (/steps/safety_questions/start) show a kick out page as per design.

![Screenshot 2020-12-16 at 15 56 40](https://user-images.githubusercontent.com/136777/102498819-59161180-4072-11eb-905a-d9e5e5d05c02.png)

I've confirmed that there was no need to change the copy of the existing page.

![Screenshot 2020-12-17 at 14 10 05](https://user-images.githubusercontent.com/136777/102498911-79de6700-4072-11eb-871f-5ed440ab4ddc.png)


Story: https://mojdigital.teamwork.com/#/tasks/22821224