### PR TITLE
Add new email and postal address for centralisation

### DIFF
--- a/app/models/concerns/court_contact_details.rb
+++ b/app/models/concerns/court_contact_details.rb
@@ -1,0 +1,44 @@
+module CourtContactDetails
+  extend ActiveSupport::Concern
+
+  CENTRAL_HUB_EMAIL = 'C100applications@justice.gov.uk'.freeze
+  CENTRAL_HUB_ADDRESS = [
+    'C100 Applications',
+    'PO Box 1792',
+    'Southampton',
+    'SO15 9GG',
+    'DX: 135986 Southampton 32',
+  ].freeze
+
+  def centralised?
+    centralised_slugs.include?(slug)
+  end
+
+  def full_address
+    # TODO: not yet enabled
+    # return CENTRAL_HUB_ADDRESS if centralised?
+
+    # If the court is not yet centralised we default to its postal address
+    [
+      name,
+      address.fetch_values(
+        'address_lines',
+        'town',
+        'postcode',
+      )
+    ].flatten.reject(&:blank?).uniq
+  end
+
+  def documents_email
+    return CENTRAL_HUB_EMAIL if centralised?
+
+    # If the court is not yet centralised we default to its email address
+    email
+  end
+
+  private
+
+  def centralised_slugs
+    Rails.configuration.court_slugs.fetch('centralisation')
+  end
+end

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -1,4 +1,6 @@
 class Court < ApplicationRecord
+  include CourtContactDetails
+
   REFRESH_DATA_AFTER = 72.hours
   UNKNOWN_GBS = 'unknown'.freeze
 
@@ -53,17 +55,6 @@ class Court < ApplicationRecord
     self[:gbs] = gbs || retrieve_gbs_from_api
   end
 
-  def full_address
-    [
-      name,
-      address.fetch_values(
-        'address_lines',
-        'town',
-        'postcode',
-      )
-    ].flatten.reject(&:blank?).uniq
-  end
-
   def best_enquiries_email
     # There's no consistency to how courts list their email addresses, so we try to find
     # the most suitable one by looking for keywords, first in the address itself, then
@@ -84,10 +75,6 @@ class Court < ApplicationRecord
 
   def gbs_known?
     !gbs.eql?(UNKNOWN_GBS)
-  end
-
-  def centralised?
-    centralised_slugs.include?(slug)
   end
 
   def stale?
@@ -112,10 +99,6 @@ class Court < ApplicationRecord
 
   def retrieve_emails_from_api
     court_data.fetch('emails')
-  end
-
-  def centralised_slugs
-    Rails.configuration.court_slugs.fetch('centralisation')
   end
 
   def court_data

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -88,7 +88,6 @@ def models
     Applicant
     Solicitor
     User
-    Court
     PaymentIntent
     CompletedApplicationsAudit
   ).freeze

--- a/spec/models/concerns/court_contact_details_spec.rb
+++ b/spec/models/concerns/court_contact_details_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe CourtContactDetails do
+  let(:test_class) { Court }
+
+  subject {
+    test_class.new(
+      id: 'court-slug',
+      name: 'Court name',
+      email: 'court@example',
+      address: address,
+    )
+  }
+
+  let(:address) { 'address' }
+
+  describe 'Centralised courts (smoke test)' do
+    it 'returns the list of slugs taking part in the centralisation' do
+      expect(
+        subject.send(:centralised_slugs)
+      ).to match_array(%w(
+        brighton-county-court
+        chelmsford-county-and-family-court
+        leeds-combined-court-centre
+        medway-county-court-and-family-court
+        west-london-family-court
+      ))
+    end
+  end
+
+  describe '#centralised?' do
+    before do
+      allow(subject).to receive(:slug).and_return(slug)
+    end
+
+    context 'for a centralised court' do
+      let(:slug) { 'west-london-family-court' }
+
+      it 'returns true' do
+        expect(subject.centralised?).to eq(true)
+      end
+    end
+
+    context 'for a non-centralised court' do
+      let(:slug) { 'derby-combined-court-centre' }
+
+      it 'returns false' do
+        expect(subject.centralised?).to eq(false)
+      end
+    end
+  end
+
+  describe '#full_address' do
+    let(:address) { { 'address_lines' => address_lines, 'town' => 'town', 'postcode' => 'postcode' } }
+    let(:address_lines){ ['line 1', 'line 2'] }
+
+    context 'for a centralised court' do
+      # TODO: pending
+    end
+
+    context 'for a not yet centralised court' do
+      it 'returns a flattened array of name, address_lines, town and postcode' do
+        expect(subject.full_address).to eq(['Court name', 'line 1', 'line 2', 'town', 'postcode'])
+      end
+
+      context 'when any lines are duplicated' do
+        let(:address_lines){ ['Court name', 'postcode'] }
+
+        it 'removes the duplicates' do
+          expect(subject.full_address).to eq(['Court name', 'postcode', 'town'])
+        end
+      end
+
+      context 'when any lines are blank' do
+        let(:address_lines){ ['line 1', ''] }
+
+        it 'removes the blank lines' do
+          expect(subject.full_address).to eq(['Court name', 'line 1', 'town', 'postcode'])
+        end
+      end
+    end
+  end
+
+  describe '#documents_email' do
+    before do
+      allow(subject).to receive(:centralised?).and_return(centralised)
+    end
+
+    context 'for a centralised court' do
+      let(:centralised) { true }
+
+      it 'returns the central hub email address' do
+        expect(subject.documents_email).to eq('C100applications@justice.gov.uk')
+      end
+    end
+
+    context 'for a not yet centralised court' do
+      let(:centralised) { false }
+
+      it 'returns the email address of the court' do
+        expect(subject.documents_email).to eq('court@example')
+      end
+    end
+  end
+end

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -8,36 +8,14 @@ describe Court do
       "name" => 'Court name',
       "slug" => 'court-slug',
       "email" => 'family@court',
