### PR TITLE
Upgrade docker version used to prevent permission error bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - checkout
 
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.0
           docker_layer_caching: true
 
       - run:


### PR DESCRIPTION
Fix from here:
https://stackoverflow.com/questions/68243042/you-dont-have-write-permissions-for-the-usr-lib-ruby-gems-2-7-0-directory-alp