### PR TITLE
Create list of centralised courts

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -86,6 +86,10 @@ class Court < ApplicationRecord
     !gbs.eql?(UNKNOWN_GBS)
   end
 
+  def centralised?
+    centralised_slugs.include?(slug)
+  end
+
   def stale?
     updated_at.nil? || updated_at <= REFRESH_DATA_AFTER.ago
   end
@@ -108,6 +112,10 @@ class Court < ApplicationRecord
 
   def retrieve_emails_from_api
     court_data.fetch('emails')
+  end
+
+  def centralised_slugs
+    Rails.configuration.court_slugs.fetch('centralisation')
   end
 
   def court_data

--- a/app/services/c100_app/court_postcode_checker.rb
+++ b/app/services/c100_app/court_postcode_checker.rb
@@ -3,9 +3,6 @@ require 'c100_app/courtfinder_api'
 module C100App
   class CourtPostcodeChecker
     AREA_OF_LAW = "Children".freeze
-    COURT_SLUGS = YAML.load_file(
-      File.join(Rails.root, 'config', 'court_slugs.yml')
-    ).freeze
 
     def court_for(postcode)
       possible_courts = CourtfinderAPI.new.court_for(AREA_OF_LAW, postcode)
@@ -15,7 +12,7 @@ module C100App
     end
 
     def court_slugs_blocklist
-      COURT_SLUGS.fetch('blocklist')
+      Rails.configuration.court_slugs.fetch('blocklist')
     end
 
     private

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,9 @@ class Application < Rails::Application
     :govuk_notify_templates, env: ENV.fetch('GOVUK_NOTIFY_ENV', 'integration')
   ).with_indifferent_access
 
+  # Load the court slugs file to handle centralisation or blocking
+  config.court_slugs = YAML.load_file(File.join(Rails.root, 'config', 'court_slugs.yml'))
+
   config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 60).to_i
   config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 

--- a/config/court_slugs.yml
+++ b/config/court_slugs.yml
@@ -3,3 +3,13 @@
 #
 blocklist:
   - blocklisted-slug-example
+
+# Add court slugs to the centralisation list.
+# Currently centralisation is disabled for any court not in this list.
+#
+centralisation:
+  - brighton-county-court
+  - chelmsford-county-and-family-court
+  - leeds-combined-court-centre
+  - medway-county-court-and-family-court
+  - west-london-family-court

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -26,6 +26,20 @@ describe Court do
     it { expect(described_class::REFRESH_DATA_AFTER).to eq(72.hours) }
   end
 
+  describe 'Centralised courts (smoke test)' do
+    it 'returns the list of slugs taking part in the centralisation' do
+      expect(
+        subject.send(:centralised_slugs)
+      ).to match_array(%w(
+        brighton-county-court
+        chelmsford-county-and-family-court
+        leeds-combined-court-centre
+        medway-county-court-and-family-court
+        west-london-family-court
+      ))
+    end
+  end
+
   describe '.build' do
     it 'sets the name' do
       expect(subject.name).to eq('Court name')
@@ -586,6 +600,28 @@ describe Court do
       it 'returns false' do
         expect(subject).to receive(:gbs).and_return('unknown')
         expect(subject.gbs_known?).to eq(false)
+      end
+    end
+  end
+
+  describe '#centralised?' do
+    before do
+      allow(subject).to receive(:slug).and_return(slug)
+    end
+
+    context 'for a centralised court' do
+      let(:slug) { 'west-london-family-court' }
+
+      it 'returns true' do
+        expect(subject.centralised?).to eq(true)
+      end
+    end
+
+    context 'for a non-centralised court' do
+      let(:slug) { 'derby-combined-court-centre' }
+
+      it 'returns false' do
+        expect(subject.centralised?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Ticket: https://trello.com/c/ODIpiZet

This is a first step towards enabling centralisation, initially in just 5 courts, and then over the time more courts will be added to this list.

Currently this PR does not have any functionality other than create the list.

In follow-up PRs we will use this to know if a court is centralised or not and do different things based on that.