-      "address" => address,
+      "address" => 'address',
       "cci_code" => 123,
       "gbs" => 'X123',
     }
   }
 
-  let(:address) {
-    {
-      "address_lines" => ["351 Silbury Boulevard", "Witan Gate East"],
-      "town" => "Central Milton Keynes",
-      "postcode" => "MK9 2DT",
-    }
-  }
-
   describe 'REFRESH_DATA_AFTER' do
     it { expect(described_class::REFRESH_DATA_AFTER).to eq(72.hours) }
-  end
-
-  describe 'Centralised courts (smoke test)' do
-    it 'returns the list of slugs taking part in the centralisation' do
-      expect(
-        subject.send(:centralised_slugs)
-      ).to match_array(%w(
-        brighton-county-court
-        chelmsford-county-and-family-court
-        leeds-combined-court-centre
-        medway-county-court-and-family-court
-        west-london-family-court
-      ))
-    end
   end
 
   describe '.build' do
@@ -50,7 +28,7 @@ describe Court do
     end
 
     it 'sets the address' do
-      expect(subject.address).to eq(address)
+      expect(subject.address).to eq('address')
     end
 
     it 'sets the cci_code' do
@@ -311,31 +289,6 @@ describe Court do
 
           expect(subject).to eq(court)
         end
-      end
-    end
-  end
-
-  describe '#full_address' do
-    let(:address) { { 'address_lines' => address_lines, 'town' => 'town', 'postcode' => 'postcode' } }
-    let(:address_lines){ ['line 1', 'line 2'] }
-
-    it 'returns a flattened array of name, address_lines, town and postcode' do
-      expect(subject.full_address).to eq(['Court name', 'line 1', 'line 2', 'town', 'postcode'])
-    end
-
-    context 'when any lines are duplicated' do
-      let(:address_lines){ ['Court name', 'postcode'] }
-
-      it 'removes the duplicates' do
-        expect(subject.full_address).to eq(['Court name', 'postcode', 'town'])
-      end
-    end
-
-    context 'when any lines are blank' do
-      let(:address_lines){ ['line 1', ''] }
-
-      it 'removes the blank lines' do
-        expect(subject.full_address).to eq(['Court name', 'line 1', 'town', 'postcode'])
       end
     end
   end
@@ -601,28 +554,6 @@ describe Court do
       it 'returns false' do
         expect(subject).to receive(:gbs).and_return('unknown')
         expect(subject.gbs_known?).to eq(false)
-      end
-    end
-  end
-
-  describe '#centralised?' do
-    before do
-      allow(subject).to receive(:slug).and_return(slug)
-    end
-
-    context 'for a centralised court' do
-      let(:slug) { 'west-london-family-court' }
-
-      it 'returns true' do
-        expect(subject.centralised?).to eq(true)
-      end
-    end
-
-    context 'for a non-centralised court' do
-      let(:slug) { 'derby-combined-court-centre' }
-
-      it 'returns false' do
-        expect(subject.centralised?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Ticket: https://trello.com/c/ODIpiZet

Follow-up to PR #1152 to prepare the centralisation.

A bit of refactor to better organise the email and postal address methods into a separate concern that will handle the logic to know if the court is centralised or not, and return the details accordingly.

This is still not in use, as the new method `#documents_email` it is not used yet and the `#full_address` keeps returning the same address as before.

In a follow-up PR we can start enabling this.