### PR TITLE
Remove C4 reference in children's postcode screen

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -919,9 +919,7 @@ en:
           lead_text: Please tell us the postcode of the children you’re making this application about.
           details:
             summary: If you do not know where the children live
-            text_html: |
-              You can use <a href="https://www.gov.uk/government/publications/form-c4-application-for-an-order-for-disclosure-of-a-childs-whereabouts"
-              class="govuk-link" rel="external" target="_blank">form C4</a> to apply for an order for someone to give a court information about where a child is.
+            text_html: If you do not know the children’s postcode please enter your own.
       no_court_found:
         show:
           page_title: Not eligible


### PR DESCRIPTION
Ticket: https://trello.com/c/4JyTmiKc

Policy has confirmed that a C4 is not required.

Remove the reference to the C4 if the child’s postcode is unknown. Advise applicant to give their own postcode in these circumstances.

**Before:**
<img width="682" alt="Screenshot 2021-02-18 at 16 11 34" src="https://user-images.githubusercontent.com/687910/108385887-04268100-7204-11eb-8a1c-4388421815f5.png">

**After:**
<img width="619" alt="Screenshot 2021-02-18 at 16 11 44" src="https://user-images.githubusercontent.com/687910/108385928-0dafe900-7204-11eb-95e7-117a6be02837.png">
