### PR TITLE
Update copy in online submissions confirmation page

### DIFF
--- a/app/views/steps/completion/confirmation/_consent_order_section.html.erb
+++ b/app/views/steps/completion/confirmation/_consent_order_section.html.erb
@@ -4,7 +4,3 @@
   As you are applying for a consent order, you need to send your agreement to the court.
   You can do this by email or post. If you post it, please send 3 copies.
 </p>
-
-<p class="govuk-body">
-  Remember to include your application reference code.
-</p>

--- a/app/views/steps/completion/confirmation/_under_age_section.html.erb
+++ b/app/views/steps/completion/confirmation/_under_age_section.html.erb
@@ -4,21 +4,6 @@
 
 <%= render partial: 'steps/shared/under_age_section' %>
 
-<%
-  court_and_tribunal_finder_url = link_to(
-    'Court and tribunal finder',
-    C100App::CourtfinderAPI.court_url(@court.slug),
-    class: 'govuk-link',
-    target: :_blank,
-    rel: :external
-  )
-%>
-
-<p class="govuk-body">
-  You need to send documents to: <%= @court.name %>. See <%= court_and_tribunal_finder_url %> for contact details.
-  Include your application reference code.
-</p>
-
 <p class="govuk-body">
   The court will not be able to process your application until these documents have been received.
 </p>

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -36,6 +36,8 @@
 
     <%= render partial: 'under_age_section' if @c100_application.applicants.under_age? %>
 
+    <%= render partial: 'steps/shared/court_documents', locals: {court: @court} %>
+
     <%= render partial: 'steps/shared/court_help', locals: {court: @court} %>
 
     <%= render partial: 'steps/shared/feedback' %>

--- a/app/views/steps/completion/confirmation/show.en.html.erb
+++ b/app/views/steps/completion/confirmation/show.en.html.erb
@@ -32,9 +32,9 @@
       } %>
     <% end %>
 
-    <%= render partial: 'under_age_section' if @c100_application.applicants.under_age? %>
-
     <%= render partial: 'consent_order_section' if @c100_application.consent_order? %>
+
+    <%= render partial: 'under_age_section' if @c100_application.applicants.under_age? %>
 
     <%= render partial: 'steps/shared/court_help', locals: {court: @court} %>
 

--- a/app/views/steps/completion/what_next/_consent_order_section.html.erb
+++ b/app/views/steps/completion/what_next/_consent_order_section.html.erb
@@ -1,0 +1,27 @@
+<% if @c100_application.consent_order? %>
+
+  <h3 class="govuk-heading-m">
+    Print your application and proposed agreement for the consent order
+  </h3>
+
+  <p class="govuk-body">
+    Print 3 copies of your whole application on A4 paper, single sided. The court will send one copy to the other
+    person, keep one copy, and return one copy to you.
+  </p>
+
+  <p class="govuk-body">
+    You must also send 3 copies of your proposed agreement for the consent order.
+  </p>
+
+<% else %>
+
+  <h3 class="govuk-heading-m">
+    Print your application
+  </h3>
+
+  <p class="govuk-body">
+    Print 3 copies of your whole application on A4 paper, single sided. The court will send one copy to the other
+    person, keep one copy, and return one copy to you.
+  </p>
+
+<% end %>

--- a/app/views/steps/completion/what_next/_under_age_section.html.erb
+++ b/app/views/steps/completion/what_next/_under_age_section.html.erb
@@ -1,0 +1,11 @@
+<li>
+  <h3 class="govuk-heading-m">
+    Send certificate of suitability or court order appointing a litigation friend
+  </h3>
+
+  <%= render partial: 'steps/shared/under_age_section' %>
+
+  <p class="govuk-body">
+    Include your application reference code. The court will not be able to process your application until these documents have been received.
+  </p>
+</li>

--- a/app/views/steps/completion/what_next/_with_consent_order.html.erb
+++ b/app/views/steps/completion/what_next/_with_consent_order.html.erb
@@ -1,9 +1,0 @@
-<h3 class="govuk-heading-m">Print your application and proposed agreement for the consent order</h3>
-<p class="govuk-body">
-  Print 3 copies of your whole application on A4 paper, single sided. The court will send one copy to the other
-  person, keep one copy, and return one copy to you.
-</p>
-
-<p class="govuk-body">
-  You must also send 3 copies of your proposed agreement for the consent order.
-</p>

