### PR TITLE
Specify version of docker to use in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
       - checkout
 
       - setup_remote_docker:
+          version: 19.03.13
           docker_layer_caching: true
 
       - run:
@@ -141,6 +142,7 @@ jobs:
       - checkout
 
       - setup_remote_docker:
+          version: 19.03.13
           docker_layer_caching: true
 
       - run:


### PR DESCRIPTION
This is neccessary as more recent versions in CircleCI starts giving errors when writing assets:

```
error An unexpected error occurred: "EPERM: operation not permitted, copyfile '/usr/local/share/.cache/yarn/v6/npm-govuk-frontend-3.10.2-6589401e4adad1ab1dc340a18057ec88c9435a84-integrity/node_modules/govuk-frontend/README.md' -> '/usr/src/app/node_modules/govuk-frontend/README.md'".
info If you think this is a bug, please open a bug report with the information provided in "/usr/src/app/yarn-error.log".
```

Kudos to another team who found this problem first and shared the solution:
https://mojdt.slack.com/archives/CCSD5F397/p1610108410041100

And their PR:
https://github.com/ministryofjustice/laa-court-data-ui/pull/416