### PR TITLE
Store the application `completed_at` timestamp

### DIFF
--- a/app/models/c100_application.rb
+++ b/app/models/c100_application.rb
@@ -59,7 +59,7 @@ class C100Application < ApplicationRecord
 
   def mark_as_completed!
     transaction do
-      completed!
+      update!(status: :completed, completed_at: Time.current)
       CompletedApplicationsAudit.log!(self)
     end
   end

--- a/app/models/completed_applications_audit.rb
+++ b/app/models/completed_applications_audit.rb
@@ -7,7 +7,7 @@ class CompletedApplicationsAudit < ApplicationRecord
   def self.log!(c100_application)
     create(
       started_at: c100_application.created_at,
-      completed_at: c100_application.updated_at,
+      completed_at: c100_application.completed_at,
       reference_code: c100_application.reference_code,
       submission_type: c100_application.submission_type,
       court: c100_application.court.name,

--- a/db/migrate/20210128153016_add_completed_at_to_c100_applications.rb
+++ b/db/migrate/20210128153016_add_completed_at_to_c100_applications.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtToC100Applications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :c100_applications, :completed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_28_095510) do
+ActiveRecord::Schema.define(version: 2021_01_28_153016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2021_01_28_095510) do
     t.string "research_consent"
     t.string "research_consent_email"
     t.string "miam_mediator_exemption"
+    t.datetime "completed_at"
     t.index ["court_id"], name: "index_c100_applications_on_court_id"
     t.index ["status"], name: "index_c100_applications_on_status"
     t.index ["user_id"], name: "index_c100_applications_on_user_id"

--- a/spec/models/c100_application_spec.rb
+++ b/spec/models/c100_application_spec.rb
@@ -179,8 +179,17 @@ RSpec.describe C100Application, type: :model do
   end
 
   describe '#mark_as_completed!' do
+    before do
+      travel_to Time.at(123)
+    end
+
     it 'marks the application as completed and saves the audit record' do
-      expect(subject).to receive(:completed!).and_return(true)
+      expect(
+        subject
+      ).to receive(:update!).with(
+        status: :completed, completed_at: Time.at(123)
+      ).and_return(true)
+
       expect(CompletedApplicationsAudit).to receive(:log!).with(subject)
 
       subject.mark_as_completed!
@@ -203,11 +212,12 @@ RSpec.describe C100Application, type: :model do
 
       it 'reverts the application status to how it was before (rollbacks)' do
         expect(subject.status).to eq('in_progress')
-        expect(subject).to receive(:completed!).and_call_original
+        expect(subject).to receive(:update!).and_call_original
 
         expect { subject.mark_as_completed! }.to raise_error
 
         expect(subject.reload.status).to eq('in_progress')
+        expect(subject.reload.completed_at).to be_nil
       end
     end
   end

--- a/spec/models/completed_applications_audit_spec.rb
+++ b/spec/models/completed_applications_audit_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CompletedApplicationsAudit, type: :model do
     C100Application.new(
       id: '449362af-0bc3-4953-82a7-1363d479b876',
       created_at: Time.at(0),
-      updated_at: Time.at(100),
+      completed_at: Time.at(100),
       submission_type: 'online',
     )
   }


### PR DESCRIPTION
Ticket: https://trello.com/c/IDdg4Kyo

Follow-up to PR #1146.

A new requirement has been raised to also print in the PDF the completion date of the application.

We had already this date but in a separate audit table and corresponding to the last `updated_at` of the application.

In order for both tables to share the same, accurate timestamp, it is best to have a specific `completed_at` attribute stored in the c100 application itself to refer to this each time the PDF needs to be generated (when it is submitted to court, or the user downloads the PDF for example).