### PR TITLE
Reintroduce MIAM exemptions playback and refactor

### DIFF
--- a/app/services/c100_app/abuse_concerns_decision_tree.rb
+++ b/app/services/c100_app/abuse_concerns_decision_tree.rb
@@ -7,7 +7,7 @@ module C100App
       when :details
         after_details_step
       when :contact
-        miam_exemptions_playback
+        edit('/steps/petition/orders')
       else
         raise InvalidStep, "Invalid step '#{step_name}'"
       end
@@ -99,12 +99,6 @@ module C100App
       else
         raise InvalidStep, "Unknown abuse kind: #{abuse_kind}"
       end
-    end
-
-    def miam_exemptions_playback
-      MiamExemptionsDecisionTree.new(
-        c100_application: c100_application
-      ).playback_destination
     end
   end
 end

--- a/app/services/c100_app/miam_exemptions_decision_tree.rb
+++ b/app/services/c100_app/miam_exemptions_decision_tree.rb
@@ -13,50 +13,26 @@ module C100App
       when :adr
         edit(:misc)
       when :misc
-        after_miam_exemption_misc
+        playback_or_exit_page
       else
         raise InvalidStep, "Invalid step '#{as || step_params}'"
       end
     end
 
-    def playback_destination
-      if miam_not_required? || has_mediator_details?
-        edit('/steps/petition/orders')
-      elsif has_miam_exemptions?
-        show('/steps/miam_exemptions/reasons_playback')
-      elsif has_safety_concerns?
-        show('/steps/miam_exemptions/safety_playback')
+    private
+
+    def playback_or_exit_page
+      if has_miam_exemptions?
+        show(:reasons_playback)
       else
-        show('/steps/miam_exemptions/exit_page')
+        show(:exit_page)
       end
     end
-
-    private
 
     def has_miam_exemptions?
       MiamExemptionsPresenter.new(
         c100_application.miam_exemption
       ).exemptions.any?
-    end
-
-    def after_miam_exemption_misc
-      if has_miam_exemptions?
-        show('/steps/safety_questions/start')
-      else
-        show('/steps/miam_exemptions/exit_page')
-      end
-    end
-
-    def has_safety_concerns?
-      c100_application.has_safety_concerns?
-    end
-
-    def has_mediator_details?
-      c100_application.miam_certification_number?
-    end
-
-    def miam_not_required?
-      c100_application.consent_order? || c100_application.child_protection_cases?
     end
   end
 end

--- a/app/services/c100_app/safety_questions_decision_tree.rb
+++ b/app/services/c100_app/safety_questions_decision_tree.rb
@@ -59,18 +59,12 @@ module C100App
       if question(:other_abuse).yes?
         start_abuse_concerns_journey
       else
-        miam_exemptions_playback
+        edit('/steps/petition/orders')
       end
     end
 
     def start_abuse_concerns_journey
       show('/steps/abuse_concerns/start')
-    end
-
-    def miam_exemptions_playback
-      MiamExemptionsDecisionTree.new(
-        c100_application: c100_application
-      ).playback_destination
     end
   end
 end

--- a/app/views/steps/miam_exemptions/reasons_playback/show.html.erb
+++ b/app/views/steps/miam_exemptions/reasons_playback/show.html.erb
@@ -15,6 +15,6 @@
       <%=t '.info_notice' %>
     </div>
 
-    <%= link_button t('.continue'), edit_steps_petition_orders_path %>
+    <%= link_button t('.continue'), steps_safety_questions_start_path %>
   </div>
 </div>

--- a/features/miam.feature
+++ b/features/miam.feature
@@ -88,7 +88,7 @@ Feature: MIAM journey
     And I click the "Continue" button
     Then I should see "You must attend a MIAM"
 
-  @unhappy_path
+  @happy_path
   Scenario: Applicant did not attend a MIAM and has selected a misc valid reason
     Then I should see "Have you attended a Mediation Information and Assessment Meeting (MIAM)?"
     And I choose "No"
@@ -112,4 +112,10 @@ Feature: MIAM journey
     And I check "You can’t access a mediator"
     And I check "There is no authorised family mediator with an office within 15 miles of your home"
     And I click the "Continue" button
+
+    Then I should see "You don’t have to attend a MIAM"
+    Then I should see "Other exemptions"
+    Then I should see "There is no authorised family mediator with an office within 15 miles of your home"
+
+    And I click the "Continue" link
     Then I should see "Safety concerns"

--- a/spec/services/c100_app/abuse_concerns_decision_tree_spec.rb
+++ b/spec/services/c100_app/abuse_concerns_decision_tree_spec.rb
@@ -300,20 +300,9 @@ RSpec.describe C100App::AbuseConcernsDecisionTree do
     end
   end
 
-  describe 'when the step is `contact`' do
+  context 'when the step is `contact`' do
     let(:as) { 'contact' }
