### PR TITLE
Add Manchester to the centralisation pilot

### DIFF
--- a/config/court_slugs.yml
+++ b/config/court_slugs.yml
@@ -8,8 +8,11 @@ blocklist:
 # Currently centralisation is disabled for any court not in this list.
 #
 centralisation:
+  # First rollout - 02/03/2021
   - brighton-county-court
   - chelmsford-county-and-family-court
   - leeds-combined-court-centre
   - medway-county-court-and-family-court
   - west-london-family-court
+  # Second rollout - 11/03/2021
+  - manchester-civil-justice-centre-civil-and-family-courts

--- a/spec/models/concerns/court_contact_details_spec.rb
+++ b/spec/models/concerns/court_contact_details_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe CourtContactDetails do
         leeds-combined-court-centre
         medway-county-court-and-family-court
         west-london-family-court
+        manchester-civil-justice-centre-civil-and-family-courts
       ))
     end
   end


### PR DESCRIPTION
Ticket: https://trello.com/c/uvP2dwj3

Manchester centralisation will go live 11/03/2021.