### PR TITLE
RST 3369 Change payment type selection

### DIFF
--- a/app/presenters/valid_payments_array.rb
+++ b/app/presenters/valid_payments_array.rb
@@ -49,6 +49,10 @@ class ValidPaymentsArray < SimpleDelegator
       choices.append(
         PaymentType::SELF_PAYMENT_CARD
       ) if phone_pay_enabled?
+
+      choices.delete(
+        PaymentType::SELF_PAYMENT_CHEQUE
+      ) if c100_application.online_submission?
     end
   end
 

--- a/spec/presenters/valid_payments_array_spec.rb
+++ b/spec/presenters/valid_payments_array_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe ValidPaymentsArray do
       let(:has_solicitor) { 'yes' }
 
       it 'has valid payment choices' do
-        expect(subject).to match_array(common_choices + [PaymentType::SOLICITOR, PaymentType::ONLINE])
+        expect(subject).to match_array([PaymentType::HELP_WITH_FEES, PaymentType::SOLICITOR, PaymentType::ONLINE])
       end
     end
 
@@ -108,7 +108,13 @@ RSpec.describe ValidPaymentsArray do
       let(:has_solicitor) { 'no' }
 
       it 'has valid payment choices' do
-        expect(subject).to match_array(common_choices + [PaymentType::ONLINE])
+        expect(subject).to match_array([PaymentType::HELP_WITH_FEES, PaymentType::ONLINE])
+      end
+    end
+
+    context 'unavailable payment type' do
+      it 'cheque' do
+        expect(subject).to_not include(PaymentType::SELF_PAYMENT_CHEQUE)
       end
     end
   end
@@ -133,6 +139,12 @@ RSpec.describe ValidPaymentsArray do
 
       it 'has valid payment choices' do
         expect(subject).to match_array(common_choices)
+      end
+    end
+
+    context 'unavailable payment type' do
+      it 'online' do
+        expect(subject).to_not include(PaymentType::ONLINE)
       end
     end
   end


### PR DESCRIPTION
**JIRA**
[RST-3369](https://tools.hmcts.net/jira/browse/RST-3369)

**Description**
To remove the ability for a user to pay the court fee by cheque or cash if submitting the application electronically
To remove the ability for a user to pay the court fee online if sending the application by post