### PR TITLE
Remove Brussels reference from PDF

### DIFF
--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -256,7 +256,7 @@ en:
     international_resident_details:
       question: *details
     international_jurisdiction:
-      question: Do you have any reason to believe that there may be an issue as to jurisdiction in this case (for example under Brussels 2 revised)?
+      question: Do you have any reason to believe that there may be an issue as to jurisdiction in this case?
       answers:
         <<: *YESNO
     international_jurisdiction_details:


### PR DESCRIPTION
Ticket: https://trello.com/c/xbDXxMyv

Just a small portion of copy removed as, after Brexit, Brussels 2 is no longer relevant to UK law.

<img width="823" alt="Screenshot 2021-01-27 at 16 37 54" src="https://user-images.githubusercontent.com/687910/106023562-d0ea4980-60be-11eb-930c-243b6f39c618.png">
