### PR TITLE
Replace Court Tribunal Finder endpoints with FaCT

### DIFF
--- a/app/models/concerns/court_contact_details.rb
+++ b/app/models/concerns/court_contact_details.rb
@@ -1,6 +1,10 @@
 module CourtContactDetails
   extend ActiveSupport::Concern
 
+  # Find a Court or Tribunal - URL used for user-facing access.
+  # For API access, refer to `services/c100_app/courtfinder_api.rb`
+  FACT_COURT_BASE_URL = 'https://www.find-court-tribunal.service.gov.uk/courts/'.freeze
+
   CENTRAL_HUB_EMAIL = 'C100applications@justice.gov.uk'.freeze
   CENTRAL_HUB_ADDRESS = [
     'C100 Applications',
@@ -15,7 +19,7 @@ module CourtContactDetails
   end
 
   def url
-    C100App::CourtfinderAPI.court_url(slug)
+    URI.join(FACT_COURT_BASE_URL, slug).to_s
   end
 
   def full_address

--- a/app/services/c100_app/courtfinder_api.rb
+++ b/app/services/c100_app/courtfinder_api.rb
@@ -1,6 +1,6 @@
 module C100App
   class CourtfinderAPI
-    API_BASE_URL = "https://courttribunalfinder.service.gov.uk".freeze
+    API_BASE_URL = "https://old.courttribunalfinder.service.gov.uk".freeze
     SEARCH_PATH  = "/search/results.json?aol=%<aol>s&postcode=%<postcode>s".freeze
     COURT_PATH   = "/courts/%<slug>s.json".freeze
     HEALTH_CHECK = "/healthcheck.json".freeze

--- a/app/services/c100_app/courtfinder_api.rb
+++ b/app/services/c100_app/courtfinder_api.rb
@@ -18,10 +18,6 @@ module C100App
       use_ssl: true,
     }.freeze
 
-    def self.court_url(slug)
-      URI.join(API_BASE_URL, '/courts/', slug).to_s
-    end
-
     def court_for(area_of_law, postcode)
       safe_postcode = postcode.gsub(/[^a-z0-9]/i, '')
       path = format(SEARCH_PATH, aol: area_of_law, postcode: safe_postcode)

--- a/app/services/c100_app/courtfinder_api.rb
+++ b/app/services/c100_app/courtfinder_api.rb
@@ -1,9 +1,9 @@
 module C100App
   class CourtfinderAPI
-    API_BASE_URL = "https://old.courttribunalfinder.service.gov.uk".freeze
+    API_BASE_URL = "https://www.find-court-tribunal.service.gov.uk".freeze
     SEARCH_PATH  = "/search/results.json?aol=%<aol>s&postcode=%<postcode>s".freeze
     COURT_PATH   = "/courts/%<slug>s.json".freeze
