### PR TITLE
RST-7077b - Remove unused phone columns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^RST-7101$/
+                - /^RST-7077b$/
       - deploy_image_to_dev:
           name: deploy-dev-live
           env_name: dev
@@ -313,7 +313,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^RST-7101$/
+                - /^RST-7077b$/
       ### staging ###
       - build_and_push_image:
           name: build-staging

--- a/db/migrate/20250130131546_remove_old_phone_columns.rb
+++ b/db/migrate/20250130131546_remove_old_phone_columns.rb
@@ -1,0 +1,21 @@
+class RemoveOldPhoneColumns < ActiveRecord::Migration[7.2]
+  def up
+    remove_column :people, :mobile_phone
+    remove_column :people, :mobile_phone_unknown
+    remove_column :people, :mobile_provided
+    remove_column :people, :mobile_not_provided_reason
+    remove_column :people, :mobile_keep_private
+    remove_column :people, :home_phone_unknown
+    remove_column :people, :home_phone
+  end
+
+  def down
+    add_column :people, :mobile_phone, :string
+    add_column :people, :mobile_phone_unknown, :boolean, default: false
+    add_column :people, :mobile_provided, :string
+    add_column :people, :mobile_not_provided_reason, :string
+    add_column :people, :mobile_keep_private, :string
+    add_column :people, :home_phone_unknown, :boolean, default: false
+    add_column :people, :home_phone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_29_111620) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_30_131546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -345,8 +345,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_111620) do
     t.string "age_estimate"
     t.string "birthplace"
     t.boolean "address_unknown", default: false
-    t.string "mobile_phone"
-    t.boolean "mobile_phone_unknown", default: false
     t.string "email"
     t.boolean "email_unknown", default: false
     t.string "residence_requirement_met"
@@ -362,17 +360,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_111620) do
     t.string "phone_keep_private"
     t.boolean "birthplace_unknown", default: false
     t.date "dob_estimate"
-    t.string "mobile_provided"
-    t.string "mobile_not_provided_reason"
     t.string "parental_responsibility"
     t.string "privacy_known"
     t.string "contact_details_private", default: [], array: true
     t.string "are_contact_details_private"
     t.string "refuge"
     t.string "cohabit_with_other"
-    t.string "mobile_keep_private"
-    t.boolean "home_phone_unknown", default: false
-    t.string "home_phone"
     t.string "phone_number"
     t.boolean "phone_number_unknown", default: false
     t.string "phone_number_provided"


### PR DESCRIPTION
Remove old mobile_phone and home_phone columns that are no longer needed because of https://tools.hmcts.net/jira/browse/RST-7077