### PR TITLE
RST-4740

### DIFF
--- a/app/forms/steps/respondent/contact_details_form.rb
+++ b/app/forms/steps/respondent/contact_details_form.rb
@@ -14,6 +14,9 @@ module Steps
       validates :mobile_phone, phone_number: true, unless: :mobile_phone_unknown?
       validates_presence_of  :home_phone, unless: :home_phone_unknown?
       validates :home_phone, phone_number: true, unless: :home_phone_unknown?
+      validates :email, unknown_respondent_input: true, if: :email_unknown?
+      validates :home_phone, unknown_respondent_input: true, if: :home_phone_unknown?
+      validates :mobile_phone, unknown_respondent_input: true, if: :mobile_phone_unknown?
 
       private
 

--- a/app/validators/unknown_respondent_input_validator.rb
+++ b/app/validators/unknown_respondent_input_validator.rb
@@ -1,0 +1,9 @@
+class UnknownRespondentInputValidator < ActiveModel::EachValidator
+  def validate_each(record, input_attribute, value)
+    return if value.nil? || value.blank?
+
+    unknown_label = I18n.t(".dictionary.PERSONAL_CONTACT_FIELDS.#{input_attribute}_unknown_options.true")
+    label_text = I18n.t(".dictionary.PERSONAL_CONTACT_FIELDS.#{input_attribute}")
+    record.errors.add(input_attribute, "Cannot select '#{unknown_label}' and input '#{label_text}'")
+  end
+end

--- a/spec/forms/steps/respondent/contact_details_form_spec.rb
+++ b/spec/forms/steps/respondent/contact_details_form_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
           expect(subject.errors[:email]).to_not be_empty
         }
       end
+
+      context 'email should be blank if unknown box is checked' do
+        let(:email) { 'name@example.com' }
+        let(:email_unknown) { true }
+        it {
+          expect(subject).not_to be_valid
+          expect(subject.errors[:email]).to_not be_empty
+        }
+      end
     end
 
     context 'phone validation' do      
@@ -86,6 +95,15 @@ RSpec.describe Steps::Respondent::ContactDetailsForm do
           context 'no input from user is invalid' do
             let(phone_type) { nil }
             let( "#{phone_type}_unknown".to_sym) { false }
+            it {
+              expect(subject).not_to be_valid
+              expect(subject.errors[phone_type]).to_not be_empty
+            }
+          end
+
+          context 'should be blank if unknown box is checked' do
+            let(phone_type) { '07777777777' }
+            let( "#{phone_type}_unknown".to_sym) { true }
             it {
               expect(subject).not_to be_valid
               expect(subject.errors[phone_type]).to_not be_empty


### PR DESCRIPTION
Added validator to not allow value when "I don't know" checkbox is true

Added validation to respondent/contact_details page.

Added test to check validation fails when there is an input and when "I don't know" checkbox is true