--- a/app/views/steps/completion/what_next/_without_consent_order.html.erb
+++ b/app/views/steps/completion/what_next/_without_consent_order.html.erb
@@ -1,5 +1,0 @@
-<h3 class="govuk-heading-m">Print your application</h3>
-<p class="govuk-body">
-  Print 3 copies of your whole application on A4 paper, single sided. The court will send one copy to the other
-  person, keep one copy, and return one copy to you.
-</p>

--- a/app/views/steps/completion/what_next/show.en.html.erb
+++ b/app/views/steps/completion/what_next/show.en.html.erb
@@ -23,27 +23,10 @@
       </li>
 
       <li>
-
-        <%= render 'with_consent_order' if @c100_application.consent_order? %>
-
-        <%= render 'without_consent_order' unless @c100_application.consent_order? %>
-
+        <%= render 'consent_order_section' %>
       </li>
 
-      <% if @c100_application.applicants.under_age? %>
-        <li>
-          <h3 class="govuk-heading-m">
-            Send certificate of suitability or court order appointing a litigation friend
-          </h3>
-
-          <%= render partial: 'steps/shared/under_age_section' %>
-
-          <p class="govuk-body">
-            Include your application reference code. The court will not be able to process your application until these documents have been received.
-          </p>
-        </li>
-      <% end %>
-
+      <%= render partial: 'under_age_section' if @c100_application.applicants.under_age? %>
 
       <li>
         <h3 class="govuk-heading-m">Post it to the court</h3>

--- a/app/views/steps/completion/what_next/show.en.html.erb
+++ b/app/views/steps/completion/what_next/show.en.html.erb
@@ -23,7 +23,7 @@
       </li>
 
       <li>
-        <%= render 'consent_order_section' %>
+        <%= render partial: 'consent_order_section' %>
       </li>
 
       <%= render partial: 'under_age_section' if @c100_application.applicants.under_age? %>

--- a/app/views/steps/shared/_court_documents.en.html.erb
+++ b/app/views/steps/shared/_court_documents.en.html.erb
@@ -1,0 +1,11 @@
+<h2 class="govuk-heading-l">If you’re sending documents</h2>
+
+<p class="govuk-body">
+  Remember to include your application reference code. Send documents (and cheque if that’s how you choose to pay) to:
+</p>
+
+<p class="govuk-body">
+  <%= mail_to court.documents_email, court.documents_email, class: 'ga-pageLink govuk-link', data: { ga_category: 'completion', ga_label: 'documents email court' } %>
+</p>
+
+<%= simple_format(court.full_address.join("\n"), { class: 'govuk-inset-text' }, { wrapper_tag: :div }) %>

--- a/spec/views/steps/completion/confirmation/show.html.erb_spec.rb
+++ b/spec/views/steps/completion/confirmation/show.html.erb_spec.rb
@@ -16,52 +16,42 @@ RSpec.describe 'steps/completion/confirmation/show', type: :view do
       double('Court',
         name: 'Test court',
         email: 'court@example.com',
-        slug: 'test-court'
+        documents_email: 'documents@example.com',
+        slug: 'test-court',
+        full_address: ['10', 'downing', 'st'],
       )
     )
 
     render
   end
 
-  context 'when applicant is under age' do
-    it 'should render the `under_age_section` partial' do
-      expect(view).to render_template('steps/shared/_under_age_section')
+  context 'consent order' do
+    it 'should render the `consent_order_section` partial' do
+      expect(view).to render_template('steps/completion/confirmation/_consent_order_section')
     end
+  end
 
-    context 'when application is a consent order' do
-      it 'should render `consent_order_section` partial' do
-        expect(view).to render_template('steps/completion/confirmation/_consent_order_section')
+  context 'litigation friend' do
+    context 'when applicant is under age' do
+      let(:under_age) { true }
+
+      it 'should render the `under_age_section` partial' do
+        expect(view).to render_template('steps/completion/confirmation/_under_age_section')
       end
     end
 
-    context 'when application is not a consent order' do
-      let(:consent_order) { GenericYesNo::NO }
+    context 'when applicant is not under age' do
+      let(:under_age) { false }
 
