### PR TITLE
Use centralisation email address in payments metadata

### DIFF
--- a/app/services/c100_app/online_payments.rb
+++ b/app/services/c100_app/online_payments.rb
@@ -79,7 +79,7 @@ module C100App
         application: APPLICATION_CODE,
         court_gbs: c100_application.court.gbs,
         court_name: c100_application.court.name,
-        court_email: c100_application.court.email,
+        court_email: c100_application.court.documents_email,
       }
     end
   end

--- a/spec/services/c100_app/online_payments_spec.rb
+++ b/spec/services/c100_app/online_payments_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe C100App::OnlinePayments do
   describe '.create_payment' do
     subject(:do_request) { described_class.create_payment(payment_intent) }
 
-    let(:court_double) { double('Court', name: 'Test court', email: 'court@example.com', gbs: 'X123') }
+    let(:court_double) { double('Court', name: 'Test court', documents_email: 'court@example.com', gbs: 'X123') }
     let(:response_double) {
       double(call: double(
         'Response', payment_id: payment_id, state: state, payment_url: 'https://payments.example.com'


### PR DESCRIPTION
Ticket: https://trello.com/c/6KRa1h1M

Rebecca has confirmed they would prefer the email address of the central hub (what we call `documents_email`) in the online payments metadata, instead of the underlying court.

For courts that are not centralised yet, this has no effect, as the court email will be the same as before.