### PR TITLE
Switch to centralised contact details

### DIFF
--- a/app/models/concerns/court_contact_details.rb
+++ b/app/models/concerns/court_contact_details.rb
@@ -15,8 +15,7 @@ module CourtContactDetails
   end
 
   def full_address
-    # TODO: not yet enabled
-    # return CENTRAL_HUB_ADDRESS if centralised?
+    return CENTRAL_HUB_ADDRESS if centralised?
 
     # If the court is not yet centralised we default to its postal address
     [

--- a/app/services/c100_app/court_online_submission.rb
+++ b/app/services/c100_app/court_online_submission.rb
@@ -5,7 +5,7 @@ module C100App
     end
 
     def to_address
-      c100_application.court.email
+      c100_application.court.documents_email
     end
 
     private

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -67,7 +67,7 @@
 
                 <% if c100 %>
                   <dt>Court receipt email address</dt>
-                  <dd><%= c100.court.email %> | <%= link_to 'web', C100App::CourtfinderAPI.court_url(c100.court.slug), rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
+                  <dd><%= c100.court.documents_email %> | <%= link_to 'web', C100App::CourtfinderAPI.court_url(c100.court.slug), rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
                   <dt>Applicant receipt email address</dt>
                   <dd><%= c100.receipt_email.presence || 'none' %></dd>
                 <% else %>

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -14,7 +14,8 @@
           <h4 class="govuk-heading-s">Current court data</h4>
           <p>
             <%= current_c100_application.court.name %><br/>
-            <%= current_c100_application.court.email %>
+            <strong>Court email:</strong> <%= current_c100_application.court.email %><br/>
+            <strong>Documents:</strong> <%= current_c100_application.court.documents_email %>
           </p>
         <% end %>
       <% end %>

--- a/spec/models/concerns/court_contact_details_spec.rb
+++ b/spec/models/concerns/court_contact_details_spec.rb
@@ -54,11 +54,23 @@ RSpec.describe CourtContactDetails do
     let(:address) { { 'address_lines' => address_lines, 'town' => 'town', 'postcode' => 'postcode' } }
     let(:address_lines){ ['line 1', 'line 2'] }
 
+    before do
+      allow(subject).to receive(:centralised?).and_return(centralised)
+    end
+
     context 'for a centralised court' do
-      # TODO: pending
+      let(:centralised) { true }
+
+      it 'returns the central hub postal address' do
+        expect(
+          subject.full_address
+        ).to eq(['C100 Applications', 'PO Box 1792', 'Southampton', 'SO15 9GG', 'DX: 135986 Southampton 32'])
+      end
     end
 
     context 'for a not yet centralised court' do
+      let(:centralised) { false }
+
       it 'returns a flattened array of name, address_lines, town and postcode' do
         expect(subject.full_address).to eq(['Court name', 'line 1', 'line 2', 'town', 'postcode'])
       end

--- a/spec/services/c100_app/court_online_submission_spec.rb
+++ b/spec/services/c100_app/court_online_submission_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe C100App::CourtOnlineSubmission do
   let(:c100_application) { instance_double(C100Application, email_submission: email_submission, court: court) }
   let(:email_submission) { instance_double(EmailSubmission, update: true) }
-  let(:court) { double(email: 'court@email.com') }
+  let(:court) { double(documents_email: 'court@email.com') }
 
   subject { described_class.new(c100_application) }
 
@@ -42,7 +42,7 @@ RSpec.describe C100App::CourtOnlineSubmission do
         ).and_return(mailer)
       end
 
-      it 'delivers the email to the court' do
+      it 'delivers the email to the court or central hub' do
         expect(
           mailer
         ).to receive(:application_to_court).with(to_address: 'court@email.com')


### PR DESCRIPTION
Ticket: https://trello.com/c/6KRa1h1M

Continuation of PR #1155.

Depending if the court is centralised or not, for online applications we submit the PDF to the central hub, or to the court email address.

For print an post applications we do the same with the postal address.

Online payments remains the same, no changes in the metadata.

In a following PR some copy changes might be needed.