### PR TITLE
Store the court county location code

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -5,6 +5,7 @@ class Court < ApplicationRecord
   has_many :c100_applications
 
   alias_attribute :slug, :id
+  alias_attribute :county_location_code, :cci_code
 
   # Using `fetch` so an exception is raised and we are alerted if the json
   # schema ever changes, instead of silently let the user continue, as all
@@ -15,6 +16,7 @@ class Court < ApplicationRecord
       slug: data.fetch('slug'),
       name: data.fetch('name'),
       address: data.fetch('address'),
+      cci_code: data.fetch('cci_code'),
       # Email and GBS code, if not already present, come from a separate API request
       email: data['email'],
       gbs: data['gbs'],

--- a/db/migrate/20210128095510_add_court_location_code.rb
+++ b/db/migrate/20210128095510_add_court_location_code.rb
@@ -1,0 +1,5 @@
+class AddCourtLocationCode < ActiveRecord::Migration[5.2]
+  def change
+    add_column :courts, :cci_code, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_08_103926) do
+ActiveRecord::Schema.define(version: 2021_01_28_095510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -254,6 +254,7 @@ ActiveRecord::Schema.define(version: 2021_01_08_103926) do
     t.string "email", null: false
     t.string "gbs", null: false
     t.jsonb "address", default: {}, null: false
+    t.integer "cci_code"
   end
 
   create_table "email_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -9,6 +9,7 @@ describe Court do
       "slug" => 'court-slug',
       "email" => 'family@court',
       "address" => address,
+      "cci_code" => 123,
       "gbs" => 'X123',
     }
   }
@@ -36,6 +37,10 @@ describe Court do
 
     it 'sets the address' do
       expect(subject.address).to eq(address)
+    end
+
+    it 'sets the cci_code' do
+      expect(subject.cci_code).to eq(123)
     end
 
     it 'sets the gbs code' do
@@ -70,6 +75,16 @@ describe Court do
           expect(Raven).to receive(:extra_context).with(data: data)
           expect(Raven).to receive(:capture_exception).with(an_instance_of(KeyError))
           expect { subject.name }.to raise_error(KeyError, 'key not found: "address"')
+        end
+      end
+
+      context 'cci_code' do
+        let(:data) { super().except('cci_code') }
+
+        it 'sends the exception to Sentry with extra context' do
+          expect(Raven).to receive(:extra_context).with(data: data)
+          expect(Raven).to receive(:capture_exception).with(an_instance_of(KeyError))
+          expect { subject.name }.to raise_error(KeyError, 'key not found: "cci_code"')
         end
       end
     end
@@ -180,6 +195,7 @@ describe Court do
         "slug" => slug,
         "name" => 'Court Test',
         "address" => {},
+        "cci_code" => 123,
         "email" => nil,
         "gbs" => nil,
       }
@@ -217,7 +233,13 @@ describe Court do
 
         expect(
           @court.attributes
-        ).to include('name' => 'Court Test', 'email' => 'family@court', 'address' => {}, 'gbs' => 'X123')
+        ).to include(
+          'name' => 'Court Test',
+          'email' => 'family@court',
+          'address' => {},
+          'cci_code' => 123,
+          'gbs' => 'X123'
+        )
       end
     end
 

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe ValidPaymentsArray do
         'name' => 'Test court',
         'email' => 'court@example.com',
         'address' => 'Court address',
+        'cci_code' => 123,
         'slug' => court_slug,
         'gbs' => court_gbs,
       }


### PR DESCRIPTION
Ticket: https://trello.com/c/IDdg4Kyo

As part of the centralisation work, we first need to take from CTF a piece of information we were not using before, and store it in our `Courts` DB table for later use.

In a follow-up PR we will print this code in the application PDF.