-    HEALTH_CHECK = "/healthcheck.json".freeze
+    HEALTH_CHECK = "/health".freeze
 
     HTTP_HEADERS = {
       'Accept' => 'application/json',
@@ -38,7 +38,7 @@ module C100App
     private
 
     def status
-      get_request(HEALTH_CHECK).dig('*', 'status')
+      get_request(HEALTH_CHECK).dig('mapit-api', 'status').eql?('UP')
     rescue StandardError
       false
     end

--- a/app/views/about/contact.en.html.erb
+++ b/app/views/about/contact.en.html.erb
@@ -17,7 +17,7 @@
 
     <p class="govuk-body">
       We cannot answer any questions about applications that have already been submitted. You can
-      <a href="https://old.courttribunalfinder.service.gov.uk/search/spoe?aol=Children" class="govuk-link" rel="external" target="_blank">contact
+      <a href="https://www.find-court-tribunal.service.gov.uk/services/childcare-and-parenting/childcare-arrangements/search-by-postcode" class="govuk-link" rel="external" target="_blank">contact
         the relevant court</a> if you need to discuss your case.
     </p>
   </div>

--- a/app/views/about/contact.en.html.erb
+++ b/app/views/about/contact.en.html.erb
@@ -17,7 +17,7 @@
 
     <p class="govuk-body">
       We cannot answer any questions about applications that have already been submitted. You can
-      <a href="https://courttribunalfinder.service.gov.uk/search/spoe?aol=Children" class="govuk-link" rel="external" target="_blank">contact
+      <a href="https://old.courttribunalfinder.service.gov.uk/search/spoe?aol=Children" class="govuk-link" rel="external" target="_blank">contact
         the relevant court</a> if you need to discuss your case.
     </p>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -836,7 +836,7 @@ en:
         edit:
           page_title: Details of urgent hearing
           heading: Details of urgent hearing
-          court_info_html: If you need to go to court now, <a href="https://old.courttribunalfinder.service.gov.uk/search/" rel="external" target="_blank" class="govuk-link">contact your nearest family court</a> for assistance.
+          court_info_html: If you need to go to court now, <a href="https://www.find-court-tribunal.service.gov.uk/services/childcare-and-parenting/childcare-arrangements/search-by-postcode" rel="external" target="_blank" class="govuk-link">contact your nearest family court</a> for assistance.
     attending_court:
       language:
         edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -836,7 +836,7 @@ en:
         edit:
           page_title: Details of urgent hearing
           heading: Details of urgent hearing
-          court_info_html: If you need to go to court now, <a href="https://courttribunalfinder.service.gov.uk/search/" rel="external" target="_blank" class="govuk-link">contact your nearest family court</a> for assistance.
+          court_info_html: If you need to go to court now, <a href="https://old.courttribunalfinder.service.gov.uk/search/" rel="external" target="_blank" class="govuk-link">contact your nearest family court</a> for assistance.
     attending_court:
       language:
         edit:

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         reference_code: '1970/01/4A362E1C',
         court_name: 'Test court',
         court_email: 'court@example.com',
-        court_url: 'https://courttribunalfinder.service.gov.uk/courts/test-court',
+        court_url: 'https://old.courttribunalfinder.service.gov.uk/courts/test-court',
         court_address: "Test court\nstreet1\nstreet2\ntown\npostcode",
         documents_email: 'court@example.com',
         is_under_age: 'no',

--- a/spec/mailers/notify_submission_mailer_spec.rb
+++ b/spec/mailers/notify_submission_mailer_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe NotifySubmissionMailer, type: :mailer do
         reference_code: '1970/01/4A362E1C',
         court_name: 'Test court',
         court_email: 'court@example.com',
-        court_url: 'https://old.courttribunalfinder.service.gov.uk/courts/test-court',
+        court_url: 'https://www.find-court-tribunal.service.gov.uk/courts/test-court',
         court_address: "Test court\nstreet1\nstreet2\ntown\npostcode",
         documents_email: 'court@example.com',
         is_under_age: 'no',

--- a/spec/models/concerns/court_contact_details_spec.rb
+++ b/spec/models/concerns/court_contact_details_spec.rb
@@ -62,9 +62,8 @@ RSpec.describe CourtContactDetails do
   end
 
   describe '#url' do
-    it 'delegates to the CourtfinderAPI class' do
-      expect(C100App::CourtfinderAPI).to receive(:court_url).with('court-slug')
-      subject.url
+    it 'returns the URL to the court in FaCT' do
+      expect(subject.url).to eq('https://www.find-court-tribunal.service.gov.uk/courts/court-slug')
     end
   end
 

--- a/spec/services/c100_app/courtfinder_api_spec.rb
+++ b/spec/services/c100_app/courtfinder_api_spec.rb
@@ -41,7 +41,7 @@ describe C100App::CourtfinderAPI do
         expect(
           Net::HTTP
         ).to receive(:start).with(
-          'old.courttribunalfinder.service.gov.uk', 443, :ENV, { open_timeout: 10, read_timeout: 20, use_ssl: true }
+          'www.find-court-tribunal.service.gov.uk', 443, :ENV, { open_timeout: 10, read_timeout: 20, use_ssl: true }
         ).and_return(response_double)
 
         subject.court_for('Children', 'MK9 3DX')
@@ -125,8 +125,8 @@ describe C100App::CourtfinderAPI do
   end
 
   describe '#is_ok?' do
-    let(:healthy_response) { { '*' => { 'status' => true } } }
-    let(:unhealthy_response) { { '*' => { 'status' => false } } }
+    let(:healthy_response) { { 'mapit-api' => { 'status' => 'UP' } } }
+    let(:unhealthy_response) { { 'mapit-api' => { 'status' => 'DOWN' } } }
 
     before do
       # Mock it as we are not testing this now
@@ -137,7 +137,7 @@ describe C100App::CourtfinderAPI do
       expect(
         Net::HTTP::Get
       ).to receive(:new).with(
-        '/healthcheck.json', http_headers
+        '/health', http_headers
       )
 
       subject.is_ok?
@@ -154,7 +154,7 @@ describe C100App::CourtfinderAPI do
 
       # mutant kill
       it 'digs the status' do
-        expect(healthy_response).to receive(:dig).with('*', 'status')
+        expect(healthy_response).to receive(:dig).with('mapit-api', 'status')
         subject.is_ok?
       end
     end

--- a/spec/services/c100_app/courtfinder_api_spec.rb
+++ b/spec/services/c100_app/courtfinder_api_spec.rb
@@ -10,7 +10,7 @@ describe C100App::CourtfinderAPI do
     it 'returns the court website URL' do
       expect(
         described_class.court_url('my-slug')
-      ).to eq('https://courttribunalfinder.service.gov.uk/courts/my-slug')
+      ).to eq('https://old.courttribunalfinder.service.gov.uk/courts/my-slug')
     end
   end
 
