### PR TITLE
hotfix - Mime magic gem 0.3.5 has been yanked due to licensing issue …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0212)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)


### PR DESCRIPTION
hotfix - Mime magic gem 0.3.5 has been yanked due to licensing issue - causing chaos with every rails app yesterday.  Upgraded to 0.3.6