### PR TITLE
Update no longer supported ttf-ubuntu-font-family to ttf-freefont

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apk --no-cache add \
   libxrender \
   libxext \
   fontconfig \
-  ttf-ubuntu-font-family \
+  ttf-freefont \
 && apk --no-cache add --virtual fonts-deps \
   msttcorefonts-installer \
 && update-ms-fonts && fc-cache -f


### PR DESCRIPTION
From recommendations here:
https://github.com/alpinelinux/docker-alpine/issues/181
https://github.com/anaynayak/aws-security-viz/commit/32930c8d4a6445ff89af1b2af9b85511dade0356