@@ -49,7 +49,7 @@ describe C100App::CourtfinderAPI do
         expect(
           Net::HTTP
         ).to receive(:start).with(
-          'courttribunalfinder.service.gov.uk', 443, :ENV, { open_timeout: 10, read_timeout: 20, use_ssl: true }
+          'old.courttribunalfinder.service.gov.uk', 443, :ENV, { open_timeout: 10, read_timeout: 20, use_ssl: true }
         ).and_return(response_double)
 
         subject.court_for('Children', 'MK9 3DX')

--- a/spec/services/c100_app/courtfinder_api_spec.rb
+++ b/spec/services/c100_app/courtfinder_api_spec.rb
@@ -6,14 +6,6 @@ describe C100App::CourtfinderAPI do
     'User-Agent' => 'child-arrangements-service',
   } }
 
-  describe '.court_url' do
-    it 'returns the court website URL' do
-      expect(
-        described_class.court_url('my-slug')
-      ).to eq('https://old.courttribunalfinder.service.gov.uk/courts/my-slug')
-    end
-  end
-
   describe '#court_for' do
     before do
       # Mock it as we are not testing this now


### PR DESCRIPTION
We have been requested to change the url to:

```
https://old.courttribunalfinder.service.gov.uk
```

**Their intention is to deploy this on Monday, 22 March 2021**.

A time has been requested so that we can try our best to sync a 
deployment,
this was not given at the time of this commit.

Test will fail until endpoint is live, visit: https://old.courttribunalfinder.service.gov.uk/search/results.json?aol=Children&postcode=MK93DX

Once live, re-run the tests.

Please see card: 
https://trello.com/c/WcVTq2VV/212-cas-court-tribunal-finder-url-change

---

⚠️ **Update 31/03/2021**

FaCT team has fixed all the showstoppers found with their API (refer to ticket https://trello.com/c/Pu2yNQXa for more details) and it seems there will be no need to use the `old` CTF subdomain as that was a workaround in case FaCT was released before fixing all the issues.

As a consequence, there have been a new commit in this PR (08b2607) to update the endpoints to call FaCT directly and we are awaiting a decision whether we are going to release this in the next few days.