### PR TITLE
Disable research consent step

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,8 +61,8 @@ class Application < Rails::Application
 
   # Show the `research consent` question (used to gather emails of users for research
   # purposes) to this percentage of applications.
-  # Defaults to 100 if ENV is not set. Set ENV to any other value, or 0 to disable.
-  config.x.opening.research_consent_weight = ENV.fetch('RESEARCH_CONSENT_WEIGHT', 100).to_i
+  # If ENV is set, takes precedence. Can be set to any value between 0 (disabled) and 100.
+  config.x.opening.research_consent_weight = ENV.fetch('RESEARCH_CONSENT_WEIGHT', 0).to_i
 
   # As part of the opening postcode step, an empty C100Application record is created.
   # If the postcode is not eligible, these records are left orphans and have no use.

--- a/features/00_opening.feature
+++ b/features/00_opening.feature
@@ -14,9 +14,14 @@ Feature: Opening
   Scenario: Complete the opening
     When I fill in "Postcode" with "MK9 3DX"
     And I click the "Continue" button
-    Then I should see "Are you willing to be contacted to share your experience of using this service?"
-    And I should not see the save draft button
-    And I choose "No"
+
+    # Note: user research question is disabled for the time being.
+    # Refer to `config.x.opening.research_consent_weight` in `config/application.rb` to enable/disable.
+    #
+    # Then I should see "Are you willing to be contacted to share your experience of using this service?"
+    # And I should not see the save draft button
+    # And I choose "No"
+
     Then I should see "What kind of application do you want to make?"
     And I should not see the save draft button
     And I choose "Child arrangements order, prohibited steps order, specific issue order, or to change or end an existing order"


### PR DESCRIPTION
We had this disabled via ENV variable in production environment (value 0) but the step was still showing on staging and localhost causing some confusion.

Set default value to 0 so the step is disabled everywhere for the time being. Can be changed again in the future if we want to enable the user research question.