### PR TITLE
Reposition C8 previous addresses section

### DIFF
--- a/app/presenters/summary/sections/c8_applicants_details.rb
+++ b/app/presenters/summary/sections/c8_applicants_details.rb
@@ -23,11 +23,12 @@ module Summary
             Separator.new("#{name}_index_title", index: index),
             FreeTextAnswer.new(:person_full_name, person.full_name),
             FreeTextAnswer.new(:person_address, person.full_address),
-            FreeTextAnswer.new(:person_residence_history, person.residence_history),
             FreeTextAnswer.new(:person_email, person.email),
             FreeTextAnswer.new(:person_home_phone, person.home_phone),
             FreeTextAnswer.new(:person_mobile_phone, person.mobile_phone),
             Answer.new(:person_voicemail_consent, person.voicemail_consent),
+            Partial.row_blank_space,
+            FreeTextAnswer.new(:person_residence_history, person.residence_history),
             Partial.row_blank_space,
           ]
         end.flatten.select(&:show?)

--- a/spec/presenters/summary/sections/c8_applicants_details_spec.rb
+++ b/spec/presenters/summary/sections/c8_applicants_details_spec.rb
@@ -49,7 +49,7 @@ module Summary
 
     describe '#answers' do
       it 'has the correct number of rows' do
-        expect(answers.count).to eq(9)
+        expect(answers.count).to eq(10)
       end
 
       it 'has the correct rows in the right order' do
@@ -66,27 +66,30 @@ module Summary
         expect(answers[2].value).to eq('full address')
 
         expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[3].question).to eq(:person_residence_history)
-        expect(answers[3].value).to eq('history')
+        expect(answers[3].question).to eq(:person_email)
+        expect(answers[3].value).to eq('email')
 
         expect(answers[4]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[4].question).to eq(:person_email)
-        expect(answers[4].value).to eq('email')
+        expect(answers[4].question).to eq(:person_home_phone)
+        expect(answers[4].value).to eq('home_phone')
 
         expect(answers[5]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[5].question).to eq(:person_home_phone)
-        expect(answers[5].value).to eq('home_phone')
+        expect(answers[5].question).to eq(:person_mobile_phone)
+        expect(answers[5].value).to eq('mobile_phone')
 
-        expect(answers[6]).to be_an_instance_of(FreeTextAnswer)
-        expect(answers[6].question).to eq(:person_mobile_phone)
-        expect(answers[6].value).to eq('mobile_phone')
+        expect(answers[6]).to be_an_instance_of(Answer)
+        expect(answers[6].question).to eq(:person_voicemail_consent)
+        expect(answers[6].value).to eq('yes')
 
-        expect(answers[7]).to be_an_instance_of(Answer)
-        expect(answers[7].question).to eq(:person_voicemail_consent)
-        expect(answers[7].value).to eq('yes')
+        expect(answers[7]).to be_an_instance_of(Partial)
+        expect(answers[7].name).to eq(:row_blank_space)
 
-        expect(answers[8]).to be_an_instance_of(Partial)
-        expect(answers[8].name).to eq(:row_blank_space)
+        expect(answers[8]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[8].question).to eq(:person_residence_history)
+        expect(answers[8].value).to eq('history')
+
+        expect(answers[9]).to be_an_instance_of(Partial)
+        expect(answers[9].name).to eq(:row_blank_space)
       end
     end
   end


### PR DESCRIPTION
Ticket: https://trello.com/c/tqvItimB

A request from HMCTS came in where some courts where having issues
with the positioning of the `previous addresses` (if applicant
entered any) in the C8 (when the address confidentiality is enabled).

A suggestion was made to reposition the previous addresses section
towards the bottom of the applicant contact details, separated from
the current address.

**BEFORE:**
<img width="833" alt="Screenshot_2021-01-18_at_12 51 53" src="https://user-images.githubusercontent.com/687910/105164308-e387e000-5b0c-11eb-9fb8-3a1263c9d5ab.png">

**AFTER:**
<img width="821" alt="Screenshot 2021-01-20 at 12 10 23" src="https://user-images.githubusercontent.com/687910/105173145-82fea000-5b18-11eb-84b8-e51b28688f83.png">
