### PR TITLE
Increase the court cache refresh time

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -1,5 +1,5 @@
 class Court < ApplicationRecord
-  REFRESH_DATA_AFTER = 1.hours
+  REFRESH_DATA_AFTER = 72.hours
   UNKNOWN_GBS = 'unknown'.freeze
 
   has_many :c100_applications

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -88,6 +88,7 @@ def models
     Applicant
     Solicitor
     User
+    Court
     PaymentIntent
     CompletedApplicationsAudit
   ).freeze

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -23,7 +23,7 @@ describe Court do
   }
 
   describe 'REFRESH_DATA_AFTER' do
-    it { expect(described_class::REFRESH_DATA_AFTER).to eq(1.hours) }
+    it { expect(described_class::REFRESH_DATA_AFTER).to eq(72.hours) }
   end
 
   describe 'Centralised courts (smoke test)' do
@@ -645,7 +645,7 @@ describe Court do
 
     context 'for a stale court record' do
       context 'exact threshold' do
-        let(:updated_at) { 1.hours.ago }
+        let(:updated_at) { 72.hours.ago }
 
         it 'returns true' do
           expect(subject.stale?).to eq(true)
@@ -663,7 +663,7 @@ describe Court do
     end
 
     context 'for an up to date court record' do
-      let(:updated_at) { 50.minutes.ago }
+      let(:updated_at) { 1.day.ago }
 
       it 'returns false' do
         expect(subject.stale?).to eq(false)


### PR DESCRIPTION
Ticket: https://trello.com/c/V23YR1mD

We reduce to 1 hour the cache in a previous PR #1153 in order for the court details in particular emails to be refreshed more quickly as some emails were incorrect due to changes in CTF.

Now all emails are correct again so we can increase the cache refresh time to the way it was before (72 hours).