### PR TITLE
Add new processing details section to PDF

### DIFF
--- a/app/assets/stylesheets/local/pdf_summary.scss
+++ b/app/assets/stylesheets/local/pdf_summary.scss
@@ -201,6 +201,17 @@ body:not(.status-completed) {
     }
   }
 
+  // Processing details can also be resized so it fits better and is not
+  // disrupting for the user (these details are just for scanning processes).
+  #processing_details {
+    td.question {
+      width: 10%;
+    }
+    td.answer {
+      width: 90%;
+    }
+  }
+
   #children_known_to_authorities {
     td {
       padding-top: 15px;

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -80,6 +80,7 @@ class SessionsController < ApplicationController
       "name" => "Milton Keynes County Court and Family Court",
       "email" => "family@miltonkeynes.countycourt.gsi.gov.uk",
       "gbs" => "Y610",
+      "cci_code" => 388,
       "address" => {
         "town" => "Central Milton Keynes",
         "postcode" => "MK9 2DT",

--- a/app/presenters/summary/c100_form.rb
+++ b/app/presenters/summary/c100_form.rb
@@ -111,6 +111,7 @@ module Summary
         Sections::SectionHeader.new(c100_application, name: :statement_of_truth),
         Sections::StatementOfTruth.new(c100_application),
         Sections::CourtFee.new(c100_application),
+        Sections::ProcessingDetails.new(c100_application),
       ]
     end
   end

--- a/app/presenters/summary/sections/processing_details.rb
+++ b/app/presenters/summary/sections/processing_details.rb
@@ -1,0 +1,34 @@
+module Summary
+  module Sections
+    class ProcessingDetails < BaseSectionPresenter
+      def name
+        :processing_details
+      end
+
+      def answers
+        [
+          FreeTextAnswer.new(:court_name_and_code, court_name_and_code),
+          FreeTextAnswer.new(:completion_date, completion_date),
+        ].select(&:show?)
+      end
+
+      private
+
+      # TODO: for a while some applications will lack the `county_location_code`
+      # or the `completed_at` date, so we need to cover these scenarios.
+      # After 1 month approximately, this code can be simplified.
+
+      def court_name_and_code
+        [court.county_location_code, court.name].compact.join(' - ')
+      end
+
+      def completion_date
+        I18n.l(c100.completed_at.to_date, format: :short) if c100.completed_at
+      end
+
+      def court
+        @_court ||= c100.court
+      end
+    end
+  end
+end

--- a/config/locales/pdf/en.yml
+++ b/config/locales/pdf/en.yml
@@ -124,6 +124,7 @@ en:
     sections:
       ### C100 ###
       c100_court_details: *to_be_completed
+      processing_details: Processing details (for court use only)
       help_with_fees: Help with fees
       applicant_respondent: Applicant and respondent
       nature_of_application: Nature of application
@@ -169,6 +170,10 @@ en:
       ### C8 ###
       c8_applicants_details_index_title: Applicant %{index}
       c8_other_parties_details_index_title: Person %{index}
+    court_name_and_code:
+      question: Court
+    completion_date:
+      question: Date
     hwf_reference_number:
       question: Reference number
       absence_answer: *not_applicable

--- a/spec/presenters/summary/c100_form_spec.rb
+++ b/spec/presenters/summary/c100_form_spec.rb
@@ -69,6 +69,7 @@ module Summary
           Sections::SectionHeader,
           Sections::StatementOfTruth,
           Sections::CourtFee,
+          Sections::ProcessingDetails,
         ])
       end
     end

--- a/spec/presenters/summary/sections/processing_details_spec.rb
+++ b/spec/presenters/summary/sections/processing_details_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+module Summary
+  describe Sections::ProcessingDetails do
+    let(:c100_application) {
+      instance_double(C100Application, completed_at: completed_at, court: court)
+    }
+
+    subject { described_class.new(c100_application) }
+
+    let(:completed_at) { Date.new(2020, 1, 31) }
+    let(:county_location_code) { 123 }
+    let(:court) { instance_double(Court, name: 'Foobar Court', county_location_code: county_location_code) }
+
+    describe '#name' do
+      it 'is expected to be correct' do
+        expect(subject.name).to eq(:processing_details)
+      end
+    end
+
+    describe '#answers' do
+      let(:answers) { subject.answers }
+
+      it 'has the correct rows' do
+        expect(subject.answers.count).to eq(2)
+
+        expect(answers[0]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[0].question).to eq(:court_name_and_code)
+        expect(answers[0].value).to eq('123 - Foobar Court')
+
+        expect(answers[1]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[1].question).to eq(:completion_date)
+        expect(answers[1].value).to eq('31/01/2020')
+      end
+
+      context 'for a court without code' do
+        let(:county_location_code) { nil }
+
+        it 'prints the name of the court, without the code' do
+          expect(answers[0].value).to eq('Foobar Court')
+        end
+      end
+
+      context 'for an application without completion date' do
+        let(:completed_at) { nil }
+
+        it 'does not print the date row, only the court row' do
+          expect(subject.answers.count).to eq(1)
+          expect(answers[0].question).to eq(:court_name_and_code)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://trello.com/c/IDdg4Kyo

Follow-up to PR #1146 and #1147.

Add a new section to the PDF, at the end of the C100 form, below the statement of truth and court fee.

This new section will print the details we captured in the previous PR: the court code and name, as well as the date of completion of the application.

This is for scanning/processing purposes and not intended for the user.

For a while some applications will have the court code or the completion date missing but that's fine.

<img width="856" alt="Screenshot 2021-01-29 at 11 44 59" src="https://user-images.githubusercontent.com/687910/106274857-d49bde80-622c-11eb-8eaf-9af99a76f51a.png">
