### PR TITLE
Update CircleCI team name for HMCTS hand over

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ references:
     docker:
       - image: ministryofjustice/cloud-platform-tools:1.24
         environment:
-          GITHUB_TEAM_NAME_SLUG: family-justice
+          GITHUB_TEAM_NAME_SLUG: sustainingdevs
           REPO_NAME: c100-application
 
 


### PR DESCRIPTION
Ticket: https://trello.com/c/SoDjxznK

We are handing over this service to HMCTS PET (Product Enhancement Team).

The new github team is `sustainingdevs` and this is used in the CircleCI to push/pull from the ECR repo.