### PR TITLE
Added webdrivers gem 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,5 +64,6 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
   gem 'simplecov-rcov'
+  gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,6 +401,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.6.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.11.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -460,6 +464,7 @@ DEPENDENCIES
   uk_postcode
   virtus
   web-console
+  webdrivers
   webmock
   wicked_pdf (~> 2.1.0)
   wkhtmltopdf-binary-edge-alpine (~> 0.12.5)


### PR DESCRIPTION
This PR adds webdrivers gem to allow new developers to get started without worrying about adding (and future management of) the webdriver for chrome.

webdrivers will automatically find and install the appropriate version of webdrivers for the installed version of chrome