### PR TITLE
Refactor court url calls

### DIFF
--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -43,7 +43,7 @@ class NotifySubmissionMailer < NotifyMailer
       shared_personalisation.merge(
         court_name: court.name,
         court_email: court.email,
-        court_url: C100App::CourtfinderAPI.court_url(court.slug),
+        court_url: court.url,
         is_under_age: notify_boolean(@c100_application.applicants.under_age?),
         is_consent_order: @c100_application.consent_order || 'no',
         payment_instructions: payment_instructions,

--- a/app/models/concerns/court_contact_details.rb
+++ b/app/models/concerns/court_contact_details.rb
@@ -14,6 +14,10 @@ module CourtContactDetails
     centralised_slugs.include?(slug)
   end
 
+  def url
+    C100App::CourtfinderAPI.court_url(slug)
+  end
+
   def full_address
     return CENTRAL_HUB_ADDRESS if centralised?
 

--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -67,9 +67,9 @@
 
                 <% if c100 %>
                   <dt>Court receipt email address</dt>
-                  <dd><%= c100.court.documents_email %> | <%= link_to 'web', C100App::CourtfinderAPI.court_url(c100.court.slug), rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
+                  <dd><%= c100.email_submission.to_address %> | <%= link_to 'web', c100.court.url, rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
                   <dt>Applicant receipt email address</dt>
-                  <dd><%= c100.receipt_email.presence || 'none' %></dd>
+                  <dd><%= c100.email_submission.email_copy_to.presence || 'none' %></dd>
                 <% else %>
                   <dt>Court receipt email address</dt>
                   <dd>(purged from database)</dd>

--- a/app/views/steps/applicant/under_age/edit.html.erb
+++ b/app/views/steps/applicant/under_age/edit.html.erb
@@ -24,7 +24,7 @@
       <%
         court_and_tribunal_finder_url = link_to(
           'Court and tribunal finder',
-          C100App::CourtfinderAPI.court_url(@court.slug),
+          @court.url,
           target: :_blank,
           rel: :external,
           class: 'govuk-link'

--- a/app/views/steps/shared/_court_help.en.html.erb
+++ b/app/views/steps/shared/_court_help.en.html.erb
@@ -13,5 +13,5 @@
   <dd><%= mail_to court.email, court.email, class: 'ga-pageLink govuk-link', data: { ga_category: 'completion', ga_label: 'email court' } %></dd>
 
   <dt>More information</dt>
-  <dd><%= link_to court.name, C100App::CourtfinderAPI.court_url(court.slug), class: 'govuk-link', rel: 'external', target: '_blank' %></dd>
+  <dd><%= link_to court.name, court.url, class: 'govuk-link', rel: 'external', target: '_blank' %></dd>
 </dl>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,7 +254,7 @@ en:
           page_title: Applicant under age
           heading: As the applicant is under 18
           lead_text_html: "You’ll need to have someone over 18 to represent you in court hearings and make decisions on your behalf. They will be known as your ‘%{litigation_url}’."
-          court_and_tribunal_html: "You need to send documents to: %{court_name}. See %{court_and_tribunal_finder_url} for contact details."
+          court_and_tribunal_html: "You need to send documents to: %{court_name}. Visit %{court_and_tribunal_finder_url} for contact details."
           continue: Continue
       has_solicitor:
         edit:

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
   let(:address_confidentiality) { 'no' }
 
   let(:court) {
-    double('Court',
+    Court.new(
       name: 'Test court',
       email: 'court@example.com',
       slug: 'test-court'

--- a/spec/models/concerns/court_contact_details_spec.rb
+++ b/spec/models/concerns/court_contact_details_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe CourtContactDetails do
     end
   end
 
+  describe '#url' do
+    it 'delegates to the CourtfinderAPI class' do
+      expect(C100App::CourtfinderAPI).to receive(:court_url).with('court-slug')
+      subject.url
+    end
+  end
+
   describe '#full_address' do
     let(:address) { { 'address_lines' => address_lines, 'town' => 'town', 'postcode' => 'postcode' } }
     let(:address_lines){ ['line 1', 'line 2'] }

--- a/spec/views/steps/completion/confirmation/show.html.erb_spec.rb
+++ b/spec/views/steps/completion/confirmation/show.html.erb_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'steps/completion/confirmation/show', type: :view do
         email: 'court@example.com',
         documents_email: 'documents@example.com',
         slug: 'test-court',
+        url: 'example.com/test-court',
         full_address: ['10', 'downing', 'st'],
       )
     )

--- a/spec/views/steps/completion/what_next/show.html.erb_spec.rb
+++ b/spec/views/steps/completion/what_next/show.html.erb_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'steps/completion/what_next/show', type: :view do
         name: 'Test court',
         email: 'court@example.com',
         slug: 'test-court',
+        url: 'example.com/test-court',
         full_address: ['10', 'downing', 'st']
       )
     )


### PR DESCRIPTION
As part of the centralisation work, I realised there are several calls to `C100App::CourtfinderAPI.court_url` that can be simplified by using the `court` instance instead.

This makes for a more readable code but functionally it is the same.

Also, in the back office, for completed applications, retrieve the court email and the applicant email, from the `email_submissions` association to be more accurate in case a court email changes after an application has been submitted.