### PR TITLE
Clarify in back office print&post emails section

### DIFF
--- a/app/views/backoffice/dashboard/_completion.en.html.erb
+++ b/app/views/backoffice/dashboard/_completion.en.html.erb
@@ -66,10 +66,17 @@
                 <dd><%= completion.metadata['signee_capacity'] %></dd>
 
                 <% if c100 %>
-                  <dt>Court receipt email address</dt>
-                  <dd><%= c100.email_submission.to_address %> | <%= link_to 'web', c100.court.url, rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
-                  <dt>Applicant receipt email address</dt>
-                  <dd><%= c100.email_submission.email_copy_to.presence || 'none' %></dd>
+                  <% if c100.online_submission? %>
+                    <dt>Court receipt email address</dt>
+                    <dd><%= c100.email_submission.to_address %> | <%= link_to 'web', c100.court.url, rel: 'external', target: '_blank', class: 'govuk-link govuk-link--no-visited-state' %></dd>
+                    <dt>Applicant receipt email address</dt>
+                    <dd><%= c100.email_submission.email_copy_to.presence || 'none' %></dd>
+                  <% else %>
+                    <dt>Court receipt email address</dt>
+                    <dd>(none - print & post application)</dd>
+                    <dt>Applicant receipt email address</dt>
+                    <dd>(none - print & post application)</dd>
+                  <% end %>
                 <% else %>
                   <dt>Court receipt email address</dt>
                   <dd>(purged from database)</dd>


### PR DESCRIPTION
In the back office, completed applications, there is a section for the court and applicant's receipt addresses.

However for print and post these details are nil because the application is not submitted by email.

Make this more clear and avoid a `nil` exception because the association `email_submission` will not be present in these cases.

<img width="403" alt="Screenshot 2021-02-26 at 15 47 30" src="https://user-images.githubusercontent.com/687910/109322698-81787400-784a-11eb-9d0c-ad3d412d0245.png">
