### PR TITLE
Skip court reset when updating children postcode

### DIFF
--- a/app/forms/steps/opening/postcode_form.rb
+++ b/app/forms/steps/opening/postcode_form.rb
@@ -11,7 +11,6 @@ module Steps
 
         c100_application.update(
           children_postcode: children_postcode,
-          court: nil, # reset court attribute, so we start fresh
         )
       end
     end

--- a/spec/forms/steps/opening/postcode_form_spec.rb
+++ b/spec/forms/steps/opening/postcode_form_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe Steps::Opening::PostcodeForm do
       it 'saves the record' do
         expect(c100_application).to receive(:update).with(
           children_postcode: children_postcode,
-          court: nil,
         ).and_return(true)
 
         expect(subject.save).to be(true)


### PR DESCRIPTION
With the recent downtimes experienced with CTF, an edge case was discovered where, if the applicant had already entered their postcode (before CTF being down) but then they return to the postcode step when CTF is down, and click continue (no need to change the postcode) the previous assigned `court` gets wiped as we try to assign a new one, but because CTF is down we can't.

So the solution is to err on the cautious side, and do not reset the `court` attribute, because even if CTF is down but it was present from before, it can be reused, otherwise the whole application will fail to be submitted if we don't have a valid court assigned to the application.