### PR TITLE
Bump mimemagic to v0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0212)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)


### PR DESCRIPTION
Fixes 'Your bundle is locked to mimemagic (0.3.5), but that version could not be found'

For more background on this issue:
https://github.com/rails/rails/issues/41750

Slack conversation:
https://mojdt.slack.com/archives/C7KCVJZSQ/p1616607583045100