### PR TITLE
Add centralisation contact details to confirmation email

### DIFF
--- a/app/mailers/notify_submission_mailer.rb
+++ b/app/mailers/notify_submission_mailer.rb
@@ -44,6 +44,8 @@ class NotifySubmissionMailer < NotifyMailer
         court_name: court.name,
         court_email: court.email,
         court_url: court.url,
+        court_address: court.full_address.join("\n"),
+        documents_email: court.documents_email,
         is_under_age: notify_boolean(@c100_application.applicants.under_age?),
         is_consent_order: @c100_application.consent_order || 'no',
         payment_instructions: payment_instructions,

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -20,7 +20,12 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
     Court.new(
       name: 'Test court',
       email: 'court@example.com',
-      slug: 'test-court'
+      slug: 'test-court',
+      address: {
+        "town" => 'town',
+        "postcode" => 'postcode',
+        "address_lines" => %w(street1 street2),
+      }
     )
   }
 
@@ -119,6 +124,8 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         court_name: 'Test court',
         court_email: 'court@example.com',
         court_url: 'https://courttribunalfinder.service.gov.uk/courts/test-court',
+        court_address: "Test court\nstreet1\nstreet2\ntown\npostcode",
+        documents_email: 'court@example.com',
         is_under_age: 'no',
         is_consent_order: 'yes',
         payment_instructions: 'payment instructions from locales',
@@ -136,6 +143,24 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         expect(
           mail.govuk_notify_personalisation
         ).to include(is_under_age: 'yes')
+      end
+    end
+
+    context 'when the court is centralised' do
+      before do
+        allow(court).to receive(:centralised?).and_return(true)
+      end
+
+      it 'has the central hub postal address' do
+        expect(
+          mail.govuk_notify_personalisation
+        ).to include(court_address: Court::CENTRAL_HUB_ADDRESS.join("\n"))
+      end
+
+      it 'has the central hub documents email' do
+        expect(
+          mail.govuk_notify_personalisation
+        ).to include(documents_email: Court::CENTRAL_HUB_EMAIL)
       end
     end
   end


### PR DESCRIPTION
Ticket: https://trello.com/c/6KRa1h1M

Propagate 2 new personalisation variables to Notify (`court_address` and `documents_email`) in order to be able to build a new "If you’re sending documents" block in the email template.

This new block is similar to the one we added to the confirmation page in PR #1157.

Note: the template in staging will be updated once this is deployed to staging, and the template in production will be updated once this is deployed to production.