### PR TITLE
Revert "RST-3299 Remove the option for 'deal with another option not listed'"

### DIFF
--- a/app/presenters/summary/html_sections/nature_of_application.rb
+++ b/app/presenters/summary/html_sections/nature_of_application.rb
@@ -28,6 +28,11 @@ module Summary
                           change_path: edit_steps_petition_orders_path(
                             anchor: 'steps-petition-orders-form-orders-consent-order-field'
                           )),
+          FreeTextAnswer.new(:other_issue_details,
+                             petition.other_issue_details,
+                             change_path: edit_steps_petition_orders_path(
+                               anchor: 'steps-petition-orders-form-orders-other-issue-field'
+                             )),
           AnswersGroup.new(
             :protection_orders,
             [

--- a/app/views/steps/petition/orders/edit.html.erb
+++ b/app/views/steps/petition/orders/edit.html.erb
@@ -22,6 +22,10 @@
             <%= f.govuk_collection_check_boxes :orders_collection, PetitionOrder::SPECIFIC_ISSUES, :to_s, :to_s %>
           <% end %>
         <% end %>
+
+        <%= f.govuk_check_box :orders, PetitionOrder::OTHER_ISSUE.to_s do
+          f.govuk_text_area :orders_additional_details
+        end %>
       <% end %>
 
       <%= f.continue_button %>

--- a/features/fixtures/files/nature_of_application.html
+++ b/features/fixtures/files/nature_of_application.html
@@ -146,6 +146,19 @@
           </fieldset>
         </div>
       </div>
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-other-issue-field"
+                                                 class="govuk-checkboxes__input" type="checkbox" value="other_issue"
+                                                 name="steps_petition_orders_form[orders][]"
+                                                 aria-controls="steps-petition-orders-form-orders-other-issue-conditional"
+                                                 aria-expanded="false"><label
+          for="steps-petition-orders-form-orders-other-issue-field" class="govuk-label govuk-checkboxes__label">Deal with another issue not listed</label></div>
+      <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+           id="steps-petition-orders-form-orders-other-issue-conditional">
+        <div class="govuk-form-group"><label for="steps-petition-orders-form-orders-additional-details-field"
+                                             class="govuk-label">Briefly provide more details</label><textarea
+            id="steps-petition-orders-form-orders-additional-details-field" class="govuk-textarea" rows="5"
+            name="steps_petition_orders_form[orders_additional_details]"></textarea></div>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/features/fixtures/files/nature_of_application_with_errors.html
+++ b/features/fixtures/files/nature_of_application_with_errors.html
@@ -147,6 +147,19 @@
           </fieldset>
         </div>
       </div>
+      <div class="govuk-checkboxes__item"><input id="steps-petition-orders-form-orders-other-issue-field"
+                                                 class="govuk-checkboxes__input" type="checkbox" value="other_issue"
+                                                 name="steps_petition_orders_form[orders][]"
+                                                 aria-controls="steps-petition-orders-form-orders-other-issue-conditional"
+                                                 aria-expanded="false"><label
+          for="steps-petition-orders-form-orders-other-issue-field" class="govuk-label govuk-checkboxes__label">Deal with another issue not listed</label></div>
+      <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+           id="steps-petition-orders-form-orders-other-issue-conditional">
+        <div class="govuk-form-group"><label for="steps-petition-orders-form-orders-additional-details-field"
+                                             class="govuk-label">Briefly provide more details</label><textarea
+            id="steps-petition-orders-form-orders-additional-details-field" class="govuk-textarea" rows="5"
+            name="steps_petition_orders_form[orders_additional_details]"></textarea></div>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/spec/presenters/summary/html_sections/nature_of_application_spec.rb
+++ b/spec/presenters/summary/html_sections/nature_of_application_spec.rb
@@ -39,7 +39,7 @@ module Summary
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(answers.count).to eq(4)
+        expect(answers.count).to eq(5)
 
         expect(answers[0]).to be_an_instance_of(MultiAnswer)
         expect(answers[0].question).to eq(:child_arrangements_orders)
@@ -68,13 +68,18 @@ module Summary
         ])
         expect(answers[2].change_path).to eq('/steps/petition/orders#steps-petition-orders-form-orders-group-specific-issues-field')
 
-        expect(answers[3]).to be_an_instance_of(AnswersGroup)
-        expect(answers[3].name).to eq(:protection_orders)
-        expect(answers[3].change_path).to eq('/steps/petition/protection')
-        expect(answers[3].answers.count).to eq(2)
+        expect(answers[3]).to be_an_instance_of(FreeTextAnswer)
+        expect(answers[3].question).to eq(:other_issue_details)
+        expect(answers[3].value).to eq('orders detail')
+        expect(answers[3].change_path).to eq('/steps/petition/orders#steps-petition-orders-form-orders-other-issue-field')
+
+        expect(answers[4]).to be_an_instance_of(AnswersGroup)
+        expect(answers[4].name).to eq(:protection_orders)
+        expect(answers[4].change_path).to eq('/steps/petition/protection')
+        expect(answers[4].answers.count).to eq(2)
 
         ## protection_orders group answers ###
-        protection = answers[3].answers
+        protection = answers[4].answers
 
         expect(protection[0]).to be_an_instance_of(Answer)
         expect(protection[0].question).to eq(:protection_orders)
@@ -89,7 +94,7 @@ module Summary
         let(:orders) { ['consent_order'] }
 
         it 'has the correct rows' do
-          expect(answers.count).to eq(2)
+          expect(answers.count).to eq(3)
 
           expect(answers[0]).to be_an_instance_of(MultiAnswer)
           expect(answers[0].question).to eq(:formalise_arrangements)


### PR DESCRIPTION
Reverts ministryofjustice/c100-application#1178

We have a query with this so need to stop it getting deployed for now until it is resolved