### PR TITLE
Add 10 new courts to the centralisation pilot

### DIFF
--- a/config/court_slugs.yml
+++ b/config/court_slugs.yml
@@ -16,3 +16,14 @@ centralisation:
   - west-london-family-court
   # Second rollout - 11/03/2021
   - manchester-civil-justice-centre-civil-and-family-courts
+  # Third rollout - 23/03/2021
+  - slough-county-court-and-family-court
+  - norwich-combined-court-centre
+  - milton-keynes-county-court-and-family-court
+  - peterborough-combined-court-centre
+  - staines-county-court-and-family-court
+  - watford-county-court-and-family-court
+  - guildford-county-court-and-family-court
+  - reading-county-court-and-family-court
+  - oxford-combined-court-centre
+  - luton-justice-centre

--- a/spec/models/concerns/court_contact_details_spec.rb
+++ b/spec/models/concerns/court_contact_details_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe CourtContactDetails do
         medway-county-court-and-family-court
         west-london-family-court
         manchester-civil-justice-centre-civil-and-family-courts
+        slough-county-court-and-family-court
+        norwich-combined-court-centre
+        milton-keynes-county-court-and-family-court
+        peterborough-combined-court-centre
+        staines-county-court-and-family-court
+        watford-county-court-and-family-court
+        guildford-county-court-and-family-court
+        reading-county-court-and-family-court
+        oxford-combined-court-centre
+        luton-justice-centre
       ))
     end
   end


### PR DESCRIPTION
Ticket: https://trello.com/c/FJjGm8My

The following courts are to be onboarded 23/03/2021 early morning:

- Slough
- Norwich
- Milton Keynes
- Peterborough
- Staines
- Watford
- Guildford
- Reading
- Oxford
- Luton