-    let(:exemptions_tree) { spy('exemptions_tree') }
-
-    before do
-      allow(C100App::MiamExemptionsDecisionTree).to receive(:new).with(
-        c100_application: c100_application
-      ).and_return(exemptions_tree)
-    end
-
-    it 'delegates the destination decision to the `MiamExemptionsDecisionTree`' do
-      expect(exemptions_tree).to receive(:playback_destination)
-      subject.destination
-    end
+    it { is_expected.to have_destination('/steps/petition/orders', :edit) }
   end
 
   describe 'when the step is not known' do

--- a/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
+++ b/spec/services/c100_app/miam_exemptions_decision_tree_spec.rb
@@ -40,86 +40,13 @@ RSpec.describe C100App::MiamExemptionsDecisionTree do
     }
 
     context 'when there are no MIAM exemptions' do
-      it { is_expected.to have_destination('/steps/miam_exemptions/exit_page', :show) }
+      it { is_expected.to have_destination(:exit_page, :show) }
     end
 
     context 'when there are MIAM exemptions' do
       let(:attributes) { super().merge(miam_exemption: MiamExemption.new(misc: ['applicant_under_age'])) }
 
-      it { is_expected.to have_destination('/steps/safety_questions/start', :show) }
-    end
-  end
-
-  describe '#playback_destination' do
-    let(:c100_application) { C100Application.new(attributes) }
-    let(:attributes) {
-      {
-        consent_order: 'no',
-        child_protection_cases: 'no',
-        miam_certification_number: nil,
-        substance_abuse: 'no',
-        miam_exemption: nil,
-      }
-    }
-
-    context 'when asking for a consent order' do
-      let(:attributes) { super().merge(consent_order: 'yes') }
-
-      it {
-        expect(
-          subject.playback_destination
-        ).to eq(controller: '/steps/petition/orders', action: :edit)
-      }
-    end
-
-    context 'when children have been involved in court cases' do
-      let(:attributes) { super().merge(child_protection_cases: 'yes') }
-
-      it {
-        expect(
-          subject.playback_destination
-        ).to eq(controller: '/steps/petition/orders', action: :edit)
-      }
-    end
-
-    context 'when MIAM certification is present' do
-      let(:attributes) { super().merge(miam_certification_number: '1234X') }
-
-      it {
-        expect(
-          subject.playback_destination
-        ).to eq(controller: '/steps/petition/orders', action: :edit)
-      }
-    end
-
-    context 'when there are MIAM exemptions' do
-      let(:attributes) { super().merge(miam_exemption: MiamExemption.new(domestic: ['anything'])) }
-
-      it {
-        expect(
-          subject.playback_destination
-        ).to eq(controller: '/steps/miam_exemptions/reasons_playback', action: :show)
-      }
-    end
-
-    context 'when there are safety concerns' do
-      let(:attributes) { super().merge(substance_abuse: 'yes') }
-
-      it {
-        expect(
-          subject.playback_destination
-        ).to eq(controller: '/steps/miam_exemptions/safety_playback', action: :show)
-      }
-    end
-
-    context 'when there are no exemptions or safety concerns' do
-      let(:c100_application) { C100Application.new }
-
-      it {
-        expect(
-          subject.playback_destination
-        ).to eq(controller: '/steps/miam_exemptions/exit_page', action: :show)
-      }
+      it { is_expected.to have_destination(:reasons_playback, :show) }
     end
   end
 end

--- a/spec/services/c100_app/safety_questions_decision_tree_spec.rb
+++ b/spec/services/c100_app/safety_questions_decision_tree_spec.rb
@@ -100,18 +100,7 @@ RSpec.describe C100App::SafetyQuestionsDecisionTree do
 
     context 'and the answer is `no`' do
       let(:value) { 'no' }
-      let(:exemptions_tree) { spy('exemptions_tree') }
-
-      before do
-        allow(C100App::MiamExemptionsDecisionTree).to receive(:new).with(
-          c100_application: c100_application
-        ).and_return(exemptions_tree)
-      end
-
-      it 'delegates the destination decision to the `MiamExemptionsDecisionTree`' do
-        expect(exemptions_tree).to receive(:playback_destination)
-        subject.destination
-      end
+      it { is_expected.to have_destination('/steps/petition/orders', :edit) }
     end
   end
 end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/22821224

After the applicant goes through the list of MIAM exemptions, if they don't select any, we show them the kick out page (that was done in PR #1135) but if the applicant select one or more exemptions we should show them the playback page.

This playback page used to be after the safety concerns journey but because we now don't let the user continue to this journey we need to show it before.

As a consequence a bit of refactor and simplification in other decisions tree have been made as the logic is now much more simpler.

<img width="608" alt="Screenshot 2020-12-18 at 11 26 56" src="https://user-images.githubusercontent.com/687910/102610012-61c72000-4124-11eb-861d-437a4cba40c1.png">
