### PR TITLE
Add centralisation metadata to the Audit table

### DIFF
--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -13,6 +13,7 @@ class AuditHelper
     {
       v: c100.version,
       postcode: postcode,
+      centralised: court.centralised?,
       c1a_form: c100.has_safety_concerns?,
       c8_form: c100.confidentiality_enabled?,
       under_age: c100.applicants.under_age?,
@@ -34,6 +35,10 @@ class AuditHelper
   # rubocop:enable Metrics/AbcSize
 
   private
+
+  def court
+    @_court ||= c100.court
+  end
 
   def arrangement
     @_arrangement ||= c100.court_arrangement
@@ -67,7 +72,7 @@ class AuditHelper
     return {} unless c100.online_payment?
 
     {
-      gbs_code: c100.court.gbs,
+      gbs_code: court.gbs,
       payment_id: c100.payment_intent.payment_id,
     }
   end

--- a/db/migrate/20210311092612_update_centralisation_metadata.rb
+++ b/db/migrate/20210311092612_update_centralisation_metadata.rb
@@ -1,0 +1,25 @@
+class UpdateCentralisationMetadata < ActiveRecord::Migration[5.2]
+  #
+  # This task is only needed to "backport" the new metadata attribute `centralised`, to the
+  # already centralised courts that took part starting 02 Mar 2021 09:00:00, in the first rollout.
+  #
+  # This is needed as the metadata was not created back then. New completions on or after this
+  # migration will already include the `centralised` attribute (true/false).
+  #
+  FIRST_BATCH_DATE = DateTime.new(2021, 3, 1, 9)
+  FIRST_BATCH_COURTS = [
+    'Brighton County Court',
+    'Chelmsford Justice Centre',
+    'Leeds Combined Court Centre',
+    'Medway County Court and Family Court',
+    'West London Family Court',
+  ].freeze
+
+  def up
+    CompletedApplicationsAudit.where(
+      'completed_at >= :date', date: FIRST_BATCH_DATE
+    ).where(court: FIRST_BATCH_COURTS).each do |record|
+      record.update_column(:metadata, record.metadata.merge(centralised: true))
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_28_153016) do
+ActiveRecord::Schema.define(version: 2021_03_11_092612) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -19,7 +19,7 @@ describe AuditHelper do
   let(:payment_type) { 'cash' }
   let(:court_arrangement) { nil }
 
-  let(:court) { instance_double(Court, name: 'Test Court', gbs: 'X123') }
+  let(:court) { instance_double(Court, name: 'Test Court', gbs: 'X123', centralised?: false) }
 
   subject { described_class.new(c100_application) }
 
@@ -37,6 +37,7 @@ describe AuditHelper do
       ).to eq(
         v: 123,
         postcode: 'ABCD1**',
+        centralised: false,
         c1a_form: false,
         c8_form: false,
         under_age: false,


### PR DESCRIPTION
As part of the centralisation rollout we are undergoing, some reports need to be generated to HMCTS so they know which completed applications are going to the central hub.

When there are few courts like now it can be done easily by court name, but soon there will be many more courts and generating these reports using the date and the court name is very tedious.

In order to simplify this we are adding to the metadata of any completed application a new attribute `centralised` true/false if the completed application has been for a centralised court.

This will allow to create reports much easily by just filtering by this flag.

A DB migration is needed to automate some already centralised courts in the first rollout.