-      it 'should not render `consent_order_section`' do
-        expect(view).to_not render_template('steps/completion/confirmation/_consent_order_section')
+      it 'should not render the `under_age_section` partial' do
+        expect(view).to_not render_template('steps/completion/confirmation/_under_age_section')
       end
     end
   end
 
-  context 'when applicant is an adult' do
-    let(:under_age) { false }
-
-    it 'should not render the `under_age_section` partial' do
-      expect(view).to_not render_template('steps/shared/_under_age_section')
-    end
-
-    context 'when application is a consent order' do
-      it 'should render `consent_order_section` partial' do
-        expect(view).to render_template('steps/completion/confirmation/_consent_order_section')
-      end
-    end
-
-    context 'when application is not a consent order' do
-      let(:consent_order) { GenericYesNo::NO }
-
-      it 'should not render `consent_order_section`' do
-        expect(view).to_not render_template('steps/completion/confirmation/_consent_order_section')
-      end
+  context 'court documents section' do
+    it 'should render the `court_documents` partial' do
+      expect(view).to render_template('steps/shared/_court_documents')
     end
   end
 end

--- a/spec/views/steps/completion/what_next/show.html.erb_spec.rb
+++ b/spec/views/steps/completion/what_next/show.html.erb_spec.rb
@@ -2,38 +2,55 @@ require 'rails_helper'
 
 RSpec.describe 'steps/completion/what_next/show', type: :view do
   let(:consent_order) { GenericYesNo::YES }
+  let(:under_age) { true }
+  let(:applicants_collection_double) { double(under_age?: under_age) }
   let(:c100_application) { C100Application.new(id: '449362af-0bc3-4953-82a7-1363d479b876', created_at: Time.at(0), consent_order: consent_order) }
 
   before do
+    allow(c100_application).to receive(:applicants).and_return(applicants_collection_double)
+
     assign(:c100_application, c100_application)
 
     assign(
-        :court,
-        double('Court',
-               name: 'Test court',
-               email: 'court@example.com',
-               slug: 'test-court',
-               full_address: ['10', 'downing', 'st']
-        )
+      :court,
+      double('Court',
+        name: 'Test court',
+        email: 'court@example.com',
+        slug: 'test-court',
+        full_address: ['10', 'downing', 'st']
+      )
     )
 
     render
   end
 
-  context 'when application is a consent order' do
-    it 'should render `with_consent_order` partial' do
-      expect(view).to_not render_template('steps/completion/what_next/_without_consent_order')
-      expect(view).to render_template('steps/completion/what_next/_with_consent_order')
+  context 'consent order' do
+    it 'should render the `consent_order_section` partial' do
+      expect(view).to render_template('steps/completion/what_next/_consent_order_section')
     end
   end
 
-  context 'when application is not a consent order' do
-    let(:consent_order) { GenericYesNo::NO }
+  context 'litigation friend' do
+    context 'when applicant is under age' do
+      let(:under_age) { true }
 
-    it 'should render `without_consent_order` partial' do
-      expect(view).to_not render_template('steps/completion/what_next/_with_consent_order')
-      expect(view).to render_template('steps/completion/what_next/_without_consent_order')
+      it 'should render the `under_age_section` partial' do
+        expect(view).to render_template('steps/completion/what_next/_under_age_section')
+      end
+    end
+
+    context 'when applicant is not under age' do
+      let(:under_age) { false }
+
+      it 'should not render the `under_age_section` partial' do
+        expect(view).to_not render_template('steps/completion/what_next/_under_age_section')
+      end
     end
   end
 
+  context 'court documents section' do
+    it 'should not render the `court_documents` partial' do
+      expect(view).to_not render_template('steps/shared/_court_documents')
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://trello.com/c/6KRa1h1M

Some copy changes are needed, only in the online submission confirmation page, to indicate the user where to send documents, as centralised courts will have a different email address (and postal address).

Essentially, added a new block to the page to show this information.

Refactoring / tiding up the other completion views and partials to reduce complexity.

<img width="719" alt="Screenshot 2021-02-25 at 16 42 10" src="https://user-images.githubusercontent.com/687910/109186005-6d6c3e00-7788-11eb-89fb-abc02c833a0a.png">
