### PR TITLE
Cleanup of unused solicitor address DB field

### DIFF
--- a/app/models/solicitor.rb
+++ b/app/models/solicitor.rb
@@ -2,13 +2,4 @@ class Solicitor < ApplicationRecord
   include PersonWithAddress
 
   belongs_to :c100_application
-
-  # TODO: we need to maintain backwards compatibility for some time
-  # with the old "free text area" address attrib. Once all applications
-  # are using the structured `address_data`, we can remove this method.
-  # If both, old and new data are present, we prioritise the new data.
-  #
-  def full_address
-    super().presence || address
-  end
 end

--- a/db/migrate/20210108103926_remove_address_from_solicitors.rb
+++ b/db/migrate/20210108103926_remove_address_from_solicitors.rb
@@ -1,0 +1,5 @@
+class RemoveAddressFromSolicitors < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :solicitors, :address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_16_130249) do
+ActiveRecord::Schema.define(version: 2021_01_08_103926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -363,7 +363,6 @@ ActiveRecord::Schema.define(version: 2020_12_16_130249) do
     t.string "full_name"
     t.string "firm_name"
     t.string "reference"
-    t.text "address"
     t.string "dx_number"
     t.string "phone_number"
     t.string "fax_number"

--- a/spec/models/solicitor_spec.rb
+++ b/spec/models/solicitor_spec.rb
@@ -2,29 +2,4 @@ require 'rails_helper'
 
 RSpec.describe Solicitor, type: :model do
   it_behaves_like 'a model with structured address details'
-
-  # TODO: we need to maintain backwards compatibility for some time
-  describe '#full_address' do
-    subject { described_class.new(address: address_string, address_data: address_hash) }
-
-    let(:address_string) { 'address' }
-    let(:address_hash) do
-      {
-        address_line_1: 'address_line_1',
-        address_line_2: '',
-        town: 'town',
-        country: 'country',
-        postcode: 'postcode'
-      }
-    end
-
-    context 'when we have old `address` but not new `address_data`' do
-      let(:address_hash) { {} }
-      it { expect(subject.full_address).to eq('address') }
-    end
-
-    context 'when we have old `address` and also new `address_data`' do
-      it { expect(subject.full_address).to eq('address_line_1, town, country, postcode') }
-    end
-  end
 end


### PR DESCRIPTION
We don't need this anymore as we've migrated the address to structured data.
No applications are using this DB field anymore.

Removal of the attribute and unused code.